### PR TITLE
fix(supergraph-metadata): improve state and collect all directives 

### DIFF
--- a/lib/query-planner/src/federation_spec/directives.rs
+++ b/lib/query-planner/src/federation_spec/directives.rs
@@ -1,24 +1,9 @@
+pub use crate::federation_spec::join_enum_value::JoinEnumValueDirective;
 pub use crate::federation_spec::join_field::JoinFieldDirective;
+pub use crate::federation_spec::join_graph::JoinGraphDirective;
 pub use crate::federation_spec::join_implements::JoinImplementsDirective;
 pub use crate::federation_spec::join_type::JoinTypeDirective;
-
-pub struct JoinEnumValueDirective {}
-
-impl JoinEnumValueDirective {
-    pub const NAME: &str = "join__enumValue";
-}
-
-pub struct JoinUnionMemberDirective {}
-
-impl JoinUnionMemberDirective {
-    pub const NAME: &str = "join__unionMember";
-}
-
-pub struct JoinGraphDirective {}
-
-impl JoinGraphDirective {
-    pub const NAME: &str = "join__graph";
-}
+pub use crate::federation_spec::join_union::JoinUnionMemberDirective;
 
 pub struct TagDirective {}
 

--- a/lib/query-planner/src/federation_spec/join_enum_value.rs
+++ b/lib/query-planner/src/federation_spec/join_enum_value.rs
@@ -1,0 +1,32 @@
+use graphql_parser_hive_fork::schema::{Directive, Value};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct JoinEnumValueDirective {
+    pub graph: String,
+}
+
+impl JoinEnumValueDirective {
+    pub const NAME: &str = "join__enumValue";
+
+    pub fn is(directive: &Directive<'_, String>) -> bool {
+        directive.name == Self::NAME
+    }
+}
+
+impl From<&Directive<'_, String>> for JoinEnumValueDirective {
+    fn from(directive: &Directive<'_, String>) -> Self {
+        let mut result = Self::default();
+
+        for (arg_name, arg_value) in &directive.arguments {
+            if arg_name.eq("graph") {
+                match arg_value {
+                    Value::String(value) => result.graph = value.clone(),
+                    Value::Enum(value) => result.graph = value.clone(),
+                    _ => {}
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/lib/query-planner/src/federation_spec/join_graph.rs
+++ b/lib/query-planner/src/federation_spec/join_graph.rs
@@ -1,0 +1,37 @@
+use graphql_parser_hive_fork::schema::{Directive, Value};
+
+#[derive(Debug, Default, Clone)]
+pub struct JoinGraphDirective {
+    pub name: String,
+    pub url: String,
+}
+
+impl JoinGraphDirective {
+    pub const NAME: &str = "join__graph";
+
+    pub fn is(directive: &Directive<'_, String>) -> bool {
+        directive.name == Self::NAME
+    }
+}
+
+impl From<&Directive<'_, String>> for JoinGraphDirective {
+    fn from(directive: &Directive<'_, String>) -> Self {
+        let mut result = Self::default();
+
+        for (arg_name, arg_value) in &directive.arguments {
+            if arg_name.eq("name") {
+                match arg_value {
+                    Value::String(value) => result.name = value.clone(),
+                    _ => {}
+                }
+            } else if arg_name.eq("url") {
+                match arg_value {
+                    Value::String(value) => result.url = value.clone(),
+                    _ => {}
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/lib/query-planner/src/federation_spec/join_union.rs
+++ b/lib/query-planner/src/federation_spec/join_union.rs
@@ -1,0 +1,37 @@
+use graphql_parser_hive_fork::schema::{Directive, Value};
+
+#[derive(Debug, Default, Clone)]
+pub struct JoinUnionMemberDirective {
+    graph: String,
+    member: String,
+}
+
+impl JoinUnionMemberDirective {
+    pub const NAME: &str = "join__unionMember";
+
+    pub fn is(directive: &Directive<'_, String>) -> bool {
+        directive.name == Self::NAME
+    }
+}
+
+impl From<&Directive<'_, String>> for JoinUnionMemberDirective {
+    fn from(directive: &Directive<'_, String>) -> Self {
+        let mut result = Self::default();
+
+        for (arg_name, arg_value) in &directive.arguments {
+            if arg_name.eq("graph") {
+                match arg_value {
+                    Value::String(value) => result.graph = value.clone(),
+                    Value::Enum(value) => result.graph = value.clone(),
+                    _ => {}
+                }
+            } else if arg_name.eq("member") {
+                if let Value::String(value) = arg_value {
+                    result.member = value.clone()
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/lib/query-planner/src/federation_spec/mod.rs
+++ b/lib/query-planner/src/federation_spec/mod.rs
@@ -1,6 +1,9 @@
 pub mod definitions;
 pub mod directives;
 
+pub(crate) mod join_enum_value;
 pub(crate) mod join_field;
+pub(crate) mod join_graph;
 pub(crate) mod join_implements;
 pub(crate) mod join_type;
+pub(crate) mod join_union;


### PR DESCRIPTION
This PR improves `SupergrapgMetadata` parsing (=IR/state) to collect and parse all metadata provided in the supergraph - it was missing before. 