### PR TITLE
Simplify boolean fields in Join directives

### DIFF
--- a/lib/query-planner/src/federation_spec/join_field.rs
+++ b/lib/query-planner/src/federation_spec/join_field.rs
@@ -2,15 +2,32 @@ use graphql_parser::schema::{Directive, Value};
 
 use super::directives::FederationDirective;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JoinFieldDirective {
     pub graph_id: Option<String>,
     pub requires: Option<String>,
     pub provides: Option<String>,
     pub type_in_graph: Option<String>,
-    pub external: Option<bool>,
+    pub external: bool,
     pub override_value: Option<String>,
-    pub used_overridden: Option<bool>,
+    pub used_overridden: bool,
+}
+
+// Kamil: I added allow(clippy), because I prefer to define the defaults explicitly,
+// instead of relying on Default macro. It's not obvious that a default for `bool` is `false`.
+#[allow(clippy::derivable_impls)]
+impl Default for JoinFieldDirective {
+    fn default() -> Self {
+        Self {
+            graph_id: Default::default(),
+            requires: None,
+            provides: None,
+            type_in_graph: None,
+            external: false,
+            override_value: None,
+            used_overridden: false,
+        }
+    }
 }
 
 impl JoinFieldDirective {
@@ -49,7 +66,7 @@ impl<'a> FederationDirective<'a> for JoinFieldDirective {
                 }
             } else if arg_name.eq("external") {
                 if let Value::Boolean(value) = arg_value {
-                    result.external = Some(*value)
+                    result.external = *value
                 }
             } else if arg_name.eq("override") {
                 if let Value::String(value) = arg_value {
@@ -57,7 +74,7 @@ impl<'a> FederationDirective<'a> for JoinFieldDirective {
                 }
             } else if arg_name.eq("usedOverridden") {
                 if let Value::Boolean(value) = arg_value {
-                    result.used_overridden = Some(*value)
+                    result.used_overridden = *value
                 }
             }
         }

--- a/lib/query-planner/src/federation_spec/join_type.rs
+++ b/lib/query-planner/src/federation_spec/join_type.rs
@@ -2,13 +2,25 @@ use graphql_parser::schema::{Directive, Value};
 
 use super::directives::FederationDirective;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct JoinTypeDirective {
     pub graph_id: String,
     pub key: Option<String>,
-    pub extension: Option<bool>,
-    pub resolvable: Option<bool>,
-    pub is_interface_object: Option<bool>,
+    pub extension: bool,
+    pub resolvable: bool,
+    pub is_interface_object: bool,
+}
+
+impl Default for JoinTypeDirective {
+    fn default() -> Self {
+        Self {
+            graph_id: Default::default(),
+            key: None,
+            extension: false,
+            resolvable: true,
+            is_interface_object: false,
+        }
+    }
 }
 
 impl JoinTypeDirective {
@@ -39,15 +51,15 @@ impl<'a> FederationDirective<'a> for JoinTypeDirective {
                 }
             } else if arg_name.eq("extension") {
                 if let Value::Boolean(value) = arg_value {
-                    result.extension = Some(*value)
+                    result.extension = *value
                 }
             } else if arg_name.eq("resolvable") {
                 if let Value::Boolean(value) = arg_value {
-                    result.resolvable = Some(*value)
+                    result.resolvable = *value
                 }
             } else if arg_name.eq("is_interface_object") {
                 if let Value::Boolean(value) = arg_value {
-                    result.is_interface_object = Some(*value)
+                    result.is_interface_object = *value
                 }
             }
         }

--- a/lib/query-planner/src/graph/edge.rs
+++ b/lib/query-planner/src/graph/edge.rs
@@ -140,7 +140,7 @@ impl Debug for Edge {
                     }
 
                     // Add other relevant directives like external, override, etc.
-                    if jf.external.unwrap_or(false) {
+                    if jf.external {
                         result = result.and_then(|_| write!(f, " @external"));
                     }
 

--- a/lib/query-planner/src/graph/mod.rs
+++ b/lib/query-planner/src/graph/mod.rs
@@ -199,7 +199,7 @@ impl Graph {
                     ));
 
                     if join_type1.graph_id != join_type2.graph_id {
-                        if let Some(key) = &join_type2.key {
+                        if let (true, Some(key)) = (&join_type2.resolvable, &join_type2.key) {
                             let tail = self.upsert_node(Node::new_node(
                                 def_name,
                                 state.resolve_graph_id(&join_type2.graph_id)?,
@@ -215,7 +215,7 @@ impl Graph {
 
                             self.upsert_edge(head, tail, Edge::create_entity_move(key, selection));
                         }
-                    } else if let Some(key) = &join_type1.key {
+                    } else if let (true, Some(key)) = (&join_type1.resolvable, &join_type1.key) {
                         let selection_resolver =
                             state.selection_resolvers_for_subgraph(&join_type1.graph_id)?;
                         let selection = selection_resolver.resolve(def_name, key)?;
@@ -371,8 +371,8 @@ impl Graph {
 
                         match (is_available, maybe_join_field) {
                             (true, Some(join_field)) => {
-                                let is_external = join_field.external.is_some_and(|v| v)
-                                    && join_field.requires.is_none();
+                                let is_external =
+                                    join_field.external && join_field.requires.is_none();
 
                                 if is_external {
                                     info!(

--- a/lib/query-planner/src/state/subgraph_state.rs
+++ b/lib/query-planner/src/state/subgraph_state.rs
@@ -264,14 +264,10 @@ impl SubgraphDefinition {
 
     pub fn is_entity_type(&self) -> bool {
         match self {
-            SubgraphDefinition::Object(obj) => {
-                obj.join_types
-                    .iter()
-                    .any(|jt| match (&jt.resolvable, &jt.key) {
-                        (Some(resolvable), Some(_key)) => *resolvable,
-                        _ => false,
-                    })
-            }
+            SubgraphDefinition::Object(obj) => obj
+                .join_types
+                .iter()
+                .any(|jt| matches!((&jt.resolvable, &jt.key), (true, Some(_key)))),
             _ => false,
         }
     }

--- a/lib/query-planner/src/tests/requires.rs
+++ b/lib/query-planner/src/tests/requires.rs
@@ -345,7 +345,7 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
     let best_paths_per_leaf = walk_operation(&graph, operation)?;
     assert_eq!(best_paths_per_leaf.len(), 4);
     assert_eq!(best_paths_per_leaf[0].len(), 1);
-    assert_eq!(best_paths_per_leaf[1].len(), 2);
+    assert_eq!(best_paths_per_leaf[1].len(), 1);
     assert_eq!(best_paths_per_leaf[2].len(), 1);
     assert_eq!(best_paths_per_leaf[3].len(), 1);
 
@@ -355,7 +355,7 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
     );
     insta::assert_snapshot!(
       best_paths_per_leaf[1][0].pretty_print(&graph),
-      @"root(Query) -(b)- Query/b -(b)- B/b -(a)- A/b -(🔑🧩{pId})- A/a -(name)- String/a"
+      @"root(Query) -(b)- Query/b -(b)- B/b -(a)- A/b -(🔑🧩{id})- A/a -(name)- String/a"
     );
     insta::assert_snapshot!(
       best_paths_per_leaf[2][0].pretty_print(&graph),
@@ -375,11 +375,6 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
           a of A/b
             🧩 [
               🧩 [
-                pId of ID/b
-              ]
-              🔑 A/a
-                name of String/a
-              🧩 [
                 id of ID/b
               ]
               🔑 A/a
@@ -394,7 +389,7 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
         b of B/b
           a of A/b
             🧩 [
-              pId of ID/b
+              id of ID/b
             ]
             🔑 A/a
               name of String/a
@@ -424,11 +419,6 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
           a of A/b
             🧩 [
               🧩 [
-                pId of ID/b
-              ]
-              🔑 A/a
-                name of String/a
-              🧩 [
                 id of ID/b
               ]
               🔑 A/a
@@ -436,7 +426,7 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
             ]
             nameInB of String/b
             🧩 [
-              pId of ID/b
+              id of ID/b
             ]
             🔑 A/a
               name of String/a


### PR DESCRIPTION
Change `Option<bool>` fields in `JoinFieldDirective` and `JoinTypeDirective` to `bool`.

Implement `Default` trait for these structs, setting explicit defaults. Notably, `JoinTypeDirective.resolvable` now defaults to `true`.