### PR TITLE
Add optimization to merge passthrough child nodes

### DIFF
--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -641,12 +641,6 @@ fn perform_passthrough_child_merge(
         false,
     );
 
-    me.output.add_at_path(
-        &other.input,
-        other.response_path.slice_from(me.response_path.len()),
-        false,
-    );
-
     let mut children_indexes: Vec<NodeIndex> = vec![];
     let mut parents_indexes: Vec<NodeIndex> = vec![];
     for edge_ref in fetch_graph.children_of(other_index) {


### PR DESCRIPTION
Merges child fetch steps into their parents if the child's input is identical to its output (a "passthrough" node). The passthrough child's own children are then re-parented.

Because we create a fetch step for fields required by `field @requires`, in some cases the fetch step is pointless as it receives the same data it gives back (input = output).