### PR TITLE
Add qp-dev-cli alias and update profiling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 # The following are aliases you can use with "cargo command_name"
 [alias]
 gateway = "run --package gateway"
+dev = "run --package qp-dev-cli"
 test_all = "test --workspace"
 test_qp = "test --package query-planner -- --nocapture"
 "clippy:fix" = "clippy --all --fix --allow-dirty --allow-staged"

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,9 +1,9 @@
 ## Profiling
 
 1. Install `samply` by following: https://github.com/mstange/samply#installation
-2. Build the QP dev-cli in profiling mode using: `cargo build --profile profiling --bin query-planner`
+2. Build the QP dev-cli in profiling mode using: `cargo build --profile profiling -p qp-dev-cli`
 3. Run `samply` with your dev-cli args, for example:
 
 ```
-samply record ./target/profiling/query-planner fetch_graph SUPERGRAPH_PATH OPERATION_PATH
+samply record ./target/profiling/qp-dev-cli plan SUPERGRAPH_PATH OPERATION_PATH
 ```

--- a/lib/query-planner/fixture/gateway-benchmark/operation.graphql
+++ b/lib/query-planner/fixture/gateway-benchmark/operation.graphql
@@ -1,0 +1,58 @@
+fragment User on User {
+  id
+  username
+  name
+}
+
+fragment Review on Review {
+  id
+  body
+}
+
+fragment Product on Product {
+  inStock
+  name
+  price
+  shippingEstimate
+  upc
+  weight
+}
+
+query TestQuery {
+  users {
+    ...User
+    reviews {
+      ...Review
+      product {
+        ...Product
+        reviews {
+          ...Review
+          author {
+            ...User
+            reviews {
+              ...Review
+              product {
+                ...Product
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  topProducts {
+    ...Product
+    reviews {
+      ...Review
+      author {
+        ...User
+        reviews {
+          ...Review
+          product {
+            ...Product
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/query-planner/fixture/gateway-benchmark/supergraph-schema.graphql
+++ b/lib/query-planner/fixture/gateway-benchmark/supergraph-schema.graphql
@@ -1,0 +1,115 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts:4001/graphql")
+  INVENTORY
+    @join__graph(name: "inventory", url: "http://inventory:4002/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews:4004/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc") {
+  upc: String!
+  weight: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+  price: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  name: String @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS) {
+  me: User @join__field(graph: ACCOUNTS)
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  users: [User] @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  body: String
+  product: Product
+  author: User @join__field(graph: REVIEWS, provides: "username")
+}
+
+type User
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS)
+  username: String
+    @join__field(graph: ACCOUNTS)
+    @join__field(graph: REVIEWS, external: true)
+  birthday: Int @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}


### PR DESCRIPTION
Adds `cargo dev` alias for running the `qp-dev-cli` package. The profiling guide is updated to use `qp-dev-cli` - `query-planner` is 404 :)

New GraphQL operation and supergraph fixtures from a benchmark are also included for the query planner.