### PR TITLE
added basic tracing and logging to gw/executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tracing",
  "tracing-subscriber",
  "tracing-tree",
 ]
@@ -2292,6 +2293,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/gateway/Cargo.toml
+++ b/bin/gateway/Cargo.toml
@@ -13,9 +13,10 @@ query-planner = { path = "../../lib/query-planner" }
 query-plan-executor = { path = "../../lib/query-plan-executor" }
 graphql-parser = "0.4.1"
 graphql-tools = "0.4.0"
-tracing-subscriber = "0.3.19"
-tracing-tree = "0.4.0"
 actix-web = "4"
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 reqwest = { version = "0.12", features = ["json"] }
 moka = { version = "0.12", features = ["future"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing = "0.1.41"
+tracing-tree = "0.4.0"

--- a/lib/query-plan-executor/Cargo.toml
+++ b/lib/query-plan-executor/Cargo.toml
@@ -14,3 +14,4 @@ reqwest = { version = "0.12", features = ["json"] }
 query-planner = { path = "../query-planner" }
 graphql-parser = "0.4.1"
 graphql-tools = "0.4.0"
+tracing = "0.1.41"

--- a/run-gw-for-audit.sh
+++ b/run-gw-for-audit.sh
@@ -1,2 +1,10 @@
+#!/bin/bash
+set -e
+
+echo "generating supergraph file for test..."
 npx graphql-federation-audit supergraph --cwd . --test $1
+
+export RUST_LOG=debug
+
+echo "running gateway..."
 cargo gateway supergraph.graphql


### PR DESCRIPTION
- [x] use `RUST_LOG` env var with `EnvFilter` instead of just `DEBUG=1`
- [x] add debug logging to Fed audit execution 
- [x] add logging and use `tracing` instead of `println` in GW and executor  