### PR TITLE
chore(qp): refactor `SupergraphState`, get rid of references, cleanup

### DIFF
--- a/bin/gateway/src/main.rs
+++ b/bin/gateway/src/main.rs
@@ -44,8 +44,7 @@ async fn main() {
         std::fs::read_to_string(supergraph_path).expect("Unable to read input file");
     let parsed_schema = parse_schema(&supergraph_sdl);
     let supergraph_state = SupergraphState::new(&parsed_schema);
-    let planner =
-        Planner::new_from_supergraph_state(&supergraph_state).expect("failed to create planner");
+    let planner = Planner::new_from_supergraph(&parsed_schema).expect("failed to create planner");
     let schema_metadata = planner.consumer_schema.schema_metadata();
     let serve_data = ServeData {
         supergraph_source: supergraph_path.to_string(),

--- a/lib/query-plan-executor/src/variables.rs
+++ b/lib/query-plan-executor/src/variables.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use query_planner::ast::operation::TypeNode;
+use query_planner::state::supergraph_state::TypeNode;
 use serde_json::Value;
 
 use crate::schema_metadata::SchemaMetadata;

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -178,8 +178,8 @@ fn transform_selection_set<'a, 'd>(
     transformed_selection_set
 }
 
-fn transform_variables<'a, 'd>(
-    parser_variables: &'a Vec<query_ast::VariableDefinition<'d, String>>,
+fn transform_variables(
+    parser_variables: &Vec<query_ast::VariableDefinition<'_, String>>,
 ) -> Option<Vec<VariableDefinition>> {
     match parser_variables.len() {
         0 => None,

--- a/lib/query-planner/src/ast/operation.rs
+++ b/lib/query-planner/src/ast/operation.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::ast::hash::ast_hash;
+use crate::{ast::hash::ast_hash, state::supergraph_state::TypeNode};
 use graphql_parser::query as parser;
 use serde::{Deserialize, Serialize};
 
@@ -103,52 +103,15 @@ impl Display for OperationDefinition {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum TypeNode {
-    List(Box<TypeNode>),
-    NonNull(Box<TypeNode>),
-    Named(String),
-}
-
-impl Display for TypeNode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TypeNode::List(inner) => write!(f, "[{}]", inner),
-            TypeNode::NonNull(inner) => write!(f, "{}!", inner),
-            TypeNode::Named(name) => write!(f, "{}", name),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VariableDefinition {
     pub name: String,
     pub variable_type: TypeNode,
     pub default_value: Option<crate::ast::value::Value>,
 }
 
-impl TypeNode {
-    pub fn is_non_null(&self) -> bool {
-        matches!(self, TypeNode::NonNull(_))
-    }
-
-    pub fn is_list(&self) -> bool {
-        matches!(self, TypeNode::List(_))
-    }
-}
-
 impl Display for VariableDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "${}:{}", self.name, self.variable_type)
-    }
-}
-
-impl From<&parser::Type<'_, String>> for TypeNode {
-    fn from(value: &parser::Type<'_, String>) -> Self {
-        match value {
-            parser::Type::ListType(inner) => TypeNode::List(Box::new(inner.as_ref().into())),
-            parser::Type::NonNullType(inner) => TypeNode::NonNull(Box::new(inner.as_ref().into())),
-            parser::Type::NamedType(name) => TypeNode::Named(name.clone()),
-        }
     }
 }
 

--- a/lib/query-planner/src/federation_spec/directive_trait.rs
+++ b/lib/query-planner/src/federation_spec/directive_trait.rs
@@ -1,7 +1,7 @@
 use graphql_parser::schema::Directive;
 
-pub trait FederationDirective<'a>: Ord + PartialOrd {
-    fn directive_name() -> &'a str;
+pub trait FederationDirective: Ord + PartialOrd {
+    fn directive_name() -> &'static str;
     fn is(directive: &Directive<'_, String>) -> bool {
         Self::directive_name() == directive.name
     }

--- a/lib/query-planner/src/federation_spec/inacessible.rs
+++ b/lib/query-planner/src/federation_spec/inacessible.rs
@@ -9,8 +9,8 @@ impl InaccessibleDirective {
     pub const NAME: &str = "inaccessible";
 }
 
-impl<'a> FederationDirective<'a> for InaccessibleDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for InaccessibleDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/federation_spec/join_enum_value.rs
+++ b/lib/query-planner/src/federation_spec/join_enum_value.rs
@@ -11,8 +11,8 @@ impl JoinEnumValueDirective {
     pub const NAME: &str = "join__enumValue";
 }
 
-impl<'a> FederationDirective<'a> for JoinEnumValueDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for JoinEnumValueDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/federation_spec/join_field.rs
+++ b/lib/query-planner/src/federation_spec/join_field.rs
@@ -34,8 +34,8 @@ impl JoinFieldDirective {
     pub const NAME: &str = "join__field";
 }
 
-impl<'a> FederationDirective<'a> for JoinFieldDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for JoinFieldDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/federation_spec/join_graph.rs
+++ b/lib/query-planner/src/federation_spec/join_graph.rs
@@ -12,8 +12,8 @@ impl JoinGraphDirective {
     pub const NAME: &str = "join__graph";
 }
 
-impl<'a> FederationDirective<'a> for JoinGraphDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for JoinGraphDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/federation_spec/join_implements.rs
+++ b/lib/query-planner/src/federation_spec/join_implements.rs
@@ -12,8 +12,8 @@ impl JoinImplementsDirective {
     pub const NAME: &str = "join__implements";
 }
 
-impl<'a> FederationDirective<'a> for JoinImplementsDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for JoinImplementsDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/federation_spec/join_type.rs
+++ b/lib/query-planner/src/federation_spec/join_type.rs
@@ -27,8 +27,8 @@ impl JoinTypeDirective {
     pub const NAME: &str = "join__type";
 }
 
-impl<'a> FederationDirective<'a> for JoinTypeDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for JoinTypeDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/federation_spec/join_union.rs
+++ b/lib/query-planner/src/federation_spec/join_union.rs
@@ -12,8 +12,8 @@ impl JoinUnionMemberDirective {
     pub const NAME: &str = "join__unionMember";
 }
 
-impl<'a> FederationDirective<'a> for JoinUnionMemberDirective {
-    fn directive_name() -> &'a str {
+impl FederationDirective for JoinUnionMemberDirective {
+    fn directive_name() -> &'static str {
         Self::NAME
     }
 

--- a/lib/query-planner/src/planner/mod.rs
+++ b/lib/query-planner/src/planner/mod.rs
@@ -68,14 +68,15 @@ impl Planner {
         parsed_supergraph: &schema::Document<'static, String>,
     ) -> Result<Self, PlannerError> {
         let supergraph_state = SupergraphState::new(parsed_supergraph);
-        Self::new_from_supergraph_state(&supergraph_state)
+        Self::new_from_supergraph_state(&supergraph_state, parsed_supergraph)
     }
 
     pub fn new_from_supergraph_state(
         supergraph_state: &SupergraphState,
+        parsed_supergraph: &schema::Document<'static, String>,
     ) -> Result<Self, PlannerError> {
         let graph = Graph::graph_from_supergraph_state(supergraph_state)?;
-        let consumer_schema = ConsumerSchema::new_from_supergraph(supergraph_state.document);
+        let consumer_schema = ConsumerSchema::new_from_supergraph(parsed_supergraph);
 
         Ok(Planner {
             graph,

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -1,13 +1,13 @@
 use super::fetch::fetch_graph::FetchStepData;
 use crate::{
     ast::{
-        operation::{OperationDefinition, SubgraphFetchOperation, TypeNode, VariableDefinition},
+        operation::{OperationDefinition, SubgraphFetchOperation, VariableDefinition},
         selection_item::SelectionItem,
         selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet},
         type_aware_selection::TypeAwareSelection,
         value::Value,
     },
-    state::supergraph_state::OperationKind,
+    state::supergraph_state::{OperationKind, TypeNode},
     utils::pretty_display::{get_indent, PrettyDisplay},
 };
 use serde::{Deserialize, Serialize};

--- a/lib/query-planner/src/state/subgraph_state.rs
+++ b/lib/query-planner/src/state/subgraph_state.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use graphql_tools::ast::TypeExtension;
 use tracing::instrument;
 
 use crate::federation_spec::{directives::JoinFieldDirective, join_type::JoinTypeDirective};
@@ -77,7 +76,7 @@ impl SubgraphState {
     fn process_object_type(
         graph_id: &str,
         graph_join_types: &[JoinTypeDirective],
-        supergraph_object_type: &SupergraphObjectType<'_>,
+        supergraph_object_type: &SupergraphObjectType,
     ) -> Option<SubgraphDefinition> {
         let relevant_fields: Vec<SubgraphField> = supergraph_object_type
             .fields_of_subgraph(graph_id)
@@ -86,8 +85,8 @@ impl SubgraphState {
                 |(field_name, (field_def, maybe_join_field))| SubgraphField {
                     name: field_name.to_string(),
                     join_field: maybe_join_field.clone(),
-                    return_type_name: field_def.source.field_type.inner_type().to_string(),
-                    is_list: field_def.source.field_type.is_list_type(),
+                    return_type_name: field_def.field_type.inner_type().to_string(),
+                    is_list: field_def.field_type.is_list(),
                 },
             )
             .collect();
@@ -97,7 +96,7 @@ impl SubgraphState {
         }
 
         let subgraph_obj_type = SubgraphDefinition::Object(SubgraphObjectType {
-            name: supergraph_object_type.source.name.to_string(),
+            name: supergraph_object_type.name.to_string(),
             fields: relevant_fields,
             join_types: graph_join_types.to_owned(),
         });
@@ -113,7 +112,7 @@ impl SubgraphState {
     fn process_interface_type(
         graph_id: &str,
         graph_join_types: &[JoinTypeDirective],
-        supergraph_interface_type: &SupergraphInterfaceType<'_>,
+        supergraph_interface_type: &SupergraphInterfaceType,
     ) -> Option<SubgraphDefinition> {
         let relevant_fields: Vec<SubgraphField> = supergraph_interface_type
             .fields_of_subgraph(graph_id)
@@ -122,8 +121,8 @@ impl SubgraphState {
                 |(field_name, (field_def, maybe_join_field))| SubgraphField {
                     name: field_name.to_string(),
                     join_field: maybe_join_field.clone(),
-                    return_type_name: field_def.source.field_type.inner_type().to_string(),
-                    is_list: field_def.source.field_type.is_list_type(),
+                    return_type_name: field_def.field_type.inner_type().to_string(),
+                    is_list: field_def.field_type.is_list(),
                 },
             )
             .collect();
@@ -133,7 +132,7 @@ impl SubgraphState {
         }
 
         let subgraph_interface_type = SubgraphDefinition::Interface(SubgraphInterfaceType {
-            name: supergraph_interface_type.source.name.to_string(),
+            name: supergraph_interface_type.name.to_string(),
             fields: relevant_fields,
             join_types: graph_join_types.to_owned(),
         });
@@ -144,7 +143,7 @@ impl SubgraphState {
     fn process_enum_type(
         graph_id: &str,
         graph_join_types: &[JoinTypeDirective],
-        enum_type: &super::supergraph_state::SupergraphEnumType<'_>,
+        enum_type: &super::supergraph_state::SupergraphEnumType,
     ) -> Option<SubgraphDefinition> {
         let relevant_values = enum_type.values_of_subgraph(graph_id);
 
@@ -155,12 +154,12 @@ impl SubgraphState {
         let values = relevant_values
             .iter()
             .map(|value| SubgraphEnumValueType {
-                name: value.source.name.to_string(),
+                name: value.name.to_string(),
             })
             .collect();
 
         Some(SubgraphDefinition::Enum(SubgraphEnumType {
-            name: enum_type.source.name.to_string(),
+            name: enum_type.name.to_string(),
             values,
             join_types: graph_join_types.to_owned(),
         }))
@@ -169,7 +168,7 @@ impl SubgraphState {
     fn process_union_type(
         graph_id: &str,
         graph_join_types: &[JoinTypeDirective],
-        union_type: &super::supergraph_state::SupergraphUnionType<'_>,
+        union_type: &super::supergraph_state::SupergraphUnionType,
     ) -> Option<SubgraphDefinition> {
         let relevant_types = union_type.relevant_types(graph_id);
 
@@ -178,17 +177,17 @@ impl SubgraphState {
         }
 
         Some(SubgraphDefinition::Union(SubgraphUnionType {
-            name: union_type.source.name.to_string(),
+            name: union_type.name.to_string(),
             types: relevant_types.iter().map(|v| v.to_string()).collect(),
             join_types: graph_join_types.to_owned(),
         }))
     }
 
     fn process_scalar_type(
-        scalar_type: &super::supergraph_state::SupergraphScalarType<'_>,
+        scalar_type: &super::supergraph_state::SupergraphScalarType,
     ) -> Option<SubgraphDefinition> {
         Some(SubgraphDefinition::Scalar(SubgraphScalarType {
-            name: scalar_type.source.name.to_string(),
+            name: scalar_type.name.to_string(),
         }))
     }
 
@@ -197,7 +196,7 @@ impl SubgraphState {
     fn process_input_object_type(
         _graph_id: &str,
         _graph_join_types: &[JoinTypeDirective],
-        _scalar_type: &super::supergraph_state::SupergraphInputObjectType<'_>,
+        _scalar_type: &super::supergraph_state::SupergraphInputObjectType,
     ) -> Option<SubgraphDefinition> {
         // TODO: unimplemented!("not there yet")
         None


### PR DESCRIPTION
- [x] remove references in `SupergraphState` that makes it impossible to work with
- [x] eliminate unused lifetime declarations
- [x] cleanup old and unused code
