### PR TITLE
Set default member (cargo) to bin/gateway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
   "bench/subgraphs",
 ]
 resolver = "2"
-default-members = ["bin/dev-cli"]
+default-members = ["bin/gateway"]
 
 [profile.dev]
 debug = 2


### PR DESCRIPTION
I think it makes more sense to have `cargo` use `gateway` by default (instead of `dev-cli`) as it includes both `query-planner-executor` and `query-planner` crates.