### PR TITLE
Add tests for interface field query planning (type expansion)

### DIFF
--- a/lib/query-planner/fixture/tests/corrupted-supergraph-node-id.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/corrupted-supergraph-node-id.supergraph.graphql
@@ -1,0 +1,103 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A
+    @join__graph(
+      name: "a"
+      url: "http://localhost:4200/corrupted-supergraph-node-id/a"
+    )
+  B
+    @join__graph(
+      name: "b"
+      url: "http://localhost:4200/corrupted-supergraph-node-id/b"
+    )
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Account implements Node
+  @join__implements(graph: A, interface: "Node")
+  @join__implements(graph: B, interface: "Node")
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id") {
+  id: ID! @join__field(graph: A) @join__field(graph: B, external: true)
+  username: String! @join__field(graph: A)
+  chats: [Chat!]! @join__field(graph: B)
+}
+
+type Chat implements Node
+  @join__implements(graph: A, interface: "Node")
+  @join__implements(graph: B, interface: "Node")
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id") {
+  id: ID! @join__field(graph: A, external: true) @join__field(graph: B)
+  account: Account! @join__field(graph: A)
+  text: String! @join__field(graph: B)
+}
+
+interface Node @join__type(graph: A) @join__type(graph: B) {
+  id: ID!
+}
+
+type Query @join__type(graph: A) @join__type(graph: B) {
+  node(id: ID!): Node
+  account(id: String!): Account @join__field(graph: A)
+  chat(id: String!): Chat @join__field(graph: B)
+}

--- a/lib/query-planner/src/ast/normalization/pipeline/flatten_fragments.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/flatten_fragments.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use graphql_parser::query::{
-    Definition, Mutation, OperationDefinition, Query, Selection, SelectionSet, Subscription,
-    TypeCondition,
+    Definition, InlineFragment, Mutation, OperationDefinition, Query, Selection, SelectionSet,
+    Subscription, TypeCondition,
 };
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
         error::NormalizationError,
         utils::{extract_type_condition, vec_to_hashset},
     },
-    state::supergraph_state::{SupergraphDefinition, SupergraphState},
+    state::supergraph_state::{SupergraphDefinition, SupergraphObjectType, SupergraphState},
 };
 
 type PossibleTypesMap<'a> = HashMap<&'a str, HashSet<String>>;
@@ -155,12 +155,150 @@ fn handle_selection_set(
     let old_items = std::mem::take(&mut selection_set.items);
     let mut new_items: Vec<Selection<'static, String>> = Vec::new();
 
+    // Get a list of fields implemented by the interface object
+    let interface_fields: Option<std::collections::HashSet<String>> = match type_def {
+        SupergraphDefinition::Interface(interface_type) => {
+            let interface_object_in_graphs = interface_type
+                .join_type
+                .iter()
+                .filter_map(|jt| match jt.is_interface_object {
+                    true => Some(&jt.graph_id),
+                    false => None,
+                })
+                .collect::<Vec<&String>>();
+
+            if !interface_object_in_graphs.is_empty() {
+                Some(
+                    interface_type
+                        .fields
+                        .iter()
+                        .filter_map(|(name, field)| {
+                            // if a field is contributed by the interface object,
+                            // it will have a single @join__field with no arguments
+                            if field.join_field.iter().all(|j| j.graph_id.is_none())
+                                || field.join_field.iter().any(|jf| {
+                                    !jf.external
+                                        && jf.graph_id.as_ref().is_some_and(|g| {
+                                            interface_object_in_graphs.contains(&g)
+                                        })
+                                })
+                            {
+                                Some(name.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect(),
+                )
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
+    let possible_object_types = match type_def {
+        SupergraphDefinition::Interface(interface_type) => {
+            let object_type_names = possible_types
+                .get(interface_type.name.as_str())
+                .ok_or_else(|| NormalizationError::PossibleTypesNotFound {
+                    type_name: interface_type.name.clone(),
+                })?;
+
+            let mut object_types: Vec<&SupergraphObjectType> =
+                Vec::with_capacity(object_type_names.len());
+
+            for name in object_type_names {
+                match state.definitions.get(name) {
+                    Some(SupergraphDefinition::Object(obj)) => {
+                        object_types.push(obj);
+                    }
+                    _ => {
+                        return Err(NormalizationError::SchemaTypeNotFound {
+                            type_name: name.clone(),
+                        });
+                    }
+                }
+            }
+            object_types.sort_by_key(|obj| &obj.name);
+            Some(object_types)
+        }
+        _ => None,
+    };
+
     for selection in old_items {
         match selection {
             Selection::Field(mut field) => {
                 if field.name.starts_with("__") {
                     new_items.push(Selection::Field(field));
                     continue;
+                }
+
+                if let Some(object_types) = &possible_object_types {
+                    let is_interface_field = interface_fields
+                        .as_ref()
+                        .map(|fields| fields.contains(&field.name))
+                        .unwrap_or(false);
+
+                    let should_type_expand = if is_interface_field {
+                        false
+                    } else {
+                        object_types.iter().any(|obj_type| {
+                            if let Some(obj_field) = obj_type.fields.get(&field.name) {
+                                obj_field.join_field.iter().any(|jf| jf.external)
+                            } else {
+                                true
+                            }
+                        })
+                    };
+
+                    // A selection set may target an interface type.
+                    // However, not all implementing object types may resolve all interface fields
+                    // (some fields may be marked as external).
+                    // Type expansion is the process of rewriting a selection on an
+                    // interface type into multiple inline fragments, each targeting a concrete object type that
+                    // implements the interface type.
+                    // With type expansion, the Query Planner will have to find at least
+                    // one resolvable query path to each field.
+                    // Instead of looking for Interface.Field edge,
+                    // the Query Planner will look for Object.Field.
+                    if should_type_expand {
+                        let mut fragments = Vec::with_capacity(object_types.len());
+                        for obj_type in object_types {
+                            let mut new_field = field.clone();
+                            if !new_field.selection_set.items.is_empty() {
+                                if let Some(field_def) = obj_type.fields.get(&new_field.name) {
+                                    let inner_type_name = field_def.field_type.inner_type();
+                                    let inner_type_def = state
+                                        .definitions
+                                        .get(inner_type_name)
+                                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
+                                            type_name: inner_type_name.to_string(),
+                                        })?;
+
+                                    handle_selection_set(
+                                        state,
+                                        possible_types,
+                                        inner_type_def,
+                                        &mut new_field.selection_set,
+                                    )?;
+                                }
+                            }
+
+                            fragments.push(Selection::InlineFragment(InlineFragment {
+                                type_condition: Some(TypeCondition::On(obj_type.name.clone())),
+                                directives: vec![],
+                                selection_set: SelectionSet {
+                                    span: Default::default(),
+                                    items: vec![Selection::Field(new_field)],
+                                },
+                                position: Default::default(),
+                            }));
+                        }
+
+                        new_items.extend(fragments);
+                        continue;
+                    }
                 }
 
                 let has_selection_set = !field.selection_set.items.is_empty();

--- a/lib/query-planner/src/planner/walker/error.rs
+++ b/lib/query-planner/src/planner/walker/error.rs
@@ -10,6 +10,8 @@ pub enum WalkOperationError {
     GraphFailure(Box<GraphError>),
     #[error("Tail node missing info")]
     TailMissingInfo(NodeIndex),
+    #[error("Type Definition of '{0}' not found in Supergraph")]
+    TypeNotFound(String),
     #[error("No paths found for selection item: {0}")]
     NoPathsFound(String),
 }

--- a/lib/query-planner/src/tests/interface.rs
+++ b/lib/query-planner/src/tests/interface.rs
@@ -1,0 +1,570 @@
+use crate::{
+    tests::testkit::{build_query_plan, init_logger},
+    utils::parsing::parse_operation,
+};
+use std::error::Error;
+
+/// Tests querying the `node` interface field using two different aliases (`account` and `chat`).
+/// Verifies that aliases work correctly when querying the same interface field with different IDs.
+#[test]
+fn node_query_with_aliases_on_interface_field() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account: node(id: "a1") {
+            __typename
+          }
+          chat: node(id: "c1") {
+            __typename
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          account: node(id: "a1") {
+            __typename
+          }
+          chat: node(id: "c1") {
+            __typename
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `node` interface field with inline fragments for concrete object types (`Account` and `Chat`).
+/// Verifies that inline fragments on specific object types are handled correctly when returned from an interface field.
+#[test]
+fn node_query_with_inline_fragments_on_object_types() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account: node(id: "a1") {
+            ... on Account {
+              id
+              username
+            }
+          }
+          chat: node(id: "c1") {
+            ... on Chat {
+              id
+              text
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "b") {
+          {
+            chat: node(id: "c1") {
+              __typename
+              ... on Chat {
+                id
+                text
+              }
+            }
+          }
+        },
+        Fetch(service: "a") {
+          {
+            account: node(id: "a1") {
+              __typename
+              ... on Account {
+                id
+                username
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `node` interface field with inline fragments for types that do not match the actual type of the returned object.
+/// Verifies that fragments for non-matching types do not cause errors and are handled gracefully.
+#[test]
+fn node_query_with_cross_type_inline_fragments() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account: node(id: "a1") {
+            ... on Chat {
+              id
+            }
+          }
+          chat: node(id: "c1") {
+            ... on Account {
+              id
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "a") {
+          {
+            chat: node(id: "c1") {
+              __typename
+              ... on Account {
+                id
+              }
+            }
+          }
+        },
+        Fetch(service: "b") {
+          {
+            account: node(id: "a1") {
+              __typename
+              ... on Chat {
+                id
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `node` interface field with both `__typename` and cross-type inline fragments.
+/// Verifies that `__typename` is always available and that fragments for non-matching types are handled correctly.
+#[test]
+fn node_query_with_typename_and_cross_type_fragments() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account: node(id: "a1") {
+            __typename
+            ... on Chat {
+              id
+            }
+          }
+          chat: node(id: "c1") {
+            __typename
+            ... on Account {
+              id
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "a") {
+          {
+            chat: node(id: "c1") {
+              __typename
+              ... on Account {
+                id
+              }
+            }
+          }
+        },
+        Fetch(service: "b") {
+          {
+            account: node(id: "a1") {
+              __typename
+              ... on Chat {
+                id
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `chat` object field directly by ID.
+/// Verifies that direct object type queries (not through an interface) are resolved as expected.
+#[test]
+fn direct_object_query_chat_by_id() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          chat(id: "c1") {
+            id
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "b") {
+        {
+          chat(id: "c1") {
+            id
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `account` object field directly by ID.
+/// Verifies that direct object type queries (not through an interface) are resolved as expected.
+#[test]
+fn direct_object_query_account_by_id() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account(id: "a1") {
+            id
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          account(id: "a1") {
+            id
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `chat` object field with a nested `account` object field.
+/// Verifies that nested object fields are resolved correctly in the query plan.
+#[test]
+fn object_query_with_nested_object_field() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          chat(id: "c1") {
+            id
+            text
+            account {
+              id
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "b") {
+          {
+            chat(id: "c1") {
+              __typename
+              id
+              text
+            }
+          }
+        },
+        Flatten(path: "chat") {
+          Fetch(service: "a") {
+              ... on Chat {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Chat {
+                account {
+                  id
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `account` object field with a nested `chats` list field.
+/// Verifies that nested list fields are resolved correctly in the query plan.
+#[test]
+fn object_query_with_nested_list_field() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account(id: "a1") {
+            id
+            username
+            chats {
+              id
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          {
+            account(id: "a1") {
+              __typename
+              id
+              username
+            }
+          }
+        },
+        Flatten(path: "account") {
+          Fetch(service: "b") {
+              ... on Account {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Account {
+                chats {
+                  id
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `node` interface field for the `id` field directly.
+/// Verifies that an error is returned if no subgraph resolves `id` for all object types implementing the interface.
+#[test]
+fn node_query_with_id_on_interface_field() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          node(id: "a1") {
+            id
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "b") {
+          {
+            node(id: "a1") {
+              __typename
+              ... on Chat {
+                id
+              }
+            }
+          }
+        },
+        Fetch(service: "a") {
+          {
+            node(id: "a1") {
+              __typename
+              ... on Account {
+                id
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `node` interface field with multiple inline fragments for different possible types (`Chat` and `Account`).
+/// Verifies that an error is returned if the required fields cannot be resolved for all possible types.
+#[test]
+fn node_query_with_multiple_type_fragments() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          node(id: "a1") {
+            ... on Chat {
+              id
+            }
+            ... on Account {
+              id
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "a") {
+          {
+            node(id: "a1") {
+              __typename
+              ... on Account {
+                id
+              }
+            }
+          }
+        },
+        Fetch(service: "b") {
+          {
+            node(id: "a1") {
+              __typename
+              ... on Chat {
+                id
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Tests querying the `node` interface field with both a direct `id` field and an inline fragment for a mismatched type.
+/// Verifies that an error is returned if the required fields cannot be resolved for all possible types.
+#[test]
+fn node_query_with_id_and_cross_type_fragment_overlap() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          account: node(id: "a1") {
+            id
+            ... on Chat {
+              id
+            }
+          }
+          chat: node(id: "c1") {
+            __typename
+            ... on Account {
+              id
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "b") {
+          {
+            account: node(id: "a1") {
+              __typename
+              ... on Chat {
+                id
+              }
+            }
+          }
+        },
+        Fetch(service: "a") {
+          {
+            account: node(id: "a1") {
+              __typename
+              ... on Account {
+                id
+              }
+            }
+            chat: node(id: "c1") {
+              __typename
+              ... on Account {
+                id
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}

--- a/lib/query-planner/src/tests/mod.rs
+++ b/lib/query-planner/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod alias;
 mod arguments;
 mod fragments;
+mod interface;
 mod interface_object;
 mod interface_object_with_requires;
 mod mutations;


### PR DESCRIPTION
Implemented Type Expansion within the query normalization pipeline, allowing the query planner to correctly handle selections on interface fields by rewriting them into inline fragments for concrete implementing types, when some interface fields are external.