### PR TITLE
Refactor projection to use a string builder

### DIFF
--- a/lib/query-plan-executor/src/projection.rs
+++ b/lib/query-plan-executor/src/projection.rs
@@ -155,6 +155,8 @@ fn project_selection_set(
         obj = ?obj
     )
 )]
+// TODO: simplfy args
+#[allow(clippy::too_many_arguments)]
 fn project_selection_set_with_map(
     obj: &mut Map<String, Value>,
     errors: &mut Vec<GraphQLError>,


### PR DESCRIPTION
This avoids allocating a new string for each intermediate result (same for vector).