### PR TITLE
Avoid extra allocation/clone in SubgraphExecutionRequest

### DIFF
--- a/bench/k6.js
+++ b/bench/k6.js
@@ -57,7 +57,7 @@ export function handleSummary(data) {
       },
     });
   }
-  return handleBenchmarkSummary(data, { vus, time });
+  return handleBenchmarkSummary(data, { vus, duration });
 }
 
 let identifiersMap = {};

--- a/bin/gateway/src/pipeline/coerce_variables_service.rs
+++ b/bin/gateway/src/pipeline/coerce_variables_service.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use axum::body::Body;
 use http::Request;
 use query_plan_executor::variables::collect_variables;
-use query_plan_executor::ExecutionRequest;
 use serde_json::Value;
 use tracing::{trace, warn};
 
@@ -12,6 +11,7 @@ use crate::pipeline::error::{PipelineError, PipelineErrorVariant};
 use crate::pipeline::gateway_layer::{
     GatewayPipelineLayer, GatewayPipelineStepDecision, ProcessorLayer,
 };
+use crate::pipeline::graphql_request_params::ExecutionRequest;
 use crate::pipeline::http_request_params::HttpRequestParams;
 use crate::pipeline::normalize_service::GraphQLNormalizationPayload;
 use crate::shared_state::GatewaySharedState;

--- a/bin/gateway/src/pipeline/graphql_request_params.rs
+++ b/bin/gateway/src/pipeline/graphql_request_params.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use axum::body::{to_bytes, Body};
 use axum::extract::Query;
 use http::{Method, Request};
-use query_plan_executor::ExecutionRequest;
+use serde::Deserialize;
+use serde_json::Value;
 use tracing::{trace, warn};
 
 use crate::pipeline::error::{PipelineError, PipelineErrorVariant};
@@ -22,6 +25,17 @@ struct GETQueryParams {
     pub operation_name: Option<String>,
     pub variables: Option<String>,
     pub extensions: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionRequest {
+    pub query: String,
+    pub operation_name: Option<String>,
+    pub variables: Option<HashMap<String, Value>>,
+    // TODO: We don't use extensions yet, but we definitely will in the future.
+    #[allow(dead_code)]
+    pub extensions: Option<HashMap<String, Value>>,
 }
 
 impl TryInto<ExecutionRequest> for GETQueryParams {
@@ -58,7 +72,6 @@ impl TryInto<ExecutionRequest> for GETQueryParams {
             operation_name: self.operation_name,
             variables,
             extensions,
-            representations: None,
         };
 
         Ok(execution_request)

--- a/bin/gateway/src/pipeline/normalize_service.rs
+++ b/bin/gateway/src/pipeline/normalize_service.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use axum::body::Body;
 use http::Request;
 use query_plan_executor::introspection::filter_introspection_fields_in_operation;
-use query_plan_executor::ExecutionRequest;
 use query_planner::ast::document::NormalizedDocument;
 use query_planner::ast::normalization::normalize_operation;
 use query_planner::ast::operation::OperationDefinition;
@@ -12,6 +11,7 @@ use crate::pipeline::error::{PipelineError, PipelineErrorVariant};
 use crate::pipeline::gateway_layer::{
     GatewayPipelineLayer, GatewayPipelineStepDecision, ProcessorLayer,
 };
+use crate::pipeline::graphql_request_params::ExecutionRequest;
 use crate::pipeline::http_request_params::HttpRequestParams;
 use crate::pipeline::parser_service::GraphQLParserPayload;
 use crate::shared_state::GatewaySharedState;

--- a/bin/gateway/src/pipeline/parser_service.rs
+++ b/bin/gateway/src/pipeline/parser_service.rs
@@ -1,13 +1,13 @@
 use axum::body::Body;
 use graphql_parser::query::Document;
 use http::Request;
-use query_plan_executor::ExecutionRequest;
 use query_planner::utils::parsing::safe_parse_operation;
 
 use crate::pipeline::error::{PipelineError, PipelineErrorVariant};
 use crate::pipeline::gateway_layer::{
     GatewayPipelineLayer, GatewayPipelineStepDecision, ProcessorLayer,
 };
+use crate::pipeline::graphql_request_params::ExecutionRequest;
 use crate::pipeline::http_request_params::HttpRequestParams;
 use tracing::{error, trace};
 

--- a/lib/query-plan-executor/src/executors/async_graphql.rs
+++ b/lib/query-plan-executor/src/executors/async_graphql.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use serde_json::json;
 
 use crate::{
-    executors::common::SubgraphExecutor, ExecutionRequest, ExecutionResult, GraphQLError,
-    GraphQLErrorLocation,
+    executors::common::SubgraphExecutor, ExecutionResult, GraphQLError, GraphQLErrorLocation,
+    SubgraphExecutionRequest,
 };
 
 #[async_trait]
@@ -13,14 +13,17 @@ impl<Executor> SubgraphExecutor for Executor
 where
     Executor: async_graphql::Executor,
 {
-    async fn execute(&self, execution_request: ExecutionRequest) -> ExecutionResult {
+    async fn execute<'a>(
+        &self,
+        execution_request: SubgraphExecutionRequest<'a>,
+    ) -> ExecutionResult {
         let response: async_graphql::Response = self.execute(execution_request.into()).await;
         response.into()
     }
 }
 
-impl From<ExecutionRequest> for async_graphql::Request {
-    fn from(exec_request: ExecutionRequest) -> Self {
+impl<'a> From<SubgraphExecutionRequest<'a>> for async_graphql::Request {
+    fn from(exec_request: SubgraphExecutionRequest) -> Self {
         let mut req = async_graphql::Request::new(exec_request.query);
         if let Some(variables) = exec_request.variables {
             req = req.variables(async_graphql::Variables::from_json(json!(variables)));

--- a/lib/query-plan-executor/src/executors/common.rs
+++ b/lib/query-plan-executor/src/executors/common.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::{ExecutionRequest, ExecutionResult};
+use crate::{ExecutionResult, SubgraphExecutionRequest};
 
 #[async_trait]
 pub trait SubgraphExecutor {
-    async fn execute(&self, execution_request: ExecutionRequest) -> ExecutionResult;
+    async fn execute<'a>(&self, execution_request: SubgraphExecutionRequest<'a>)
+        -> ExecutionResult;
     fn to_boxed_arc<'a>(self) -> Arc<Box<dyn SubgraphExecutor + Send + Sync + 'a>>
     where
         Self: Sized + Send + Sync + 'a,

--- a/lib/query-plan-executor/src/executors/map.rs
+++ b/lib/query-plan-executor/src/executors/map.rs
@@ -22,10 +22,10 @@ impl SubgraphExecutorMap {
     }
 
     #[instrument(level = "trace", name = "subgraph_execute", skip_all, fields(subgraph_name = %subgraph_name, execution_request = ?execution_request))]
-    pub async fn execute(
+    pub async fn execute<'a>(
         &self,
         subgraph_name: &str,
-        execution_request: crate::ExecutionRequest,
+        execution_request: crate::SubgraphExecutionRequest<'a>,
     ) -> crate::ExecutionResult {
         match self.inner.get(subgraph_name) {
             Some(executor) => executor.execute(execution_request).await,


### PR DESCRIPTION
Avoid cloning variables and operation string(aka `query`) for subgraph requests