### PR TITLE
feat(multi-type-step): make `FetchStep` compatible with multiple definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,18 +426,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64",
  "bytes",
@@ -2182,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2204,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3552,9 +3552,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/lib/query-planner/src/ast/type_aware_selection.rs
+++ b/lib/query-planner/src/ast/type_aware_selection.rs
@@ -162,7 +162,7 @@ fn selection_items_are_subset_of(source: &[SelectionItem], target: &[SelectionIt
     })
 }
 
-fn merge_selection_set(target: &mut SelectionSet, source: &SelectionSet, as_first: bool) {
+pub fn merge_selection_set(target: &mut SelectionSet, source: &SelectionSet, as_first: bool) {
     if source.items.is_empty() {
         return;
     }

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -6,6 +6,7 @@ use crate::graph::edge::{Edge, FieldMove, InterfaceObjectTypeMove, PlannerOverri
 use crate::graph::node::Node;
 use crate::graph::Graph;
 use crate::planner::fetch::fetch_step_data::{FetchStepData, FetchStepKind};
+use crate::planner::fetch::selections::FetchStepSelections;
 use crate::planner::plan_nodes::{FetchNodePathSegment, FetchRewrite, ValueSetter};
 use crate::planner::tree::query_tree::QueryTree;
 use crate::planner::tree::query_tree_node::{MutationFieldPosition, QueryTreeNode};
@@ -18,7 +19,7 @@ use petgraph::visit::EdgeRef;
 use petgraph::visit::{Bfs, IntoNodeReferences};
 use petgraph::Directed;
 use petgraph::Direction;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::{Debug, Display};
 use tracing::{instrument, trace};
 
@@ -110,10 +111,6 @@ impl FetchGraph {
         Ok(self.graph.index_twice_mut(index1, index2))
     }
 
-    #[instrument(level = "trace",skip_all, fields(
-      parent = parent_index.index(),
-      child = child_index.index(),
-    ))]
     pub fn connect(&mut self, parent_index: NodeIndex, child_index: NodeIndex) -> EdgeIndex {
         self.graph.update_edge(parent_index, child_index, ())
     }
@@ -242,6 +239,10 @@ fn create_noop_fetch_step(fetch_graph: &mut FetchGraph, created_from_requires: b
             selection_set: SelectionSet::default(),
             type_name: "*".to_string(),
         },
+        output_new: FetchStepSelections::Root {
+            type_name: "*".to_string(),
+            selection_set: SelectionSet::default(),
+        },
         used_for_requires: created_from_requires,
         condition: None,
         kind: FetchStepKind::Root,
@@ -276,6 +277,9 @@ fn create_fetch_step_for_entity_call(
             selection_set: SelectionSet::default(),
             type_name: output_type_name.to_string(),
         },
+        output_new: FetchStepSelections::Entities {
+            selections: HashMap::default(),
+        },
         used_for_requires,
         condition: condition.cloned(),
         kind: FetchStepKind::Entity,
@@ -304,6 +308,10 @@ fn create_fetch_step_for_root_move(
         },
         output: TypeAwareSelection {
             selection_set: SelectionSet::default(),
+            type_name: type_name.to_string(),
+        },
+        output_new: FetchStepSelections::Root {
+            selection_set: Default::default(),
             type_name: type_name.to_string(),
         },
         used_for_requires: false,
@@ -499,7 +507,8 @@ fn ensure_fetch_step_for_requirement(
 #[instrument(level = "trace", skip_all, fields(
   count = query_node.children.len(),
   parent_fetch_step_index = parent_fetch_step_index.index(),
-  requiring_fetch_step_index = requiring_fetch_step_index.map(|s| s.index())
+  requiring_fetch_step_index = requiring_fetch_step_index.map(|s| s.index()),
+  root_output_type_name = root_output_type_name
 ))]
 fn process_children_for_fetch_steps(
     graph: &Graph,
@@ -512,6 +521,7 @@ fn process_children_for_fetch_steps(
     requiring_fetch_step_index: Option<NodeIndex>,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     if query_node.children.is_empty() {
         return Ok(vec![parent_fetch_step_index]);
@@ -530,6 +540,7 @@ fn process_children_for_fetch_steps(
             requiring_fetch_step_index,
             condition,
             created_from_requires,
+            root_output_type_name,
         )?);
     }
 
@@ -539,7 +550,8 @@ fn process_children_for_fetch_steps(
 // TODO: simplfy args
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "trace",skip_all, fields(
-  count = query_node.requirements.len()
+  count = query_node.requirements.len(),
+  root_output_type_name = root_output_type_name,
 ))]
 fn process_requirements_for_fetch_steps(
     graph: &Graph,
@@ -551,6 +563,7 @@ fn process_requirements_for_fetch_steps(
     condition: Option<&Condition>,
     response_path: &MergePath,
     fetch_path: &MergePath,
+    root_output_type_name: &str,
 ) -> Result<(), FetchGraphError> {
     if query_node.requirements.is_empty() {
         return Ok(());
@@ -568,6 +581,7 @@ fn process_requirements_for_fetch_steps(
             requiring_fetch_step_index,
             condition,
             true,
+            root_output_type_name,
         )?;
     }
 
@@ -576,7 +590,7 @@ fn process_requirements_for_fetch_steps(
 
 // TODO: simplfy args
 #[allow(clippy::too_many_arguments)]
-#[instrument(level = "trace", skip_all)]
+#[instrument(level = "trace", skip_all, fields(root_output_type_name = root_output_type_name))]
 fn process_noop_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph,
@@ -588,6 +602,7 @@ fn process_noop_edge(
     requiring_fetch_step_index: Option<NodeIndex>,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     // We're at the root
     let fetch_step_index = parent_fetch_step_index
@@ -604,6 +619,7 @@ fn process_noop_edge(
         requiring_fetch_step_index,
         condition,
         created_from_requires,
+        root_output_type_name,
     )
 }
 
@@ -634,6 +650,7 @@ fn add_typename_field_to_output(
   edge = graph.pretty_print_edge(edge_index, false),
   parent_fetch_step_index = parent_fetch_step_index.index(),
   requiring_fetch_step_index = requiring_fetch_step_index.map(|f| f.index()),
+  root_output_type_name = root_output_type_name
 ))]
 fn process_entity_move_edge(
     graph: &Graph,
@@ -647,6 +664,7 @@ fn process_entity_move_edge(
     edge_index: EdgeIndex,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     let edge = graph.edge(edge_index)?;
     let (requirement, is_interface) = match edge {
@@ -719,6 +737,9 @@ fn process_entity_move_edge(
 
     let parent_fetch_step = fetch_graph.get_step_data_mut(parent_fetch_step_index)?;
     add_typename_field_to_output(parent_fetch_step, output_type_name, fetch_path)?;
+    parent_fetch_step
+        .output_new
+        .add_selection_typename(root_output_type_name, &fetch_path);
 
     // Make the fetch step a child of the parent fetch step
     trace!(
@@ -738,6 +759,7 @@ fn process_entity_move_edge(
         condition,
         response_path,
         fetch_path,
+        root_output_type_name,
     )?;
 
     process_children_for_fetch_steps(
@@ -751,6 +773,7 @@ fn process_entity_move_edge(
         requiring_fetch_step_index,
         condition,
         created_from_requires,
+        output_type_name,
     )
 }
 
@@ -760,6 +783,7 @@ fn process_entity_move_edge(
   edge = graph.pretty_print_edge(edge_index, false),
   parent_fetch_step_index = parent_fetch_step_index.index(),
   requiring_fetch_step_index = requiring_fetch_step_index.map(|f| f.index()),
+  root_output_type_name = root_output_type_name
 ))]
 fn process_interface_object_type_move_edge(
     graph: &Graph,
@@ -774,6 +798,7 @@ fn process_interface_object_type_move_edge(
     object_type_name: &str,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     if fetch_graph.parents_of(parent_fetch_step_index).count() != 1 {
         return Err(FetchGraphError::NonSingleParent(
@@ -857,6 +882,9 @@ fn process_interface_object_type_move_edge(
 
     let parent_fetch_step = fetch_graph.get_step_data_mut(parent_fetch_step_index)?;
     add_typename_field_to_output(parent_fetch_step, interface_type_name, fetch_path)?;
+    parent_fetch_step
+        .output_new
+        .add_selection_typename(root_output_type_name, &fetch_path);
 
     // In all cases it's `__typename` that needs to be resolved by another subgraph.
     trace!("Creating a fetch step for requirement of @interfaceObject");
@@ -903,6 +931,7 @@ fn process_interface_object_type_move_edge(
         None,
         condition,
         true,
+        interface_type_name,
     )?;
 
     if leaf_fetch_step_indexes.is_empty() {
@@ -925,6 +954,7 @@ fn process_interface_object_type_move_edge(
         requiring_fetch_step_index,
         condition,
         created_from_requires,
+        interface_type_name,
     )
 }
 
@@ -934,6 +964,7 @@ fn process_interface_object_type_move_edge(
   subgraph = subgraph_name.0,
   type_name = type_name,
   parent_fetch_step_index = parent_fetch_step_index.index(),
+  root_output_type_name = type_name,
 ))]
 fn process_subgraph_entrypoint_edge(
     graph: &Graph,
@@ -966,6 +997,7 @@ fn process_subgraph_entrypoint_edge(
         None,
         None,
         created_from_requires,
+        type_name,
     )
 }
 
@@ -976,7 +1008,8 @@ fn process_subgraph_entrypoint_edge(
   requiring_fetch_step_index = requiring_fetch_step_index.map(|f| f.index()),
   type_name = target_type_name,
   response_path = response_path.to_string(),
-  fetch_path = fetch_path.to_string()
+  fetch_path = fetch_path.to_string(),
+  root_output_type_name = root_output_type_name
 ))]
 fn process_abstract_edge(
     graph: &Graph,
@@ -990,6 +1023,7 @@ fn process_abstract_edge(
     target_type_name: &String,
     edge_index: &EdgeIndex,
     condition: Option<&Condition>,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     let head_index = graph.get_edge_head(edge_index)?;
     let head = graph.node(head_index)?;
@@ -1003,6 +1037,22 @@ fn process_abstract_edge(
         "adding output field '__typename' and starting an inline fragment for type '{}' to fetch step [{}]",
         parent_fetch_step_index.index(),
         target_type_name,
+    );
+
+    parent_fetch_step.output_new.add_at_path(
+        root_output_type_name,
+        &fetch_path,
+        SelectionSet {
+            items: vec![
+                SelectionItem::Field(FieldSelection::new_typename()),
+                SelectionItem::InlineFragment(InlineFragmentSelection {
+                    type_condition: target_type_name.clone(),
+                    selections: SelectionSet::default(),
+                    skip_if: None,
+                    include_if: None,
+                }),
+            ],
+        },
     );
     parent_fetch_step.output.add_at_path(
         &TypeAwareSelection {
@@ -1037,6 +1087,7 @@ fn process_abstract_edge(
         requiring_fetch_step_index,
         condition,
         false,
+        root_output_type_name,
     )
 }
 
@@ -1052,7 +1103,8 @@ fn process_abstract_edge(
   leaf = field_move.is_leaf,
   list = field_move.is_list,
   response_path = response_path.to_string(),
-  fetch_path = fetch_path.to_string()
+  fetch_path = fetch_path.to_string(),
+  root_output_type_name = root_output_type_name
 ))]
 fn process_plain_field_edge(
     graph: &Graph,
@@ -1066,6 +1118,7 @@ fn process_plain_field_edge(
     field_move: &FieldMove,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     if let Some(requiring_fetch_step_index) = requiring_fetch_step_index {
         trace!(
@@ -1081,6 +1134,21 @@ fn process_plain_field_edge(
         "adding output field '{}' to fetch step [{}]",
         field_move.name,
         parent_fetch_step_index.index()
+    );
+
+    parent_fetch_step.output_new.add_at_path(
+        root_output_type_name,
+        &fetch_path,
+        SelectionSet {
+            items: vec![SelectionItem::Field(FieldSelection {
+                name: field_move.name.to_string(),
+                alias: query_node.selection_alias().map(|a| a.to_string()),
+                selections: SelectionSet::default(),
+                arguments: query_node.selection_arguments().cloned(),
+                skip_if: None,
+                include_if: None,
+            })],
+        },
     );
 
     parent_fetch_step.output.add_at_path(
@@ -1133,6 +1201,7 @@ fn process_plain_field_edge(
         requiring_fetch_step_index,
         condition,
         created_from_requires,
+        root_output_type_name,
     )
 }
 
@@ -1141,6 +1210,7 @@ fn process_plain_field_edge(
 #[instrument(level = "trace",skip_all, fields(
   parent_fetch_step_index = parent_fetch_step_index.index(),
   requiring_fetch_step_index = requiring_fetch_step_index.map(|s| s.index()),
+  root_output_type_name = root_output_type_name
 ))]
 fn process_requires_field_edge(
     graph: &Graph,
@@ -1154,6 +1224,7 @@ fn process_requires_field_edge(
     edge_index: EdgeIndex,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     if fetch_graph.parents_of(parent_fetch_step_index).count() != 1 {
         return Err(FetchGraphError::NonSingleParent(
@@ -1230,6 +1301,21 @@ fn process_requires_field_edge(
     )?;
 
     let step_for_children = fetch_graph.get_step_data_mut(step_for_children_index)?;
+
+    step_for_children.output_new.add_at_path(
+        head_type_name,
+        &MergePath::default(),
+        SelectionSet {
+            items: vec![SelectionItem::Field(FieldSelection {
+                name: field_move.name.to_string(),
+                alias: query_node.selection_alias().map(|a| a.to_string()),
+                selections: SelectionSet::default(),
+                arguments: query_node.selection_arguments().cloned(),
+                skip_if: None,
+                include_if: None,
+            })],
+        },
+    );
 
     step_for_children.output.add_at_path(
         &TypeAwareSelection {
@@ -1313,6 +1399,11 @@ fn process_requires_field_edge(
         key_to_reenter_at
     );
 
+    real_parent_fetch_step.output_new.add_at_path(
+        root_output_type_name,
+        &key_to_reenter_at,
+        key_to_reenter_subgraph.clone().selection_set,
+    );
     real_parent_fetch_step.output.add_at_path(
         key_to_reenter_subgraph,
         key_to_reenter_at.clone(),
@@ -1354,6 +1445,7 @@ fn process_requires_field_edge(
         None,
         condition,
         true,
+        head_type_name,
     )?;
 
     //
@@ -1396,6 +1488,7 @@ fn process_requires_field_edge(
         requiring_fetch_step_index,
         condition,
         created_from_requires,
+        root_output_type_name,
     )
 }
 
@@ -1487,6 +1580,7 @@ fn process_query_node(
     requiring_fetch_step_index: Option<NodeIndex>,
     condition: Option<&Condition>,
     created_from_requires: bool,
+    root_output_type_name: &str,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     let condition = query_node.condition.as_ref().or(condition);
     if let Some(edge_index) = query_node.edge_from_parent {
@@ -1527,6 +1621,7 @@ fn process_query_node(
                 edge_index,
                 condition,
                 created_from_requires,
+                root_output_type_name,
             ),
             Edge::FieldMove(field) => match field.requirements.is_some() {
                 true => process_requires_field_edge(
@@ -1541,6 +1636,7 @@ fn process_query_node(
                     edge_index,
                     condition,
                     created_from_requires,
+                    root_output_type_name,
                 ),
                 false => process_plain_field_edge(
                     graph,
@@ -1554,6 +1650,7 @@ fn process_query_node(
                     field,
                     condition,
                     created_from_requires,
+                    root_output_type_name,
                 ),
             },
             Edge::AbstractMove(type_name) => process_abstract_edge(
@@ -1568,6 +1665,7 @@ fn process_query_node(
                 type_name,
                 &edge_index,
                 condition,
+                root_output_type_name,
             ),
             Edge::InterfaceObjectTypeMove(InterfaceObjectTypeMove {
                 object_type_name, ..
@@ -1584,6 +1682,7 @@ fn process_query_node(
                 object_type_name,
                 condition,
                 created_from_requires,
+                root_output_type_name,
             ),
         }
     } else {
@@ -1598,6 +1697,7 @@ fn process_query_node(
             requiring_fetch_step_index,
             condition,
             created_from_requires,
+            root_output_type_name,
         )
     }
 }
@@ -1640,6 +1740,7 @@ pub fn build_fetch_graph_from_query_tree(
         None,
         None,
         false,
+        "",
     )?;
 
     trace!("Done");

--- a/lib/query-planner/src/planner/fetch/mod.rs
+++ b/lib/query-planner/src/planner/fetch/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod error;
 pub mod fetch_graph;
 pub(crate) mod fetch_step_data;
 pub(crate) mod optimize;
+pub(crate) mod selections;

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -1,0 +1,156 @@
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Display,
+};
+
+use crate::ast::{
+    merge_path::MergePath,
+    selection_item::SelectionItem,
+    selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet},
+    type_aware_selection::{find_selection_set_by_path_mut, merge_selection_set},
+};
+
+#[derive(Debug, Clone)]
+pub enum FetchStepSelections {
+    Root {
+        type_name: String,
+        selection_set: SelectionSet,
+    },
+    Entities {
+        selections: HashMap<String, SelectionSet>,
+    },
+}
+
+impl Display for FetchStepSelections {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let as_selection_set: SelectionSet = self.into();
+
+        write!(f, "{}", as_selection_set)
+    }
+}
+
+impl From<&FetchStepSelections> for SelectionSet {
+    fn from(value: &FetchStepSelections) -> Self {
+        match value {
+            FetchStepSelections::Root { selection_set, .. } => selection_set.clone(),
+            FetchStepSelections::Entities { selections } => SelectionSet {
+                items: selections
+                    .iter()
+                    .map(|(def_name, selections)| {
+                        SelectionItem::InlineFragment(InlineFragmentSelection {
+                            type_condition: def_name.clone(),
+                            include_if: None,
+                            skip_if: None,
+                            selections: selections.clone(),
+                        })
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
+impl FetchStepSelections {
+    pub fn selections_for_definition(&mut self, definition_name: &str) -> &mut SelectionSet {
+        match self {
+            Self::Root {
+                type_name,
+                selection_set,
+            } => {
+                if type_name == definition_name {
+                    selection_set
+                } else {
+                    panic!(
+                        "failed to lookup root type. current: {}, requested: {}",
+                        type_name, definition_name
+                    )
+                }
+            }
+            Self::Entities { selections } => selections
+                .entry(definition_name.to_string())
+                .or_insert_with(SelectionSet::default),
+        }
+    }
+
+    pub fn is_selecting_definition(&self, definition_name: &str) -> bool {
+        match self {
+            Self::Root { type_name, .. } => type_name == definition_name,
+            Self::Entities { selections } => selections.contains_key(definition_name),
+        }
+    }
+
+    pub fn variable_usages(&self) -> BTreeSet<String> {
+        let mut usages = BTreeSet::new();
+
+        match self {
+            Self::Root { selection_set, .. } => {
+                usages.extend(selection_set.variable_usages());
+            }
+            Self::Entities { selections } => {
+                for selection_set in selections.values() {
+                    usages.extend(selection_set.variable_usages());
+                }
+            }
+        }
+
+        usages
+    }
+
+    pub fn add_at_path(
+        &mut self,
+        definition_name: &str,
+        fetch_path: &MergePath,
+        selection_set: SelectionSet,
+    ) {
+        self.add_at_path_inner(definition_name, fetch_path, selection_set, false);
+    }
+
+    pub fn add_selection_typename(&mut self, definition_name: &str, fetch_path: &MergePath) {
+        self.add_at_path_inner(
+            definition_name,
+            fetch_path,
+            SelectionSet {
+                items: vec![SelectionItem::Field(FieldSelection::new_typename())],
+            },
+            true,
+        );
+    }
+
+    fn get_definition_to_modify<'a>(
+        &'a self,
+        target_def_name: &'a str,
+        fetch_step: &MergePath,
+    ) -> &'a str {
+        if !fetch_step.is_empty() {
+            if let Self::Root { type_name, .. } = self {
+                type_name.as_str()
+            } else {
+                target_def_name
+            }
+        } else {
+            target_def_name
+        }
+    }
+
+    fn add_at_path_inner(
+        &mut self,
+        definition_name: &str,
+        fetch_path: &MergePath,
+        selection_set: SelectionSet,
+        as_first: bool,
+    ) {
+        let target_def = self
+            .get_definition_to_modify(definition_name, fetch_path)
+            .to_string();
+        let mut current = self.selections_for_definition(&target_def);
+
+        if let Some(selection_at_path) = find_selection_set_by_path_mut(&mut current, &fetch_path) {
+            merge_selection_set(selection_at_path, &selection_set, as_first);
+        } else {
+            panic!(
+                "[{}] Path '{}' cannot be found in selection set: '{}'",
+                target_def, fetch_path, current
+            );
+        }
+    }
+}


### PR DESCRIPTION
- [x] figure out how to construct multi-type selections for `output`
- [x] adjust `Display` for `output`
- [x] confirm `output` builds the same way (no panics)
- [ ] Remove existing `output` + Adjust optimizations (https://github.com/graphql-hive/gateway-rs/pull/270)

`...`


- [ ] figure out how to construct multi-type selections for `input`
