### PR TITLE
fix(fetch_step_data): print output type name when using `Display`

### DIFF
--- a/lib/query-planner/src/planner/fetch/fetch_step_data.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_step_data.rs
@@ -44,10 +44,11 @@ impl Display for FetchStepData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}/{} {} → {} at $.{}",
+            "{}/{} {} → {}/{} at $.{}",
             self.input.type_name,
             self.service_name,
             self.input,
+            self.output.type_name,
             self.output,
             self.response_path.join("."),
         )?;


### PR DESCRIPTION
While working on multi-type, i noticed that I need to compare and validate some aspects of the selection set building. This helped me to do so :) 