### PR TITLE
feat(multi-type-step): make `FetchStep` compatible with multiple definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,18 +426,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64",
  "bytes",
@@ -2189,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2211,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3559,9 +3559,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/lib/query-planner/src/ast/mismatch_finder.rs
+++ b/lib/query-planner/src/ast/mismatch_finder.rs
@@ -7,8 +7,8 @@ use crate::{
         merge_path::{MergePath, Segment},
         selection_item::SelectionItem,
         selection_set::{FieldSelection, SelectionSet},
-        type_aware_selection::TypeAwareSelection,
     },
+    planner::fetch::selections::FetchStepSelections,
     state::{
         subgraph_state::{SubgraphDefinition, SubgraphState},
         supergraph_state::{SubgraphName, SupergraphState, TypeNode},
@@ -20,46 +20,43 @@ pub struct SelectionMismatchFinder<'a> {
     supergraph_state: &'a SupergraphState,
 }
 
-type MismatchesFound = Vec<MergePath>;
+type MismatchesFound = Vec<(String, MergePath)>;
 
 impl<'a> SelectionMismatchFinder<'a> {
     pub fn new(supergraph_state: &'a SupergraphState) -> Self {
         Self { supergraph_state }
     }
 
-    #[instrument(level = "trace", skip_all, fields(
-      subgraph_name,
-      selection = format!("{}", selection_set)
-    ))]
+    #[instrument(level = "trace", skip_all, fields(subgraph_name,))]
     pub fn find_mismatches_in_node(
         &self,
         subgraph_name: &SubgraphName,
-        selection_set: &TypeAwareSelection,
+        selections: &FetchStepSelections,
     ) -> MismatchesFound {
-        let subgraph_state = self
-            .supergraph_state
-            .subgraphs_state
-            .get(subgraph_name)
-            .unwrap();
-
-        let entrypoint_type = subgraph_state
-            .definitions
-            .get(&selection_set.type_name)
-            .unwrap();
-
         let mut mismtaches_found = MismatchesFound::new();
-        let start_path = MergePath::default();
 
-        handle_selection_set(
-            self.supergraph_state,
-            subgraph_state,
-            entrypoint_type,
-            &selection_set.selection_set,
-            start_path,
-            &mut mismtaches_found,
-        );
+        for (definition_name, selection_set) in selections.selections() {
+            let subgraph_state = self
+                .supergraph_state
+                .subgraphs_state
+                .get(subgraph_name)
+                .unwrap();
 
-        trace!("found total of {} mismatches", mismtaches_found.len(),);
+            let entrypoint_type = subgraph_state.definitions.get(definition_name).unwrap();
+            let start_path = MergePath::new_empty_root(definition_name);
+
+            handle_selection_set(
+                definition_name,
+                self.supergraph_state,
+                subgraph_state,
+                entrypoint_type,
+                selection_set,
+                start_path,
+                &mut mismtaches_found,
+            );
+
+            trace!("found total of {} mismatches", mismtaches_found.len());
+        }
 
         mismtaches_found
     }
@@ -73,6 +70,7 @@ impl<'a> SelectionMismatchFinder<'a> {
   selection = format!("{}", selection_set)
 ))]
 fn handle_selection_set<'field, 'schema>(
+    root_def_type_name: &str,
     supergraph_state: &'schema SupergraphState,
     subgraph_state: &'schema SubgraphState,
     parent_def: &'schema SubgraphDefinition,
@@ -105,6 +103,7 @@ fn handle_selection_set<'field, 'schema>(
                     ));
 
                     let next_parent_type_name = handle_field(
+                        root_def_type_name,
                         supergraph_state,
                         type_def,
                         field,
@@ -117,6 +116,7 @@ fn handle_selection_set<'field, 'schema>(
                         next_parent_type_name.and_then(|n| subgraph_state.definitions.get(n))
                     {
                         handle_selection_set(
+                            root_def_type_name,
                             supergraph_state,
                             subgraph_state,
                             next_parent_def,
@@ -156,6 +156,7 @@ fn handle_selection_set<'field, 'schema>(
 ///
 /// Returns the return type of the selection, if the inner selection needs to be processed (in case nested selections are defined).
 fn handle_field<'field, 'schema>(
+    root_def_type_name: &str,
     state: &'schema SupergraphState,
     parent_def: &'schema SubgraphDefinition,
     field: &'field FieldSelection,
@@ -201,7 +202,7 @@ fn handle_field<'field, 'schema>(
                   field_path,
               );
 
-                mismatches_found.push(field_path.clone());
+                mismatches_found.push((root_def_type_name.to_string(), field_path.clone()));
             }
         }
     } else {

--- a/lib/query-planner/src/ast/safe_merge.rs
+++ b/lib/query-planner/src/ast/safe_merge.rs
@@ -59,7 +59,7 @@ impl SafeSelectionSetMerger {
             source,
             (self_used_for_requires, other_used_for_requires),
             as_first,
-            MergePath::default(),
+            MergePath::empty(),
             &mut aliases_performed,
         );
 
@@ -409,7 +409,7 @@ mod tests {
         let mut merger = SafeSelectionSetMerger::default();
         let merge_locations = merger.merge_selection_set(&mut a, &b, (false, true), false);
         assert_eq!(merge_locations.len(), 1);
-        insta::assert_snapshot!(merge_locations[0].0, @"p.a");
+        insta::assert_snapshot!(merge_locations[0].0, @"''->p.a");
         insta::assert_snapshot!(merge_locations[0].1, @"_internal_qp_alias_0");
     }
 }

--- a/lib/query-planner/src/ast/type_aware_selection.rs
+++ b/lib/query-planner/src/ast/type_aware_selection.rs
@@ -162,7 +162,7 @@ fn selection_items_are_subset_of(source: &[SelectionItem], target: &[SelectionIt
     })
 }
 
-fn merge_selection_set(target: &mut SelectionSet, source: &SelectionSet, as_first: bool) {
+pub fn merge_selection_set(target: &mut SelectionSet, source: &SelectionSet, as_first: bool) {
     if source.items.is_empty() {
         return;
     }

--- a/lib/query-planner/src/planner/fetch/mod.rs
+++ b/lib/query-planner/src/planner/fetch/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod error;
 pub mod fetch_graph;
 pub(crate) mod fetch_step_data;
 pub(crate) mod optimize;
+pub(crate) mod selections;

--- a/lib/query-planner/src/planner/fetch/optimize/apply_internal_aliases_patching.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/apply_internal_aliases_patching.rs
@@ -36,70 +36,75 @@ impl FetchGraph {
             nodes_with_aliases.len(),
         );
 
-        while let Some((aliased_node_index, aliases_locations)) = nodes_with_aliases.pop() {
-            let mut bfs = Bfs::new(&self.graph, aliased_node_index);
+        while let Some((aliased_node_index, scoped_aliases_locations)) = nodes_with_aliases.pop() {
+            for (root_type_name, aliases_locations) in scoped_aliases_locations {
+                let mut bfs = Bfs::new(&self.graph, aliased_node_index);
 
-            trace!(
-                "Iterating step [{}], total of {} aliased fields in output selections",
-                aliased_node_index.index(),
-                aliases_locations.len()
-            );
+                trace!(
+                    "Iterating step [{}], total of {} aliased fields in output selections of type {}",
+                    aliased_node_index.index(),
+                    aliases_locations.len(),
+                    root_type_name
+                );
 
-            // Iterate and find all possible children of a node that needed aliasing.
-            // We can't really tell which nodes are affected, as they might be at any level of the hierarchy, so we travel the graph.
-            while let Some(decendent_idx) = bfs.next(&self.graph) {
-                if decendent_idx != aliased_node_index {
-                    let decendent = self.get_step_data_mut(decendent_idx)?;
+                // Iterate and find all possible children of a node that needed aliasing.
+                // We can't really tell which nodes are affected, as they might be at any level of the hierarchy, so we travel the graph.
+                while let Some(decendent_idx) = bfs.next(&self.graph) {
+                    if decendent_idx != aliased_node_index {
+                        let decendent = self.get_step_data_mut(decendent_idx)?;
 
-                    trace!(
-                        "Checking if decendent [{}] is relevant for aliasing patching...",
-                        decendent_idx.index()
-                    );
+                        trace!(
+                            "Checking if decendent [{}] is relevant for aliasing patching...",
+                            decendent_idx.index()
+                        );
 
-                    for (alias_path, new_name) in aliases_locations.iter() {
-                        // Last segment is the field that was aliased
-                        let maybe_patched_field = alias_path.last();
-                        // Build a path without the alias path, to make sure we don't patch the wrong field
-                        let relative_path = decendent.response_path.slice_from(alias_path.len());
+                        for (alias_path, new_name) in aliases_locations.iter() {
+                            // Last segment is the field that was aliased
+                            let maybe_patched_field = alias_path.last();
+                            // Build a path without the alias path, to make sure we don't patch the wrong field
+                            let relative_path =
+                                decendent.response_path.slice_from(alias_path.len());
 
-                        if let Some(Segment::Field(field_name, args_hash, condition)) =
-                            maybe_patched_field
-                        {
-                            trace!(
+                            if let Some(Segment::Field(field_name, args_hash, condition)) =
+                                maybe_patched_field
+                            {
+                                trace!(
                               "field '{}' was aliased, relative selection path: '{}', checking if need to patch selection '{}'",
                               field_name,
                               relative_path,
                               decendent.input.selection_set
                           );
 
-                            // First, check if the node's input selection set contains the field that was aliased
-                            if let Some(selection) = find_selection_set_by_path_mut(
-                                &mut decendent.input.selection_set,
-                                &relative_path,
-                            ) {
-                                trace!("found selection to patch: {}", selection);
-                                let item_to_patch = selection.items.iter_mut().find(|item| matches!(item, SelectionItem::Field(field) if field.name == *field_name && field.arguments_hash() == *args_hash));
+                                // First, check if the node's input selection set contains the field that was aliased
+                                if let Some(selection) = find_selection_set_by_path_mut(
+                                    &mut decendent.input.selection_set,
+                                    &relative_path,
+                                ) {
+                                    trace!("found selection to patch: {}", selection);
+                                    let item_to_patch = selection.items.iter_mut().find(|item| matches!(item, SelectionItem::Field(field) if field.name == *field_name && field.arguments_hash() == *args_hash));
 
-                                if let Some(SelectionItem::Field(field_to_patch)) = item_to_patch {
-                                    field_to_patch.alias = Some(field_to_patch.name.clone());
-                                    field_to_patch.name = new_name.clone();
+                                    if let Some(SelectionItem::Field(field_to_patch)) =
+                                        item_to_patch
+                                    {
+                                        field_to_patch.alias = Some(field_to_patch.name.clone());
+                                        field_to_patch.name = new_name.clone();
 
-                                    trace!(
+                                        trace!(
                                       "path '{}' found in selection, patched applied, new selection: {}",
                                       relative_path,
                                       field_to_patch
                                   );
+                                    }
+                                } else {
+                                    trace!(
+                                        "path '{}' was not found in selection '{}', skipping...",
+                                        relative_path,
+                                        decendent.input.selection_set
+                                    );
                                 }
-                            } else {
-                                trace!(
-                                    "path '{}' was not found in selection '{}', skipping...",
-                                    relative_path,
-                                    decendent.input.selection_set
-                                );
-                            }
 
-                            // Then, check if the node's response_path is using the part that was aliased
-                            let segment_idx_to_patch = decendent
+                                // Then, check if the node's response_path is using the part that was aliased
+                                let segment_idx_to_patch = decendent
                               .response_path
                               .inner
                               .iter()
@@ -112,8 +117,8 @@ impl FetchGraph {
                                   }
                               });
 
-                            if let Some(segment_idx_to_patch) = segment_idx_to_patch {
-                                trace!(
+                                if let Some(segment_idx_to_patch) = segment_idx_to_patch {
+                                    trace!(
                                 "Node [{}] is using aliased field {} in response_path (segment idx: {}, alias: {:?})",
                                 decendent_idx.index(),
                                 field_name,
@@ -121,13 +126,20 @@ impl FetchGraph {
                                 alias_path
                             );
 
-                                let mut new_path = (*decendent.response_path.inner).to_vec();
+                                    let mut new_path = (*decendent.response_path.inner).to_vec();
 
-                                if let Some(Segment::Field(name, _, _)) =
-                                    new_path.get_mut(segment_idx_to_patch)
-                                {
-                                    *name = new_name.clone();
-                                    decendent.response_path = MergePath::new(new_path);
+                                    if let Some(Segment::Field(name, _, _)) =
+                                        new_path.get_mut(segment_idx_to_patch)
+                                    {
+                                        *name = new_name.clone();
+                                        decendent.response_path = MergePath::new(
+                                            decendent
+                                                .response_path
+                                                .entrypoint_definition_name
+                                                .clone(),
+                                            new_path,
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/lib/query-planner/src/planner/fetch/optimize/deduplicate_and_prune_fetch_steps.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/deduplicate_and_prune_fetch_steps.rs
@@ -29,9 +29,7 @@ impl FetchGraph {
                     Err(_) => return false,
                 };
 
-                if !step.output.selection_set.items.is_empty()
-                    && self.parents_of(step_index).next().is_some()
-                {
+                if !step.output_new.is_empty() && self.parents_of(step_index).next().is_some() {
                     return false;
                 }
 

--- a/lib/query-planner/src/planner/fetch/optimize/turn_mutations_into_sequence.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/turn_mutations_into_sequence.rs
@@ -69,7 +69,7 @@ fn is_mutation_fetch_step(
     for edge_ref in fetch_graph.children_of(fetch_step_index) {
         let child = fetch_graph.get_step_data(edge_ref.target().id())?;
 
-        if child.output.type_name.ne("Mutation") {
+        if !child.output_new.is_selecting_definition("Mutation") {
             return Ok(false);
         }
     }

--- a/lib/query-planner/src/planner/fetch/optimize/utils.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/utils.rs
@@ -6,13 +6,7 @@ use petgraph::{
 };
 use tracing::{instrument, trace};
 
-use crate::{
-    ast::{
-        merge_path::Condition, selection_item::SelectionItem,
-        selection_set::InlineFragmentSelection,
-    },
-    planner::fetch::{error::FetchGraphError, fetch_graph::FetchGraph},
-};
+use crate::planner::fetch::{error::FetchGraphError, fetch_graph::FetchGraph};
 
 // Return true in case an alias was applied during the merge process.
 #[instrument(level = "trace", skip_all)]
@@ -42,29 +36,11 @@ pub(crate) fn perform_fetch_step_merge(
         // { products { ... on Product @skip(if: $bool) { __typename id price } } }
         //
         // We can't do it when both are entity calls fetch steps.
-        other.output.add(&other.input);
+        other
+            .output_new
+            .add(&other.input.type_name, &other.input.selection_set);
 
-        let old_selection_set = other.output.selection_set.clone();
-        match condition {
-            Condition::Include(var_name) => {
-                other.output.selection_set.items =
-                    vec![SelectionItem::InlineFragment(InlineFragmentSelection {
-                        type_condition: other.output.type_name.clone(),
-                        selections: old_selection_set,
-                        skip_if: None,
-                        include_if: Some(var_name),
-                    })];
-            }
-            Condition::Skip(var_name) => {
-                other.output.selection_set.items =
-                    vec![SelectionItem::InlineFragment(InlineFragmentSelection {
-                        type_condition: other.output.type_name.clone(),
-                        selections: old_selection_set,
-                        skip_if: Some(var_name),
-                        include_if: None,
-                    })];
-            }
-        }
+        other.output_new.wrap_with_condition(condition);
     } else if me.is_entity_call() && other.condition.is_some() {
         // We don't want to pass a condition
         // to a regular (non-entity call) fetch step,
@@ -72,16 +48,19 @@ pub(crate) fn perform_fetch_step_merge(
         me.condition = other.condition.take();
     }
 
-    let maybe_aliases = me.output.add_at_path_and_solve_conflicts(
-        &other.output,
-        other.response_path.slice_from(me.response_path.len()),
+    let scoped_aliases = me.output_new.safe_add_from_another_at_path(
+        &other.output_new,
+        &other.response_path.slice_from(me.response_path.len()),
         (me.used_for_requires, other.used_for_requires),
-        false,
     );
 
-    // In cases where merging a step resulted in internal aliasing, keep a record of the aliases.
-    if let Some(aliases) = maybe_aliases {
-        me.internal_aliases_locations.extend(aliases);
+    if !scoped_aliases.is_empty() {
+        trace!(
+            "Total of {} alises applied during safe merge of selections",
+            scoped_aliases.len()
+        );
+        // In cases where merging a step resulted in internal aliasing, keep a record of the aliases.
+        me.internal_aliases_locations.extend(scoped_aliases);
     }
 
     if let Some(input_rewrites) = other.input_rewrites.take() {

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -1,0 +1,311 @@
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Display,
+};
+
+use crate::ast::{
+    merge_path::{Condition, MergePath},
+    safe_merge::{AliasesRecords, SafeSelectionSetMerger},
+    selection_item::SelectionItem,
+    selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet},
+    type_aware_selection::{find_selection_set_by_path_mut, merge_selection_set},
+};
+
+#[derive(Debug, Clone)]
+pub enum FetchStepSelections {
+    Root {
+        type_name: String,
+        selection_set: SelectionSet,
+    },
+    Entities {
+        selections: HashMap<String, SelectionSet>,
+    },
+}
+
+impl Display for FetchStepSelections {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let as_selection_set: SelectionSet = self.into();
+
+        write!(f, "{}", as_selection_set)
+    }
+}
+
+impl From<&FetchStepSelections> for SelectionSet {
+    fn from(value: &FetchStepSelections) -> Self {
+        match value {
+            FetchStepSelections::Root { selection_set, .. } => selection_set.clone(),
+            FetchStepSelections::Entities { selections } => SelectionSet {
+                items: selections
+                    .iter()
+                    .map(|(def_name, selections)| {
+                        SelectionItem::InlineFragment(InlineFragmentSelection {
+                            type_condition: def_name.clone(),
+                            include_if: None,
+                            skip_if: None,
+                            selections: selections.clone(),
+                        })
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
+impl FetchStepSelections {
+    pub fn new_root(root_type_name: &str) -> Self {
+        Self::Root {
+            type_name: root_type_name.to_string(),
+            selection_set: SelectionSet::default(),
+        }
+    }
+
+    pub fn type_name(&self) -> &str {
+        match self {
+            Self::Root { type_name, .. } => type_name,
+            Self::Entities { selections } => selections.keys().next().unwrap(),
+        }
+    }
+
+    pub fn new_entities(entity_name: &str) -> Self {
+        let mut map = HashMap::new();
+        map.insert(entity_name.to_string(), SelectionSet::default());
+
+        Self::Entities { selections: map }
+    }
+
+    pub fn selections_for_definition(&mut self, definition_name: &str) -> &mut SelectionSet {
+        match self {
+            Self::Root {
+                type_name,
+                selection_set,
+            } => {
+                if type_name == definition_name {
+                    selection_set
+                } else {
+                    panic!(
+                        "failed to lookup root type. current: {}, requested: {}",
+                        type_name, definition_name
+                    )
+                }
+            }
+            Self::Entities { selections } => {
+                if let Some(selection_set) = selections.get_mut(definition_name) {
+                    selection_set
+                } else {
+                    panic!(
+                        "failed to lookup entity type.  requested: {}",
+                        definition_name
+                    )
+                }
+            }
+        }
+    }
+
+    pub fn is_selecting_definition(&self, definition_name: &str) -> bool {
+        match self {
+            Self::Root { type_name, .. } => type_name == definition_name,
+            Self::Entities { selections } => selections.contains_key(definition_name),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Root { selection_set, .. } => selection_set.is_empty(),
+            Self::Entities { selections } => {
+                selections.is_empty()
+                    || selections
+                        .values()
+                        .all(|selection_set| selection_set.is_empty())
+            }
+        }
+    }
+
+    pub fn variable_usages(&self) -> BTreeSet<String> {
+        let mut usages = BTreeSet::new();
+
+        match self {
+            Self::Root { selection_set, .. } => {
+                usages.extend(selection_set.variable_usages());
+            }
+            Self::Entities { selections } => {
+                for selection_set in selections.values() {
+                    usages.extend(selection_set.variable_usages());
+                }
+            }
+        }
+
+        usages
+    }
+
+    pub fn migrate_from_another(&mut self, other: &Self, fetch_path: &MergePath) {
+        for (definition_name, selection_set) in other.selections() {
+            println!(
+                "migrate_from_another, fetch_path: {}, definition_name={}",
+                fetch_path, definition_name
+            );
+
+            self.add_at_path_inner(fetch_path, selection_set.clone(), false);
+        }
+    }
+
+    pub fn selections(&self) -> Box<dyn Iterator<Item = (&String, &SelectionSet)> + '_> {
+        match self {
+            Self::Root {
+                selection_set,
+                type_name,
+            } => Box::new(std::iter::once((type_name, selection_set))),
+            Self::Entities { selections } => Box::new(selections.iter()),
+        }
+    }
+
+    pub fn add_at_path(&mut self, fetch_path: &MergePath, selection_set: SelectionSet) {
+        self.add_at_path_inner(fetch_path, selection_set, false);
+    }
+
+    pub fn add_selection_typename(&mut self, fetch_path: &MergePath) {
+        self.add_at_path_inner(
+            fetch_path,
+            SelectionSet {
+                items: vec![SelectionItem::Field(FieldSelection::new_typename())],
+            },
+            true,
+        );
+    }
+
+    fn get_definition_to_modify<'a>(
+        &'a self,
+        fetch_path: &'a MergePath,
+        fallback_definition_name: &'a str,
+    ) -> &'a str {
+        if !fetch_path.is_empty() {
+            if let Self::Root { type_name, .. } = self {
+                type_name.as_str()
+            } else {
+                &fetch_path.entrypoint_definition_name
+            }
+        } else {
+            fallback_definition_name
+        }
+    }
+
+    pub fn add(&mut self, definition_name: &str, selection_set: &SelectionSet) {
+        let selections = self.selections_for_definition(definition_name);
+        merge_selection_set(selections, selection_set, false);
+    }
+
+    pub fn safe_add_from_another_at_path(
+        &mut self,
+        other: &Self,
+        fetch_path: &MergePath,
+        (self_used_for_requires, other_used_for_requires): (bool, bool),
+    ) -> Vec<(String, AliasesRecords)> {
+        let mut aliases_made: Vec<(String, AliasesRecords)> = Vec::new();
+
+        for (definition_name, selection_set) in other.selections() {
+            let target_type_name = self
+                .get_definition_to_modify(fetch_path, definition_name)
+                .to_string();
+            let current = self.selections_for_definition(&target_type_name);
+
+            if let Some(selection_at_path) = find_selection_set_by_path_mut(current, fetch_path) {
+                let mut merger = SafeSelectionSetMerger::default();
+                let current_aliases_made = merger.merge_selection_set(
+                    selection_at_path,
+                    selection_set,
+                    (self_used_for_requires, other_used_for_requires),
+                    false,
+                );
+
+                if !current_aliases_made.is_empty() {
+                    aliases_made.push((target_type_name.to_string(), current_aliases_made));
+                }
+            } else {
+                // TODO: Replace with error handling
+                panic!(
+                    "[{}]: Path '{}' cannot be found in selection set: '{}'",
+                    target_type_name, fetch_path, current
+                );
+            }
+        }
+
+        aliases_made
+    }
+
+    pub fn wrap_with_condition(&mut self, condition: Condition) {
+        match self {
+            Self::Root {
+                type_name,
+                selection_set,
+            } => {
+                let prev = selection_set.clone();
+
+                match &condition {
+                    Condition::Include(var_name) => {
+                        selection_set.items =
+                            vec![SelectionItem::InlineFragment(InlineFragmentSelection {
+                                type_condition: type_name.to_string(),
+                                selections: prev,
+                                skip_if: None,
+                                include_if: Some(var_name.clone()),
+                            })];
+                    }
+                    Condition::Skip(var_name) => {
+                        selection_set.items =
+                            vec![SelectionItem::InlineFragment(InlineFragmentSelection {
+                                type_condition: type_name.to_string(),
+                                selections: prev,
+                                skip_if: Some(var_name.clone()),
+                                include_if: None,
+                            })];
+                    }
+                }
+            }
+            Self::Entities { selections } => {
+                for (def_name, selection_set) in selections {
+                    let prev = selection_set.clone();
+                    match &condition {
+                        Condition::Include(var_name) => {
+                            selection_set.items =
+                                vec![SelectionItem::InlineFragment(InlineFragmentSelection {
+                                    type_condition: def_name.to_string(),
+                                    selections: prev,
+                                    skip_if: None,
+                                    include_if: Some(var_name.clone()),
+                                })];
+                        }
+                        Condition::Skip(var_name) => {
+                            selection_set.items =
+                                vec![SelectionItem::InlineFragment(InlineFragmentSelection {
+                                    type_condition: def_name.to_string(),
+                                    selections: prev,
+                                    skip_if: Some(var_name.clone()),
+                                    include_if: None,
+                                })];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_at_path_inner(
+        &mut self,
+        fetch_path: &MergePath,
+        selection_set: SelectionSet,
+        as_first: bool,
+    ) {
+        let target_def = self
+            .get_definition_to_modify(fetch_path, &fetch_path.entrypoint_definition_name)
+            .to_string();
+        let current = self.selections_for_definition(&target_def);
+
+        if let Some(selection_at_path) = find_selection_set_by_path_mut(current, fetch_path) {
+            merge_selection_set(selection_at_path, &selection_set, as_first);
+        } else {
+            panic!(
+                "[{}] Path '{}' cannot be found in selection set: '{}'",
+                target_def, fetch_path, current
+            );
+        }
+    }
+}

--- a/lib/query-planner/src/tests/mod.rs
+++ b/lib/query-planner/src/tests/mod.rs
@@ -18,3 +18,20 @@ mod requires_requires;
 mod root_types;
 mod testkit;
 mod union;
+
+use crate::{
+    tests::testkit::{build_query_plan, init_logger},
+    utils::parsing::parse_operation,
+};
+
+#[test]
+fn test_bench_operation() -> Result<(), Box<dyn std::error::Error>> {
+    init_logger();
+    let document = parse_operation(
+        &std::fs::read_to_string("../../bench/operation.graphql")
+            .expect("Unable to read input file"),
+    );
+    let _query_plan = build_query_plan("../../bench/supergraph.graphql", document)?;
+
+    Ok(())
+}


### PR DESCRIPTION
- [x] figure out how to construct multi-type selections for `output`
- [x] adjust `Display` for `output`
- [x] confirm `output` builds the same way (no panics)
- [x] Remove existing `output` + adjust optimizations 

`...`


- [ ] figure out how to construct multi-type selections for `input`
