### PR TITLE
fix(lifetime): i'm happy but not proud of this fix

### DIFF
--- a/lib/executor/src/lib.rs
+++ b/lib/executor/src/lib.rs
@@ -67,7 +67,7 @@ impl<'a> Executor<'a> {
         }
     }
 
-    pub async fn execute(&'a mut self, plan: Option<&PlanNode>) {
+    pub async fn execute(&mut self, plan: Option<&PlanNode>) {
         match plan {
             Some(PlanNode::Fetch(node)) => self.execute_fetch_wave(node).await,
             Some(PlanNode::Parallel(node)) => self.execute_parallel_wave(node).await,
@@ -86,7 +86,7 @@ impl<'a> Executor<'a> {
         )
     }
 
-    async fn execute_fetch_wave(&'a mut self, node: &FetchNode) {
+    async fn execute_fetch_wave(&mut self, node: &FetchNode) {
         // no need to deep_merge,
         // we .into() and pass to final
         let result = self.get_result().await;
@@ -94,18 +94,18 @@ impl<'a> Executor<'a> {
         self.execution_context.response_storage.add_response(result);
     }
 
-    async fn execute_sequence_wave(&'a mut self, node: &SequenceNode) {
+    async fn execute_sequence_wave(&mut self, node: &SequenceNode) {
         // merge after every sequence
         // so the next step can read it.
         // It can hold a list of mix of Parallel blocks and Fetch and Flatten(Fetch)
     }
 
-    async fn execute_parallel_wave(&'a mut self, node: &ParallelNode) {
+    async fn execute_parallel_wave(&mut self, node: &ParallelNode) {
         // we merge after all fetches
         // it can hold a list of Fetch or Flatten(Fetch)
     }
 
-    async fn get_result(&'a self) -> ParsedResponse {
+    async fn get_result(&self) -> ParsedResponse {
         // 1. Fetch data from the network.
         let response_body = br#"{"data": {"product": "super-fast-widget"}}"#.to_vec();
         let parsed_response =

--- a/lib/executor/src/response/storage.rs
+++ b/lib/executor/src/response/storage.rs
@@ -1,3 +1,5 @@
+use simd_json::BorrowedValue;
+
 use crate::{
     response::{merge::deep_merge, value::Value},
     ParsedResponse,
@@ -17,11 +19,12 @@ impl<'req> ResponsesStorage<'req> {
         }
     }
 
-    pub fn add_response<'sub_req: 'req>(&'req mut self, response: ParsedResponse) {
+    pub fn add_response(&mut self, response: ParsedResponse) {
         let new_item_index = self.responses.len();
         self.responses.push(response);
         self.responses[new_item_index].with_json(|json| {
-            deep_merge(&mut self.final_response, &json);
+            let json_with_req_lifetime: &BorrowedValue<'req> = unsafe { std::mem::transmute(json) };
+            deep_merge(&mut self.final_response, &json_with_req_lifetime);
         });
     }
 }


### PR DESCRIPTION
jk 🙃 

So since we are using `ouroboros`, it creates a hidden lifetime (you probably noticed it as `'this`), and the compiler is confused, it doesn’t know the lifetime of json in this call:

```rs
deep_merge(&mut self.final_response, &json);
                                                                         ^ this is `'_` or `'this` 
```

But in real life we do know it’s not just outlives `'req`, it’s matching it because they are eventually both lives in the same `ResponseStorage` instance with `'req` lifetime. 

So by removing the rolling lifetime and stick to just `&mut self` , and did `transmute` , it’s overriding the compiler’s "mistake" and corrects it to the `'req` lifetime:

```rs
            let json_with_req_lifetime: &BorrowedValue<'req> = unsafe { std::mem::transmute(json) };
            deep_merge(&mut self.final_response, &json_with_req_lifetime);
```