### PR TITLE
Temporarily remove instrument macros from the executor

### DIFF
--- a/bin/gateway/src/pipeline/coerce_variables_service.rs
+++ b/bin/gateway/src/pipeline/coerce_variables_service.rs
@@ -32,7 +32,6 @@ impl CoerceVariablesService {
 
 #[async_trait::async_trait]
 impl GatewayPipelineLayer for CoerceVariablesService {
-    #[tracing::instrument(level = "trace", name = "CoerceVariablesService", skip_all)]
     async fn process(
         &self,
         req: &mut Request<Body>,

--- a/bin/gateway/src/pipeline/execution_service.rs
+++ b/bin/gateway/src/pipeline/execution_service.rs
@@ -40,7 +40,6 @@ impl Service<Request<Body>> for ExecutionService {
         Poll::Ready(Ok(()))
     }
 
-    #[tracing::instrument(level = "trace", name = "ExecutionService", skip_all)]
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         let mut expose_query_plan: ExposeQueryPlanMode = match self.expose_query_plan {
             true => ExposeQueryPlanMode::Yes,

--- a/bin/gateway/src/pipeline/graphql_request_params.rs
+++ b/bin/gateway/src/pipeline/graphql_request_params.rs
@@ -79,7 +79,6 @@ impl TryInto<ExecutionRequest> for GETQueryParams {
 
 #[async_trait::async_trait]
 impl GatewayPipelineLayer for GraphQLRequestParamsExtractor {
-    #[tracing::instrument(level = "trace", name = "GraphQLRequestParamsExtractor", skip_all)]
     async fn process(
         &self,
         req: &mut Request<Body>,

--- a/bin/gateway/src/pipeline/parser_service.rs
+++ b/bin/gateway/src/pipeline/parser_service.rs
@@ -31,7 +31,6 @@ impl GraphQLParserService {
 
 #[async_trait::async_trait]
 impl GatewayPipelineLayer for GraphQLParserService {
-    #[tracing::instrument(level = "trace", name = "GraphQLParserService", skip_all)]
     async fn process(
         &self,
         req: &mut Request<Body>,

--- a/bin/gateway/src/pipeline/progressive_override_service.rs
+++ b/bin/gateway/src/pipeline/progressive_override_service.rs
@@ -29,7 +29,6 @@ impl ProgressiveOverrideExtractor {
 
 #[async_trait::async_trait]
 impl GatewayPipelineLayer for ProgressiveOverrideExtractor {
-    #[tracing::instrument(level = "trace", name = "ProgressiveOverrideExtractor", skip_all)]
     async fn process(
         &self,
         req: &mut Request<Body>,

--- a/bin/gateway/src/pipeline/query_plan_service.rs
+++ b/bin/gateway/src/pipeline/query_plan_service.rs
@@ -65,7 +65,6 @@ impl QueryPlanService {
 
 #[async_trait::async_trait]
 impl GatewayPipelineLayer for QueryPlanService {
-    #[tracing::instrument(level = "trace", name = "QueryPlanService", skip_all)]
     async fn process(
         &self,
         req: &mut Request<Body>,

--- a/bin/gateway/src/pipeline/validation_service.rs
+++ b/bin/gateway/src/pipeline/validation_service.rs
@@ -22,7 +22,6 @@ impl GraphQLValidationService {
 
 #[async_trait::async_trait]
 impl GatewayPipelineLayer for GraphQLValidationService {
-    #[tracing::instrument(level = "trace", name = "GraphQLValidationService", skip_all)]
     async fn process(
         &self,
         req: &mut Request<Body>,

--- a/lib/query-plan-executor/src/deep_merge.rs
+++ b/lib/query-plan-executor/src/deep_merge.rs
@@ -1,8 +1,7 @@
 use serde_json::Value;
-use tracing::{instrument, trace};
+use tracing::trace;
 
 // Deeply merges two serde_json::Values (mutates target in place)
-#[instrument(level = "trace", name = "deep_merge", skip_all)]
 pub fn deep_merge(target: &mut Value, source: Value) {
     match (target, source) {
         (_, Value::Null) => {
@@ -43,12 +42,6 @@ pub fn deep_merge(target: &mut Value, source: Value) {
     }
 }
 
-#[instrument(
-    level = "trace", 
-    name = "deep_merge_objects", 
-    skip_all,
-    fields(target_map_len = target_map.len(), source_map_len = source_map.len(), typename= %target_map.get("typename").and_then(|a| a.as_str()).unwrap_or("unknown"))
-)]
 pub fn deep_merge_objects(
     target_map: &mut serde_json::Map<String, Value>,
     source_map: serde_json::Map<String, Value>,

--- a/lib/query-plan-executor/src/executors/http.rs
+++ b/lib/query-plan-executor/src/executors/http.rs
@@ -8,7 +8,7 @@ use http_body_util::BodyExt;
 use http_body_util::Full;
 use hyper::{body::Bytes, Version};
 use hyper_util::client::legacy::{connect::HttpConnector, Client};
-use tracing::{error, instrument, trace};
+use tracing::{error, trace};
 
 use crate::{
     executors::common::SubgraphExecutor, json_writer::write_and_escape_string, ExecutionResult,
@@ -138,7 +138,6 @@ impl HTTPSubgraphExecutor {
 
 #[async_trait]
 impl SubgraphExecutor for HTTPSubgraphExecutor {
-    #[instrument(level = "trace", skip(self), name = "http_subgraph_execute", fields(endpoint = %self.endpoint))]
     async fn execute<'a>(
         &self,
         execution_request: SubgraphExecutionRequest<'a>,

--- a/lib/query-plan-executor/src/executors/map.rs
+++ b/lib/query-plan-executor/src/executors/map.rs
@@ -4,7 +4,7 @@ use hyper_util::{
     client::legacy::Client,
     rt::{TokioExecutor, TokioTimer},
 };
-use tracing::{instrument, warn};
+use tracing::warn;
 
 use crate::executors::{
     common::{SubgraphExecutor, SubgraphExecutorBoxedArc},
@@ -28,7 +28,6 @@ impl SubgraphExecutorMap {
         }
     }
 
-    #[instrument(level = "trace", name = "subgraph_execute", skip_all, fields(subgraph_name = %subgraph_name, execution_request = ?execution_request))]
     pub async fn execute<'a>(
         &self,
         subgraph_name: &str,

--- a/lib/query-plan-executor/src/lib.rs
+++ b/lib/query-plan-executor/src/lib.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::VecDeque;
 use std::{collections::HashMap, vec};
-use tracing::{instrument, trace, warn}; // For reading file in main
+use tracing::{trace, warn}; // For reading file in main
 
 use crate::{
     executors::map::SubgraphExecutorMap,
@@ -80,11 +80,6 @@ impl ExecutablePlanNode for PlanNode {
     }
 }
 
-#[instrument(
-    level = "trace",
-    skip(execution_context),
-    name = "process_errors_and_extensions"
-)]
 fn process_errors_and_extensions(
     execution_context: &mut QueryPlanExecutionContext<'_>,
     errors: Option<Vec<GraphQLError>>,
@@ -129,7 +124,6 @@ trait ExecutableFetchNode {
 
 #[async_trait]
 impl ExecutablePlanNode for FetchNode {
-    #[instrument(level = "debug", skip_all, name = "FetchNode::execute")]
     async fn execute(
         &self,
         execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -143,16 +137,6 @@ impl ExecutablePlanNode for FetchNode {
 
 #[async_trait]
 impl ExecutableFetchNode for FetchNode {
-    #[instrument(
-        level = "trace",
-        skip_all,
-        name="FetchNode::execute_for_root",
-        fields(
-            service_name = self.service_name,
-            operation_name = ?self.operation_name,
-            operation_str = %self.operation.document_str,
-        )
-    )]
     async fn execute_for_root(
         &self,
         execution_context: &QueryPlanExecutionContext<'_>,
@@ -180,14 +164,6 @@ impl ExecutableFetchNode for FetchNode {
         fetch_result
     }
 
-    #[instrument(
-        level = "debug",
-        skip_all,
-        name = "execute_for_projected_representations",
-        fields(
-            representations_count = %filtered_representations.len(),
-        ),
-    )]
     async fn execute_for_projected_representations(
         &self,
         execution_context: &QueryPlanExecutionContext<'_>,
@@ -243,11 +219,6 @@ impl ExecutableFetchNode for FetchNode {
         }
     }
 
-    #[instrument(
-        level = "debug",
-        skip(self, variable_values),
-        name = "prepare_variables_for_fetch_node"
-    )]
     fn prepare_variables_for_fetch_node<'a>(
         &'a self,
         variable_values: &'a Option<HashMap<String, Value>>,
@@ -413,9 +384,6 @@ impl ApplyFetchRewrite for ValueSetter {
 
 #[async_trait]
 impl ExecutablePlanNode for SequenceNode {
-    #[instrument(level = "trace", skip_all, name = "SequenceNode::execute", fields(
-        nodes_count = %self.nodes.len()
-    ))]
     async fn execute(
         &self,
         execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -428,10 +396,6 @@ impl ExecutablePlanNode for SequenceNode {
     }
 }
 
-#[instrument(level = "debug", skip_all, name = "process_root_result", fields(
-    fetch_result = ?fetch_result.data.as_ref().map(|d| d.to_string()),
-    errors_count = %fetch_result.errors.as_ref().map_or(0, |e| e.len()),
-))]
 fn process_root_result(
     fetch_result: ExecutionResult,
     execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -463,9 +427,6 @@ enum ParallelJob<'a> {
 
 #[async_trait]
 impl ExecutablePlanNode for ParallelNode {
-    #[instrument(level = "trace", skip_all, name = "ParallelNode::execute", fields(
-        nodes_count = %self.nodes.len()
-    ))]
     async fn execute(
         &self,
         execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -671,9 +632,6 @@ impl ExecutablePlanNode for ParallelNode {
 
 #[async_trait]
 impl ExecutablePlanNode for FlattenNode {
-    #[instrument(level = "trace", skip_all, name = "FlattenNode::execute", fields(
-        path = ?self.path
-    ))]
     async fn execute(
         &self,
         execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -815,7 +773,6 @@ impl GetInnerNodeByVariables for ConditionNode {
 
 #[async_trait]
 impl ExecutablePlanNode for ConditionNode {
-    #[instrument(level = "trace", skip_all, name = "ConditionNode::execute")]
     async fn execute(
         &self,
         execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -834,7 +791,6 @@ impl ExecutablePlanNode for ConditionNode {
 
 #[async_trait]
 impl ExecutableQueryPlan for QueryPlan {
-    #[instrument(level = "trace", skip_all, name = "QueryPlan::execute")]
     async fn execute(
         &self,
         execution_context: &mut QueryPlanExecutionContext<'_>,
@@ -1232,14 +1188,6 @@ pub enum ExposeQueryPlanMode {
     DryRun,
 }
 
-#[instrument(
-    level = "trace",
-    skip_all,
-    fields(
-        query_plan = ?query_plan,
-        variable_values = ?variable_values,
-    )
-)]
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_query_plan(
     query_plan: &QueryPlan,


### PR DESCRIPTION
It seems they have a performance cost. I will put them back after restructuring the executor