### PR TITLE
fix(executor): if `data` is empty, add `null` to the serialized response instead of leaving it empty

### DIFF
--- a/lib/executor/src/projection/response.rs
+++ b/lib/executor/src/projection/response.rs
@@ -53,7 +53,6 @@ pub fn project_by_operation(
             buffer.put(EMPTY_OBJECT);
         }
     } else {
-        warn!("The root data is not an object. Returning null for data field.");
         buffer.put(NULL);
     }
 


### PR DESCRIPTION
In case of a `data` property with a non-object value, it was skipping the serialization of `data` which ends up with an invalid JSON result.
```diff
{
-   "data": ,
+  "data": null,
"errors": []
}
``` 