### PR TITLE
feat(router): add a flag to disable the caching for query plans

### DIFF
--- a/bin/router/src/pipeline/query_plan.rs
+++ b/bin/router/src/pipeline/query_plan.rs
@@ -9,6 +9,7 @@ use hive_router_query_planner::planner::plan_nodes::QueryPlan;
 use hive_router_query_planner::planner::PlannerError;
 use hive_router_query_planner::utils::cancellation::CancellationToken;
 use ntex::web::HttpRequest;
+use tracing::debug;
 use xxhash_rust::xxh3::Xxh3;
 
 #[inline]
@@ -74,6 +75,7 @@ fn get_plan(
     let is_pure_introspection = filtered_operation_for_plan.selection_set.is_empty()
         && normalized_operation.operation_for_introspection.is_some();
     if is_pure_introspection {
+        debug!("No need for a plan, as the incoming query only involves introspection fields");
         return Ok(QueryPlan {
             kind: "QueryPlan".to_string(),
             node: None,

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 |----|----|-----------|--------|
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"host":"0.0.0.0","port":4000}`<br/>||
 |[**log**](#log)|`object`|The router logger configuration.<br/>Default: `{"filter":null,"format":"json","level":"info"}`<br/>||
-|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout":"10s"}`<br/>||
+|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"cache":{"enabled":true},"timeout":"10s"}`<br/>|yes|
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>Default: `{"path":"supergraph.graphql","source":"file"}`<br/>||
 |[**traffic\_shaping**](#traffic_shaping)|`object`|Configuration for the traffic-shaper executor. Use these configurations to control how requests are being executed to subgraphs.<br/>Default: `{"dedupe_enabled":true,"dedupe_fingerprint_headers":["authorization"],"max_connections_per_host":100,"pool_idle_timeout_seconds":50}`<br/>||
 
@@ -23,6 +23,8 @@ log:
   level: info
 query_planner:
   allow_expose: false
+  cache:
+    enabled: true
   timeout: 10s
 supergraph:
   path: supergraph.graphql
@@ -92,16 +94,28 @@ Query planning configuration.
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>||
-|**timeout**|`string`|The maximum time for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10s.<br/>Default: `"10s"`<br/>||
+|**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>|no|
+|[**cache**](#query_plannercache)|`object`||yes|
+|**timeout**|`string`|The maximum time for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10s.<br/>Default: `"10s"`<br/>|no|
 
 **Example**
 
 ```yaml
 allow_expose: false
+cache:
+  enabled: true
 timeout: 10s
 
 ```
+
+<a name="query_plannercache"></a>
+### query\_planner\.cache: object
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**enabled**|`boolean`||yes|
 
 <a name="supergraph"></a>
 ## supergraph: object

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -21,6 +21,7 @@ pub struct QueryPlannerConfig {
     )]
     #[schemars(with = "String")]
     pub timeout: Duration,
+    pub cache: QueryPlannerCacheConfig,
 }
 
 impl Default for QueryPlannerConfig {
@@ -28,6 +29,7 @@ impl Default for QueryPlannerConfig {
         Self {
             allow_expose: default_query_planning_allow_expose(),
             timeout: default_query_planning_timeout(),
+            cache: QueryPlannerCacheConfig::default(),
         }
     }
 }
@@ -38,4 +40,15 @@ fn default_query_planning_allow_expose() -> bool {
 
 fn default_query_planning_timeout() -> Duration {
     Duration::from_secs(10)
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+pub struct QueryPlannerCacheConfig {
+    pub enabled: bool,
+}
+
+impl Default for QueryPlannerCacheConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }


### PR DESCRIPTION
The following disables the caching of the query plans, the caching is enabled by default.

```yaml
query_planner:
   cache:
      enabled: true | false
```