### PR TITLE
refactor(router, executor): refactor request fingerprinting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,6 +1284,7 @@ dependencies = [
  "hyper-util",
  "indexmap 2.11.0",
  "itoa",
+ "ntex-http",
  "ryu",
  "serde",
  "sonic-rs",
@@ -1837,12 +1838,12 @@ dependencies = [
 
 [[package]]
 name = "ntex-http"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3102673534f57dbc7fc9e7f1aac4126f353366c67518eac0a7763bb2515f0a7a"
+checksum = "61da3d6c8bec83c5481d7e36ed4cf1a8cd0edee3e2fa411290932b17549d5cf2"
 dependencies = [
+ "ahash",
  "futures-core",
- "fxhash",
  "http",
  "itoa",
  "log",

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -21,6 +21,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 
 fn main() {
     let tree_layer = tracing_tree::HierarchicalLayer::new(2)
+        .with_writer(std::io::stdout)
         .with_bracketed_fields(true)
         .with_deferred_spans(false)
         .with_wraparound(25)

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -65,6 +65,7 @@ pub async fn execute_plan(
         query_plan: query_plan_payload,
         projection_plan: &normalized_payload.projection_plan,
         variable_values: &variable_payload.variables_map,
+        upstream_headers: req.headers(),
         extensions,
         introspection_context: &introspection_context,
         operation_type_name: normalized_payload.root_type_name,

--- a/lib/executor/Cargo.toml
+++ b/lib/executor/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
+ntex-http = "0.1.15"
 hyper = { workspace = true, features = ["client"] }
 serde = { workspace = true }
 sonic-rs = { workspace = true }

--- a/lib/executor/src/executors/common.rs
+++ b/lib/executor/src/executors/common.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use ntex_http::HeaderMap;
 
 #[async_trait]
 pub trait SubgraphExecutor {
@@ -21,6 +22,7 @@ pub type SubgraphExecutorBoxedArc = Arc<Box<SubgraphExecutorType>>;
 pub struct HttpExecutionRequest<'a> {
     pub query: &'a str,
     pub dedupe: bool,
+    pub upstream_headers: &'a HeaderMap,
     pub operation_name: Option<&'a str>,
     // TODO: variables could be stringified before even executing the request
     pub variables: Option<HashMap<&'a str, &'a sonic_rs::Value>>,

--- a/lib/executor/src/executors/dedupe.rs
+++ b/lib/executor/src/executors/dedupe.rs
@@ -21,7 +21,7 @@ pub fn request_fingerprint(
     let build_hasher = ABuildHasher::default();
     let mut hasher = build_hasher.build_hasher();
 
-    /// BTreeMap to ensure case-insensitivity and consistent order for hashing
+    // BTreeMap to ensure case-insensitivity and consistent order for hashing
     let mut headers = BTreeMap::new();
     if fingerprint_headers.is_empty() {
         // fingerprint all headers

--- a/lib/executor/src/executors/dedupe.rs
+++ b/lib/executor/src/executors/dedupe.rs
@@ -2,7 +2,7 @@ use ahash::AHasher;
 use bytes::Bytes;
 use http::{HeaderMap, Method, StatusCode, Uri};
 use std::collections::BTreeMap;
-use std::hash::{BuildHasherDefault, Hash, Hasher};
+use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
 
 #[derive(Debug, Clone)]
 pub struct SharedResponse {
@@ -11,66 +11,41 @@ pub struct SharedResponse {
     pub body: Bytes,
 }
 
-#[derive(Debug, Clone, Eq)]
-pub struct RequestFingerprint {
-    method: Method,
-    url: Uri,
+pub fn request_fingerprint(
+    method: &Method,
+    url: &Uri,
+    req_headers: &HeaderMap,
+    body_bytes: &[u8],
+    fingerprint_headers: &[String],
+) -> u64 {
+    let build_hasher = ABuildHasher::default();
+    let mut hasher = build_hasher.build_hasher();
+
     /// BTreeMap to ensure case-insensitivity and consistent order for hashing
-    headers: BTreeMap<String, String>,
-    body: Vec<u8>,
-}
-
-impl RequestFingerprint {
-    pub fn new(
-        method: &Method,
-        url: &Uri,
-        req_headers: &HeaderMap,
-        body_bytes: &[u8],
-        fingerprint_headers: &[String],
-    ) -> Self {
-        let mut headers = BTreeMap::new();
-        if fingerprint_headers.is_empty() {
-            // fingerprint all headers
-            for (key, value) in req_headers.iter() {
+    let mut headers = BTreeMap::new();
+    if fingerprint_headers.is_empty() {
+        // fingerprint all headers
+        for (key, value) in req_headers.iter() {
+            if let Ok(value_str) = value.to_str() {
+                headers.insert(key.as_str(), value_str);
+            }
+        }
+    } else {
+        for header_name in fingerprint_headers.iter() {
+            if let Some(value) = req_headers.get(header_name) {
                 if let Ok(value_str) = value.to_str() {
-                    headers.insert(key.as_str().to_lowercase(), value_str.to_string());
-                }
-            }
-        } else {
-            for header_name in fingerprint_headers.iter() {
-                if let Some(value) = req_headers.get(header_name) {
-                    if let Ok(value_str) = value.to_str() {
-                        headers.insert(header_name.to_lowercase(), value_str.to_string());
-                    }
+                    headers.insert(header_name, value_str);
                 }
             }
         }
-
-        Self {
-            method: method.clone(),
-            url: url.clone(),
-            headers,
-            body: body_bytes.to_vec(),
-        }
     }
-}
 
-impl Hash for RequestFingerprint {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.method.hash(state);
-        self.url.hash(state);
-        self.headers.hash(state);
-        self.body.hash(state);
-    }
-}
+    method.hash(&mut hasher);
+    url.hash(&mut hasher);
+    headers.hash(&mut hasher);
+    body_bytes.hash(&mut hasher);
 
-impl PartialEq for RequestFingerprint {
-    fn eq(&self, other: &Self) -> bool {
-        self.method == other.method
-            && self.url == other.url
-            && self.headers == other.headers
-            && self.body == other.body
-    }
+    hasher.finish()
 }
 
 pub type ABuildHasher = BuildHasherDefault<AHasher>;

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -186,6 +186,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             &http::Method::POST,
             &self.endpoint,
             &self.header_map,
+            &execution_request.upstream_headers,
             &body,
             &self.config.dedupe_fingerprint_headers,
         );

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -186,7 +186,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             &http::Method::POST,
             &self.endpoint,
             &self.header_map,
-            &execution_request.upstream_headers,
+            execution_request.upstream_headers,
             &body,
             &self.config.dedupe_fingerprint_headers,
         );
@@ -195,7 +195,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
         // Prevents any deadlocks.
         let cell = self
             .in_flight_requests
-            .entry(fingerprint.clone())
+            .entry(fingerprint)
             .or_default()
             .value()
             .clone();

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -14,7 +14,7 @@ use tokio::sync::{OnceCell, Semaphore};
 use crate::{
     executors::{
         common::{HttpExecutionRequest, SubgraphExecutor, SubgraphExecutorBoxedArc},
-        dedupe::{ABuildHasher, RequestFingerprint, SharedResponse},
+        dedupe::{ABuildHasher, SharedResponse},
         error::SubgraphExecutorError,
         http::HTTPSubgraphExecutor,
     },
@@ -81,9 +81,8 @@ impl SubgraphExecutorMap {
         let semaphores_by_origin: DashMap<String, Arc<Semaphore>> = DashMap::new();
         let max_connections_per_host = config.max_connections_per_host;
         let config_arc = Arc::new(config);
-        let in_flight_requests: Arc<
-            DashMap<RequestFingerprint, Arc<OnceCell<SharedResponse>>, ABuildHasher>,
-        > = Arc::new(DashMap::with_hasher(ABuildHasher::default()));
+        let in_flight_requests: Arc<DashMap<u64, Arc<OnceCell<SharedResponse>>, ABuildHasher>> =
+            Arc::new(DashMap::with_hasher(ABuildHasher::default()));
 
         let executor_map = subgraph_endpoint_map
             .into_iter()


### PR DESCRIPTION
- Refactors the request fingerprinting logic to use a function rather than a struct with `Hash` and `PartialEq` traits. This simplifies the code and improves performance. It also adds header normalization in config to handle case-insensitivity.
- Passes upstream headers to subgraph executors
- Log to stdout in dev cli