### PR TITLE
Add cancellation and deduplication to the query planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "serde",
  "sonic-rs",
  "thiserror 2.0.16",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,7 @@ name = "hive-router-config"
 version = "0.0.4"
 dependencies = [
  "config",
+ "humantime-serde",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -1340,6 +1341,22 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-tree = "0.4.0"
 insta = { version = "1.42.1" }
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 lazy_static = "1.5.0"
+dashmap = { version = "6.0.0" }
 async-trait = "0.1.88"
 futures = "0.3.31"
 http = "1.3.1"
@@ -48,4 +49,5 @@ hyper = { version = "1.6.0" }
 thiserror = "2.0.14"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 tokio = { version = "1.47.1", features = ["full"] }
+tokio-util = { version = "0.7.16" }
 rand = "0.9.2"

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -75,7 +75,7 @@ pub enum PipelineErrorVariant {
     #[error("Failed to execute a plan: {0}")]
     PlanExecutionError(PlanExecutionError),
     #[error("Failed to produce a plan: {0}")]
-    PlannerError(PlannerError),
+    PlannerError(Arc<PlannerError>),
 }
 
 impl PipelineErrorVariant {

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -6,7 +6,6 @@ use ntex::{
     util::Bytes,
     web::{self, HttpRequest},
 };
-use tokio::time::Duration;
 
 use crate::{
     pipeline::{
@@ -85,9 +84,8 @@ pub async fn execute_pipeline(
     let variable_payload =
         coerce_request_variables(req, state, execution_request, &normalize_payload)?;
 
-    let query_plan_cancellation_token = CancellationToken::with_timeout(Duration::from_millis(
-        state.router_config.query_planner.timeout_ms,
-    ));
+    let query_plan_cancellation_token =
+        CancellationToken::with_timeout(state.router_config.query_planner.timeout);
 
     let query_plan_payload = plan_operation_with_cache(
         req,

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ Query planning configuration.
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>||
-|**timeout**|`string`|The maximum time in milliseconds for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10s.<br/>Default: `"10s"`<br/>||
+|**timeout**|`string`|The maximum time for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10s.<br/>Default: `"10s"`<br/>||
 
 **Example**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 |----|----|-----------|--------|
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"host":"0.0.0.0","port":4000}`<br/>||
 |[**log**](#log)|`object`|The router logger configuration.<br/>Default: `{"filter":null,"format":"json","level":"info"}`<br/>||
-|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false}`<br/>||
+|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout_ms":10000}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>Default: `{"path":"supergraph.graphql","source":"file"}`<br/>||
 |[**traffic\_shaping**](#traffic_shaping)|`object`|Configuration for the traffic-shaper executor. Use these configurations to control how requests are being executed to subgraphs.<br/>Default: `{"dedupe_enabled":true,"dedupe_fingerprint_headers":["authorization"],"max_connections_per_host":100,"pool_idle_timeout_seconds":50}`<br/>||
 
@@ -23,6 +23,7 @@ log:
   level: info
 query_planner:
   allow_expose: false
+  timeout_ms: 10000
 supergraph:
   path: supergraph.graphql
   source: file
@@ -92,11 +93,13 @@ Query planning configuration.
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>||
+|**timeout\_ms**|`integer`|The maximum time in milliseconds for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10000 (10 seconds).<br/>Default: `10000`<br/>Format: `"uint64"`<br/>Minimum: `0`<br/>||
 
 **Example**
 
 ```yaml
 allow_expose: false
+timeout_ms: 10000
 
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 |----|----|-----------|--------|
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"host":"0.0.0.0","port":4000}`<br/>||
 |[**log**](#log)|`object`|The router logger configuration.<br/>Default: `{"filter":null,"format":"json","level":"info"}`<br/>||
-|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout_ms":10000}`<br/>||
+|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout":"10s"}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>Default: `{"path":"supergraph.graphql","source":"file"}`<br/>||
 |[**traffic\_shaping**](#traffic_shaping)|`object`|Configuration for the traffic-shaper executor. Use these configurations to control how requests are being executed to subgraphs.<br/>Default: `{"dedupe_enabled":true,"dedupe_fingerprint_headers":["authorization"],"max_connections_per_host":100,"pool_idle_timeout_seconds":50}`<br/>||
 
@@ -23,7 +23,7 @@ log:
   level: info
 query_planner:
   allow_expose: false
-  timeout_ms: 10000
+  timeout: 10s
 supergraph:
   path: supergraph.graphql
   source: file
@@ -93,13 +93,37 @@ Query planning configuration.
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>||
-|**timeout\_ms**|`integer`|The maximum time in milliseconds for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10000 (10 seconds).<br/>Default: `10000`<br/>Format: `"uint64"`<br/>Minimum: `0`<br/>||
+|[**timeout**](#query_plannertimeout)|`object`|The maximum time in milliseconds for the query planner to create an execution plan.<br/>Default: `"10s"`<br/>|yes|
 
 **Example**
 
 ```yaml
 allow_expose: false
-timeout_ms: 10000
+timeout: 10s
+
+```
+
+<a name="query_plannertimeout"></a>
+### query\_planner\.timeout: object
+
+The maximum time in milliseconds for the query planner to create an execution plan.
+This acts as a safeguard against overly complex or malicious queries that could degrade server performance.
+When the timeout is reached, the planning process is cancelled.
+
+Default: 10s.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**nanos**|`integer`|Format: `"uint32"`<br/>Minimum: `0`<br/>|yes|
+|**secs**|`integer`|Format: `"uint64"`<br/>Minimum: `0`<br/>|yes|
+
+**Example**
+
+```yaml
+10s
 
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,37 +93,13 @@ Query planning configuration.
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>||
-|[**timeout**](#query_plannertimeout)|`object`|The maximum time in milliseconds for the query planner to create an execution plan.<br/>Default: `"10s"`<br/>|yes|
+|**timeout**|`string`|The maximum time in milliseconds for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10s.<br/>Default: `"10s"`<br/>||
 
 **Example**
 
 ```yaml
 allow_expose: false
 timeout: 10s
-
-```
-
-<a name="query_plannertimeout"></a>
-### query\_planner\.timeout: object
-
-The maximum time in milliseconds for the query planner to create an execution plan.
-This acts as a safeguard against overly complex or malicious queries that could degrade server performance.
-When the timeout is reached, the planning process is cancelled.
-
-Default: 10s.
-
-
-**Properties**
-
-|Name|Type|Description|Required|
-|----|----|-----------|--------|
-|**nanos**|`integer`|Format: `"uint32"`<br/>Minimum: `0`<br/>|yes|
-|**secs**|`integer`|Format: `"uint64"`<br/>Minimum: `0`<br/>|yes|
-
-**Example**
-
-```yaml
-10s
 
 ```
 

--- a/lib/executor/Cargo.toml
+++ b/lib/executor/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 xxhash-rust = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
-dashmap = "6.0.0"
+dashmap = { workspace = true }
 ahash = "0.8.12"
 
 hyper-tls = { version = "0.6.0", features = ["vendored"] }

--- a/lib/query-planner/Cargo.toml
+++ b/lib/query-planner/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 sonic-rs = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
+tokio-util = { workspace = true }
 
 petgraph = "0.8.2"
 bitflags = "2.9.1"

--- a/lib/query-planner/benches/qp_benches.rs
+++ b/lib/query-planner/benches/qp_benches.rs
@@ -103,18 +103,25 @@ fn query_plan_pipeline(c: &mut Criterion) {
                 bb_supergraph_state,
                 bb_override_context,
                 bb_operation,
+                &cancellation_token,
             )
             .expect("walk_operation failed during benchmark");
-            let query_tree = find_best_combination(bb_graph, best_paths_per_leaf).unwrap();
+            let query_tree =
+                find_best_combination(bb_graph, best_paths_per_leaf, &cancellation_token).unwrap();
             let fetch_graph = build_fetch_graph_from_query_tree(
                 bb_graph,
                 bb_supergraph_state,
                 bb_override_context,
                 query_tree,
+                &cancellation_token,
             )
             .unwrap();
-            let query_plan =
-                build_query_plan_from_fetch_graph(fetch_graph, bb_supergraph_state).unwrap();
+            let query_plan = build_query_plan_from_fetch_graph(
+                fetch_graph,
+                bb_supergraph_state,
+                &cancellation_token,
+            )
+            .unwrap();
             black_box(query_plan);
         })
     });

--- a/lib/query-planner/benches/qp_benches.rs
+++ b/lib/query-planner/benches/qp_benches.rs
@@ -10,6 +10,7 @@ use hive_router_query_planner::planner::fetch::fetch_graph::build_fetch_graph_fr
 use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_graph;
 use hive_router_query_planner::planner::walker::walk_operation;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
+use hive_router_query_planner::utils::cancellation::CancellationToken;
 use hive_router_query_planner::utils::parsing::{parse_operation, parse_schema};
 use std::hint::black_box;
 
@@ -40,6 +41,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
     let operation =
         get_executable_operation(&parsed_document, &supergraph_state, Some("TestQuery"));
     let override_context = PlannerOverrideContext::default();
+    let cancellation_token = CancellationToken::new();
 
     c.bench_function("query_plan", |b| {
         b.iter(|| {
@@ -53,18 +55,25 @@ fn query_plan_pipeline(c: &mut Criterion) {
                 bb_supergraph_state,
                 bb_override_context,
                 bb_operation,
+                &cancellation_token,
             )
             .expect("walk_operation failed during benchmark");
-            let query_tree = find_best_combination(bb_graph, best_paths_per_leaf).unwrap();
+            let query_tree =
+                find_best_combination(bb_graph, best_paths_per_leaf, &cancellation_token).unwrap();
             let fetch_graph = build_fetch_graph_from_query_tree(
                 bb_graph,
                 bb_supergraph_state,
                 bb_override_context,
                 query_tree,
+                &cancellation_token,
             )
             .unwrap();
-            let query_plan =
-                build_query_plan_from_fetch_graph(fetch_graph, bb_supergraph_state).unwrap();
+            let query_plan = build_query_plan_from_fetch_graph(
+                fetch_graph,
+                bb_supergraph_state,
+                &cancellation_token,
+            )
+            .unwrap();
             black_box(query_plan);
         })
     });

--- a/lib/query-planner/src/planner/error.rs
+++ b/lib/query-planner/src/planner/error.rs
@@ -1,8 +1,8 @@
-use crate::graph::error::GraphError;
+use crate::{graph::error::GraphError, utils::cancellation::CancellationError};
 
 use super::fetch::error::FetchGraphError;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum QueryPlanError {
     #[error("FetchGraph error: {0}")]
     FetchGraphFailure(Box<FetchGraphError>),
@@ -16,6 +16,8 @@ pub enum QueryPlanError {
     UnexpectedPendingState,
     #[error("Internal Error: {0}")]
     Internal(String),
+    #[error(transparent)]
+    CancellationError(#[from] CancellationError),
 }
 
 impl From<FetchGraphError> for QueryPlanError {

--- a/lib/query-planner/src/planner/fetch/error.rs
+++ b/lib/query-planner/src/planner/fetch/error.rs
@@ -2,9 +2,10 @@ use crate::{
     ast::type_aware_selection::TypeAwareSelectionError,
     graph::{error::GraphError, node::Node},
     planner::walker::error::WalkOperationError,
+    utils::cancellation::CancellationError,
 };
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum FetchGraphError {
     #[error("Internal Error: {0}")]
     Internal(String),
@@ -48,6 +49,8 @@ pub enum FetchGraphError {
     MissingRequires,
     #[error(transparent)]
     SelectionSetManipulationError(#[from] TypeAwareSelectionError),
+    #[error(transparent)]
+    CancellationError(#[from] CancellationError),
 }
 
 impl From<GraphError> for FetchGraphError {

--- a/lib/query-planner/src/planner/fetch/optimize/mod.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/mod.rs
@@ -13,14 +13,20 @@ use tracing::instrument;
 use crate::{
     planner::fetch::{error::FetchGraphError, fetch_graph::FetchGraph},
     state::supergraph_state::SupergraphState,
+    utils::cancellation::CancellationToken,
 };
 
 impl FetchGraph {
     #[instrument(level = "trace", skip_all)]
-    pub fn optimize(&mut self, supergraph_state: &SupergraphState) -> Result<(), FetchGraphError> {
+    pub fn optimize(
+        &mut self,
+        supergraph_state: &SupergraphState,
+        cancellation_token: &CancellationToken,
+    ) -> Result<(), FetchGraphError> {
         // Run optimization passes repeatedly until the graph stabilizes, as one optimization can create
         // opportunities for others.
         loop {
+            cancellation_token.bail_if_cancelled()?;
             let node_count_before = self.graph.node_count();
             let edge_count_before = self.graph.edge_count();
 

--- a/lib/query-planner/src/planner/walker/error.rs
+++ b/lib/query-planner/src/planner/walker/error.rs
@@ -1,8 +1,11 @@
 use petgraph::graph::NodeIndex;
 
-use crate::{graph::error::GraphError, state::supergraph_state::OperationKind};
+use crate::{
+    graph::error::GraphError, state::supergraph_state::OperationKind,
+    utils::cancellation::CancellationError,
+};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum WalkOperationError {
     #[error("Root type of {0} not found")]
     MissingRootType(OperationKind),
@@ -16,6 +19,8 @@ pub enum WalkOperationError {
     FieldNotFound(String, String),
     #[error("No paths found for selection item: {0}")]
     NoPathsFound(String),
+    #[error(transparent)]
+    CancellationError(#[from] CancellationError),
     /// In case of a shareable field resolving an interface, all object types implementing the interface
     /// must resolve the field in the same way.
     ///

--- a/lib/query-planner/src/utils/cancellation.rs
+++ b/lib/query-planner/src/utils/cancellation.rs
@@ -1,0 +1,96 @@
+use std::{
+    num::NonZeroU32,
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Default)]
+pub struct CancellationToken(tokio_util::sync::CancellationToken, Option<Instant>);
+
+impl CancellationToken {
+    pub fn new() -> Self {
+        Self(tokio_util::sync::CancellationToken::new(), None)
+    }
+
+    pub fn with_timeout(duration: Duration) -> Self {
+        let deadline = Instant::now() + duration;
+        Self(tokio_util::sync::CancellationToken::new(), Some(deadline))
+    }
+
+    pub fn cancel(&self) {
+        self.0.cancel();
+    }
+
+    #[inline]
+    pub fn bail_if_cancelled(&self) -> Result<(), CancellationError> {
+        self.bail_if_timedout()?;
+
+        if self.0.is_cancelled() {
+            return Err(CancellationError::Cancelled);
+        }
+
+        Ok(())
+    }
+
+    fn bail_if_timedout(&self) -> Result<(), CancellationError> {
+        if let Some(deadline) = self.1 {
+            if deadline <= Instant::now() {
+                self.cancel();
+                return Err(CancellationError::TimedOut);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn throttle_check<'a>(&'a self, every: NonZeroU32) -> CancelTick<'a> {
+        CancelTick::new(self, every)
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum CancellationError {
+    #[error("cancelled")]
+    Cancelled,
+    #[error("timed out")]
+    TimedOut,
+}
+
+#[derive(Debug)]
+pub struct CancelTick<'a> {
+    cancellation_token: &'a CancellationToken,
+    every_minus_one: NonZeroU32,
+    ticks: u32,
+}
+
+impl<'a> CancelTick<'a> {
+    #[inline]
+    pub fn new(cancellation_token: &'a CancellationToken, every: NonZeroU32) -> Self {
+        if !every.is_power_of_two() {
+            panic!("every must be a power of two");
+        }
+
+        Self {
+            cancellation_token,
+            every_minus_one: NonZeroU32::new(every.get() - 1).unwrap(),
+            ticks: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn bail_if_cancelled(&mut self) -> Result<(), CancellationError> {
+        // We know that `every_minus_one` is a power of two subtracted by one,
+        // that's why we can use bit-and instead of modulo.
+        // It's the same as
+        //    x % n == 0
+        // but cheaper.
+        // This is the formula we're using, but the `n-1` is precomputed.
+        //    x & (n - 1) == 0
+        if self.ticks & self.every_minus_one.get() == 0 {
+            self.cancellation_token.bail_if_cancelled()?;
+        }
+        self.ticks += 1;
+
+        Ok(())
+    }
+}

--- a/lib/query-planner/src/utils/mod.rs
+++ b/lib/query-planner/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+pub mod cancellation;
 pub mod parsing;
 pub mod pretty_display;
 pub mod schema_transformer;

--- a/lib/router-config/Cargo.toml
+++ b/lib/router-config/Cargo.toml
@@ -20,4 +20,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 schemars = "1.0.4"
+humantime-serde = "1.1.1"
 config = { version = "0.15.14", features = ["yaml", "json", "json5"] }

--- a/lib/router-config/README.md
+++ b/lib/router-config/README.md
@@ -15,11 +15,11 @@ TL;DR: Use `cargo router-config` to re-generate the config file.
 To view the JSON schema of the configuration, use the following command:
 
 ```
-cargo run --release -p router-config
+cargo run --release -p hive-router-config
 ```
 
 To generate a JSON schema file, use the following command:
 
 ```
-cargo run --release -p router-config <output_file>
+cargo run --release -p hive-router-config <output_file>
 ```

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -9,7 +9,7 @@ pub struct QueryPlannerConfig {
     /// When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.
     #[serde(default = "default_query_planning_allow_expose")]
     pub allow_expose: bool,
-    /// The maximum time in milliseconds for the query planner to create an execution plan.
+    /// The maximum time for the query planner to create an execution plan.
     /// This acts as a safeguard against overly complex or malicious queries that could degrade server performance.
     /// When the timeout is reached, the planning process is cancelled.
     ///

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -19,6 +19,7 @@ pub struct QueryPlannerConfig {
         deserialize_with = "humantime_serde::deserialize",
         serialize_with = "humantime_serde::serialize"
     )]
+    #[schemars(with = "String")]
     pub timeout: Duration,
 }
 

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -1,10 +1,34 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, JsonSchema, Default)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct QueryPlannerConfig {
     /// A flag to allow exposing the query plan in the response.
     /// When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.
-    #[serde(default)]
+    #[serde(default = "default_query_planning_allow_expose")]
     pub allow_expose: bool,
+    /// The maximum time in milliseconds for the query planner to create an execution plan.
+    /// This acts as a safeguard against overly complex or malicious queries that could degrade server performance.
+    /// When the timeout is reached, the planning process is cancelled.
+    ///
+    /// Default: 10000 (10 seconds).
+    #[serde(default = "default_query_planning_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for QueryPlannerConfig {
+    fn default() -> Self {
+        Self {
+            allow_expose: default_query_planning_allow_expose(),
+            timeout_ms: default_query_planning_timeout_ms(),
+        }
+    }
+}
+
+fn default_query_planning_allow_expose() -> bool {
+    false
+}
+
+fn default_query_planning_timeout_ms() -> u64 {
+    10_000
 }

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -11,16 +13,20 @@ pub struct QueryPlannerConfig {
     /// This acts as a safeguard against overly complex or malicious queries that could degrade server performance.
     /// When the timeout is reached, the planning process is cancelled.
     ///
-    /// Default: 10000 (10 seconds).
-    #[serde(default = "default_query_planning_timeout_ms")]
-    pub timeout_ms: u64,
+    /// Default: 10s.
+    #[serde(
+        default = "default_query_planning_timeout",
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    pub timeout: Duration,
 }
 
 impl Default for QueryPlannerConfig {
     fn default() -> Self {
         Self {
             allow_expose: default_query_planning_allow_expose(),
-            timeout_ms: default_query_planning_timeout_ms(),
+            timeout: default_query_planning_timeout(),
         }
     }
 }
@@ -29,6 +35,6 @@ fn default_query_planning_allow_expose() -> bool {
     false
 }
 
-fn default_query_planning_timeout_ms() -> u64 {
-    10_000
+fn default_query_planning_timeout() -> Duration {
+    Duration::from_secs(10)
 }


### PR DESCRIPTION
Few things to unpack here:
- deduplication
- cancellation
- timeout

**Deduplication**
When Router receives one or more queries that are identical and have no plan yet, it shares the planning phase for them and produces a single plan that is distributed to all of them. We save CPU time.

**Cancellation**
Sometimes the query planning may take a long time. That's why I added an option to cancel it at any time.
We pass a cancellation token (like AbortSignal in JS) all over the places and check from time to time if bail or continue planning.

**Timeout**
Cancellation feature + deadline. I added a config option to the planner, to timeout (and cancel) a long running planning phase. It's 10s by default, but it can be adjusted by the user.