### PR TITLE
Disable comments from http and fed audits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           check_name: graphql-over-http
           comment_title: GraphQL over HTTP Audit Results
-          comment_mode: changes
+          comment_mode: off
           files: |
             audits/reports/*.xml
       - name: Publish Test Results for details
@@ -167,8 +167,7 @@ jobs:
           include_time_in_summary: true
           simplified_summary: true
           group_suite: true
-          comment: true
-          updateComment: true
+          comment: false
           exclude_sources: /lib/,/audits/node_modules/
 
   federation-audit:
@@ -199,7 +198,7 @@ jobs:
           fail_on: "nothing"
           check_name: federation-audit
           comment_title: Federation Audit Results
-          comment_mode: changes
+          comment_mode: off
           files: |
             audits/reports/*.xml
       - name: Publish Test Results for details
@@ -221,6 +220,5 @@ jobs:
           include_time_in_summary: true
           simplified_summary: true
           group_suite: true
-          comment: true
-          updateComment: true
+          comment: false
           exclude_sources: /lib/,/audits/node_modules/


### PR DESCRIPTION
Not sure why we need comments in Pull Requests (they are outdated most of the time anyway), when we have github checks with the same content.

<img width="1842" height="1102" alt="Screenshot 2025-09-17 at 10 23 24" src="https://github.com/user-attachments/assets/6a055357-b626-45c1-83a1-e8a9e4e96c52" />

<img width="1598" height="1206" alt="Screenshot 2025-09-17 at 10 24 29" src="https://github.com/user-attachments/assets/6dd01f55-15c7-4522-8eea-71c99246eb53" />
<img width="1598" height="1206" alt="Screenshot 2025-09-17 at 10 24 19" src="https://github.com/user-attachments/assets/0c582bc2-1ad5-4db0-ada6-ef63b0e9f543" />
