### PR TITLE
fix(executor): fix escaped strings in subgraph responses

### DIFF
--- a/lib/executor/src/execution/rewrites.rs
+++ b/lib/executor/src/execution/rewrites.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use hive_router_query_planner::planner::plan_nodes::{
     FetchNodePathSegment, FetchRewrite, KeyRenamer, ValueSetter,
 };
@@ -93,7 +91,7 @@ impl RewriteApplier for ValueSetter {
         path: &'a [FetchNodePathSegment],
     ) {
         if path.is_empty() {
-            *data = Value::String(Cow::Borrowed(self.set_value_to.as_str()));
+            *data = Value::String(self.set_value_to.as_str().into());
             return;
         }
 

--- a/lib/executor/src/execution/rewrites.rs
+++ b/lib/executor/src/execution/rewrites.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use hive_router_query_planner::planner::plan_nodes::{
     FetchNodePathSegment, FetchRewrite, KeyRenamer, ValueSetter,
 };
@@ -91,7 +93,7 @@ impl RewriteApplier for ValueSetter {
         path: &'a [FetchNodePathSegment],
     ) {
         if path.is_empty() {
-            *data = Value::String(self.set_value_to.as_str());
+            *data = Value::String(Cow::Borrowed(self.set_value_to.as_str()));
             return;
         }
 


### PR DESCRIPTION
This change uses `Cow` for string values in the `Value` enum to support escaped strings.
Thanks to Cow we borrow strings when possible and own them only when necessary.