### PR TITLE
refactor(error-handling): add context to `PlanExecutionError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.26.3",
  "syn 2.0.108",
  "thiserror 1.0.69",
 ]
@@ -2071,6 +2071,7 @@ dependencies = [
  "ryu",
  "serde",
  "sonic-rs",
+ "strum 0.27.2",
  "subgraphs",
  "thiserror 2.0.17",
  "tokio",
@@ -5121,7 +5122,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -5135,6 +5145,18 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/lib/executor/Cargo.toml
+++ b/lib/executor/Cargo.toml
@@ -32,6 +32,7 @@ dashmap = { workspace = true }
 ahash = "0.8.12"
 regex-automata = "0.4.10"
 vrl = { version = "0.27.0", features = ["compiler", "parser", "value", "diagnostic", "stdlib", "core"] }
+strum = { version = "0.27.2", features = ["derive"] }
 
 ntex-http = "0.1.15"
 hyper-tls = { version = "0.6.0", features = ["vendored"] }

--- a/lib/executor/src/execution/error.rs
+++ b/lib/executor/src/execution/error.rs
@@ -1,9 +1,136 @@
-use crate::{headers::errors::HeaderRuleRuntimeError, projection::error::ProjectionError};
+use strum::IntoStaticStr;
 
-#[derive(thiserror::Error, Debug, Clone)]
-pub enum PlanExecutionError {
+use crate::{
+    headers::errors::HeaderRuleRuntimeError,
+    projection::error::ProjectionError,
+    response::graphql_error::{GraphQLError, GraphQLErrorExtensions},
+};
+
+#[derive(thiserror::Error, Debug, Clone, IntoStaticStr)]
+pub enum PlanExecutionErrorKind {
     #[error("Projection faiure: {0}")]
+    #[strum(serialize = "PROJECTION_FAILURE")]
     ProjectionFailure(#[from] ProjectionError),
+
     #[error(transparent)]
+    #[strum(serialize = "HEADER_PROPAGATION_FAILURE")]
     HeaderPropagation(#[from] HeaderRuleRuntimeError),
+}
+
+/// The central error type for all query plan execution failures.
+///
+/// This struct combines a specific `PlanExecutionErrorKind` with a
+/// `PlanExecutionErrorContext` that holds shared, dynamic information
+/// like the subgraph name or affected GraphQL path.
+#[derive(thiserror::Error, Debug, Clone)]
+#[error("{kind}")]
+pub struct PlanExecutionError {
+    #[source]
+    kind: PlanExecutionErrorKind,
+    context: PlanExecutionErrorContext,
+}
+
+#[derive(Debug, Clone)]
+pub struct PlanExecutionErrorContext {
+    subgraph_name: Option<String>,
+    affected_path: Option<String>,
+}
+
+pub struct LazyPlanContext<SN, AP> {
+    pub subgraph_name: SN,
+    pub affected_path: AP,
+}
+
+impl PlanExecutionError {
+    pub(crate) fn new<SN, AP>(
+        kind: PlanExecutionErrorKind,
+        lazy_context: LazyPlanContext<SN, AP>,
+    ) -> Self
+    where
+        SN: FnOnce() -> Option<String>,
+        AP: FnOnce() -> Option<String>,
+    {
+        Self {
+            kind,
+            context: PlanExecutionErrorContext {
+                subgraph_name: (lazy_context.subgraph_name)(),
+                affected_path: (lazy_context.affected_path)(),
+            },
+        }
+    }
+
+    pub fn error_code(&self) -> &'static str {
+        (&self.kind).into()
+    }
+
+    pub fn subgraph_name(&self) -> &Option<String> {
+        &self.context.subgraph_name
+    }
+
+    pub fn affected_path(&self) -> &Option<String> {
+        &self.context.affected_path
+    }
+}
+
+impl From<PlanExecutionError> for GraphQLError {
+    fn from(val: PlanExecutionError) -> Self {
+        let message = val.to_string();
+        GraphQLError {
+            extensions: GraphQLErrorExtensions {
+                code: Some(val.error_code().into()),
+                service_name: val.context.subgraph_name,
+                affected_path: val.context.affected_path,
+                extensions: Default::default(),
+            },
+            message,
+            locations: None,
+            path: None,
+        }
+    }
+}
+
+/// An extension trait for `Result` types that can be converted into a `PlanExecutionError`.
+///
+/// This trait provides a lazy, performant way to add contextual information to
+/// an error, only performing work (like cloning strings) if the `Result` is an `Err`.
+pub trait IntoPlanExecutionError<T> {
+    fn with_plan_context<SN, AP>(
+        self,
+        context: LazyPlanContext<SN, AP>,
+    ) -> Result<T, PlanExecutionError>
+    where
+        SN: FnOnce() -> Option<String>,
+        AP: FnOnce() -> Option<String>;
+}
+
+impl<T> IntoPlanExecutionError<T> for Result<T, ProjectionError> {
+    fn with_plan_context<SN, AP>(
+        self,
+        context: LazyPlanContext<SN, AP>,
+    ) -> Result<T, PlanExecutionError>
+    where
+        SN: FnOnce() -> Option<String>,
+        AP: FnOnce() -> Option<String>,
+    {
+        self.map_err(|source| {
+            let kind = PlanExecutionErrorKind::ProjectionFailure(source);
+            PlanExecutionError::new(kind, context)
+        })
+    }
+}
+
+impl<T> IntoPlanExecutionError<T> for Result<T, HeaderRuleRuntimeError> {
+    fn with_plan_context<SN, AP>(
+        self,
+        context: LazyPlanContext<SN, AP>,
+    ) -> Result<T, PlanExecutionError>
+    where
+        SN: FnOnce() -> Option<String>,
+        AP: FnOnce() -> Option<String>,
+    {
+        self.map_err(|source| {
+            let kind = PlanExecutionErrorKind::HeaderPropagation(source);
+            PlanExecutionError::new(kind, context)
+        })
+    }
 }


### PR DESCRIPTION
This commit adds context to the `PlanExecutionError` enum. It includes the subgraph name and the affected path in case of a projection or header propagation failure.

It also adds a `ResultExt` trait to map `ProjectionError` and `HeaderRuleRuntimeError` to `PlanExecutionError`.

I will improve names soon, it's a draft anyway, I just wanted to showcase how we could do errors, instead of manually creating GraphQL Error with code and stuff in extensions.