### PR TITLE
feat(router): added support for label overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tree",
  "ulid",
+ "vrl",
  "xxhash-rust",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ reqwest = "0.12.23"
 retry-policies = "0.4.0"
 reqwest-retry = "0.7.0"
 reqwest-middleware = "0.4.2"
+vrl = { version = "0.27.0", features = ["compiler", "parser", "value", "diagnostic", "stdlib", "core"] }

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -43,6 +43,7 @@ jsonwebtoken = { workspace = true }
 retry-policies = { workspace = true}
 reqwest-retry = { workspace = true }
 reqwest-middleware = { workspace = true }
+vrl = { workspace = true }
 
 mimalloc = { version = "0.1.48", features = ["v3"] }
 moka = { version = "0.12.10", features = ["future"] }

--- a/bin/router/src/pipeline/progressive_override.rs
+++ b/bin/router/src/pipeline/progressive_override.rs
@@ -1,12 +1,44 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
+use hive_router_config::override_labels::{LabelOverrideValue, OverrideLabelsConfig};
+use hive_router_plan_executor::execution::plan::ClientRequestDetails;
 use hive_router_query_planner::{
     graph::{PlannerOverrideContext, PERCENTAGE_SCALE_FACTOR},
     state::supergraph_state::SupergraphState,
 };
 use rand::Rng;
+use vrl::{
+    compiler::{compile as vrl_compile, Program as VrlProgram, TargetValue as VrlTargetValue},
+    core::Value as VrlValue,
+    prelude::{
+        state::RuntimeState as VrlState, Context as VrlContext, ExpressionError,
+        TimeZone as VrlTimeZone,
+    },
+    stdlib::all as vrl_build_functions,
+    value::Secrets as VrlSecrets,
+};
 
-use super::error::PipelineError;
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to compile override label expression for label '{label}': {error}")]
+pub struct OverrideLabelsCompileError {
+    pub label: String,
+    pub error: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LabelEvaluationError {
+    #[error(
+        "Failed to resolve VRL expression for override label '{label}'. Runtime error: {source}"
+    )]
+    ExpressionResolutionFailure {
+        label: String,
+        source: ExpressionError,
+    },
+    #[error(
+        "VRL expression for override label '{label}' did not evaluate to a boolean. Got: {got}"
+    )]
+    ExpressionWrongType { label: String, got: String },
+}
 
 /// Contains the request-specific context for progressive overrides.
 /// This is stored in the request extensions
@@ -19,9 +51,14 @@ pub struct RequestOverrideContext {
 }
 
 #[inline]
-pub fn request_override_context() -> Result<RequestOverrideContext, PipelineError> {
-    // No active flags by default - until we implement it
-    let active_flags = HashSet::new();
+pub fn request_override_context<'req, F>(
+    override_labels_evaluator: &OverrideLabelsEvaluator,
+    get_client_request: F,
+) -> Result<RequestOverrideContext, LabelEvaluationError>
+where
+    F: FnOnce() -> ClientRequestDetails<'req>,
+{
+    let active_flags = override_labels_evaluator.evaluate(get_client_request)?;
 
     // Generate the random percentage value for this request.
     // Percentage is 0 - 100_000_000_000 (100*PERCENTAGE_SCALE_FACTOR)
@@ -75,5 +112,107 @@ impl StableOverrideContext {
             active_flags,
             percentage_outcomes,
         }
+    }
+}
+
+/// Evaluator for override labels based on configuration.
+/// This struct compiles and evaluates the override label expressions.
+/// It's intended to be used as a shared state in the router.
+pub struct OverrideLabelsEvaluator {
+    static_enabled_labels: HashSet<String>,
+    expressions: HashMap<String, VrlProgram>,
+}
+
+impl OverrideLabelsEvaluator {
+    pub(crate) fn from_config(
+        override_labels_config: &OverrideLabelsConfig,
+    ) -> Result<Self, OverrideLabelsCompileError> {
+        let mut static_enabled_labels = HashSet::new();
+        let mut expressions = HashMap::new();
+        let vrl_functions = vrl_build_functions();
+
+        for (label, value) in override_labels_config.iter() {
+            match value {
+                LabelOverrideValue::Boolean(true) => {
+                    static_enabled_labels.insert(label.clone());
+                }
+                LabelOverrideValue::Expression { expression } => {
+                    let compilation_result =
+                        vrl_compile(expression, &vrl_functions).map_err(|diagnostics| {
+                            OverrideLabelsCompileError {
+                                label: label.clone(),
+                                error: diagnostics
+                                    .errors()
+                                    .into_iter()
+                                    .map(|d| d.code.to_string() + ": " + &d.message)
+                                    .collect::<Vec<_>>()
+                                    .join(", "),
+                            }
+                        })?;
+                    expressions.insert(label.clone(), compilation_result.program);
+                }
+                _ => {} // Skip false booleans
+            }
+        }
+
+        Ok(Self {
+            static_enabled_labels,
+            expressions,
+        })
+    }
+
+    pub(crate) fn evaluate<'req, F>(
+        &self,
+        get_client_request: F,
+    ) -> Result<HashSet<String>, LabelEvaluationError>
+    where
+        F: FnOnce() -> ClientRequestDetails<'req>,
+    {
+        let mut active_flags = self.static_enabled_labels.clone();
+
+        if self.expressions.is_empty() {
+            return Ok(active_flags);
+        }
+
+        let client_request = get_client_request();
+        let mut target = VrlTargetValue {
+            value: VrlValue::Object(BTreeMap::from([(
+                "request".into(),
+                (&client_request).into(),
+            )])),
+            metadata: VrlValue::Object(BTreeMap::new()),
+            secrets: VrlSecrets::default(),
+        };
+
+        let mut state = VrlState::default();
+        let timezone = VrlTimeZone::default();
+        let mut ctx = VrlContext::new(&mut target, &mut state, &timezone);
+
+        for (label, expression) in &self.expressions {
+            match expression.resolve(&mut ctx) {
+                Ok(evaluated_value) => match evaluated_value {
+                    VrlValue::Boolean(true) => {
+                        active_flags.insert(label.clone());
+                    }
+                    VrlValue::Boolean(false) => {
+                        // Do nothing for false
+                    }
+                    invalid_value => {
+                        return Err(LabelEvaluationError::ExpressionWrongType {
+                            label: label.clone(),
+                            got: format!("{:?}", invalid_value),
+                        });
+                    }
+                },
+                Err(err) => {
+                    return Err(LabelEvaluationError::ExpressionResolutionFailure {
+                        label: label.clone(),
+                        source: err,
+                    });
+                }
+            }
+        }
+
+        Ok(active_flags)
     }
 }

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -8,12 +8,14 @@ use std::sync::Arc;
 
 use crate::jwt::JwtAuthRuntime;
 use crate::pipeline::cors::{CORSConfigError, Cors};
+use crate::pipeline::progressive_override::{OverrideLabelsCompileError, OverrideLabelsEvaluator};
 
 pub struct RouterSharedState {
     pub validation_plan: ValidationPlan,
     pub parse_cache: Cache<u64, Arc<graphql_parser::query::Document<'static, String>>>,
     pub router_config: Arc<HiveRouterConfig>,
     pub headers_plan: HeaderRulesPlan,
+    pub override_labels_evaluator: OverrideLabelsEvaluator,
     pub cors_runtime: Option<Cors>,
     pub jwt_auth_runtime: Option<JwtAuthRuntime>,
 }
@@ -29,6 +31,10 @@ impl RouterSharedState {
             parse_cache: moka::future::Cache::new(1000),
             cors_runtime: Cors::from_config(&router_config.cors).map_err(Box::new)?,
             router_config: router_config.clone(),
+            override_labels_evaluator: OverrideLabelsEvaluator::from_config(
+                &router_config.override_labels,
+            )
+            .map_err(Box::new)?,
             jwt_auth_runtime,
         })
     }
@@ -37,7 +43,9 @@ impl RouterSharedState {
 #[derive(thiserror::Error, Debug)]
 pub enum SharedStateError {
     #[error("invalid headers config: {0}")]
-    HeaderRuleCompileError(#[from] Box<HeaderRuleCompileError>),
+    HeaderRuleCompile(#[from] Box<HeaderRuleCompileError>),
     #[error("invalid regex in CORS config: {0}")]
-    CORSConfigError(#[from] Box<CORSConfigError>),
+    CORSConfig(#[from] Box<CORSConfigError>),
+    #[error("invalid override labels config: {0}")]
+    OverrideLabelsCompile(#[from] Box<OverrideLabelsCompileError>),
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"host":"0.0.0.0","port":4000}`<br/>||
 |[**jwt**](#jwt)|`object`, `null`|Configuration for JWT authentication plugin.<br/>|yes|
 |[**log**](#log)|`object`|The router logger configuration.<br/>Default: `{"filter":null,"format":"json","level":"info"}`<br/>||
+|[**override\_labels**](#override_labels)|`object`|Configuration for overriding labels.<br/>||
 |[**override\_subgraph\_urls**](#override_subgraph_urls)|`object`|Configuration for overriding subgraph URLs.<br/>Default: `{}`<br/>||
 |[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout":"10s"}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>||
@@ -63,6 +64,7 @@ log:
   filter: null
   format: json
   level: info
+override_labels: {}
 override_subgraph_urls:
   accounts:
     url: https://accounts.example.com/graphql
@@ -1535,6 +1537,18 @@ format: json
 level: info
 
 ```
+
+<a name="override_labels"></a>
+## override\_labels: object
+
+Configuration for overriding labels.
+
+
+**Additional Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**Additional Properties**||Defines the value for a label override.<br/><br/>It can be a simple boolean,<br/>or an object containing the expression that evaluates to a boolean.<br/>||
 
 <a name="override_subgraph_urls"></a>
 ## override\_subgraph\_urls: object

--- a/lib/executor/Cargo.toml
+++ b/lib/executor/Cargo.toml
@@ -29,11 +29,11 @@ thiserror = { workspace = true }
 xxhash-rust = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 dashmap = { workspace = true }
+vrl = { workspace = true }
+
 ahash = "0.8.12"
 regex-automata = "0.4.10"
-vrl = { version = "0.27.0", features = ["compiler", "parser", "value", "diagnostic", "stdlib", "core"] }
 strum = { version = "0.27.2", features = ["derive"] }
-
 ntex-http = "0.1.15"
 hyper-tls = { version = "0.6.0", features = ["vendored"] }
 hyper-util = { version = "0.1.16", features = [

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -6,6 +6,7 @@ pub mod headers;
 pub mod http_server;
 pub mod jwt_auth;
 pub mod log;
+pub mod override_labels;
 pub mod override_subgraph_urls;
 pub mod primitives;
 pub mod query_planner;
@@ -16,6 +17,7 @@ use config::{Config, File, FileFormat, FileSourceFile};
 use envconfig::Envconfig;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::{
@@ -23,6 +25,7 @@ use crate::{
     graphiql::GraphiQLConfig,
     http_server::HttpServerConfig,
     log::LoggingConfig,
+    override_labels::OverrideLabelsConfig,
     primitives::file_path::with_start_path,
     query_planner::QueryPlannerConfig,
     supergraph::SupergraphSource,
@@ -81,6 +84,10 @@ pub struct HiveRouterConfig {
     /// Configuration for overriding subgraph URLs.
     #[serde(default)]
     pub override_subgraph_urls: override_subgraph_urls::OverrideSubgraphUrlsConfig,
+
+    /// Configuration for overriding labels.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub override_labels: OverrideLabelsConfig,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/lib/router-config/src/override_labels.rs
+++ b/lib/router-config/src/override_labels.rs
@@ -1,0 +1,28 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A map of label names to their override configuration.
+pub type OverrideLabelsConfig = HashMap<String, LabelOverrideValue>;
+
+/// Defines the value for a label override.
+///
+/// It can be a simple boolean,
+/// or an object containing the expression that evaluates to a boolean.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum LabelOverrideValue {
+    /// A static boolean value to enable or disable the label.
+    Boolean(bool),
+    /// A dynamic value computed by an expression.
+    Expression {
+        /// An expression that must evaluate to a boolean. If true, the label will be applied.
+        expression: String,
+    },
+}
+
+impl LabelOverrideValue {
+    pub fn is_bool_and_true(&self) -> bool {
+        matches!(self, LabelOverrideValue::Boolean(true))
+    }
+}


### PR DESCRIPTION
ROUTER-163

This pull request introduces a new top-level configuration option, `override_labels`, allowing for fine-grained control over progressive override labels (`@override(label: "<string>")`). This feature enables teams to dynamically activate or deactivate field overrides based on static booleans or runtime expressions evaluated against incoming request data.

**How to Configure Override Labels**

The new `override_labels` key can be added to your `router.config.yaml`. It accepts a map where each key is the name of an override label and the value defines the condition under which it should be considered "active".

**Example 1: Static Override**

For simple on/off toggling, you can use a boolean value.

```yaml
override_labels:
  # This label will be active for every single request, enabling the associated override.
  use_new_billing_service: true
  # This label will never be active.
  use_legacy_inventory: false
```

**Example 2: Dynamic Override with an Expression**
For more complex scenarios, you can provide an object with an `expression` key. The expression is evaluated at runtime for each request using the VRL. If the expression evaluates to `true`, the label becomes active for that request.

```yaml
override_labels:
  # Activate a label only for internal users or beta testers based on a header.
  activate-beta-feature:
    expression: "request.headers['x-user-group'] == 'beta'"
```

**Error Handling**

- **Startup**: If an expression in the configuration is invalid, the router will fail to start and log a descriptive error, preventing deployment with a broken configuration.
- **Runtime**: If an expression fails to execute during a request (e.g., it produces a non-boolean result), the router will return a `500 Internal Server Error` with the error code `LABEL_EVALUATION_FAILED`.