### PR TITLE
fix(query-planner, router): fix introspection for federation v1 supergraph

### DIFF
--- a/lib/query-planner/src/consumer_schema/strip_schema_internals.rs
+++ b/lib/query-planner/src/consumer_schema/strip_schema_internals.rs
@@ -3,12 +3,15 @@ use graphql_parser::schema::*;
 
 use crate::{
     federation_spec::{
-        definitions::{JoinFieldSetScalar, JoinGraphEnum, LinkImportScalar, LinkPurposeEnum},
-        directives::{
-            InaccessibleDirective, JoinEnumValueDirective, JoinFieldDirective, JoinGraphDirective,
-            JoinImplementsDirective, JoinTypeDirective, JoinUnionMemberDirective, LinkDirective,
-            TagDirective,
+        definitions::{
+            CorePurposesEnum, JoinFieldSetScalar, JoinGraphEnum, LinkImportScalar, LinkPurposeEnum,
         },
+        directives::{
+            CoreDirective, InaccessibleDirective, JoinEnumValueDirective, JoinFieldDirective,
+            JoinGraphDirective, JoinImplementsDirective, JoinTypeDirective,
+            JoinUnionMemberDirective, LinkDirective, TagDirective,
+        },
+        join_owner::JoinOwnerDirective,
     },
     utils::schema_transformer::{SchemaTransformer, TransformedValue},
 };
@@ -16,23 +19,26 @@ use crate::{
 // directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ENUM | ENUM_VALUE | SCALAR | INPUT_OBJECT | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
 pub(crate) struct StripSchemaInternals;
 
-static DIRECTIVES_TO_STRIP: [&str; 9] = [
+static DIRECTIVES_TO_STRIP: [&str; 11] = [
     JoinTypeDirective::NAME,
     JoinEnumValueDirective::NAME,
     JoinFieldDirective::NAME,
     JoinImplementsDirective::NAME,
     JoinUnionMemberDirective::NAME,
     JoinGraphDirective::NAME,
+    JoinOwnerDirective::NAME,
     LinkDirective::NAME,
     TagDirective::NAME,
     InaccessibleDirective::NAME,
+    CoreDirective::NAME,
 ];
 
-static DEFINITIONS_TO_STRIP: [&str; 4] = [
+static DEFINITIONS_TO_STRIP: [&str; 5] = [
     LinkPurposeEnum::NAME,
     LinkImportScalar::NAME,
     JoinGraphEnum::NAME,
     JoinFieldSetScalar::NAME,
+    CorePurposesEnum::NAME,
 ];
 
 impl StripSchemaInternals {

--- a/lib/query-planner/src/federation_spec/definitions.rs
+++ b/lib/query-planner/src/federation_spec/definitions.rs
@@ -21,3 +21,9 @@ pub struct JoinGraphEnum {}
 impl JoinGraphEnum {
     pub const NAME: &str = "join__Graph";
 }
+
+pub struct CorePurposesEnum {}
+
+impl CorePurposesEnum {
+    pub const NAME: &str = "core__Purpose";
+}

--- a/lib/query-planner/src/federation_spec/directives.rs
+++ b/lib/query-planner/src/federation_spec/directives.rs
@@ -18,3 +18,9 @@ pub struct LinkDirective {}
 impl LinkDirective {
     pub const NAME: &str = "link";
 }
+
+pub struct CoreDirective {}
+
+impl CoreDirective {
+    pub const NAME: &str = "core";
+}

--- a/lib/query-planner/src/federation_spec/join_owner.rs
+++ b/lib/query-planner/src/federation_spec/join_owner.rs
@@ -1,0 +1,49 @@
+use graphql_parser::schema::{Directive, Value};
+
+use super::directives::FederationDirective;
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct JoinOwnerDirective {
+    pub graph_id: String,
+}
+
+impl JoinOwnerDirective {
+    pub const NAME: &str = "join__owner";
+}
+
+impl FederationDirective for JoinOwnerDirective {
+    fn directive_name() -> &'static str {
+        Self::NAME
+    }
+
+    fn parse(directive: &Directive<'_, String>) -> Self
+    where
+        Self: Sized,
+    {
+        let mut result = Self::default();
+
+        for (arg_name, arg_value) in &directive.arguments {
+            if arg_name.eq("graph") {
+                match arg_value {
+                    Value::String(value) => result.graph_id = value.clone(),
+                    Value::Enum(value) => result.graph_id = value.clone(),
+                    _ => {}
+                }
+            }
+        }
+
+        result
+    }
+}
+
+impl Ord for JoinOwnerDirective {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.graph_id.cmp(&other.graph_id)
+    }
+}
+
+impl PartialOrd for JoinOwnerDirective {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/lib/query-planner/src/federation_spec/mod.rs
+++ b/lib/query-planner/src/federation_spec/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod join_enum_value;
 pub(crate) mod join_field;
 pub(crate) mod join_graph;
 pub(crate) mod join_implements;
+pub(crate) mod join_owner;
 pub(crate) mod join_type;
 pub(crate) mod join_union;
 


### PR DESCRIPTION
The consumer-facing schema was missing filtering for `enum core__Purpose`, `directive @core`, and `directive @join_owner`. This caused introspection errors due to failure to find other associated types. 