### PR TITLE
refactor(executor, router): define `ClientRequestDetails` only once and avoid all clones, improve how coerce_variables is done 

### DIFF
--- a/bin/router/src/pipeline/coerce_variables.rs
+++ b/bin/router/src/pipeline/coerce_variables.rs
@@ -22,7 +22,7 @@ pub struct CoerceVariablesPayload {
 pub fn coerce_request_variables(
     req: &HttpRequest,
     supergraph: &SupergraphData,
-    execution_params: ExecutionRequest,
+    execution_params: &mut ExecutionRequest,
     normalized_operation: &Arc<GraphQLNormalizationPayload>,
 ) -> Result<CoerceVariablesPayload, PipelineError> {
     if req.method() == Method::GET {
@@ -37,7 +37,7 @@ pub fn coerce_request_variables(
 
     match collect_variables(
         &normalized_operation.operation_for_plan,
-        execution_params.variables,
+        &mut execution_params.variables,
         &supergraph.metadata,
     ) {
         Ok(values) => {

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use hive_router_plan_executor::execution::plan::{
     ClientRequestDetails, OperationDetails, PlanExecutionOutput,
@@ -110,7 +110,7 @@ pub async fn execute_pipeline(
 ) -> Result<PlanExecutionOutput, PipelineError> {
     perform_csrf_prevention(req, &shared_state.router_config.csrf)?;
 
-    let execution_request = get_execution_request(req, body_bytes).await?;
+    let mut execution_request = get_execution_request(req, body_bytes).await?;
     let parser_payload = parse_operation_with_cache(req, shared_state, &execution_request).await?;
     validate_operation_with_cache(req, supergraph, schema_state, shared_state, &parser_payload)
         .await?;
@@ -123,34 +123,33 @@ pub async fn execute_pipeline(
         &parser_payload,
     )
     .await?;
-    let query: Cow<'_, str> = Cow::Owned(execution_request.query.clone());
     let variable_payload =
-        coerce_request_variables(req, supergraph, execution_request, &normalize_payload)?;
+        coerce_request_variables(req, supergraph, &mut execution_request, &normalize_payload)?;
 
     let query_plan_cancellation_token =
         CancellationToken::with_timeout(shared_state.router_config.query_planner.timeout);
 
-    let progressive_override_ctx =
-        request_override_context(&shared_state.override_labels_evaluator, || {
-            ClientRequestDetails {
-                method: req.method().clone(),
-                url: req.uri().clone(),
-                headers: req.headers(),
-                operation: OperationDetails {
-                    name: normalize_payload.operation_for_plan.name.clone(),
-                    kind: match normalize_payload.operation_for_plan.operation_kind {
-                        Some(OperationKind::Query) => "query",
-                        Some(OperationKind::Mutation) => "mutation",
-                        Some(OperationKind::Subscription) => "subscription",
-                        None => "query",
-                    },
-                    query: query.clone(),
-                },
-            }
-        })
-        .map_err(|error| {
-            req.new_pipeline_error(PipelineErrorVariant::LabelEvaluationError(error))
-        })?;
+    let client_request_details = ClientRequestDetails {
+        method: req.method(),
+        url: req.uri(),
+        headers: req.headers(),
+        operation: OperationDetails {
+            name: normalize_payload.operation_for_plan.name.as_deref(),
+            kind: match normalize_payload.operation_for_plan.operation_kind {
+                Some(OperationKind::Query) => "query",
+                Some(OperationKind::Mutation) => "mutation",
+                Some(OperationKind::Subscription) => "subscription",
+                None => "query",
+            },
+            query: &execution_request.query,
+        },
+    };
+
+    let progressive_override_ctx = request_override_context(
+        &shared_state.override_labels_evaluator,
+        &client_request_details,
+    )
+    .map_err(|error| req.new_pipeline_error(PipelineErrorVariant::LabelEvaluationError(error)))?;
 
     let query_plan_payload = plan_operation_with_cache(
         req,
@@ -164,12 +163,12 @@ pub async fn execute_pipeline(
 
     let execution_result = execute_plan(
         req,
-        query,
         supergraph,
         shared_state,
         &normalize_payload,
         &query_plan_payload,
         &variable_payload,
+        &client_request_details,
     )
     .await?;
 

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -115,11 +115,11 @@ impl SubgraphExecutorMap {
         Ok(subgraph_executor_map)
     }
 
-    pub async fn execute<'a>(
+    pub async fn execute<'a, 'req>(
         &self,
         subgraph_name: &str,
         execution_request: HttpExecutionRequest<'a>,
-        client_request: &ClientRequestDetails<'a>,
+        client_request: &ClientRequestDetails<'a, 'req>,
     ) -> HttpExecutionResponse {
         match self.get_or_create_executor(subgraph_name, client_request) {
             Ok(Some(executor)) => executor.execute(execution_request).await,
@@ -164,7 +164,7 @@ impl SubgraphExecutorMap {
     fn get_or_create_executor(
         &self,
         subgraph_name: &str,
-        client_request: &ClientRequestDetails<'_>,
+        client_request: &ClientRequestDetails<'_, '_>,
     ) -> Result<Option<SubgraphExecutorBoxedArc>, SubgraphExecutorError> {
         let from_expression =
             self.get_or_create_executor_from_expression(subgraph_name, client_request)?;
@@ -183,7 +183,7 @@ impl SubgraphExecutorMap {
     fn get_or_create_executor_from_expression(
         &self,
         subgraph_name: &str,
-        client_request: &ClientRequestDetails<'_>,
+        client_request: &ClientRequestDetails<'_, '_>,
     ) -> Result<Option<SubgraphExecutorBoxedArc>, SubgraphExecutorError> {
         if let Some(expression) = self.expressions_by_subgraph.get(subgraph_name) {
             let original_url_value = VrlValue::Bytes(Bytes::from(

--- a/lib/executor/src/headers/expression.rs
+++ b/lib/executor/src/headers/expression.rs
@@ -62,7 +62,7 @@ fn client_header_map_to_vrl_value(headers: &ntex_http::HeaderMap) -> Value {
     Value::Object(obj)
 }
 
-impl From<&RequestExpressionContext<'_>> for Value {
+impl From<&RequestExpressionContext<'_, '_>> for Value {
     /// NOTE: If performance becomes an issue, consider pre-computing parts of this context that do not change
     fn from(ctx: &RequestExpressionContext) -> Self {
         // .subgraph
@@ -81,7 +81,7 @@ impl From<&RequestExpressionContext<'_>> for Value {
     }
 }
 
-impl From<&ResponseExpressionContext<'_>> for Value {
+impl From<&ResponseExpressionContext<'_, '_>> for Value {
     /// NOTE: If performance becomes an issue, consider pre-computing parts of this context that do not change
     fn from(ctx: &ResponseExpressionContext) -> Self {
         // .subgraph
@@ -102,7 +102,7 @@ impl From<&ResponseExpressionContext<'_>> for Value {
     }
 }
 
-impl From<&ClientRequestDetails<'_>> for Value {
+impl From<&ClientRequestDetails<'_, '_>> for Value {
     fn from(details: &ClientRequestDetails) -> Self {
         // .request.headers
         let headers_value = client_header_map_to_vrl_value(details.headers);
@@ -132,9 +132,9 @@ impl From<&ClientRequestDetails<'_>> for Value {
 
         // .request.operation
         let operation_value = Self::Object(BTreeMap::from([
-            ("name".into(), details.operation.name.clone().into()),
+            ("name".into(), details.operation.name.into()),
             ("type".into(), details.operation.kind.into()),
-            ("query".into(), details.operation.query.clone().into()),
+            ("query".into(), details.operation.query.into()),
         ]));
 
         Self::Object(BTreeMap::from([

--- a/lib/executor/src/headers/mod.rs
+++ b/lib/executor/src/headers/mod.rs
@@ -72,12 +72,12 @@ mod tests {
         );
 
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -105,12 +105,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -151,12 +151,12 @@ mod tests {
         );
 
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -188,12 +188,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
-                name: Some("MyQuery".to_string()),
-                query: "{ __typename }".to_string().into(),
+                name: Some("MyQuery"),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -221,12 +221,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -260,12 +260,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -303,12 +303,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -367,12 +367,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -430,12 +430,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -486,12 +486,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -543,12 +543,12 @@ mod tests {
         let plan = compile_headers_plan(&config.headers).unwrap();
         let client_headers = NtexHeaderMap::new();
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };
@@ -601,12 +601,12 @@ mod tests {
         client_headers.insert(header_name_owned("x-keep"), header_value_owned("hi").into());
 
         let client_details = ClientRequestDetails {
-            method: http::Method::POST,
-            url: "http://example.com".parse().unwrap(),
+            method: &http::Method::POST,
+            url: &"http://example.com".parse().unwrap(),
             headers: &client_headers,
             operation: OperationDetails {
                 name: None,
-                query: "{ __typename }".to_string().into(),
+                query: "{ __typename }",
                 kind: "query",
             },
         };

--- a/lib/executor/src/headers/request.rs
+++ b/lib/executor/src/headers/request.rs
@@ -45,9 +45,9 @@ pub fn modify_subgraph_request_headers(
     Ok(())
 }
 
-pub struct RequestExpressionContext<'a> {
+pub struct RequestExpressionContext<'a, 'req> {
     pub subgraph_name: &'a str,
-    pub client_request: &'a ClientRequestDetails<'a>,
+    pub client_request: &'a ClientRequestDetails<'a, 'req>,
 }
 
 trait ApplyRequestHeader {

--- a/lib/executor/src/headers/response.rs
+++ b/lib/executor/src/headers/response.rs
@@ -50,9 +50,9 @@ pub fn apply_subgraph_response_headers(
     Ok(())
 }
 
-pub struct ResponseExpressionContext<'a> {
+pub struct ResponseExpressionContext<'a, 'req> {
     pub subgraph_name: &'a str,
-    pub client_request: &'a ClientRequestDetails<'a>,
+    pub client_request: &'a ClientRequestDetails<'a, 'req>,
     pub subgraph_headers: &'a HeaderMap,
 }
 

--- a/lib/executor/src/variables/mod.rs
+++ b/lib/executor/src/variables/mod.rs
@@ -8,20 +8,19 @@ use crate::introspection::schema::SchemaMetadata;
 #[inline]
 pub fn collect_variables(
     operation: &hive_router_query_planner::ast::operation::OperationDefinition,
-    mut variables: Option<HashMap<String, Value>>,
+    variables_map: &mut HashMap<String, Value>,
     schema_metadata: &SchemaMetadata,
 ) -> Result<Option<HashMap<String, Value>>, String> {
     if operation.variable_definitions.is_none() {
         return Ok(None);
     }
     let variable_definitions = operation.variable_definitions.as_ref().unwrap();
-    let mut incoming_variables_map = variables.take().unwrap_or_default();
 
     let collected_variables: Result<Vec<Option<(String, Value)>>, String> = variable_definitions
         .iter()
         .map(|variable_definition| {
             let variable_name = variable_definition.name.as_str();
-            if let Some(variable_value) = incoming_variables_map.remove(variable_name) {
+            if let Some(variable_value) = variables_map.remove(variable_name) {
                 validate_runtime_value(
                     variable_value.as_ref(),
                     &variable_definition.variable_type,


### PR DESCRIPTION
We've seen that `ClientRequestDetails` is already used in multiple places, and the current implementation tries to avoid re-creating it by doing lazy init only when it's really used - which might still lead to multiple creation. 
The original reason behind it was an issue with the lifetime definition of `ClientRequestDetails`. 

Since `ClientRequestDetails` is constructed with data from multiple places, it needs to declare multiple lifetimes, based on where the data actually came from. This is the new definition: 

```rust
/// The `ClientRequestDetails` itself + `OperationDetails` that's inside are both defined inside `execute_pipeline`. So both has `'exec` lifetime. 
/// The rest of the parameters are based on the `'req` lifetimes because the originated in the `ntex::Request`. 
pub struct ClientRequestDetails<'exec, 'req> {
    pub method: &'req Method,
    pub url: &'req http::Uri,
    pub headers: &'req NtexHeaderMap,
    pub operation: OperationDetails<'exec>,
}
```

In addition, this PR removed the need to clone the `query` and put it into a `Cow` in order to pass it around during execution. To do that, I changed the way `ExecutionRequest` is passed around - `coerce_variables` no longer takes ownership, and the way we have variables (and no variables) is also improved now. 