### PR TITLE
Improve version fetching from crates.io

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,3 @@
-curl -o- https://raw.githubusercontent.com/graphql-hive/router/main/install.sh | sh -s v0.0.8
 #!/bin/sh
 set -e
 


### PR DESCRIPTION
Updated version fetching method to use crates.io index for reliability.

crates.io is rate limited to 1 rps

Tested:
- [x] `curl -o- https://raw.githubusercontent.com/graphql-hive/router/kamilkisiela-patch-1/install.sh | sh -s v0.0.17`
- [x] `curl -o- https://raw.githubusercontent.com/graphql-hive/router/kamilkisiela-patch-1/install.sh | sh -s v0.0.16`
- [x] `curl -o- https://raw.githubusercontent.com/graphql-hive/router/kamilkisiela-patch-1/install.sh | sh`