### PR TITLE
fix(query-planner): prevent planner failure when combining conditional directives and interfaces

### DIFF
--- a/.changeset/fix_include.md
+++ b/.changeset/fix_include.md
@@ -1,0 +1,9 @@
+---
+query-planner: patch
+node-addon: patch
+router: patch
+---
+
+# Prevent planner failure when combining conditional directives and interfaces
+
+Fixed a bug where the query planner failed to handle the combination of conditional directives (`@include`/`@skip`) and the automatic `__typename` injection required for abstract types.

--- a/lib/query-planner/fixture/issues/190.supergraph.graphql
+++ b/lib/query-planner/fixture/issues/190.supergraph.graphql
@@ -48,36 +48,30 @@ directive @link(
 scalar link__Import
 
 enum link__Purpose {
-  """
-  `SECURITY` features provide metadata necessary to securely resolve fields.
-  """
   SECURITY
-
-  """
-  `EXECUTION` features provide metadata necessary for operation execution.
-  """
   EXECUTION
 }
 
 enum join__Graph {
-  PRODUCTS_SERVICE @join__graph(name: "products_service", url: "http://localhost:4001/graphql")
+  RECOMMENDER
+    @join__graph(name: "recommender", url: "http://localhost:4001/graphql")
 }
 
-type Query @join__type(graph: PRODUCTS_SERVICE) {
-  productRecommender: ProductRecommender
+type Query @join__type(graph: RECOMMENDER) {
+  recommender: Recommender
 }
 
-type ProductRecommender @join__type(graph: PRODUCTS_SERVICE) {
+type Recommender @join__type(graph: RECOMMENDER) {
   id: ID!
-  recommendations: [Recommendation!]!
+  results: [Recommendable!]!
 }
 
-type Product implements Recommendation
-  @join__type(graph: PRODUCTS_SERVICE)
-  @join__implements(graph: PRODUCTS_SERVICE, interface: "Recommendation") {
+type Product implements Recommendable
+  @join__type(graph: RECOMMENDER)
+  @join__implements(graph: RECOMMENDER, interface: "Recommendable") {
   id: ID!
 }
 
-interface Recommendation @join__type(graph: PRODUCTS_SERVICE) {
+interface Recommendable @join__type(graph: RECOMMENDER) {
   id: ID!
 }

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1274,7 +1274,7 @@ fn process_plain_field_edge(
     )?;
 
     let child_segment = query_node.selection_alias().unwrap_or(&field_move.name);
-    let segment_condition = if ancestor_of_condition {
+    let segment_condition = if should_strip_condition {
         None
     } else {
         condition.cloned()


### PR DESCRIPTION
Fixed a bug where the query planner failed to handle the combination of conditional directives (`@include`/`@skip`) and the automatic `__typename` injection required for abstract types.

The condition was passed to the fetch path and response path, but it shouldn't.