### PR TITLE
Avoid clones in impl From<PlanExecutionError> for GraphQLError

### DIFF
--- a/lib/executor/src/execution/error.rs
+++ b/lib/executor/src/execution/error.rs
@@ -31,8 +31,8 @@ pub struct PlanExecutionError {
 
 #[derive(Debug, Clone)]
 pub struct PlanExecutionErrorContext {
-    pub subgraph_name: Option<String>,
-    pub affected_path: Option<String>,
+    subgraph_name: Option<String>,
+    affected_path: Option<String>,
 }
 
 pub struct LazyPlanContext<SN, AP> {


### PR DESCRIPTION
**Before**

```rust
impl From<PlanExecutionError> for GraphQLError {
    fn from(val: PlanExecutionError) -> Self {
        let mut error = GraphQLError::from_message_and_code(val.to_string(), val.error_code());
        
        if let Some(subgraph_name) = val.subgraph_name() {   // Returns &Option<String>
            error = error.add_subgraph_name(subgraph_name);  // Clones via Into<String>
        }
        
        if let Some(affected_path) = val.affected_path() {   // Returns &Option<String>
            error = error.add_affected_path(affected_path);  // Clones via Into<String>
        }
        error
    }
}
```

What happens:
1. `val.subgraph_name()` returns `&Option<String>`
2. `add_subgraph_name<TStr: Into<String>>()` expects an `Into<String>`
3. When Rust sees `&String` -> `Into<String>`, it uses the impl that clones the String
4. Same issue for `affected_path`

We end up with 2 unnecessary heap allocations per error conversion.

**After**

I moved owned values out of the structure, to the `add_subgraph_name` and `add_affected_path` methods.
When Rust sees `Stirng` -> `Into<String>`, it will just use the owned String, so no clones.