### PR TITLE
Refactor timeout resolution to use a context factory

### DIFF
--- a/.changeset/lazy_context_for_program.md
+++ b/.changeset/lazy_context_for_program.md
@@ -1,0 +1,13 @@
+---
+router: patch
+internal: patch
+executor: patch
+---
+
+# Improved Performance for Expressions
+
+This change introduces "lazy evaluation" for contextual information used in expressions (like dynamic timeouts).
+
+Previously, the Router would prepare and clone data (such as request details or subgraph names) every time it performed an operation, even if that data wasn't actually needed.
+Now, this work is only performed "on-demand" - for example, only if an expression is actually being executed.
+This reduces unnecessary CPU usage and memory allocations during the hot path of request execution.

--- a/lib/internal/src/expressions/lib.rs
+++ b/lib/internal/src/expressions/lib.rs
@@ -123,12 +123,16 @@ where
     /// If this is a static value, returns it immediately.
     /// If this is a program, executes it against the provided context and converts the result.
     ///
-    /// - `vrl_context` - The VRL value context for expression execution
+    /// - `vrl_context_fn` - A function that returns the VRL value context for expression execution
     #[inline]
-    pub fn resolve(&self, vrl_context: VrlValue) -> Result<T, ProgramResolutionError<T::Error>> {
+    pub fn resolve<F>(&self, vrl_context_fn: F) -> Result<T, ProgramResolutionError<T::Error>>
+    where
+        F: FnOnce() -> VrlValue,
+    {
         match self {
             ValueOrProgram::Value(v) => Ok(v.clone()),
             ValueOrProgram::Program(vrl_program) => {
+                let vrl_context = vrl_context_fn();
                 let result_value = vrl_program
                     .execute(vrl_context)
                     .map_err(ProgramResolutionError::ExecutionFailed)?;


### PR DESCRIPTION
When `ValueOrProgram<T>` is `Value<T>`, we don't need to build the context. That's why I made it lazy.