### PR TITLE
Move usage_reporting under telemetry.hive and reuse options

### DIFF
--- a/.changeset/unify-hive-telemetry-config.md
+++ b/.changeset/unify-hive-telemetry-config.md
@@ -1,0 +1,40 @@
+---
+config: minor
+router: minor
+internal: minor
+---
+
+# Unified Hive Telemetry Configuration
+
+Refactored the configuration structure to unify Hive-specific telemetry (tracing and usage reporting) and centralize client identification.
+
+- **Unified Hive Config**: Moved `usage_reporting` under `telemetry.hive.usage`. Usage reporting now shares the `token` and `target` configuration with Hive tracing, eliminating redundant settings.
+- **Centralized Client Identification**: Introduced `telemetry.client_identification` to define client name and version headers once. These are now propagated to both OpenTelemetry spans and Hive usage reports.
+- **Enhanced Expression Support**: Both Hive token and target ID now support VRL expressions for usage reporting, matching the existing behavior of tracing.
+
+### Breaking Changes:
+
+The top-level `usage_reporting` block has been moved. 
+
+**Before:**
+```yaml
+usage_reporting:
+  enabled: true
+  access_token: "..."
+  target_id: "..."
+  client_name_header: "..."
+  client_version_header: "..."
+```
+
+**After:**
+```yaml
+telemetry:
+  client_identification:
+    name_header: "..."
+    version_header: "..."
+  hive:
+    token: "..."
+    target: "..."
+    usage:
+      enabled: true
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,6 +2117,8 @@ dependencies = [
  "http",
  "humantime-serde",
  "jsonwebtoken",
+ "once_cell",
+ "regex-automata",
  "retry-policies 0.5.1",
  "schemars 1.0.5",
  "serde",

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -19,7 +19,7 @@ use crate::{
         probes::{health_check_handler, readiness_check_handler},
     },
     jwt::JwtAuthRuntime,
-    pipeline::{graphql_request_handler, usage_reporting::init_hive_user_agent},
+    pipeline::{graphql_request_handler, usage_reporting::init_hive_usage_agent},
     telemetry::HeaderExtractor,
 };
 
@@ -129,12 +129,11 @@ pub async fn configure_app_from_config(
         false => None,
     };
 
-    let hive_usage_agent = match router_config.usage_reporting.enabled {
-        true => Some(init_hive_user_agent(
-            bg_tasks_manager,
-            &router_config.usage_reporting,
-        )?),
-        false => None,
+    let hive_usage_agent = match router_config.telemetry.hive.as_ref() {
+        Some(hive_config) if hive_config.usage_reporting.enabled => {
+            Some(init_hive_usage_agent(bg_tasks_manager, hive_config)?)
+        }
+        _ => None,
     };
 
     let router_config_arc = Arc::new(router_config);

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -7,11 +7,15 @@ use async_trait::async_trait;
 use graphql_tools::parser::schema::Document;
 use hive_console_sdk::agent::usage_agent::{AgentError, UsageAgentExt};
 use hive_console_sdk::agent::usage_agent::{ExecutionReport, UsageAgent};
+use hive_router_config::telemetry::hive::{
+    is_slug_target_ref, is_uuid_target_ref, HiveTelemetryConfig,
+};
 use hive_router_config::usage_reporting::UsageReportingConfig;
+use hive_router_internal::telemetry::resolve_value_or_expression;
 use hive_router_plan_executor::execution::{
     client_request_details::ClientRequestDetails, plan::PlanExecutionOutput,
 };
-use ntex::web::HttpRequest;
+
 use rand::Rng;
 use tokio_util::sync::CancellationToken;
 
@@ -22,47 +26,71 @@ use crate::{
 
 #[derive(Debug, thiserror::Error)]
 pub enum UsageReportingError {
-    #[error("Usage Reporting - Access token is missing. Please provide it via 'HIVE_ACCESS_TOKEN' environment variable or under 'usage_reporting.access_token' in the configuration.")]
+    #[error("Usage Reporting - Access token is missing. Please provide it via 'HIVE_ACCESS_TOKEN' environment variable or under 'telemetry.hive.token' in the configuration.")]
     MissingAccessToken,
     #[error("Usage Reporting - Failed to initialize usage agent: {0}")]
     AgentCreationError(#[from] AgentError),
+    #[error("Usage Reporting - Configuration error: {0}")]
+    ConfigurationError(String),
 }
 
-pub fn init_hive_user_agent(
+pub fn init_hive_usage_agent(
     bg_tasks_manager: &mut BackgroundTasksManager,
-    usage_config: &UsageReportingConfig,
+    hive_config: &HiveTelemetryConfig,
 ) -> Result<UsageAgent, UsageReportingError> {
+    let usage_config = &hive_config.usage_reporting;
     let user_agent = format!("hive-router/{}", ROUTER_VERSION);
-    let access_token = usage_config
-        .access_token
-        .as_deref()
-        .ok_or(UsageReportingError::MissingAccessToken)?;
+    let access_token = match &hive_config.token {
+        Some(t) => resolve_value_or_expression(t, "Hive Telemetry token")
+            .map_err(|e| UsageReportingError::ConfigurationError(e.to_string()))?,
+        None => return Err(UsageReportingError::MissingAccessToken),
+    };
 
-    let mut agent = UsageAgent::builder()
+    let target = match &hive_config.target {
+        Some(t) => Some(
+            resolve_value_or_expression(t, "Hive Telemetry target")
+                .map_err(|e| UsageReportingError::ConfigurationError(e.to_string()))?,
+        ),
+        None => None,
+    };
+
+    if let Some(target) = &target {
+        if !is_uuid_target_ref(target) && !is_slug_target_ref(target) {
+            return Err(UsageReportingError::ConfigurationError(format!(
+                "Invalid Hive Telemetry target format: '{}'. It must be either in slug format '$organizationSlug/$projectSlug/$targetSlug' or UUID format 'a0f4c605-6541-4350-8cfe-b31f21a4bf80'",
+                target
+            )));
+        }
+    }
+
+    let mut agent_builder = UsageAgent::builder()
         .user_agent(user_agent)
         .endpoint(usage_config.endpoint.clone())
-        .token(access_token.to_string())
+        .token(access_token)
         .buffer_size(usage_config.buffer_size)
         .connect_timeout(usage_config.connect_timeout)
         .request_timeout(usage_config.request_timeout)
         .accept_invalid_certs(usage_config.accept_invalid_certs)
         .flush_interval(usage_config.flush_interval);
 
-    if let Some(target_id) = usage_config.target_id.as_ref() {
-        agent = agent.target_id(target_id.clone());
+    if let Some(target_id) = target {
+        agent_builder = agent_builder.target_id(target_id);
     }
 
-    let agent = agent.build()?;
+    let agent = agent_builder.build()?;
 
     bg_tasks_manager.register_task(agent.clone());
     Ok(agent)
 }
 
+// TODO: simplfy args
+#[allow(clippy::too_many_arguments)]
 #[inline]
 pub async fn collect_usage_report<'a>(
     schema: Arc<Document<'static, String>>,
     duration: Duration,
-    req: &HttpRequest,
+    client_name: Option<&str>,
+    client_version: Option<&str>,
     client_request_details: &ClientRequestDetails<'a, 'a>,
     hive_usage_agent: &UsageAgent,
     usage_config: &UsageReportingConfig,
@@ -79,16 +107,14 @@ pub async fn collect_usage_report<'a>(
     {
         return;
     }
-    let client_name = get_header_value(req, &usage_config.client_name_header);
-    let client_version = get_header_value(req, &usage_config.client_version_header);
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64;
     let execution_report = ExecutionReport {
         schema,
-        client_name: client_name.map(|s| s.to_owned()),
-        client_version: client_version.map(|s| s.to_owned()),
+        client_name: client_name.map(|name| name.to_string()),
+        client_version: client_version.map(|version| version.to_string()),
         timestamp,
         duration,
         ok: execution_result.error_count == 0,
@@ -104,11 +130,6 @@ pub async fn collect_usage_report<'a>(
     if let Err(err) = hive_usage_agent.add_report(execution_report).await {
         tracing::error!("Failed to send usage report: {}", err);
     }
-}
-
-#[inline]
-fn get_header_value<'req>(req: &'req HttpRequest, header_name: &str) -> Option<&'req str> {
-    req.headers().get(header_name).and_then(|v| v.to_str().ok())
 }
 
 #[async_trait]

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,8 @@
 |[**override\_subgraph\_urls**](#override_subgraph_urls)|`object`|Configuration for overriding subgraph URLs.<br/>Default: `{}`<br/>||
 |[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout":"10s"}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>||
-|[**telemetry**](#telemetry)|`object`|Default: `{"hive":null,"resource":{"attributes":{}},"tracing":{"collect":{"max_attributes_per_event":16,"max_attributes_per_link":32,"max_attributes_per_span":128,"max_events_per_span":128,"parent_based_sampler":false,"sampling":1},"exporters":[],"instrumentation":{"spans":{"mode":"spec_compliant"}},"propagation":{"b3":false,"baggage":false,"jaeger":false,"trace_context":true}}}`<br/>||
+|[**telemetry**](#telemetry)|`object`|Default: `{"client_identification":{"name_header":"graphql-client-name","version_header":"graphql-client-version"},"hive":null,"resource":{"attributes":{}},"tracing":{"collect":{"max_attributes_per_event":16,"max_attributes_per_link":32,"max_attributes_per_span":128,"max_events_per_span":128,"parent_based_sampler":false,"sampling":1},"exporters":[],"instrumentation":{"spans":{"mode":"spec_compliant"}},"propagation":{"b3":false,"baggage":false,"jaeger":false,"trace_context":true}}}`<br/>||
 |[**traffic\_shaping**](#traffic_shaping)|`object`|Configuration for the traffic-shaping of the executor. Use these configurations to control how requests are being executed to subgraphs.<br/>Default: `{"all":{"dedupe_enabled":true,"pool_idle_timeout":"50s","request_timeout":"30s"},"max_connections_per_host":100}`<br/>||
-|[**usage\_reporting**](#usage_reporting)|`object`|Configuration for usage reporting to GraphQL Hive.<br/>Default: `{"accept_invalid_certs":false,"access_token":null,"buffer_size":1000,"client_name_header":"graphql-client-name","client_version_header":"graphql-client-version","connect_timeout":"5s","enabled":false,"endpoint":"https://app.graphql-hive.com/usage","exclude":[],"flush_interval":"5s","request_timeout":"15s","sample_rate":"100%","target_id":null}`<br/>||
 
 **Additional Properties:** not allowed  
 **Example**
@@ -116,6 +115,9 @@ query_planner:
   timeout: 10s
 supergraph: {}
 telemetry:
+  client_identification:
+    name_header: graphql-client-name
+    version_header: graphql-client-version
   hive: null
   resource:
     attributes: {}
@@ -142,20 +144,6 @@ traffic_shaping:
     pool_idle_timeout: 50s
     request_timeout: 30s
   max_connections_per_host: 100
-usage_reporting:
-  accept_invalid_certs: false
-  access_token: null
-  buffer_size: 1000
-  client_name_header: graphql-client-name
-  client_version_header: graphql-client-version
-  connect_timeout: 5s
-  enabled: false
-  endpoint: https://app.graphql-hive.com/usage
-  exclude: []
-  flush_interval: 5s
-  request_timeout: 15s
-  sample_rate: 100%
-  target_id: null
 
 ```
 
@@ -1858,6 +1846,7 @@ max_retries: 10
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
+|[**client\_identification**](#telemetryclient_identification)|`object`|Default: `{"name_header":"graphql-client-name","version_header":"graphql-client-version"}`<br/>||
 |[**hive**](#telemetryhive)|`object`, `null`|||
 |[**resource**](#telemetryresource)|`object`|Default: `{"attributes":{}}`<br/>||
 |[**tracing**](#telemetrytracing)|`object`|Default: `{"collect":{"max_attributes_per_event":16,"max_attributes_per_link":32,"max_attributes_per_span":128,"max_events_per_span":128,"parent_based_sampler":false,"sampling":1},"exporters":[],"instrumentation":{"spans":{"mode":"spec_compliant"}},"propagation":{"b3":false,"baggage":false,"jaeger":false,"trace_context":true}}`<br/>||
@@ -1866,6 +1855,9 @@ max_retries: 10
 **Example**
 
 ```yaml
+client_identification:
+  name_header: graphql-client-name
+  version_header: graphql-client-version
 hive: null
 resource:
   attributes: {}
@@ -1889,6 +1881,25 @@ tracing:
 
 ```
 
+<a name="telemetryclient_identification"></a>
+### telemetry\.client\_identification: object
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**name\_header**|`string`|Default: `"graphql-client-name"`<br/>||
+|**version\_header**|`string`|Default: `"graphql-client-version"`<br/>||
+
+**Additional Properties:** not allowed  
+**Example**
+
+```yaml
+name_header: graphql-client-name
+version_header: graphql-client-version
+
+```
+
 <a name="telemetryhive"></a>
 ### telemetry\.hive: object,null
 
@@ -1897,9 +1908,10 @@ tracing:
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**endpoint**||Default: `"https://api.graphql-hive.com/otel/v1/traces"`<br/>||
-|**target**||||
-|**token**||||
+|**target**||A target ID, this can either be a slug following the format “$organizationSlug/$projectSlug/$targetSlug” (e.g “the-guild/graphql-hive/staging”) or an UUID (e.g. “a0f4c605-6541-4350-8cfe-b31f21a4bf80”). To be used when the token is configured with an organization access token.<br/>||
+|**token**||Your [Registry Access Token](https://the-guild.dev/graphql/hive/docs/management/targets#registry-access-tokens) with write permission.<br/>||
 |[**tracing**](#telemetryhivetracing)|`object`|Default: `{"batch_processor":{"max_concurrent_exports":1,"max_export_batch_size":512,"max_export_timeout":"5s","max_queue_size":2048,"scheduled_delay":"5s"},"enabled":true,"grpc":null,"http":null,"protocol":"http"}`<br/>|yes|
+|[**usage\_reporting**](#telemetryhiveusage_reporting)|`object`|Default: `{"accept_invalid_certs":false,"buffer_size":1000,"connect_timeout":"5s","enabled":false,"endpoint":"https://app.graphql-hive.com/usage","exclude":[],"flush_interval":"5s","request_timeout":"15s","sample_rate":"100%"}`<br/>||
 
 **Additional Properties:** not allowed  
 **Example**
@@ -2040,6 +2052,49 @@ key: null
 |----|----|-----------|--------|
 |**Additional Properties**||||
 
+<a name="telemetryhiveusage_reporting"></a>
+#### telemetry\.hive\.usage\_reporting: object
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**accept\_invalid\_certs**|`boolean`|Accepts invalid SSL certificates<br/>Default: false<br/>Default: `false`<br/>||
+|**buffer\_size**|`integer`|A maximum number of operations to hold in a buffer before sending to Hive Console<br/>Default: 1000<br/>Default: `1000`<br/>Format: `"uint"`<br/>Minimum: `0`<br/>||
+|**connect\_timeout**|`string`|A timeout for only the connect phase of a request to Hive Console<br/>Default: 5 seconds<br/>Default: `"5s"`<br/>||
+|**enabled**|`boolean`|Default: `false`<br/>||
+|**endpoint**|`string`|For self-hosting, you can override `/usage` endpoint (defaults to `https://app.graphql-hive.com/usage`).<br/>Default: `"https://app.graphql-hive.com/usage"`<br/>||
+|[**exclude**](#telemetryhiveusage_reportingexclude)|`string[]`|A list of operations (by name) to be ignored by Hive.<br/>Default: <br/>||
+|**flush\_interval**|`string`|Frequency of flushing the buffer to the server<br/>Default: 5 seconds<br/>Default: `"5s"`<br/>||
+|**request\_timeout**|`string`|A timeout for the entire request to Hive Console<br/>Default: 15 seconds<br/>Default: `"15s"`<br/>||
+|**sample\_rate**|`string`|Sample rate to determine sampling.<br/>0% = never being sent<br/>50% = half of the requests being sent<br/>100% = always being sent<br/>Default: 100%<br/>Default: `"100%"`<br/>||
+
+**Additional Properties:** not allowed  
+**Example**
+
+```yaml
+accept_invalid_certs: false
+buffer_size: 1000
+connect_timeout: 5s
+enabled: false
+endpoint: https://app.graphql-hive.com/usage
+exclude: []
+flush_interval: 5s
+request_timeout: 15s
+sample_rate: 100%
+
+```
+
+<a name="telemetryhiveusage_reportingexclude"></a>
+##### telemetry\.hive\.usage\_reporting\.exclude\[\]: array
+
+A list of operations (by name) to be ignored by Hive.
+Example: ["IntrospectionQuery", "MeQuery"]
+
+
+**Items**
+
+**Item Type:** `string`  
 <a name="telemetryresource"></a>
 ### telemetry\.resource: object
 
@@ -2398,58 +2453,4 @@ Optional per-subgraph configurations that will override the default configuratio
 |**request\_timeout**||Optional timeout configuration for requests to subgraphs.<br/><br/>Example with a fixed duration:<br/>```yaml<br/>  timeout:<br/>    duration: 5s<br/>```<br/><br/>Or with a VRL expression that can return a duration based on the operation kind:<br/>```yaml<br/>  timeout:<br/>    expression: \|<br/>     if (.request.operation.type == "mutation") {<br/>       "10s"<br/>     } else {<br/>       "15s"<br/>     }<br/>```<br/>||
 
 **Additional Properties:** not allowed  
-<a name="usage_reporting"></a>
-## usage\_reporting: object
-
-Configuration for usage reporting to GraphQL Hive.
-
-
-**Properties**
-
-|Name|Type|Description|Required|
-|----|----|-----------|--------|
-|**accept\_invalid\_certs**|`boolean`|Accepts invalid SSL certificates<br/>Default: false<br/>Default: `false`<br/>||
-|**access\_token**|`string`, `null`|Your [Registry Access Token](https://the-guild.dev/graphql/hive/docs/management/targets#registry-access-tokens) with write permission.<br/>||
-|**buffer\_size**|`integer`|A maximum number of operations to hold in a buffer before sending to Hive Console<br/>Default: 1000<br/>Default: `1000`<br/>Format: `"uint"`<br/>Minimum: `0`<br/>||
-|**client\_name\_header**|`string`|Default: `"graphql-client-name"`<br/>||
-|**client\_version\_header**|`string`|Default: `"graphql-client-version"`<br/>||
-|**connect\_timeout**|`string`|A timeout for only the connect phase of a request to Hive Console<br/>Default: 5 seconds<br/>Default: `"5s"`<br/>||
-|**enabled**|`boolean`|Default: `false`<br/>||
-|**endpoint**|`string`|For self-hosting, you can override `/usage` endpoint (defaults to `https://app.graphql-hive.com/usage`).<br/>Default: `"https://app.graphql-hive.com/usage"`<br/>||
-|[**exclude**](#usage_reportingexclude)|`string[]`|A list of operations (by name) to be ignored by Hive.<br/>Default: <br/>||
-|**flush\_interval**|`string`|Frequency of flushing the buffer to the server<br/>Default: 5 seconds<br/>Default: `"5s"`<br/>||
-|**request\_timeout**|`string`|A timeout for the entire request to Hive Console<br/>Default: 15 seconds<br/>Default: `"15s"`<br/>||
-|**sample\_rate**|`string`|Sample rate to determine sampling.<br/>0% = never being sent<br/>50% = half of the requests being sent<br/>100% = always being sent<br/>Default: 100%<br/>Default: `"100%"`<br/>||
-|**target\_id**|`string`, `null`|A target ID, this can either be a slug following the format “$organizationSlug/$projectSlug/$targetSlug” (e.g “the-guild/graphql-hive/staging”) or an UUID (e.g. “a0f4c605-6541-4350-8cfe-b31f21a4bf80”). To be used when the token is configured with an organization access token.<br/>||
-
-**Additional Properties:** not allowed  
-**Example**
-
-```yaml
-accept_invalid_certs: false
-access_token: null
-buffer_size: 1000
-client_name_header: graphql-client-name
-client_version_header: graphql-client-version
-connect_timeout: 5s
-enabled: false
-endpoint: https://app.graphql-hive.com/usage
-exclude: []
-flush_interval: 5s
-request_timeout: 15s
-sample_rate: 100%
-target_id: null
-
-```
-
-<a name="usage_reportingexclude"></a>
-### usage\_reporting\.exclude\[\]: array
-
-A list of operations (by name) to be ignored by Hive.
-Example: ["IntrospectionQuery", "MeQuery"]
-
-
-**Items**
-
-**Item Type:** `string`  
 

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -768,7 +768,7 @@ impl<'exec, 'req> Executor<'exec, 'req> {
                     Some(OperationKind::Mutation) => "mutation",
                     Some(OperationKind::Subscription) => "subscription",
                 },
-                client_document_hash: &node.operation.hash.to_string(),
+                client_document_hash: node.operation.hash.to_string().as_str(),
             });
 
             if let Some(jwt_forwarding_plan) = &self.jwt_forwarding_plan {

--- a/lib/internal/src/telemetry/traces/spans/graphql.rs
+++ b/lib/internal/src/telemetry/traces/spans/graphql.rs
@@ -354,7 +354,6 @@ impl GraphQLOperationSpan {
             "hive.graphql.error.count" = Empty,
             "hive.graphql.error.codes" = Empty,
             "hive.graphql.operation.hash" = Empty,
-            // TODO: populate these fields when we have client info
             "hive.client.name" = Empty,
             "hive.client.version" = Empty,
         );
@@ -391,9 +390,19 @@ impl GraphQLOperationSpan {
             attributes::GRAPHQL_DOCUMENT_HASH,
             identity.client_document_hash,
         );
+
         // if let Some(id) = &identity.document_id {
         //     self.span().record(attributes::GRAPHQL_OPERATION_ID, id.as_str());
         // }
+    }
+
+    pub fn record_client_identity(&self, client_name: Option<&str>, client_version: Option<&str>) {
+        if let Some(name) = client_name {
+            self.span.record(attributes::HIVE_CLIENT_NAME, name);
+        }
+        if let Some(version) = client_version {
+            self.span.record(attributes::HIVE_CLIENT_VERSION, version);
+        }
     }
 }
 

--- a/lib/router-config/Cargo.toml
+++ b/lib/router-config/Cargo.toml
@@ -24,6 +24,8 @@ tonic = { workspace = true }
 jsonwebtoken = { workspace = true }
 retry-policies = { workspace = true}
 tracing = { workspace = true }
+regex-automata = { workspace = true }
+once_cell = "1.21.3"
 
 schemars = "1.0.4"
 humantime-serde = "1.1.1"

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -103,20 +103,17 @@ impl EnvVarOverrides {
             }
         }
 
+        if self.hive_access_token.is_some() && self.hive_target.is_some() {
+            config = config.set_override("telemetry.hive.usage.enabled", true)?;
+            config = config.set_override("telemetry.hive.tracing.enabled", true)?;
+        }
+
         if let Some(hive_access_token) = self.hive_access_token.take() {
-            config =
-                config.set_override("usage_reporting.access_token", hive_access_token.clone())?;
             config = config.set_override("telemetry.hive.token", hive_access_token)?;
         }
 
         if let Some(hive_target) = self.hive_target.take() {
-            config = config.set_override("usage_reporting.target_id", hive_target.clone())?;
             config = config.set_override("telemetry.hive.target", hive_target)?;
-        }
-
-        if self.hive_access_token.is_some() && self.hive_target.is_some() {
-            config = config.set_override("usage_reporting.enabled", true)?;
-            config = config.set_override("telemetry.hive.tracing.enabled", true)?;
         }
 
         // GraphiQL overrides

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -98,9 +98,6 @@ pub struct HiveRouterConfig {
 
     #[serde(default)]
     pub authorization: authorization::AuthorizationConfig,
-    /// Configuration for usage reporting to GraphQL Hive.
-    #[serde(default)]
-    pub usage_reporting: usage_reporting::UsageReportingConfig,
 
     #[serde(default)]
     pub telemetry: telemetry::TelemetryConfig,

--- a/lib/router-config/src/telemetry.rs
+++ b/lib/router-config/src/telemetry.rs
@@ -19,6 +19,8 @@ pub struct TelemetryConfig {
     pub tracing: TracingConfig,
     #[serde(default)]
     pub resource: ResourceConfig,
+    #[serde(default)]
+    pub client_identification: ClientIdentificationConfig,
 }
 
 impl TelemetryConfig {
@@ -32,4 +34,30 @@ impl TelemetryConfig {
 pub struct ResourceConfig {
     #[serde(default)]
     pub attributes: HashMap<String, ValueOrExpression<String>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ClientIdentificationConfig {
+    #[serde(default = "default_client_name_header")]
+    pub name_header: String,
+    #[serde(default = "default_client_version_header")]
+    pub version_header: String,
+}
+
+impl Default for ClientIdentificationConfig {
+    fn default() -> Self {
+        Self {
+            name_header: default_client_name_header(),
+            version_header: default_client_version_header(),
+        }
+    }
+}
+
+fn default_client_name_header() -> String {
+    "graphql-client-name".to_string()
+}
+
+fn default_client_version_header() -> String {
+    "graphql-client-version".to_string()
 }

--- a/lib/router-config/src/telemetry/hive.rs
+++ b/lib/router-config/src/telemetry/hive.rs
@@ -1,9 +1,11 @@
+use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     primitives::value_or_expression::ValueOrExpression,
     telemetry::tracing::{BatchProcessorConfig, OtlpGrpcConfig, OtlpHttpConfig, OtlpProtocol},
+    usage_reporting::UsageReportingConfig,
 };
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -12,12 +14,37 @@ use crate::{
 pub struct HiveTelemetryConfig {
     #[serde(default = "default_hive_tracing_endpoint")]
     pub endpoint: ValueOrExpression<String>,
+    /// Your [Registry Access Token](https://the-guild.dev/graphql/hive/docs/management/targets#registry-access-tokens) with write permission.
     #[serde(default)]
     pub token: Option<ValueOrExpression<String>>,
+    /// A target ID, this can either be a slug following the format “$organizationSlug/$projectSlug/$targetSlug” (e.g “the-guild/graphql-hive/staging”) or an UUID (e.g. “a0f4c605-6541-4350-8cfe-b31f21a4bf80”). To be used when the token is configured with an organization access token.
     #[serde(default)]
     pub target: Option<ValueOrExpression<String>>,
     #[serde(default)]
     pub tracing: TracingConfig,
+    #[serde(default)]
+    pub usage_reporting: UsageReportingConfig,
+}
+
+// Target ID regexp for validation: slug format
+static TARGET_ID_SLUG_REGEX: Lazy<regex_automata::meta::Regex> = Lazy::new(|| {
+    regex_automata::meta::Regex::new(r"^[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+$")
+        .expect("Failed to compile slug regex")
+});
+// Target ID regexp for validation: UUID format
+static TARGET_ID_UUID_REGEX: Lazy<regex_automata::meta::Regex> = Lazy::new(|| {
+    regex_automata::meta::Regex::new(
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+    )
+    .expect("Failed to compile UUID regex")
+});
+
+pub fn is_uuid_target_ref(target_id: &str) -> bool {
+    TARGET_ID_UUID_REGEX.is_match(target_id.trim())
+}
+
+pub fn is_slug_target_ref(target_id: &str) -> bool {
+    TARGET_ID_SLUG_REGEX.is_match(target_id.trim())
 }
 
 fn default_hive_tracing_endpoint() -> ValueOrExpression<String> {

--- a/lib/router-config/src/usage_reporting.rs
+++ b/lib/router-config/src/usage_reporting.rs
@@ -9,11 +9,6 @@ pub struct UsageReportingConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
-    /// Your [Registry Access Token](https://the-guild.dev/graphql/hive/docs/management/targets#registry-access-tokens) with write permission.
-    pub access_token: Option<String>,
-
-    /// A target ID, this can either be a slug following the format “$organizationSlug/$projectSlug/$targetSlug” (e.g “the-guild/graphql-hive/staging”) or an UUID (e.g. “a0f4c605-6541-4350-8cfe-b31f21a4bf80”). To be used when the token is configured with an organization access token.
-    pub target_id: Option<String>,
     /// For self-hosting, you can override `/usage` endpoint (defaults to `https://app.graphql-hive.com/usage`).
     #[serde(default = "default_endpoint")]
     pub endpoint: String,
@@ -31,11 +26,6 @@ pub struct UsageReportingConfig {
     /// Example: ["IntrospectionQuery", "MeQuery"]
     #[serde(default)]
     pub exclude: Vec<String>,
-
-    #[serde(default = "default_client_name_header")]
-    pub client_name_header: String,
-    #[serde(default = "default_client_version_header")]
-    pub client_version_header: String,
 
     /// A maximum number of operations to hold in a buffer before sending to Hive Console
     /// Default: 1000
@@ -82,13 +72,9 @@ impl Default for UsageReportingConfig {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
-            access_token: None,
-            target_id: None,
             endpoint: default_endpoint(),
             sample_rate: default_sample_rate(),
             exclude: Vec::new(),
-            client_name_header: default_client_name_header(),
-            client_version_header: default_client_version_header(),
             buffer_size: default_buffer_size(),
             accept_invalid_certs: default_accept_invalid_certs(),
             connect_timeout: default_connect_timeout(),
@@ -108,14 +94,6 @@ fn default_endpoint() -> String {
 
 fn default_sample_rate() -> Percentage {
     Percentage::from_f64(1.0).unwrap()
-}
-
-fn default_client_name_header() -> String {
-    "graphql-client-name".to_string()
-}
-
-fn default_client_version_header() -> String {
-    "graphql-client-version".to_string()
 }
 
 fn default_buffer_size() -> usize {


### PR DESCRIPTION
**Before**

```yaml
usage_reporting:
  enabled: true
  access_token: "your-hive-token" # Duplicated
  target_id: "org/project/target" # Duplicated
  # Client identification was tied only to usage reporting
  client_name_header: "x-client-name"
  client_version_header: "x-client-version"
  sample_rate: "50%"
  exclude: ["IntrospectionQuery"]

telemetry:
  hive:
    token: "your-hive-token" # Duplicated
    target: "org/project/target" # Duplicated
    tracing:
      enabled: true
```

**After**

```yaml
telemetry:
  # Client identification is now global for all telemetry (traces, usage, etc.)
  client_identification:
    name_header: "x-client-name"
    version_header: "x-client-version"
    
  hive:
    # Credentials are defined once and shared by both usage and tracing
    token: "your-hive-token"
    target: "org/project/target"
    
    usage_reporting:
      enabled: true
      sample_rate: "50%"
      exclude: ["IntrospectionQuery"]
      
    tracing:
      enabled: true
```