### PR TITLE
Downgrade reqwest and related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,9 +2368,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4503,6 +4505,7 @@ checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4512,9 +4515,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4526,6 +4532,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -5538,6 +5545,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6512,8 +6540,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.2.1",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6551,12 +6579,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tokio-util = { version = "0.7.16" }
 rand = "0.9.2"
 jsonwebtoken = { version = "10.0.0", features = ["rust_crypto"] }
 ntex = { version = "2", features = ["tokio"] }
-reqwest = { version = "0.12.23", default-features = false,  features = [ "blocking", "rustls-tls" ] }
+reqwest = { version = "0.12.23" }
 reqwest-retry = "0.8.0"
 reqwest-middleware = "0.4.2"
 retry-policies = "0.5.1"

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -26,7 +26,7 @@ graphql-tools =  { path = "../../lib/graphql-tools", version = "0.4.1" }
 tokio = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
-reqwest = { workspace = true, default-features = false,  features = [ "blocking", "rustls-tls" ] }
+reqwest = { workspace = true }
 sonic-rs = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -16,7 +16,7 @@ sonic-rs = { workspace = true }
 lazy_static = { workspace = true }
 jsonwebtoken = { workspace = true }
 insta = { workspace = true }
-reqwest = { workspace = true, default-features = false,  features = [ "blocking", "rustls-tls" ] }
+reqwest = { workspace = true }
 
 hive-router = { path = "../bin/router" }
 hive-router-config = { path = "../lib/router-config" }


### PR DESCRIPTION
This PR **downgrades `reqwest`** to avoid a runtime crash introduced after upgrading to `reqwest 0.13` in the Hive Apollo Router integration.

After upgrading, the router started **panicking at startup** with the following error (from `rustls`):

> `Could not automatically determine the process-level CryptoProvider`

With `reqwest 0.13`:

- defaults to `rustls` instead of native TLS
- requires **explicit selection of a process-wide crypto provider** (`aws-lc-rs` or `ring`)
- panics at runtime if the provider is ambiguous

Reverts #670
