### PR TITLE
enhance(router/executor): correct error code for `PlanExecutionError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sonic-rs",
+ "strum 0.27.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,4 @@ anyhow = "1.0.100"
 moka = { version = "0.12.11", features = ["future", "sync"] }
 hyper-rustls = { version = "0.27.7", features = ["http1", "http2"] }
 combine = "4.6.6"
+strum = { version = "0.27.2", features = ["derive"] }

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -61,6 +61,7 @@ arc-swap = "1.7.1"
 lasso2 = "0.8.2"
 anyhow = { workspace = true }
 combine= { workspace = true }
+strum = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/lib/executor/Cargo.toml
+++ b/lib/executor/Cargo.toml
@@ -33,7 +33,7 @@ dashmap = { workspace = true }
 regex-automata = { workspace = true }
 
 ahash = { workspace = true }
-strum = { version = "0.27.2", features = ["derive"] }
+strum = { workspace = true }
 ntex = { workspace = true }
 hyper-rustls = { workspace = true}
 


### PR DESCRIPTION
- Use `strum` to define explicit error codes for error types
- Inherit the error codes from `JwtError` and `PlanExecutionError` types correctly, by default the fallback was always `BAD_REQUEST` which looks a bit weird