### PR TITLE
Add unique leader fingerprint for inflight spans

### DIFF
--- a/.changeset/inflight-key.md
+++ b/.changeset/inflight-key.md
@@ -1,0 +1,7 @@
+---
+hive-router-internal: patch
+hive-router: patch
+hive-router-plan-executor: patch
+---
+
+Make `hive.inflight.key` span attribute unique per inflight group, for better identification of the leader and joiners in a distributed system.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "once_cell",
+ "regex",
  "similar",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ codegen-units = 1
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 sonic-rs = "0.5.3"
-insta = { version = "1.42.1" }
+insta = { version = "1.42.1", features= ["filters"] }
 criterion = { version = "0.8", features = ["html_reports", "async_tokio"] }
 lazy_static = "1.5.0"
 dashmap = { version = "6.0.0" }

--- a/e2e/src/telemetry/hive.rs
+++ b/e2e/src/telemetry/hive.rs
@@ -222,6 +222,9 @@ async fn test_hive_http_export() {
     "
     );
 
+    insta::with_settings!({filters => vec![
+      (r"(hive\.inflight\.key:\s+)\d+", "$1[random]"),
+    ]}, {
     insta::assert_snapshot!(
       http_inflight_span,
       @r"
@@ -229,7 +232,7 @@ async fn test_hive_http_export() {
       Kind: Internal
       Status: message='' code='1'
       Attributes:
-        hive.inflight.key: 15555024578502296811
+        hive.inflight.key: [random]
         hive.inflight.role: leader
         hive.kind: http.inflight
         http.request.body.size: 23
@@ -240,6 +243,7 @@ async fn test_hive_http_export() {
         url.scheme: http
     "
     );
+    });
 
     insta::assert_snapshot!(
       http_client_span,

--- a/e2e/src/telemetry/otlp_attributes.rs
+++ b/e2e/src/telemetry/otlp_attributes.rs
@@ -84,6 +84,9 @@ async fn test_deprecated_span_attributes() {
     "
     );
 
+    insta::with_settings!({filters => vec![
+      (r"(hive\.inflight\.key:\s+)\d+", "$1[random]"),
+    ]}, {
     insta::assert_snapshot!(
       http_inflight_span,
       @r"
@@ -91,7 +94,7 @@ async fn test_deprecated_span_attributes() {
       Kind: Internal
       Status: message='' code='1'
       Attributes:
-        hive.inflight.key: 15555024578502296811
+        hive.inflight.key: [random]
         hive.inflight.role: leader
         hive.kind: http.inflight
         http.flavor: 1.1
@@ -107,6 +110,7 @@ async fn test_deprecated_span_attributes() {
         url.scheme: http
     "
     );
+    });
 
     insta::assert_snapshot!(
       http_client_span,
@@ -218,6 +222,9 @@ async fn test_spec_and_deprecated_span_attributes() {
     "
     );
 
+    insta::with_settings!({filters => vec![
+      (r"(hive\.inflight\.key:\s+)\d+", "$1[random]"),
+    ]}, {
     insta::assert_snapshot!(
       http_inflight_span,
       @r"
@@ -225,7 +232,7 @@ async fn test_spec_and_deprecated_span_attributes() {
       Kind: Internal
       Status: message='' code='1'
       Attributes:
-        hive.inflight.key: 15555024578502296811
+        hive.inflight.key: [random]
         hive.inflight.role: leader
         hive.kind: http.inflight
         http.flavor: 1.1
@@ -249,6 +256,7 @@ async fn test_spec_and_deprecated_span_attributes() {
         url.scheme: http
     "
     );
+    });
 
     insta::assert_snapshot!(
       http_client_span,

--- a/e2e/src/telemetry/otlp_basic.rs
+++ b/e2e/src/telemetry/otlp_basic.rs
@@ -196,6 +196,9 @@ async fn test_otlp_http_export_with_graphql_request() {
     "
     );
 
+    insta::with_settings!({filters => vec![
+      (r"(hive\.inflight\.key:\s+)\d+", "$1[random]"),
+    ]}, {
     insta::assert_snapshot!(
       http_inflight_span,
       @r"
@@ -203,7 +206,7 @@ async fn test_otlp_http_export_with_graphql_request() {
       Kind: Internal
       Status: message='' code='1'
       Attributes:
-        hive.inflight.key: 15555024578502296811
+        hive.inflight.key: [random]
         hive.inflight.role: leader
         hive.kind: http.inflight
         http.request.body.size: 23
@@ -219,6 +222,7 @@ async fn test_otlp_http_export_with_graphql_request() {
         url.scheme: http
     "
     );
+    });
 
     insta::assert_snapshot!(
       http_client_span,
@@ -434,6 +438,9 @@ async fn test_otlp_grpc_export_with_graphql_request() {
     "
     );
 
+    insta::with_settings!({filters => vec![
+      (r"(hive\.inflight\.key:\s+)\d+", "$1[random]"),
+    ]}, {
     insta::assert_snapshot!(
       http_inflight_span,
       @r"
@@ -441,7 +448,7 @@ async fn test_otlp_grpc_export_with_graphql_request() {
       Kind: Internal
       Status: message='' code='1'
       Attributes:
-        hive.inflight.key: 15555024578502296811
+        hive.inflight.key: [random]
         hive.inflight.role: leader
         hive.kind: http.inflight
         http.request.body.size: 23
@@ -457,6 +464,7 @@ async fn test_otlp_grpc_export_with_graphql_request() {
         url.scheme: http
     "
     );
+    });
 
     insta::assert_snapshot!(
       http_client_span,

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -47,7 +47,7 @@ struct ResolvedSubgraphConfig<'a> {
     dedupe_enabled: bool,
 }
 
-pub type InflightRequestsMap = Arc<DashMap<u64, Arc<OnceCell<HttpResponse>>, ABuildHasher>>;
+pub type InflightRequestsMap = Arc<DashMap<u64, Arc<OnceCell<(HttpResponse, u64)>>, ABuildHasher>>;
 
 pub struct SubgraphExecutorMap {
     executors_by_subgraph: ExecutorsBySubgraphMap,


### PR DESCRIPTION
Makes `hive.inflight.key` span attribute unique, for better identification of the leader and joiners in a distributed system.
