### PR TITLE
Adds `noop_otlp_exporter` feature for internal usage

### DIFF
--- a/.changeset/adds_noop_otlp_exporter_feature_for_internal_usage.md
+++ b/.changeset/adds_noop_otlp_exporter_feature_for_internal_usage.md
@@ -1,0 +1,7 @@
+---
+hive-router-internal: patch
+hive-router: patch
+hive-router-plan-executor: patch
+---
+
+# Adds noop_otlp_exporter feature for internal usage

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -15,6 +15,9 @@ homepage = "https://github.com/graphql-hive/router"
 name = "hive_router"
 path = "src/main.rs"
 
+[features]
+noop_otlp_exporter = ["hive-router-internal/noop_otlp_exporter"]
+
 [dependencies]
 hive-router-query-planner = { path = "../../lib/query-planner", version = "2.2.1" }
 hive-router-plan-executor = { path = "../../lib/executor", version = "6.5.1" }

--- a/lib/internal/Cargo.toml
+++ b/lib/internal/Cargo.toml
@@ -11,6 +11,9 @@ authors = ["The Guild"]
 
 [lib]
 
+[features]
+noop_otlp_exporter = []
+
 [dependencies]
 hive-router-config = { path = "../router-config", version = "0.0.23" }
 

--- a/lib/internal/src/telemetry/traces/mod.rs
+++ b/lib/internal/src/telemetry/traces/mod.rs
@@ -36,6 +36,8 @@ use opentelemetry_sdk::{
 };
 use tracing_opentelemetry::OpenTelemetryLayer;
 
+#[cfg(feature = "noop_otlp_exporter")]
+use self::noop_exporter::NoopExporter;
 use self::standard_pipeline_exporter::StandardPipelineExporter;
 use crate::telemetry::{
     error::TelemetryError,
@@ -154,6 +156,12 @@ fn setup_exporters(
                 }
                 .map_err(|e| TelemetryError::TracesExporterSetup(e.to_string()))?;
 
+                #[cfg(feature = "noop_otlp_exporter")]
+                let exporter = {
+                    let _ = exporter;
+                    NoopExporter::new()
+                };
+
                 tracer_provider_builder =
                     tracer_provider_builder.with_span_processor(build_batched_span_processor(
                         &otlp_config.batch_processor,
@@ -263,6 +271,12 @@ fn setup_hive_exporter(
         .with_protocol(Protocol::HttpBinary)
         .build()
         .map_err(|e| TelemetryError::TracesExporterSetup(e.to_string()))?;
+
+    #[cfg(feature = "noop_otlp_exporter")]
+    let exporter = {
+        let _ = exporter;
+        NoopExporter::new()
+    };
 
     let hive_exporter = HiveConsoleExporter::new(exporter);
     let mut trace_batching_processor =


### PR DESCRIPTION
Meant for benchmarking and local testing.

Related: https://github.com/graphql-hive/router/pull/743