### PR TITLE
Fix Federation audits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,7 +1066,6 @@
       "version": "7.0.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2075,7 +2074,6 @@
       "version": "16.12.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }


### PR DESCRIPTION
- Fix timeout string env var `GATEWAY_TIMEOUT`, it is needed because Rust compilation takes time
- Fail audit checkrun if any of audit tests fails