### PR TITLE
feat(router, query-planner, executor): add entity alias batching

### DIFF
--- a/.changeset/batch_fetch_node.md
+++ b/.changeset/batch_fetch_node.md
@@ -1,0 +1,117 @@
+---
+node-addon: minor
+hive-router-query-planner: minor
+hive-router: minor
+hive-router-plan-executor: minor
+---
+
+# Introduce BatchFetch for compatible entity fetches to improve query performance
+
+When multiple `Flatten(Fetch)` steps target the same subgraph and have compatible shape, the planner can group them into one batched fetch operation with aliases.
+
+Batching keeps execution depth the same, but **reduces request fanout**.
+In our benchmark query, **downstream requests drop from `13` to `7`** while the number of execution waves stays unchanged.
+This should also reduce pressure on subgraphs, because entities are resolved in one batched subgraph call instead of being resolved across multiple incoming GraphQL requests, where the lack of DataLoader or another caching layer could otherwise cause duplicate resolution work.
+
+Before: 
+
+```graphql
+Parallel {
+  Flatten(path: "products.@") {
+    Fetch(service: "inventory") {
+      {
+        ... on Product {
+          upc
+        }
+      } =>
+      {
+        ... on Product {
+          shippingEstimate
+        }
+      }
+    }
+  }
+  Flatten(path: "topProducts.@") {
+    Fetch(service: "inventory") {
+      {
+        ... on Product {
+          upc
+        }
+      } =>
+      {
+        ... on Product {
+          shippingEstimate
+        }
+      }
+    }
+  }
+}
+```
+
+After:
+
+```graphql
+BatchFetch(service: "inventory") {
+  {
+    _e0 {
+      paths: [
+        "products.@"
+        "topProducts.@"
+      ]
+      {
+        ... on Product {
+          upc
+        }
+      }
+    }
+  }
+  {
+    _e0: _entities(representations: $__batch_reps_0) {
+      ... on Product {
+        shippingEstimate
+      }
+    }
+  }
+}
+```
+
+When two entity fetches go to the same subgraph but request different output fields, they are batched into one `BatchFetch` node with two aliases, but share the same variables, to reduce the payload size.
+
+```
+BatchFetch(service: "inventory") {
+  {
+    _e0 {
+      paths: [
+        "products.@"
+      ]
+      {
+        ... on Product {
+          upc
+        }
+      }
+    }
+    _e1 {
+      paths: [
+        "products.@"
+      ]
+      {
+        ... on Product {
+          upc
+        }
+      }
+    }
+  }
+  {
+    _e0: _entities(representations: $__batch_reps_0) {
+      ... on Product {
+        shippingEstimate
+      }
+    }
+    _e1: _entities(representations: $__batch_reps_0) {
+      ... on Product {
+        inStock
+      }
+    }
+  }
+}
+```

--- a/.changeset/type_condition_as_ref.md
+++ b/.changeset/type_condition_as_ref.md
@@ -1,0 +1,9 @@
+---
+graphql-tools: minor
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-console-sdk: patch
+hive-router: patch
+---
+
+Implements `AsRef` trait for `graphql_tools::parser::query::ast::TypeCondition`

--- a/e2e/src/entity_batching.rs
+++ b/e2e/src/entity_batching.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+mod entity_batching_e2e_tests {
+    use std::collections::BTreeMap;
+
+    use sonic_rs::JsonValueTrait;
+
+    use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
+
+    #[ntex::test]
+    async fn measure_bench_operation_subgraph_calls() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  traffic_shaping:
+                    all:
+                      dedupe_enabled: false
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(include_str!("../../bench/operation.graphql"), None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        let json_body = res.json_body().await;
+
+        assert!(json_body["data"].is_object());
+        assert!(
+            json_body["errors"].is_null(),
+            "expected no GraphQL errors in bench operation response"
+        );
+
+        let mut subgraph_request_counts: BTreeMap<&str, usize> = BTreeMap::new();
+        for subgraph in ["accounts", "inventory", "products", "reviews"] {
+            let request_count = subgraphs
+                .get_requests_log(subgraph)
+                .map_or(0, |requests| requests.len());
+            subgraph_request_counts.insert(subgraph, request_count);
+        }
+
+        insta::assert_snapshot!(
+            sonic_rs::to_string_pretty(&subgraph_request_counts).unwrap(),
+            @r#"
+        {
+          "accounts": 2,
+          "inventory": 2,
+          "products": 2,
+          "reviews": 1
+        }
+        "#
+        );
+    }
+}

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -7,6 +7,8 @@ mod body_limit;
 #[cfg(test)]
 mod disable_introspection;
 #[cfg(test)]
+mod entity_batching;
+#[cfg(test)]
 mod env_vars;
 #[cfg(test)]
 mod error_handling;

--- a/lib/executor/src/context.rs
+++ b/lib/executor/src/context.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 
-use hive_router_query_planner::planner::plan_nodes::{
-    FetchNode, FetchRewrite, FlattenNodePath, QueryPlan,
-};
+use hive_router_query_planner::planner::plan_nodes::FlattenNodePath;
 
 use crate::{
     headers::plan::ResponseHeaderAggregator,
@@ -17,7 +15,6 @@ pub struct ExecutionContext<'a> {
     pub response_storage: ResponsesStorage,
     pub data: Value<'a>,
     pub errors: Vec<GraphQLError>,
-    pub output_rewrites: OutputRewritesStorage<'a>,
     pub response_headers_aggregator: ResponseHeaderAggregator,
 }
 
@@ -25,7 +22,6 @@ impl<'a> Default for ExecutionContext<'a> {
     fn default() -> Self {
         ExecutionContext {
             response_storage: Default::default(),
-            output_rewrites: Default::default(),
             errors: Vec::new(),
             data: Value::Null,
             response_headers_aggregator: Default::default(),
@@ -34,11 +30,10 @@ impl<'a> Default for ExecutionContext<'a> {
 }
 
 impl<'a> ExecutionContext<'a> {
-    pub fn new(query_plan: &'a QueryPlan, data: Value<'a>, errors: Vec<GraphQLError>) -> Self {
+    pub fn new(data: Value<'a>, errors: Vec<GraphQLError>) -> Self {
         ExecutionContext {
             data,
             errors,
-            output_rewrites: OutputRewritesStorage::from_query_plan(query_plan),
             ..Default::default()
         }
     }
@@ -68,34 +63,5 @@ impl<'a> ExecutionContext<'a> {
                 }
             }
         }
-    }
-}
-
-#[derive(Default)]
-pub struct OutputRewritesStorage<'exec> {
-    output_rewrites: HashMap<i64, &'exec [FetchRewrite]>,
-}
-
-impl<'exec> OutputRewritesStorage<'exec> {
-    pub fn from_query_plan(query_plan: &'exec QueryPlan) -> OutputRewritesStorage<'exec> {
-        let mut output_rewrites = OutputRewritesStorage {
-            output_rewrites: HashMap::new(),
-        };
-
-        for fetch_node in query_plan.fetch_nodes() {
-            output_rewrites.add_maybe(fetch_node);
-        }
-
-        output_rewrites
-    }
-
-    fn add_maybe(&mut self, fetch_node: &'exec FetchNode) {
-        if let Some(rewrites) = &fetch_node.output_rewrites {
-            self.output_rewrites.insert(fetch_node.id, rewrites);
-        }
-    }
-
-    pub fn get(&self, id: i64) -> Option<&'exec [FetchRewrite]> {
-        self.output_rewrites.get(&id).copied()
     }
 }

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -1,15 +1,21 @@
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
 
+use ahash::{HashMap as AHashMap, HashMapExt};
 use bytes::BufMut;
+use futures::TryFutureExt;
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use hive_router_internal::telemetry::metrics::graphql_metrics::GraphQLErrorMetricsRecorder;
 use hive_router_internal::telemetry::traces::spans::graphql::{
     GraphQLOperationSpan, GraphQLSpanOperationIdentity, GraphQLSubgraphOperationSpan,
 };
+use hive_router_query_planner::ast::operation::SubgraphFetchOperation;
 use hive_router_query_planner::{
     ast::operation::OperationDefinition,
     planner::plan_nodes::{
-        ConditionNode, FetchNode, FetchRewrite, FlattenNodePath, PlanNode, QueryPlan,
+        ConditionNode, EntityBatch, EntityBatchAlias, FetchRewrite, FlattenNodePath, PlanNode,
+        QueryPlan,
     },
     state::supergraph_state::OperationKind,
 };
@@ -45,7 +51,7 @@ use crate::{
         plan::FieldProjectionPlan, request::project_requires, response::project_by_operation,
     },
     response::{
-        graphql_error::{GraphQLError, GraphQLErrorPath},
+        graphql_error::{GraphQLError, GraphQLErrorPath, GraphQLErrorPathSegment},
         merge::deep_merge,
         subgraph_response::SubgraphResponse,
         value::Value,
@@ -137,7 +143,7 @@ pub async fn execute_query_plan<'exec>(
         extensions = start_payload.extensions;
     }
 
-    let mut exec_ctx = ExecutionContext::new(query_plan, data, errors);
+    let mut exec_ctx = ExecutionContext::new(data, errors);
     // No need for `new`, it has too many parameters
     // We can directly create `Executor` instance here
     let executor = Executor {
@@ -253,18 +259,43 @@ pub struct Executor<'exec> {
 
 enum ExecutionJob<'exec> {
     Fetch {
-        fetch_node_id: i64,
         subgraph_name: &'exec str,
         response: SubgraphResponse<'exec>,
+        output_rewrites: Option<&'exec [FetchRewrite]>,
     },
     FlattenFetch {
-        fetch_node_id: i64,
         subgraph_name: &'exec str,
         response: SubgraphResponse<'exec>,
         flatten_node_path: &'exec FlattenNodePath,
         representation_hashes: Vec<u64>,
-        representation_hash_to_index: HashMap<u64, usize>,
+        representation_hash_to_index: AHashMap<u64, usize>,
+        output_rewrites: Option<&'exec [FetchRewrite]>,
     },
+    BatchFetch {
+        subgraph_name: &'exec str,
+        response: SubgraphResponse<'exec>,
+        aliases: Vec<AliasBatchState<'exec>>,
+    },
+}
+
+struct AliasBatchState<'exec> {
+    alias_spec: &'exec EntityBatchAlias,
+    representation_hash_to_index: AHashMap<u64, usize>,
+    paths: Vec<AliasPathState<'exec>>,
+}
+
+struct AliasPathState<'exec> {
+    merge_path: &'exec FlattenNodePath,
+    representation_hashes: Arc<Vec<u64>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct AliasIndex(usize);
+
+#[derive(Default)]
+struct BatchFetchErrors {
+    by_alias_index: AHashMap<AliasIndex, Vec<GraphQLError>>,
+    unmatched: Vec<GraphQLError>,
 }
 
 impl<'exec> ExecutionJob<'exec> {
@@ -272,24 +303,21 @@ impl<'exec> ExecutionJob<'exec> {
         match self {
             ExecutionJob::Fetch { response, .. } => response,
             ExecutionJob::FlattenFetch { response, .. } => response,
+            ExecutionJob::BatchFetch { response, .. } => response,
         }
     }
     fn response_ref(&self) -> &SubgraphResponse<'exec> {
         match self {
             ExecutionJob::Fetch { response, .. } => response,
             ExecutionJob::FlattenFetch { response, .. } => response,
-        }
-    }
-    fn fetch_node_id(&self) -> i64 {
-        match self {
-            ExecutionJob::Fetch { fetch_node_id, .. } => *fetch_node_id,
-            ExecutionJob::FlattenFetch { fetch_node_id, .. } => *fetch_node_id,
+            ExecutionJob::BatchFetch { response, .. } => response,
         }
     }
     fn subgraph_name(&self) -> &'exec str {
         match self {
             ExecutionJob::Fetch { subgraph_name, .. } => subgraph_name,
             ExecutionJob::FlattenFetch { subgraph_name, .. } => subgraph_name,
+            ExecutionJob::BatchFetch { subgraph_name, .. } => subgraph_name,
         }
     }
     fn affected_path(&self) -> Option<&'exec FlattenNodePath> {
@@ -298,8 +326,28 @@ impl<'exec> ExecutionJob<'exec> {
             ExecutionJob::FlattenFetch {
                 flatten_node_path, ..
             } => Some(flatten_node_path),
+            ExecutionJob::BatchFetch { .. } => None,
         }
     }
+}
+
+struct PrepareExecutionJobOpts<'exec> {
+    // The name of the subgraph
+    subgraph_name: &'exec str,
+    // Variable usages
+    variable_usages: Option<&'exec BTreeSet<String>>,
+    // Operation name
+    operation_name: Option<&'exec str>,
+    // Operation Kind
+    operation_kind: Option<&'exec OperationKind>,
+    // Operation
+    operation: &'exec SubgraphFetchOperation,
+    // Output rewrites
+    output_rewrites: Option<&'exec [FetchRewrite]>,
+    // If the fetch job is for a flatten node, we pass the filtered representations,
+    raw_variable_values: Option<Vec<(&'exec str, Vec<u8>)>>,
+    // and the path to the representations in the original response for error handling and normalization
+    affected_path: Option<&'exec FlattenNodePath>,
 }
 
 impl<'exec> Executor<'exec> {
@@ -359,8 +407,54 @@ impl<'exec> Executor<'exec> {
         data: &Value<'exec>,
     ) -> Option<BoxFuture<'wave, Result<ExecutionJob<'exec>, PlanExecutionError>>> {
         match node {
-            PlanNode::Fetch(fetch_node) => {
-                Some(self.prepare_fetch_job(fetch_node, None, None).boxed())
+            PlanNode::Fetch(fetch_node) => Some(
+                self.prepare_execution_job(PrepareExecutionJobOpts {
+                    subgraph_name: &fetch_node.service_name,
+                    variable_usages: fetch_node.variable_usages.as_ref(),
+                    operation_name: fetch_node.operation_name.as_deref(),
+                    operation_kind: fetch_node.operation_kind.as_ref(),
+                    operation: &fetch_node.operation,
+                    output_rewrites: fetch_node.output_rewrites.as_deref(),
+                    raw_variable_values: None,
+                    affected_path: None,
+                })
+                .boxed(),
+            ),
+            PlanNode::BatchFetch(batch_fetch_node) => {
+                let (raw_variable_values, aliases) =
+                    self.prepare_batch_fetch_job_state(&batch_fetch_node.entity_batch, data);
+
+                if aliases
+                    .iter()
+                    .all(|alias| alias.representation_hash_to_index.is_empty())
+                {
+                    // All alias lists are empty, so nothing to fetch.
+                    // We skip the network call to save time.
+                    tracing::trace!(
+                        alias_count = aliases.len(),
+                        "Skipping batched entity fetch with no representations"
+                    );
+                    return None;
+                }
+
+                Some(
+                    self.prepare_execution_job(PrepareExecutionJobOpts {
+                        subgraph_name: &batch_fetch_node.service_name,
+                        variable_usages: batch_fetch_node.variable_usages.as_ref(),
+                        operation_name: batch_fetch_node.operation_name.as_deref(),
+                        operation_kind: batch_fetch_node.operation_kind.as_ref(),
+                        operation: &batch_fetch_node.operation,
+                        output_rewrites: None,
+                        raw_variable_values: Some(raw_variable_values),
+                        affected_path: None,
+                    })
+                    .map_ok(|fetch_job| ExecutionJob::BatchFetch {
+                        subgraph_name: fetch_job.subgraph_name(),
+                        response: fetch_job.response(),
+                        aliases,
+                    })
+                    .boxed(),
+                )
             }
             PlanNode::Flatten(flatten_node) => {
                 let fetch_node = match flatten_node.node.as_ref() {
@@ -375,7 +469,7 @@ impl<'exec> Executor<'exec> {
                 filtered_representations.put(OPEN_BRACKET);
                 let possible_types = &self.schema_metadata.possible_types;
                 let mut representation_hashes: Vec<u64> = Vec::new();
-                let mut representation_hash_to_index: HashMap<u64, usize> = HashMap::new();
+                let mut representation_hash_to_index: AHashMap<u64, usize> = AHashMap::new();
                 let arena = bumpalo::Bump::new();
 
                 traverse_and_callback(
@@ -389,9 +483,11 @@ impl<'exec> Executor<'exec> {
                             representation_hashes.push(hash);
                         }
 
-                        if representation_hash_to_index.contains_key(&hash) {
-                            return;
-                        }
+                        let is_first_representation = representation_hash_to_index.is_empty();
+                        let vacant_entry = match representation_hash_to_index.entry(hash) {
+                            Entry::Occupied(_) => return,
+                            Entry::Vacant(vacant_entry) => vacant_entry,
+                        };
 
                         let entity = if let Some(input_rewrites) = &fetch_node.input_rewrites {
                             let new_entity = arena.alloc(entity.clone());
@@ -409,12 +505,12 @@ impl<'exec> Executor<'exec> {
                             &requires_nodes.items,
                             entity,
                             &mut filtered_representations,
-                            representation_hash_to_index.is_empty(),
+                            is_first_representation,
                             None,
                         );
 
                         if is_projected {
-                            representation_hash_to_index.insert(hash, index);
+                            vacant_entry.insert(index);
                         }
 
                         index += 1;
@@ -429,23 +525,27 @@ impl<'exec> Executor<'exec> {
 
                 // This is the future for the actual fetch job
                 Some(
-                    async {
-                        let fetch_job = self
-                            .prepare_fetch_job(
-                                fetch_node,
-                                Some(filtered_representations),
-                                Some(&flatten_node.path),
-                            )
-                            .await?;
-                        Ok(ExecutionJob::FlattenFetch {
-                            flatten_node_path: &flatten_node.path,
-                            response: fetch_job.response(),
-                            fetch_node_id: fetch_node.id,
-                            subgraph_name: fetch_node.service_name.as_str(),
-                            representation_hashes,
-                            representation_hash_to_index,
-                        })
-                    }
+                    self.prepare_execution_job(PrepareExecutionJobOpts {
+                        subgraph_name: &fetch_node.service_name,
+                        variable_usages: fetch_node.variable_usages.as_ref(),
+                        operation_name: fetch_node.operation_name.as_deref(),
+                        operation_kind: fetch_node.operation_kind.as_ref(),
+                        operation: &fetch_node.operation,
+                        output_rewrites: fetch_node.output_rewrites.as_deref(),
+                        raw_variable_values: Some(vec![(
+                            "representations",
+                            filtered_representations,
+                        )]),
+                        affected_path: Some(&flatten_node.path),
+                    })
+                    .map_ok(|fetch_job| ExecutionJob::FlattenFetch {
+                        flatten_node_path: &flatten_node.path,
+                        response: fetch_job.response(),
+                        subgraph_name: fetch_node.service_name.as_str(),
+                        representation_hashes,
+                        representation_hash_to_index,
+                        output_rewrites: fetch_node.output_rewrites.as_deref(),
+                    })
                     .boxed(),
                 )
             }
@@ -492,11 +592,12 @@ impl<'exec> Executor<'exec> {
                     }
                 }
 
-                let output_rewrites: Option<&[FetchRewrite]> =
-                    ctx.output_rewrites.get(job.fetch_node_id());
-
-                let (errors, entity_index_error_map) = match job {
-                    ExecutionJob::Fetch { mut response, .. } => {
+                match job {
+                    ExecutionJob::Fetch {
+                        mut response,
+                        output_rewrites,
+                        ..
+                    } => {
                         if let Some(response_bytes) = response.bytes {
                             ctx.response_storage.add_response(response_bytes);
                         }
@@ -510,13 +611,14 @@ impl<'exec> Executor<'exec> {
                         }
                         deep_merge(&mut ctx.data, response.data);
 
-                        (response.errors, None)
+                        ctx.handle_errors(subgraph_name, affected_path, response.errors, None);
                     }
                     ExecutionJob::FlattenFetch {
                         mut response,
                         flatten_node_path,
                         representation_hashes,
                         ref representation_hash_to_index,
+                        output_rewrites,
                         ..
                     } => {
                         if let Some(response_bytes) = response.bytes {
@@ -572,14 +674,71 @@ impl<'exec> Executor<'exec> {
                                     index += 1;
                                 },
                             );
-                            (response.errors, entity_index_error_map)
+
+                            ctx.handle_errors(
+                                subgraph_name,
+                                affected_path,
+                                response.errors,
+                                entity_index_error_map,
+                            );
                         } else {
-                            (response.errors, None)
+                            ctx.handle_errors(subgraph_name, affected_path, response.errors, None);
                         }
                     }
-                };
+                    ExecutionJob::BatchFetch {
+                        mut response,
+                        aliases,
+                        ..
+                    } => {
+                        if let Some(response_bytes) = response.bytes {
+                            ctx.response_storage.add_response(response_bytes);
+                        }
 
-                ctx.handle_errors(subgraph_name, affected_path, errors, entity_index_error_map);
+                        // Split errors by alias
+                        let mut errors =
+                            self.partition_batch_errors_by_alias(&aliases, response.errors.take());
+                        // Take returned entities per alias
+                        let mut entities_by_alias =
+                            Self::collect_batched_entities_by_alias(&mut response.data, &aliases);
+
+                        for (alias_index, alias_state) in aliases.iter().enumerate() {
+                            let alias_index = AliasIndex(alias_index);
+                            let mut alias_errors = errors.by_alias_index.remove(&alias_index);
+                            // Merge entities back into execution context (final data)
+                            // and attach alias errors and unmatched errors
+                            let entity_index_error_map = self.merge_batch_alias_entities(
+                                ctx,
+                                alias_state,
+                                entities_by_alias.get_mut(&alias_index),
+                                alias_errors.as_deref(),
+                            );
+
+                            let affected_path = if alias_state.paths.len() == 1 {
+                                Some(alias_state.paths[0].merge_path)
+                            } else {
+                                None
+                            };
+
+                            // Attach alias errors
+                            ctx.handle_errors(
+                                subgraph_name,
+                                affected_path,
+                                alias_errors.take(),
+                                entity_index_error_map,
+                            );
+                        }
+
+                        // Attach errors that do not point to any known alias.
+                        if !errors.unmatched.is_empty() {
+                            ctx.handle_errors(subgraph_name, None, Some(errors.unmatched), None);
+                        }
+
+                        tracing::trace!(
+                            alias_count = aliases.len(),
+                            "Patched entity batch alias results"
+                        );
+                    }
+                }
             }
         }
     }
@@ -596,27 +755,293 @@ impl<'exec> Executor<'exec> {
         }
     }
 
-    async fn prepare_fetch_job(
+    fn partition_batch_errors_by_alias(
         &self,
-        node: &'exec FetchNode,
-        // If the fetch job is for a flatten node, we pass the filtered representations,
-        representations: Option<Vec<u8>>,
-        // and the path to the representations in the original response for error handling and normalization
-        affected_path: Option<&FlattenNodePath>,
+        aliases: &[AliasBatchState<'exec>],
+        response_errors: Option<Vec<GraphQLError>>,
+    ) -> BatchFetchErrors {
+        // Split subgraph errors into:
+        // - errors that belong to a known alias
+        // - errors that do not match any alias
+        let mut alias_index_by_name: AHashMap<&str, AliasIndex> =
+            AHashMap::with_capacity(aliases.len());
+        for (alias_index, alias_state) in aliases.iter().enumerate() {
+            alias_index_by_name.insert(
+                alias_state.alias_spec.alias.as_str(),
+                AliasIndex(alias_index),
+            );
+        }
+
+        let mut errors_by_alias_index: AHashMap<AliasIndex, Vec<GraphQLError>> = AHashMap::new();
+        let mut unmatched_errors: Vec<GraphQLError> = Vec::new();
+
+        let Some(response_errors) = response_errors else {
+            return BatchFetchErrors::default();
+        };
+
+        for mut error in response_errors {
+            let maybe_alias = error.path.as_ref().and_then(|path| {
+                path.segments.first().and_then(|segment| match segment {
+                    GraphQLErrorPathSegment::String(alias) => Some(alias.as_str()),
+                    _ => None,
+                })
+            });
+
+            let Some(alias) = maybe_alias else {
+                unmatched_errors.push(error);
+                continue;
+            };
+
+            let Some(alias_index) = alias_index_by_name.get(alias) else {
+                unmatched_errors.push(error);
+                continue;
+            };
+
+            if let Some(path) = error.path.as_mut() {
+                // Subgraph batch errors use alias names like "_e0".
+                // Our error normalizer (GraphQLError::normalize_entity_error)
+                // expects paths like ["_entities", index, ...].
+                // So we replace the first path segment with "_entities".
+                // Before: ["_e0", 2, "price"]
+                // After : ["_entities", 2, "price"]
+                if let Some(GraphQLErrorPathSegment::String(first)) = path.segments.first_mut() {
+                    *first = "_entities".to_string();
+                }
+            }
+
+            errors_by_alias_index
+                .entry(*alias_index)
+                .or_default()
+                .push(error);
+        }
+
+        BatchFetchErrors {
+            by_alias_index: errors_by_alias_index,
+            unmatched: unmatched_errors,
+        }
+    }
+
+    fn collect_batched_entities_by_alias(
+        response_data: &mut Value<'exec>,
+        aliases: &[AliasBatchState<'exec>],
+    ) -> AHashMap<AliasIndex, Vec<Value<'exec>>> {
+        // Take entity arrays from response data once per alias.
+        // This avoids repeated lookups/mutations on response data.
+        let mut entities_by_alias: AHashMap<AliasIndex, Vec<Value<'exec>>> =
+            AHashMap::with_capacity(aliases.len());
+
+        for (alias_index, alias_state) in aliases.iter().enumerate() {
+            let Some(entities) =
+                response_data.take_entities_by_key(alias_state.alias_spec.alias.as_str())
+            else {
+                continue;
+            };
+            entities_by_alias.insert(AliasIndex(alias_index), entities);
+        }
+
+        entities_by_alias
+    }
+
+    /// Merge one alias's returned entities back into `ctx.data`.
+    fn merge_batch_alias_entities<'alias>(
+        &self,
+        ctx: &mut ExecutionContext<'exec>,
+        alias_state: &'alias AliasBatchState<'exec>,
+        entities: Option<&mut Vec<Value<'exec>>>,
+        alias_errors: Option<&[GraphQLError]>,
+    ) -> Option<HashMap<&'alias usize, Vec<GraphQLErrorPath>>> {
+        let has_alias_errors = alias_errors.is_some();
+        let mut entity_index_error_map = has_alias_errors.then(HashMap::new);
+        let Some(entities) = entities else {
+            return entity_index_error_map;
+        };
+
+        if let Some(output_rewrites) = alias_state.alias_spec.output_rewrites.as_ref() {
+            for output_rewrite in output_rewrites {
+                for entity in entities.iter_mut() {
+                    output_rewrite.rewrite(&self.schema_metadata.possible_types, entity);
+                }
+            }
+        }
+
+        if alias_state.representation_hash_to_index.is_empty() {
+            return entity_index_error_map;
+        }
+
+        // We walk each merge path
+        for path_state in &alias_state.paths {
+            let mut index = 0;
+            let normalized_path = path_state.merge_path.as_slice();
+            let initial_error_path = has_alias_errors
+                // Small extra capacity for path segments that will be appended later.
+                .then(|| GraphQLErrorPath::with_capacity(normalized_path.len() + 2));
+
+            // For each visited target:
+            traverse_and_callback_mut(
+                &mut ctx.data,
+                normalized_path,
+                self.schema_metadata,
+                initial_error_path,
+                &mut |target_data, error_path| {
+                    let hash = path_state.representation_hashes[index];
+                    // Find matching entity index from hash->index map
+                    if let Some(entity_index) = alias_state.representation_hash_to_index.get(&hash)
+                    {
+                        // If this alias has errors, we also collect target paths
+                        // so one subgraph error can be copied to all matching targets.
+                        if let (Some(error_path), Some(entity_index_error_map)) =
+                            (error_path, entity_index_error_map.as_mut())
+                        {
+                            let error_paths = entity_index_error_map
+                                .entry(entity_index)
+                                .or_insert_with(Vec::new);
+                            error_paths.push(error_path);
+                        }
+                        if let Some(entity) = entities.get(*entity_index) {
+                            // SAFETY: `new_val` is a clone of an entity that lives for `'a`.
+                            // The transmute is to satisfy the compiler, but the lifetime is valid.
+                            let new_val: Value<'_> = unsafe { std::mem::transmute(entity.clone()) };
+                            deep_merge(target_data, new_val);
+                        }
+                    }
+
+                    index += 1;
+                },
+            );
+        }
+
+        entity_index_error_map
+    }
+
+    // The preperation includes:
+    // - building one `_entities` input list for each alias
+    // - remembering where each item came from (so we can put results back)
+    fn prepare_batch_fetch_job_state(
+        &self,
+        entity_batch: &'exec EntityBatch,
+        data: &Value<'exec>,
+    ) -> (Vec<(&'exec str, Vec<u8>)>, Vec<AliasBatchState<'exec>>) {
+        let mut raw_variable_values: Vec<(&'exec str, Vec<u8>)> =
+            Vec::with_capacity(entity_batch.aliases.len());
+        let mut raw_variable_indices_by_name: AHashMap<&'exec str, usize> =
+            AHashMap::with_capacity(entity_batch.aliases.len());
+        let mut aliases = Vec::with_capacity(entity_batch.aliases.len());
+
+        let possible_types = &self.schema_metadata.possible_types;
+
+        for alias_spec in &entity_batch.aliases {
+            let mut index = 0;
+            let mut filtered_representations = Vec::new();
+            filtered_representations.put(OPEN_BRACKET);
+            let mut representation_hash_to_index: AHashMap<u64, usize> = AHashMap::new();
+            let arena = bumpalo::Bump::new();
+            let mut path_hashes_by_index: Vec<Option<Arc<Vec<u64>>>> =
+                vec![None; alias_spec.merge_paths.len()];
+
+            let mut path_groups: Vec<(&FlattenNodePath, Vec<usize>)> =
+                Vec::with_capacity(alias_spec.merge_paths.len());
+            for (path_index, merge_path) in alias_spec.merge_paths.iter().enumerate() {
+                if let Some((_, target_indices)) =
+                    path_groups.iter_mut().find(|(path, _)| *path == merge_path)
+                {
+                    target_indices.push(path_index);
+                } else {
+                    path_groups.push((merge_path, vec![path_index]));
+                }
+            }
+
+            for (merge_path, grouped_target_indices) in path_groups {
+                let mut representation_hashes: Vec<u64> = Vec::new();
+
+                traverse_and_callback(data, merge_path.as_slice(), possible_types, &mut |entity| {
+                    let hash = entity.to_hash(&alias_spec.requires.items, possible_types);
+
+                    if !entity.is_null() {
+                        representation_hashes.push(hash);
+                    }
+
+                    let is_first_representation = representation_hash_to_index.is_empty();
+                    let vacant_entry = match representation_hash_to_index.entry(hash) {
+                        Entry::Occupied(_) => return,
+                        Entry::Vacant(vacant_entry) => vacant_entry,
+                    };
+
+                    let entity = if let Some(input_rewrites) = &alias_spec.input_rewrites {
+                        let new_entity = arena.alloc(entity.clone());
+                        for input_rewrite in input_rewrites {
+                            input_rewrite.rewrite(&self.schema_metadata.possible_types, new_entity);
+                        }
+                        new_entity
+                    } else {
+                        entity
+                    };
+
+                    let is_projected = project_requires(
+                        possible_types,
+                        &alias_spec.requires.items,
+                        entity,
+                        &mut filtered_representations,
+                        is_first_representation,
+                        None,
+                    );
+
+                    if is_projected {
+                        vacant_entry.insert(index);
+                    }
+
+                    index += 1;
+                });
+
+                let representation_hashes = Arc::new(representation_hashes);
+
+                for path_index in grouped_target_indices {
+                    path_hashes_by_index[path_index] = Some(Arc::clone(&representation_hashes));
+                }
+            }
+
+            filtered_representations.put(CLOSE_BRACKET);
+
+            let mut paths = Vec::with_capacity(alias_spec.merge_paths.len());
+            for (path_index, merge_path) in alias_spec.merge_paths.iter().enumerate() {
+                paths.push(AliasPathState {
+                    merge_path,
+                    representation_hashes: path_hashes_by_index[path_index]
+                        .take()
+                        .unwrap_or_else(|| Arc::new(Vec::new())),
+                });
+            }
+
+            let variable_name = alias_spec.representations_variable_name.as_str();
+            if !raw_variable_indices_by_name.contains_key(variable_name) {
+                raw_variable_indices_by_name.insert(variable_name, raw_variable_values.len());
+                raw_variable_values.push((variable_name, filtered_representations));
+            }
+
+            aliases.push(AliasBatchState {
+                alias_spec,
+                representation_hash_to_index,
+                paths,
+            });
+        }
+
+        (raw_variable_values, aliases)
+    }
+
+    async fn prepare_execution_job(
+        &self,
+        opts: PrepareExecutionJobOpts<'exec>,
     ) -> Result<ExecutionJob<'exec>, PlanExecutionError> {
-        let subgraph_operation_span = GraphQLSubgraphOperationSpan::new(
-            node.service_name.as_str(),
-            &node.operation.document_str,
-        );
+        let subgraph_operation_span =
+            GraphQLSubgraphOperationSpan::new(opts.subgraph_name, &opts.operation.document_str);
 
         async {
             // TODO: We could optimize header map creation by caching them per service name
             let mut headers_map = HeaderMap::new();
-            let subgraph_name_factory = || Some(node.service_name.clone());
-            let affected_path_factory = || affected_path.map(|p| p.to_string());
+            let subgraph_name_factory = || Some(opts.subgraph_name.to_string());
+            let affected_path_factory = || opts.affected_path.map(|p| p.to_string());
             modify_subgraph_request_headers(
                 self.headers_plan,
-                &node.service_name,
+                opts.subgraph_name,
                 self.client_request,
                 &mut headers_map,
             )
@@ -624,27 +1049,27 @@ impl<'exec> Executor<'exec> {
                 subgraph_name: subgraph_name_factory,
                 affected_path: affected_path_factory,
             })?;
-            let variable_refs =
-                select_fetch_variables(self.variable_values, node.variable_usages.as_ref());
+            let variable_refs = select_fetch_variables(self.variable_values, opts.variable_usages);
 
             let mut subgraph_request = SubgraphExecutionRequest {
-                query: node.operation.document_str.as_str(),
+                query: &opts.operation.document_str,
                 dedupe: self.dedupe_subgraph_requests,
-                operation_name: node.operation_name.as_deref(),
+                operation_name: opts.operation_name,
                 variables: variable_refs,
-                representations,
+                raw_variable_values: opts.raw_variable_values,
                 headers: headers_map,
                 extensions: None,
             };
 
+            let client_document_hash_str = opts.operation.hash.to_string();
             subgraph_operation_span.record_operation_identity(GraphQLSpanOperationIdentity {
-                name: subgraph_request.operation_name,
-                operation_type: match node.operation_kind {
+                name: opts.operation_name,
+                operation_type: match opts.operation_kind {
                     Some(OperationKind::Query) | None => "query",
                     Some(OperationKind::Mutation) => "mutation",
                     Some(OperationKind::Subscription) => "subscription",
                 },
-                client_document_hash: node.operation.hash.to_string().as_str(),
+                client_document_hash: &client_document_hash_str,
             });
 
             if let Some(jwt_forwarding_plan) = &self.jwt_forwarding_plan {
@@ -657,7 +1082,7 @@ impl<'exec> Executor<'exec> {
             let response = self
                 .executors
                 .execute(
-                    &node.service_name,
+                    opts.subgraph_name,
                     subgraph_request,
                     self.client_request,
                     self.plugin_req_state,
@@ -677,9 +1102,9 @@ impl<'exec> Executor<'exec> {
             }
 
             Ok(ExecutionJob::Fetch {
-                fetch_node_id: node.id,
-                subgraph_name: &node.service_name,
+                subgraph_name: opts.subgraph_name,
                 response,
+                output_rewrites: opts.output_rewrites,
             })
         }
         .instrument(subgraph_operation_span.clone())
@@ -731,10 +1156,12 @@ mod tests {
         headers::plan::HeaderRulesPlan,
         introspection::schema::SchemaMetadata,
         response::graphql_error::{GraphQLErrorExtensions, GraphQLErrorPath},
+        response::value::Value as ResponseValue,
         SubgraphExecutorMap,
     };
 
     use super::select_fetch_variables;
+    use graphql_tools::parser::query;
     use hive_router_config::HiveRouterConfig;
     use hive_router_internal::telemetry::TelemetryContext;
     use hive_router_query_planner::{
@@ -743,7 +1170,8 @@ mod tests {
             operation::{OperationDefinition, SubgraphFetchOperation},
             selection_set::SelectionSet,
         },
-        planner::plan_nodes::{FetchNode, ParallelNode, PlanNode},
+        planner::plan_nodes::{EntityBatch, EntityBatchAlias, FetchNode, ParallelNode, PlanNode},
+        utils::parsing::parse_operation,
     };
     use ntex::http::HeaderMap;
     use sonic_rs::Value;
@@ -869,6 +1297,107 @@ mod tests {
                 GraphQLErrorPathSegment::String("field1".to_string())
             ]
         );
+    }
+
+    #[test]
+    fn prepare_batch_fetch_job_state_deduplicates_shared_variable_payloads() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let subgraph_endpoint_map = HashMap::from([(
+            "inventory".to_string(),
+            "http://example.com/graphql".parse().unwrap(),
+        )]);
+
+        let executors = SubgraphExecutorMap::from_http_endpoint_map(
+            &subgraph_endpoint_map,
+            HiveRouterConfig::default().into(),
+            Arc::new(TelemetryContext::from_propagation_config(
+                &Default::default(),
+            )),
+        )
+        .unwrap();
+
+        let executor = Executor {
+            variable_values: &None,
+            schema_metadata: &SchemaMetadata::default(),
+            executors: &executors,
+            client_request: &ClientRequestDetails {
+                method: &http::Method::POST,
+                url: &"http://example.com".parse().unwrap(),
+                headers: &HeaderMap::new(),
+                operation: OperationDetails {
+                    name: None,
+                    query: "{ products { upc } }",
+                    kind: "query",
+                },
+                jwt: JwtRequestDetails::Unauthenticated,
+            },
+            headers_plan: &HeaderRulesPlan::default(),
+            jwt_forwarding_plan: None,
+            dedupe_subgraph_requests: false,
+            plugin_req_state: &None,
+        };
+
+        let data: ResponseValue = sonic_rs::from_str(
+            r#"{
+                "products": [
+                    {"__typename": "Product", "upc": "1"},
+                    {"__typename": "Product", "upc": "2"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        fn document_into_selection<'a>(
+            doc: query::Document<'a, String>,
+        ) -> query::SelectionSet<'a, String> {
+            doc.definitions
+                .iter()
+                .find_map(|def| {
+                    let query::Definition::Operation(op) = def else {
+                        return None;
+                    };
+                    match op {
+                        query::OperationDefinition::SelectionSet(sel) => Some(sel),
+                        query::OperationDefinition::Query(q) => Some(&q.selection_set),
+                        query::OperationDefinition::Mutation(m) => Some(&m.selection_set),
+                        query::OperationDefinition::Subscription(s) => Some(&s.selection_set),
+                    }
+                })
+                .unwrap()
+                .clone()
+        }
+
+        let requires_query = parse_operation("{ ... on Product { upc } }");
+        let requires_selection = document_into_selection(requires_query);
+
+        let shared_var = "__batch_reps_0".to_string();
+        let entity_batch = EntityBatch {
+            aliases: vec![
+                EntityBatchAlias {
+                    alias: "_e0".to_string(),
+                    representations_variable_name: shared_var.clone(),
+                    merge_paths: vec![],
+                    requires: requires_selection.clone().into(),
+                    input_rewrites: None,
+                    output_rewrites: None,
+                },
+                EntityBatchAlias {
+                    alias: "_e1".to_string(),
+                    representations_variable_name: shared_var,
+                    merge_paths: vec![],
+                    requires: requires_selection.into(),
+                    input_rewrites: None,
+                    output_rewrites: None,
+                },
+            ],
+        };
+
+        let (raw_variable_values, aliases) =
+            executor.prepare_batch_fetch_job_state(&entity_batch, &data);
+
+        assert_eq!(aliases.len(), 2);
+        assert_eq!(raw_variable_values.len(), 1);
+        assert_eq!(raw_variable_values[0].0, "__batch_reps_0");
     }
 
     #[tokio::test]

--- a/lib/executor/src/executors/common.rs
+++ b/lib/executor/src/executors/common.rs
@@ -40,7 +40,7 @@ pub struct SubgraphExecutionRequest<'a> {
     // TODO: variables could be stringified before even executing the request
     pub variables: Option<HashMap<&'a str, &'a sonic_rs::Value>>,
     pub headers: HeaderMap,
-    pub representations: Option<Vec<u8>>,
+    pub raw_variable_values: Option<Vec<(&'a str, Vec<u8>)>>,
     pub extensions: Option<SubgraphRequestExtensions>,
 }
 

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -134,15 +134,20 @@ impl HTTPSubgraphExecutor {
                 body.put(value_str.as_bytes());
             }
         }
-        if let Some(representations) = &execution_request.representations {
-            if first_variable {
-                body.put(FIRST_VARIABLE_STR);
-                first_variable = false;
-            } else {
-                body.put(COMMA);
+        if let Some(raw_variable_values) = &execution_request.raw_variable_values {
+            for (variable_name, variable_value) in raw_variable_values {
+                if first_variable {
+                    body.put(FIRST_VARIABLE_STR);
+                    first_variable = false;
+                } else {
+                    body.put(COMMA);
+                }
+                body.put(QUOTE);
+                body.put(variable_name.as_bytes());
+                body.put(QUOTE);
+                body.put(COLON);
+                body.extend_from_slice(variable_value);
             }
-            body.put("\"representations\":".as_bytes());
-            body.extend_from_slice(representations);
         }
         // "first_variable" should be still true if there are no variables
         if !first_variable {

--- a/lib/executor/src/response/value.rs
+++ b/lib/executor/src/response/value.rs
@@ -44,9 +44,13 @@ impl Hash for Value<'_> {
 
 impl<'a> Value<'a> {
     pub fn take_entities(&mut self) -> Option<Vec<Value<'a>>> {
+        self.take_entities_by_key("_entities")
+    }
+
+    pub fn take_entities_by_key(&mut self, key: &str) -> Option<Vec<Value<'a>>> {
         match self {
             Value::Object(data) => {
-                if let Ok(entities_idx) = data.binary_search_by_key(&"_entities", |(k, _)| *k) {
+                if let Ok(entities_idx) = data.binary_search_by_key(&key, |(k, _)| *k) {
                     if let Value::Array(arr) = data.remove(entities_idx).1 {
                         return Some(arr);
                     }

--- a/lib/graphql-tools/src/parser/query/ast.rs
+++ b/lib/graphql-tools/src/parser/query/ast.rs
@@ -7,6 +7,7 @@
 //!
 pub use crate::parser::common::{Directive, Number, Text, Type, Value};
 use crate::parser::position::Pos;
+use std::convert::AsRef;
 
 /// Root of query data
 #[derive(Debug, Clone, PartialEq)]
@@ -124,6 +125,14 @@ pub struct FragmentSpread<'a, T: Text<'a>> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeCondition<'a, T: Text<'a>> {
     On(T::Value),
+}
+
+impl<'a, T: Text<'a>> AsRef<T::Value> for TypeCondition<'a, T> {
+    fn as_ref(&self) -> &T::Value {
+        match self {
+            Self::On(type_condition) => type_condition,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/lib/node-addon/dist/index.d.ts
+++ b/lib/node-addon/dist/index.d.ts
@@ -13,6 +13,7 @@ export interface QueryPlan {
 
 export type PlanNode =
   | FetchNode
+  | BatchFetchNode
   | SequenceNode
   | ParallelNode
   | FlattenNode
@@ -28,6 +29,30 @@ export interface FetchNode {
   operationName?: string;
   operation: string;
   requires?: RequiresSelection[];
+  inputRewrites?: InputRewrite[];
+  outputRewrites?: OutputRewrite[];
+}
+
+export interface BatchFetchNode {
+  kind: "BatchFetch";
+  serviceName: string;
+  variableUsages?: string[];
+  operationKind?: "query" | "mutation" | "subscription";
+  operationName?: string;
+  operation: string;
+  entityBatch: EntityBatch;
+}
+
+export interface EntityBatch {
+  aliases: EntityBatchAlias[];
+}
+
+export interface EntityBatchAlias {
+  alias: string;
+  representationsVariableName: string;
+  paths: FlattenNodePathSegment[][];
+  requires: RequiresSelection[];
+  entitiesSelection: RequiresSelection[];
   inputRewrites?: InputRewrite[];
   outputRewrites?: OutputRewrite[];
 }

--- a/lib/node-addon/src/query-plan.d.ts
+++ b/lib/node-addon/src/query-plan.d.ts
@@ -5,6 +5,7 @@ export interface QueryPlan {
 
 export type PlanNode =
   | FetchNode
+  | BatchFetchNode
   | SequenceNode
   | ParallelNode
   | FlattenNode
@@ -20,6 +21,29 @@ export interface FetchNode {
   operationName?: string;
   operation: string;
   requires?: RequiresSelection[];
+  inputRewrites?: InputRewrite[];
+  outputRewrites?: OutputRewrite[];
+}
+
+export interface BatchFetchNode {
+  kind: "BatchFetch";
+  serviceName: string;
+  variableUsages?: string[];
+  operationKind?: "query" | "mutation" | "subscription";
+  operationName?: string;
+  operation: string;
+  entityBatch: EntityBatch;
+}
+
+export interface EntityBatch {
+  aliases: EntityBatchAlias[];
+}
+
+export interface EntityBatchAlias {
+  alias: string;
+  representationsVariableName: string;
+  paths: FlattenNodePathSegment[][];
+  requires: RequiresSelection[];
   inputRewrites?: InputRewrite[];
   outputRewrites?: OutputRewrite[];
 }

--- a/lib/node-addon/tests/index.ts.snapshot
+++ b/lib/node-addon/tests/index.ts.snapshot
@@ -64,66 +64,70 @@ exports[`fixtures > should plan federation-example/query.graphql 1`] = `
             ]
           },
           {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{reviews{id body author{__typename id reviews{id body product{__typename upc}} username}}}}}",
-              "operationKind": "query",
-              "requires": [
+            "entityBatch": {
+              "aliases": [
                 {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "upc"
-                    }
+                  "alias": "_e0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "topProducts"
+                      },
+                      "@"
+                    ]
                   ],
-                  "typeCondition": "Product"
-                }
-              ],
-              "serviceName": "reviews"
-            },
-            "path": [
-              {
-                "Field": "topProducts"
-              },
-              "@"
-            ]
-          },
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{reviews{id body product{__typename upc reviews{id body author{__typename id reviews{id body product{__typename upc}} username}}}}}}}",
-              "operationKind": "query",
-              "requires": [
+                  "representationsVariableName": "__batch_reps_0",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "kind": "Field",
+                          "name": "__typename"
+                        },
+                        {
+                          "kind": "Field",
+                          "name": "upc"
+                        }
+                      ],
+                      "typeCondition": "Product"
+                    }
+                  ]
+                },
                 {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "id"
-                    }
+                  "alias": "_e1",
+                  "paths": [
+                    [
+                      {
+                        "Field": "users"
+                      },
+                      "@"
+                    ]
                   ],
-                  "typeCondition": "User"
+                  "representationsVariableName": "__batch_reps_1",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "kind": "Field",
+                          "name": "__typename"
+                        },
+                        {
+                          "kind": "Field",
+                          "name": "id"
+                        }
+                      ],
+                      "typeCondition": "User"
+                    }
+                  ]
                 }
-              ],
-              "serviceName": "reviews"
+              ]
             },
-            "path": [
-              {
-                "Field": "users"
-              },
-              "@"
-            ]
+            "kind": "BatchFetch",
+            "operation": "query($__batch_reps_0:[_Any!]!, $__batch_reps_1:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{reviews{...a}}} _e1: _entities(representations: $__batch_reps_1){...on User{reviews{id body product{__typename upc reviews{...a}}}}}}\\n\\nfragment a on Review {id body author{__typename id reviews{id body product{__typename upc}} username}}\\n",
+            "operationKind": "query",
+            "serviceName": "reviews"
           }
         ]
       },
@@ -131,234 +135,232 @@ exports[`fixtures > should plan federation-example/query.graphql 1`] = `
         "kind": "Parallel",
         "nodes": [
           {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{price weight name}}}",
-              "operationKind": "query",
-              "requires": [
+            "entityBatch": {
+              "aliases": [
                 {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "upc"
-                    }
+                  "alias": "_e0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "topProducts"
+                      },
+                      "@",
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "author"
+                      },
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "product"
+                      }
+                    ],
+                    [
+                      {
+                        "Field": "users"
+                      },
+                      "@",
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "product"
+                      }
+                    ],
+                    [
+                      {
+                        "Field": "users"
+                      },
+                      "@",
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "product"
+                      },
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "author"
+                      },
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "product"
+                      }
+                    ]
                   ],
-                  "typeCondition": "Product"
+                  "representationsVariableName": "__batch_reps_0",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "kind": "Field",
+                          "name": "__typename"
+                        },
+                        {
+                          "kind": "Field",
+                          "name": "upc"
+                        }
+                      ],
+                      "typeCondition": "Product"
+                    }
+                  ]
                 }
-              ],
-              "serviceName": "products"
+              ]
             },
-            "path": [
-              {
-                "Field": "topProducts"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "author"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              }
-            ]
+            "kind": "BatchFetch",
+            "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{price weight name}}}",
+            "operationKind": "query",
+            "serviceName": "products"
           },
           {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{name}}}",
-              "operationKind": "query",
-              "requires": [
+            "entityBatch": {
+              "aliases": [
                 {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "id"
-                    }
+                  "alias": "_e0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "topProducts"
+                      },
+                      "@",
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "author"
+                      }
+                    ],
+                    [
+                      {
+                        "Field": "users"
+                      },
+                      "@",
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "product"
+                      },
+                      {
+                        "Field": "reviews"
+                      },
+                      "@",
+                      {
+                        "Field": "author"
+                      }
+                    ]
                   ],
-                  "typeCondition": "User"
-                }
-              ],
-              "serviceName": "accounts"
-            },
-            "path": [
-              {
-                "Field": "topProducts"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "author"
-              }
-            ]
-          },
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{price weight name}}}",
-              "operationKind": "query",
-              "requires": [
-                {
-                  "kind": "InlineFragment",
-                  "selections": [
+                  "representationsVariableName": "__batch_reps_0",
+                  "requires": [
                     {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "upc"
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "kind": "Field",
+                          "name": "__typename"
+                        },
+                        {
+                          "kind": "Field",
+                          "name": "id"
+                        }
+                      ],
+                      "typeCondition": "User"
                     }
-                  ],
-                  "typeCondition": "Product"
+                  ]
                 }
-              ],
-              "serviceName": "products"
+              ]
             },
-            "path": [
-              {
-                "Field": "users"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              }
-            ]
-          },
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{price weight name}}}",
-              "operationKind": "query",
-              "requires": [
-                {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "upc"
-                    }
-                  ],
-                  "typeCondition": "Product"
-                }
-              ],
-              "serviceName": "products"
-            },
-            "path": [
-              {
-                "Field": "users"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "author"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              }
-            ]
-          },
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{name}}}",
-              "operationKind": "query",
-              "requires": [
-                {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "id"
-                    }
-                  ],
-                  "typeCondition": "User"
-                }
-              ],
-              "serviceName": "accounts"
-            },
-            "path": [
-              {
-                "Field": "users"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "author"
-              }
-            ]
+            "kind": "BatchFetch",
+            "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on User{name}}}",
+            "operationKind": "query",
+            "serviceName": "accounts"
           }
         ]
       },
       {
-        "kind": "Parallel",
-        "nodes": [
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{inStock shippingEstimate}}}",
-              "operationKind": "query",
+        "entityBatch": {
+          "aliases": [
+            {
+              "alias": "_e0",
+              "paths": [
+                [
+                  {
+                    "Field": "topProducts"
+                  },
+                  "@",
+                  {
+                    "Field": "reviews"
+                  },
+                  "@",
+                  {
+                    "Field": "author"
+                  },
+                  {
+                    "Field": "reviews"
+                  },
+                  "@",
+                  {
+                    "Field": "product"
+                  }
+                ],
+                [
+                  {
+                    "Field": "users"
+                  },
+                  "@",
+                  {
+                    "Field": "reviews"
+                  },
+                  "@",
+                  {
+                    "Field": "product"
+                  }
+                ],
+                [
+                  {
+                    "Field": "users"
+                  },
+                  "@",
+                  {
+                    "Field": "reviews"
+                  },
+                  "@",
+                  {
+                    "Field": "product"
+                  },
+                  {
+                    "Field": "reviews"
+                  },
+                  "@",
+                  {
+                    "Field": "author"
+                  },
+                  {
+                    "Field": "reviews"
+                  },
+                  "@",
+                  {
+                    "Field": "product"
+                  }
+                ]
+              ],
+              "representationsVariableName": "__batch_reps_0",
               "requires": [
                 {
                   "kind": "InlineFragment",
@@ -382,137 +384,14 @@ exports[`fixtures > should plan federation-example/query.graphql 1`] = `
                   ],
                   "typeCondition": "Product"
                 }
-              ],
-              "serviceName": "inventory"
-            },
-            "path": [
-              {
-                "Field": "topProducts"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "author"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              }
-            ]
-          },
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{inStock shippingEstimate}}}",
-              "operationKind": "query",
-              "requires": [
-                {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "upc"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "price"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "weight"
-                    }
-                  ],
-                  "typeCondition": "Product"
-                }
-              ],
-              "serviceName": "inventory"
-            },
-            "path": [
-              {
-                "Field": "users"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              }
-            ]
-          },
-          {
-            "kind": "Flatten",
-            "node": {
-              "kind": "Fetch",
-              "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{inStock shippingEstimate}}}",
-              "operationKind": "query",
-              "requires": [
-                {
-                  "kind": "InlineFragment",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "name": "__typename"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "upc"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "price"
-                    },
-                    {
-                      "kind": "Field",
-                      "name": "weight"
-                    }
-                  ],
-                  "typeCondition": "Product"
-                }
-              ],
-              "serviceName": "inventory"
-            },
-            "path": [
-              {
-                "Field": "users"
-              },
-              "@",
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "author"
-              },
-              {
-                "Field": "reviews"
-              },
-              "@",
-              {
-                "Field": "product"
-              }
-            ]
-          }
-        ]
+              ]
+            }
+          ]
+        },
+        "kind": "BatchFetch",
+        "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{inStock shippingEstimate}}}",
+        "operationKind": "query",
+        "serviceName": "inventory"
       }
     ]
   }

--- a/lib/query-planner/src/ast/fragment.rs
+++ b/lib/query-planner/src/ast/fragment.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use graphql_tools::parser::query as parser;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -31,6 +32,16 @@ impl Eq for FragmentDefinition {}
 impl PartialEq for FragmentDefinition {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
+    }
+}
+
+impl<'a, T: parser::Text<'a>> From<parser::FragmentDefinition<'a, T>> for FragmentDefinition {
+    fn from(fragment_def: parser::FragmentDefinition<'a, T>) -> Self {
+        FragmentDefinition {
+            name: fragment_def.name.as_ref().to_string(),
+            selection_set: fragment_def.selection_set.into(),
+            type_condition: fragment_def.type_condition.as_ref().as_ref().to_string(),
+        }
     }
 }
 

--- a/lib/query-planner/src/ast/fragment_expansion.rs
+++ b/lib/query-planner/src/ast/fragment_expansion.rs
@@ -1,0 +1,76 @@
+use super::{
+    fragment::FragmentDefinition,
+    selection_item::SelectionItem,
+    selection_set::{InlineFragmentSelection, SelectionSet},
+};
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum FragmentExpansionError {
+    #[error("Could not find fragment definition '{0}'")]
+    MissingFragment(String),
+    #[error("Detected cycle while expanding fragment spread '{0}'")]
+    Cycle(String),
+}
+
+impl SelectionSet {
+    pub fn inline_fragment_spreads(
+        &self,
+        fragments: &[FragmentDefinition],
+    ) -> Result<SelectionSet, FragmentExpansionError> {
+        let mut visiting = Vec::new();
+        inline_fragment_spreads_inner(self, fragments, &mut visiting)
+    }
+}
+
+fn inline_fragment_spreads_inner(
+    selection_set: &SelectionSet,
+    fragments: &[FragmentDefinition],
+    visiting: &mut Vec<String>,
+) -> Result<SelectionSet, FragmentExpansionError> {
+    let mut items = Vec::with_capacity(selection_set.items.len());
+
+    for item in &selection_set.items {
+        match item {
+            SelectionItem::Field(field) => {
+                let expanded_selections =
+                    inline_fragment_spreads_inner(&field.selections, fragments, visiting)?;
+                items.push(SelectionItem::Field(
+                    field.with_new_selections(expanded_selections),
+                ));
+            }
+            SelectionItem::InlineFragment(fragment) => {
+                let expanded_selections =
+                    inline_fragment_spreads_inner(&fragment.selections, fragments, visiting)?;
+                items.push(SelectionItem::InlineFragment(
+                    fragment.with_new_selections(expanded_selections),
+                ));
+            }
+            SelectionItem::FragmentSpread(fragment_name) => {
+                if visiting.contains(fragment_name) {
+                    return Err(FragmentExpansionError::Cycle(fragment_name.clone()));
+                }
+
+                let fragment = fragments
+                    .iter()
+                    .find(|fragment| fragment.name == *fragment_name)
+                    .ok_or_else(|| {
+                        FragmentExpansionError::MissingFragment(fragment_name.clone())
+                    })?;
+
+                visiting.push(fragment_name.clone());
+                let expanded_selections =
+                    inline_fragment_spreads_inner(&fragment.selection_set, fragments, visiting)?;
+                visiting.pop();
+
+                items.push(SelectionItem::InlineFragment(InlineFragmentSelection {
+                    type_condition: fragment.type_condition.clone(),
+                    selections: expanded_selections,
+                    skip_if: None,
+                    include_if: None,
+                }));
+            }
+        }
+    }
+
+    Ok(SelectionSet { items })
+}

--- a/lib/query-planner/src/ast/hash.rs
+++ b/lib/query-planner/src/ast/hash.rs
@@ -1,7 +1,9 @@
-use rustc_hash::{FxBuildHasher, FxHasher};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
+use std::cell::RefCell;
 use std::hash::{BuildHasher, Hash, Hasher};
 
 use crate::ast::arguments::ArgumentsMap;
+use crate::ast::fragment::FragmentDefinition;
 use crate::ast::operation::{OperationDefinition, VariableDefinition};
 use crate::ast::selection_item::SelectionItem;
 use crate::ast::selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet};
@@ -9,8 +11,49 @@ use crate::ast::value::Value;
 use crate::state::supergraph_state::{self, OperationKind, TypeNode};
 
 /// A trait for hashing AST nodes, with support for both order-dependent and order-independent hashing.
+pub struct SemanticShapeHashContext<'a> {
+    fragments: &'a [FragmentDefinition],
+    fragment_indices_by_name: FxHashMap<String, usize>,
+    visiting_fragment_names: RefCell<FxHashSet<String>>,
+}
+
+impl<'a> SemanticShapeHashContext<'a> {
+    pub fn new(fragments: &'a [FragmentDefinition]) -> Self {
+        let mut fragment_indices_by_name = FxHashMap::default();
+        for (index, fragment) in fragments.iter().enumerate() {
+            fragment_indices_by_name.insert(fragment.name.clone(), index);
+        }
+
+        Self {
+            fragments,
+            fragment_indices_by_name,
+            visiting_fragment_names: RefCell::new(FxHashSet::default()),
+        }
+    }
+
+    fn get_fragment_by_name(&self, name: &str) -> Option<&'a FragmentDefinition> {
+        let fragment_index = *self.fragment_indices_by_name.get(name)?;
+        self.fragments.get(fragment_index)
+    }
+
+    fn mark_visiting(&self, name: &str) -> bool {
+        self.visiting_fragment_names
+            .borrow_mut()
+            .insert(name.to_owned())
+    }
+
+    fn unmark_visiting(&self, name: &str) {
+        self.visiting_fragment_names.borrow_mut().remove(name);
+    }
+}
+
 pub trait ASTHash {
     fn ast_hash<H: Hasher, const ORDER_INDEPENDENT: bool>(&self, hasher: &mut H);
+
+    /// Order-independent hashing with fragment spreads inlined
+    fn semantic_shape_hash<H: Hasher>(&self, hasher: &mut H, _ctx: &SemanticShapeHashContext<'_>) {
+        self.ast_hash::<_, true>(hasher);
+    }
 }
 
 pub fn ast_hash(query: &OperationDefinition) -> u64 {
@@ -79,6 +122,26 @@ impl ASTHash for SelectionSet {
             }
         }
     }
+
+    fn semantic_shape_hash<H: Hasher>(&self, hasher: &mut H, ctx: &SemanticShapeHashContext<'_>) {
+        // Use xor + sum + count to avoid collisions like {a b a a} vs {a b c c}
+        let mut xor = 0u64;
+        let mut sum = 0u64;
+        let mut count = 0u64;
+
+        for item in &self.items {
+            let mut item_hasher = FxHasher::default();
+            item.semantic_shape_hash(&mut item_hasher, ctx);
+            let value = item_hasher.finish();
+            xor ^= value;
+            sum = sum.wrapping_add(value);
+            count = count.wrapping_add(1);
+        }
+
+        xor.hash(hasher);
+        sum.hash(hasher);
+        count.hash(hasher);
+    }
 }
 
 impl ASTHash for SelectionItem {
@@ -87,6 +150,23 @@ impl ASTHash for SelectionItem {
             SelectionItem::Field(field) => field.ast_hash::<_, ORDER_INDEPENDENT>(hasher),
             SelectionItem::InlineFragment(frag) => frag.ast_hash::<_, ORDER_INDEPENDENT>(hasher),
             SelectionItem::FragmentSpread(name) => name.hash(hasher),
+        }
+    }
+
+    fn semantic_shape_hash<H: Hasher>(&self, hasher: &mut H, ctx: &SemanticShapeHashContext<'_>) {
+        match self {
+            SelectionItem::Field(field) => field.semantic_shape_hash(hasher, ctx),
+            SelectionItem::InlineFragment(inline) => inline.semantic_shape_hash(hasher, ctx),
+            SelectionItem::FragmentSpread(name) => {
+                if !ctx.mark_visiting(name) {
+                    // Cycle detected - hash nothing (unique marker)
+                    return;
+                }
+                if let Some(fragment) = ctx.get_fragment_by_name(name) {
+                    fragment.selection_set.semantic_shape_hash(hasher, ctx);
+                }
+                ctx.unmark_visiting(name);
+            }
         }
     }
 }
@@ -110,12 +190,46 @@ impl ASTHash for &FieldSelection {
             var_name.hash(hasher);
         }
     }
+
+    fn semantic_shape_hash<H: Hasher>(&self, hasher: &mut H, ctx: &SemanticShapeHashContext<'_>) {
+        self.name.hash(hasher);
+        self.alias.hash(hasher);
+        self.selections.semantic_shape_hash(hasher, ctx);
+
+        if let Some(args) = &self.arguments {
+            args.ast_hash::<_, true>(hasher);
+        }
+
+        if let Some(var_name) = self.include_if.as_ref() {
+            "@include".hash(hasher);
+            var_name.hash(hasher);
+        }
+        if let Some(var_name) = self.skip_if.as_ref() {
+            "@skip".hash(hasher);
+            var_name.hash(hasher);
+        }
+    }
 }
 
 impl ASTHash for &InlineFragmentSelection {
     fn ast_hash<H: Hasher, const ORDER_INDEPENDENT: bool>(&self, hasher: &mut H) {
         self.type_condition.hash(hasher);
         self.selections.ast_hash::<_, ORDER_INDEPENDENT>(hasher);
+        if let Some(var_name) = self.include_if.as_ref() {
+            "@include".hash(hasher);
+            var_name.hash(hasher);
+        }
+        if let Some(var_name) = self.skip_if.as_ref() {
+            "@skip".hash(hasher);
+            var_name.hash(hasher);
+        }
+    }
+
+    fn semantic_shape_hash<H: Hasher>(&self, hasher: &mut H, ctx: &SemanticShapeHashContext<'_>) {
+        // Include type_condition (key for "... on Product" vs "... on User")
+        self.type_condition.hash(hasher);
+        self.selections.semantic_shape_hash(hasher, ctx);
+
         if let Some(var_name) = self.include_if.as_ref() {
             "@include".hash(hasher);
             var_name.hash(hasher);

--- a/lib/query-planner/src/ast/mod.rs
+++ b/lib/query-planner/src/ast/mod.rs
@@ -1,5 +1,6 @@
 pub mod document;
 pub mod fragment;
+pub mod fragment_expansion;
 pub mod hash;
 pub mod minification;
 pub mod normalization;

--- a/lib/query-planner/src/ast/operation.rs
+++ b/lib/query-planner/src/ast/operation.rs
@@ -48,11 +48,11 @@ pub struct SubgraphFetchOperation {
 
 impl SubgraphFetchOperation {
     pub fn get_inner_selection_set(&self) -> &SelectionSet {
-        if let SelectionItem::Field(field) = &self.document.operation.selection_set.items[0] {
-            if field.name == "_entities" {
-                return &field.selections;
-            } else {
-                return &self.document.operation.selection_set;
+        if self.document.operation.selection_set.items.len() == 1 {
+            if let SelectionItem::Field(field) = &self.document.operation.selection_set.items[0] {
+                if field.name == "_entities" && field.alias.is_none() {
+                    return &field.selections;
+                }
             }
         }
 
@@ -171,6 +171,17 @@ pub struct VariableDefinition {
     pub name: String,
     pub variable_type: TypeNode,
     pub default_value: Option<crate::ast::value::Value>,
+}
+
+impl VariableDefinition {
+    /// Checks if this variable definition is compatible with another
+    pub fn can_merge(&self, other: &Self) -> bool {
+        if self.name != other.name {
+            return false;
+        }
+
+        self.variable_type == other.variable_type && self.default_value == other.default_value
+    }
 }
 
 impl Display for VariableDefinition {

--- a/lib/query-planner/src/ast/selection_item.rs
+++ b/lib/query-planner/src/ast/selection_item.rs
@@ -5,7 +5,6 @@ use crate::{
 use graphql_tools::parser::query as query_ast;
 
 use super::selection_set::{FieldSelection, InlineFragmentSelection};
-use core::panic;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeSet,
@@ -225,8 +224,8 @@ impl<'a, T: query_ast::Text<'a>> From<query_ast::Selection<'a, T>> for Selection
             query_ast::Selection::InlineFragment(fragment) => {
                 SelectionItem::InlineFragment(fragment.into())
             }
-            query_ast::Selection::FragmentSpread(_) => {
-                panic!("Received a fragment spread, but it should be inlined after normalization");
+            query_ast::Selection::FragmentSpread(fragment) => {
+                SelectionItem::FragmentSpread(fragment.fragment_name.as_ref().into())
             }
         }
     }

--- a/lib/query-planner/src/ast/selection_set.rs
+++ b/lib/query-planner/src/ast/selection_set.rs
@@ -8,6 +8,7 @@ use std::{
 
 use crate::{
     ast::merge_path::{Condition, MergePath, Segment},
+    ast::value::Value,
     utils::pretty_display::{get_indent, PrettyDisplay},
 };
 
@@ -91,6 +92,17 @@ impl SelectionSet {
                 .map(|item| item.strip_for_plan_input())
                 .collect(),
         }
+    }
+
+    pub fn entities_field(&self) -> Option<&FieldSelection> {
+        self.items.iter().find_map(|item| {
+            if let SelectionItem::Field(field) = item {
+                if field.name == "_entities" {
+                    return Some(field);
+                }
+            }
+            None
+        })
     }
 }
 
@@ -235,6 +247,16 @@ impl FieldSelection {
 
     pub fn is_introspection_field(&self) -> bool {
         self.name.starts_with("__")
+    }
+
+    /// Returns the name of the variable if this field represents a representation variable.
+    pub fn representations_variable_name(&self) -> Option<&str> {
+        let value = self.arguments.as_ref()?.get_argument("representations")?;
+
+        match value {
+            Value::Variable(variable_name) => Some(variable_name.as_str()),
+            _ => None,
+        }
     }
 }
 

--- a/lib/query-planner/src/planner/error.rs
+++ b/lib/query-planner/src/planner/error.rs
@@ -1,4 +1,7 @@
-use crate::{graph::error::GraphError, utils::cancellation::CancellationError};
+use crate::{
+    ast::fragment_expansion::FragmentExpansionError, graph::error::GraphError,
+    utils::cancellation::CancellationError,
+};
 
 use super::fetch::error::FetchGraphError;
 
@@ -16,6 +19,8 @@ pub enum QueryPlanError {
     UnexpectedPendingState,
     #[error("Internal Error: {0}")]
     Internal(String),
+    #[error("Fragment expansion error: {0}")]
+    FragmentExpansionFailure(#[from] FragmentExpansionError),
     #[error(transparent)]
     CancellationError(#[from] CancellationError),
 }

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -29,65 +29,76 @@ pub struct QueryPlan {
     pub node: Option<PlanNode>,
 }
 
-impl QueryPlan {
-    pub fn fetch_nodes(&self) -> Vec<&FetchNode> {
-        match self.node.as_ref() {
-            Some(node) => {
-                let mut list = vec![];
-                Self::fetch_nodes_from_node(node, &mut list);
-                list
-            }
-            None => vec![],
-        }
-    }
-
-    fn fetch_nodes_from_node<'a>(node: &'a PlanNode, list: &mut Vec<&'a FetchNode>) {
-        match node {
-            PlanNode::Condition(node) => {
-                if let Some(node) = node.else_clause.as_ref() {
-                    Self::fetch_nodes_from_node(node.as_ref(), list);
-                }
-                if let Some(node) = node.if_clause.as_ref() {
-                    Self::fetch_nodes_from_node(node.as_ref(), list);
-                }
-            }
-            PlanNode::Fetch(node) => {
-                list.push(node);
-            }
-            PlanNode::Sequence(node) => {
-                for child in &node.nodes {
-                    Self::fetch_nodes_from_node(child, list);
-                }
-            }
-            PlanNode::Parallel(node) => {
-                for child in &node.nodes {
-                    Self::fetch_nodes_from_node(child, list);
-                }
-            }
-            PlanNode::Flatten(node) => {
-                Self::fetch_nodes_from_node(&node.node, list);
-            }
-            PlanNode::Subscription(node) => {
-                Self::fetch_nodes_from_node(node.primary.as_ref(), list);
-            }
-            PlanNode::Defer(_) => {
-                unreachable!("DeferNode is not supported yet");
-            }
-        }
-    }
-}
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "kind")]
 pub enum PlanNode {
     Fetch(FetchNode),
+    BatchFetch(BatchFetchNode),
     Sequence(SequenceNode),
     Parallel(ParallelNode),
     Flatten(FlattenNode),
     Condition(ConditionNode),
     Subscription(SubscriptionNode),
     Defer(DeferNode),
+}
+
+impl PlanNode {
+    pub fn as_fetch(&self) -> Option<&FetchNode> {
+        match self {
+            PlanNode::Fetch(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_batch_fetch(&self) -> Option<&BatchFetchNode> {
+        match self {
+            PlanNode::BatchFetch(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_sequence(&self) -> Option<&SequenceNode> {
+        match self {
+            PlanNode::Sequence(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_parallel(&self) -> Option<&ParallelNode> {
+        match self {
+            PlanNode::Parallel(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_flatten(&self) -> Option<&FlattenNode> {
+        match self {
+            PlanNode::Flatten(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_condition(&self) -> Option<&ConditionNode> {
+        match self {
+            PlanNode::Condition(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_subscription(&self) -> Option<&SubscriptionNode> {
+        match self {
+            PlanNode::Subscription(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub fn as_defer(&self) -> Option<&DeferNode> {
+        match self {
+            PlanNode::Defer(node) => Some(node),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,6 +116,42 @@ pub struct FetchNode {
     pub operation: SubgraphFetchOperation,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<SelectionSet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_rewrites: Option<Vec<FetchRewrite>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_rewrites: Option<Vec<FetchRewrite>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchFetchNode {
+    #[serde(skip_serializing)]
+    pub id: i64,
+    pub service_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variable_usages: Option<BTreeSet<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_kind: Option<OperationKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_name: Option<String>,
+    pub operation: SubgraphFetchOperation,
+    pub entity_batch: EntityBatch,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityBatch {
+    pub aliases: Vec<EntityBatchAlias>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityBatchAlias {
+    pub alias: String,
+    pub representations_variable_name: String,
+    #[serde(rename = "paths")]
+    pub merge_paths: Vec<FlattenNodePath>,
+    pub requires: SelectionSet,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_rewrites: Option<Vec<FetchRewrite>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -136,14 +183,51 @@ pub struct ConditionNode {
     pub else_clause: Option<Box<PlanNode>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+impl ConditionNode {
+    /// Checks if this condition node can be merged with another.
+    pub fn can_merge_with(&self, other: &Self) -> bool {
+        if self.condition != other.condition {
+            return false;
+        }
+
+        let both_if = self.else_clause.is_none() && other.else_clause.is_none();
+        let both_else = self.if_clause.is_none() && other.if_clause.is_none();
+
+        both_if || both_else
+    }
+
+    /// Merges another compatible condition node into this one.
+    pub fn merge(&mut self, mut other: Self) {
+        let merge_into_if_clause = self.if_clause.is_some();
+        let mut nodes = self.take_inner_nodes();
+        nodes.extend(other.take_inner_nodes());
+
+        let merged_body = PlanNode::sequence(nodes);
+
+        if merge_into_if_clause {
+            self.if_clause = Some(Box::new(merged_body));
+        } else {
+            self.else_clause = Some(Box::new(merged_body));
+        }
+    }
+
+    fn take_inner_nodes(&mut self) -> Vec<PlanNode> {
+        self.if_clause
+            .take()
+            .or_else(|| self.else_clause.take())
+            .map(|n| n.flatten_sequence())
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyRenamer {
     pub path: Vec<FetchNodePathSegment>,
     pub rename_key_to: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FetchNodePathSegment {
     Key(String),
     TypenameEquals(BTreeSet<String>),
@@ -155,13 +239,13 @@ impl FetchNodePathSegment {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FetchRewrite {
     ValueSetter(ValueSetter),
     KeyRenamer(KeyRenamer),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FlattenNodePathSegment {
     Field(String),
     TypeCondition(BTreeSet<String>),
@@ -196,7 +280,7 @@ impl FlattenNodePathSegment {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FlattenNodePath(Vec<FlattenNodePathSegment>);
 
 impl FlattenNodePath {
@@ -265,7 +349,7 @@ impl From<MergePath> for FlattenNodePath {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct ValueSetter {
     pub path: Vec<FetchNodePathSegment>,
@@ -318,6 +402,53 @@ impl PlanNode {
             PlanNode::Sequence(node) => node.nodes,
             PlanNode::Parallel(node) => node.nodes,
             other => vec![other],
+        }
+    }
+
+    /// If the node is a Sequence, returns its children. Otherwise, returns the node itself in a Vec.
+    /// This is used to "splice" nodes into a parent Sequence without creating nested Sequences.
+    pub fn flatten_sequence(self) -> Vec<PlanNode> {
+        match self {
+            PlanNode::Sequence(node) => node.nodes,
+            other => vec![other],
+        }
+    }
+
+    /// Flattens nested Parallel nodes into a single list of nodes.
+    pub fn flatten_parallel(nodes: Vec<PlanNode>) -> Vec<PlanNode> {
+        let mut flattened = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            match node {
+                PlanNode::Parallel(p) => flattened.extend(p.nodes),
+                other => flattened.push(other),
+            }
+        }
+        flattened
+    }
+
+    pub fn sequence(mut nodes: Vec<PlanNode>) -> PlanNode {
+        if nodes.len() == 1 {
+            nodes.remove(0)
+        } else {
+            PlanNode::Sequence(SequenceNode { nodes })
+        }
+    }
+
+    pub fn parallel(mut nodes: Vec<PlanNode>) -> PlanNode {
+        if nodes.len() == 1 {
+            nodes.remove(0)
+        } else {
+            PlanNode::Parallel(ParallelNode { nodes })
+        }
+    }
+
+    pub fn is_fetching_node(&self) -> bool {
+        match self {
+            PlanNode::Fetch(_) | PlanNode::BatchFetch(_) => true,
+            PlanNode::Flatten(flatten_node) => {
+                matches!(flatten_node.node.as_ref(), PlanNode::Fetch(_))
+            }
+            _ => false,
         }
     }
 }
@@ -492,6 +623,12 @@ impl Display for FetchNode {
     }
 }
 
+impl Display for BatchFetchNode {
+    fn fmt(&self, f: &mut FmtFormatter<'_>) -> FmtResult {
+        self.pretty_fmt(f, 0)
+    }
+}
+
 impl Display for FlattenNode {
     fn fmt(&self, f: &mut FmtFormatter<'_>) -> FmtResult {
         self.pretty_fmt(f, 0)
@@ -521,6 +658,35 @@ impl PrettyDisplay for FetchNode {
             requires.pretty_fmt(f, depth + 2)?;
             writeln!(f, "{indent}  }} =>")?;
         }
+        self.operation.pretty_fmt(f, depth)?;
+        writeln!(f, "{indent}}},")?;
+
+        Ok(())
+    }
+}
+
+impl PrettyDisplay for BatchFetchNode {
+    fn pretty_fmt(&self, f: &mut FmtFormatter<'_>, depth: usize) -> FmtResult {
+        let indent = get_indent(depth);
+        writeln!(
+            f,
+            "{indent}BatchFetch(service: \"{}\") {{",
+            self.service_name
+        )?;
+        writeln!(f, "{indent}  {{")?;
+        for alias in &self.entity_batch.aliases {
+            writeln!(f, "{indent}    {} {{", alias.alias)?;
+            writeln!(f, "{indent}      paths: [")?;
+            for merge_path in &alias.merge_paths {
+                writeln!(f, "{indent}        \"{}\"", merge_path)?;
+            }
+            writeln!(f, "{indent}      ]")?;
+            writeln!(f, "{indent}      {{")?;
+            alias.requires.pretty_fmt(f, depth + 4)?;
+            writeln!(f, "{indent}      }}")?;
+            writeln!(f, "{indent}    }}")?;
+        }
+        writeln!(f, "{indent}  }}")?;
         self.operation.pretty_fmt(f, depth)?;
         writeln!(f, "{indent}}},")?;
 
@@ -592,6 +758,7 @@ impl PrettyDisplay for PlanNode {
     fn pretty_fmt(&self, f: &mut FmtFormatter<'_>, depth: usize) -> FmtResult {
         match self {
             PlanNode::Fetch(node) => node.pretty_fmt(f, depth),
+            PlanNode::BatchFetch(node) => node.pretty_fmt(f, depth),
             PlanNode::Flatten(node) => node.pretty_fmt(f, depth),
             PlanNode::Sequence(node) => node.pretty_fmt(f, depth),
             PlanNode::Parallel(node) => node.pretty_fmt(f, depth),
@@ -601,7 +768,7 @@ impl PrettyDisplay for PlanNode {
     }
 }
 
-fn hash_minified_query(minified_query: &str) -> u64 {
+pub fn hash_minified_query(minified_query: &str) -> u64 {
     let mut hasher = Xxh3::new();
     minified_query.hash(&mut hasher);
     hasher.finish()

--- a/lib/query-planner/src/planner/query_plan.rs
+++ b/lib/query-planner/src/planner/query_plan.rs
@@ -3,15 +3,22 @@ use std::collections::{HashMap, VecDeque};
 use petgraph::{graph::NodeIndex, visit::EdgeRef};
 
 use crate::{
-    planner::fetch::state::MultiTypeFetchStep, planner::plan_nodes::ConditionNode,
-    state::supergraph_state::SupergraphState, utils::cancellation::CancellationToken,
+    planner::{
+        fetch::state::MultiTypeFetchStep,
+        plan_nodes::PlanNode,
+        query_plan::optimize::{optimize_root_node, optimize_top_level_sequence},
+    },
+    state::supergraph_state::SupergraphState,
+    utils::cancellation::CancellationToken,
 };
 
 use super::{
     error::QueryPlanError,
     fetch::fetch_graph::FetchGraph,
-    plan_nodes::{ParallelNode, PlanNode, QueryPlan, SequenceNode},
+    plan_nodes::{ParallelNode, QueryPlan, SequenceNode},
 };
+
+mod optimize;
 
 /// Tracks the in-degree of FetchGraph (DAG) in a dependency graph.
 /// The in-degree of a step is the number of its prerequisite parent steps
@@ -167,7 +174,8 @@ pub fn build_query_plan_from_fetch_graph(
         }
     }
 
-    let overall_plan_sequence = optimize_plan_sequence(overall_plan_sequence);
+    // First do light top-level normalization (e.g. flatten nested Sequence wrappers).
+    let overall_plan_sequence = optimize_top_level_sequence(overall_plan_sequence);
 
     let root_node = match overall_plan_sequence.len() == 1 {
         true => overall_plan_sequence.into_iter().next().unwrap(),
@@ -176,95 +184,11 @@ pub fn build_query_plan_from_fetch_graph(
         }),
     };
 
+    // Then run full recursive optimization + batching rewrites.
+    let root_node = optimize_root_node(root_node, supergraph)?;
+
     Ok(QueryPlan {
         kind: QUERY_PLAN_KIND,
         node: Some(root_node),
-    })
-}
-
-fn are_conditions_compatible(c1: &ConditionNode, c2: &ConditionNode) -> bool {
-    // They refer to different variables
-    if c1.condition != c2.condition {
-        return false;
-    }
-
-    // Skip and Skip
-    if c1.if_clause.is_none() && c2.if_clause.is_none() {
-        return true;
-    }
-
-    // Include and Include
-    if c1.else_clause.is_none() && c2.else_clause.is_none() {
-        return true;
-    }
-
-    // Skip/Include and Include/Skip
-    false
-}
-
-fn merge_two_condition_nodes(a: PlanNode, b: PlanNode) -> PlanNode {
-    let (mut a, mut b) = match (a, b) {
-        (PlanNode::Condition(c1), PlanNode::Condition(c2)) => (c1, c2),
-        _ => panic!("Can only merge two ConditionNodes"),
-    };
-
-    let is_if = a.if_clause.is_some();
-
-    let mut inner_nodes: Vec<PlanNode> = a
-        .if_clause
-        .take()
-        .or_else(|| a.else_clause.take())
-        .map(|n| n.into_nodes())
-        .unwrap_or_default()
-        .into_iter()
-        .chain(
-            b.if_clause
-                .take()
-                .or_else(|| b.else_clause.take())
-                .map(|n| n.into_nodes())
-                .unwrap_or_default(),
-        )
-        .collect();
-
-    // Use Sequence only if there are multiple nodes
-    let merged_body = if inner_nodes.len() == 1 {
-        inner_nodes.remove(0)
-    } else {
-        PlanNode::Sequence(SequenceNode { nodes: inner_nodes })
-    };
-
-    // Re-create the parent ConditionNode with the newly merged body.
-    if is_if {
-        PlanNode::Condition(ConditionNode {
-            condition: a.condition,
-            if_clause: Some(Box::new(merged_body)),
-            else_clause: None,
-        })
-    } else {
-        PlanNode::Condition(ConditionNode {
-            condition: a.condition,
-            if_clause: None,
-            else_clause: Some(Box::new(merged_body)),
-        })
-    }
-}
-
-fn optimize_plan_sequence(nodes: Vec<PlanNode>) -> Vec<PlanNode> {
-    nodes.into_iter().fold(Vec::new(), |mut acc, current_node| {
-        match (acc.last_mut(), &current_node) {
-            // Check if the last node and the current node
-            // have compatible conditions
-            (Some(PlanNode::Condition(last_cond)), PlanNode::Condition(current_cond))
-                if are_conditions_compatible(last_cond, current_cond) =>
-            {
-                let last_node = acc.pop().unwrap();
-                let merged_node = merge_two_condition_nodes(last_node, current_node);
-                acc.push(merged_node);
-            }
-            _ => {
-                acc.push(current_node);
-            }
-        }
-        acc
     })
 }

--- a/lib/query-planner/src/planner/query_plan/optimize.rs
+++ b/lib/query-planner/src/planner/query_plan/optimize.rs
@@ -1,0 +1,2365 @@
+//! This module rewrites the query plan to make execution faster.
+//!
+//! It merges multiple Flatten(Fetch) nodes to the same subgraph into one batched fetch.
+//! This reduces the number of HTTP requests.
+//!
+//! If we have multiple entity fetches inside one `Parallel` block:
+//! ```ignore
+//! Parallel {
+//!   Flatten(path: "a") { Fetch(service: "a") }
+//!   Flatten(path: "b") { Fetch(service: "a") }
+//!   Flatten(path: "c") { Fetch(service: "a") }
+//! }
+//! ```
+//!
+//! The optimization will merge them into:
+//! ```ignore
+//! Parallel {
+//!   BatchFetch {
+//!     entityBatch {
+//!       aliases: [
+//!         { alias: "_e0", paths: ["a", "b", "c"], ... }
+//!       ]
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! We batch only compatible fetches:
+//! - Fetches must target the same subgraph
+//! - Variable type and default value must be compatible
+//! - `input + output + rewrites` must match
+//!
+//! Each final shape group becomes one alias in `BatchFetchNode`.
+//!
+//! Here's an explanation of how the optimization works:
+//! 4 fetches to same service
+//! - F1: input: Product, selection: { name },   vars: `$locale: String`
+//! - F2: input: Product, selection: { name },   vars: `$locale: String`
+//! - F3: input: Product, selection: { price },  vars: `$locale: String`
+//! - F4: input: User,    selection: { name },   vars: `$locale: String`
+//!
+//! Partitioning:
+//! 1. By subgraph:     [F1, F2, F3, F4] (all same service)
+//! 2. By variables:    [F1, F2, F3]     (compatible $locale),  [F4] (different input)
+//! 3. By shape:        [F1, F2]         (same Product.name),   [F3] (different output)
+//!
+//! The outcome is a single http request with multiple entity aliases:
+//!   BatchFetch
+//!     e0: _entities (for F1 and F2)
+//!     e1: _entities (for F3)
+//!     e2: _entities (for F4)
+//!
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    hash::{Hash, Hasher},
+};
+
+use xxhash_rust::xxh3::Xxh3;
+
+use crate::{
+    ast::{
+        hash::{ASTHash, SemanticShapeHashContext},
+        minification::minify_operation,
+        operation::{OperationDefinition, SubgraphFetchOperation, VariableDefinition},
+        selection_item::SelectionItem,
+        selection_set::{FieldSelection, SelectionSet},
+        value::Value,
+    },
+    planner::error::QueryPlanError,
+    planner::plan_nodes::{
+        hash_minified_query, BatchFetchNode, EntityBatch, EntityBatchAlias, FetchRewrite,
+        FlattenNodePath, PlanNode,
+    },
+    state::supergraph_state::{OperationKind, SupergraphState, TypeNode},
+};
+
+/// Fast key used before full shape comparison
+///
+/// Shape = `requires + entities_selection + input_rewrites + output_rewrites`.
+///
+/// We first compare hashes (fast), then compare full values (exact).
+/// This keeps grouping fast and still safe with hash collisions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ShapeKey {
+    requires_hash: u64,
+    entities_selection_hash: u64,
+    input_rewrites_hash: u64,
+    output_rewrites_hash: u64,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct RepresentationsInputKey {
+    requires: SelectionSet,
+    input_rewrites: Option<Vec<FetchRewrite>>,
+    merge_paths: Vec<FlattenNodePath>,
+}
+
+struct BatchFetchBuilder<'a> {
+    merged_non_representation_variables: &'a [VariableDefinition],
+    operation_variable_definitions: Vec<VariableDefinition>,
+    operation_selection_items: Vec<SelectionItem>,
+    batched_aliases: Vec<EntityBatchAlias>,
+    used_variable_names: HashSet<String>,
+    representations_var_index: usize,
+    variable_usages: BTreeSet<String>,
+    representations_var_by_input_key: HashMap<RepresentationsInputKey, String>,
+}
+
+impl<'a> BatchFetchBuilder<'a> {
+    fn new(
+        merged_non_representation_variables: &'a [VariableDefinition],
+        alias_count: usize,
+    ) -> Self {
+        Self {
+            merged_non_representation_variables,
+            operation_variable_definitions: Vec::with_capacity(
+                alias_count + merged_non_representation_variables.len(),
+            ),
+            operation_selection_items: Vec::with_capacity(alias_count),
+            batched_aliases: Vec::with_capacity(alias_count),
+            used_variable_names: merged_non_representation_variables
+                .iter()
+                .map(|var| var.name.clone())
+                .collect(),
+            representations_var_index: 0,
+            variable_usages: BTreeSet::new(),
+            representations_var_by_input_key: HashMap::new(),
+        }
+    }
+
+    fn add_shape_group(
+        &mut self,
+        alias_index: usize,
+        shape_group: &[EntityFetch],
+    ) -> Result<(), QueryPlanError> {
+        let representative = shape_group.first().ok_or_else(|| {
+            QueryPlanError::Internal("Batched entities shape group cannot be empty".to_string())
+        })?;
+
+        for candidate in shape_group {
+            if let Some(candidate_variable_usages) = &candidate.variable_usages {
+                self.variable_usages
+                    .extend(candidate_variable_usages.iter().cloned());
+            }
+        }
+
+        let alias = format!("_e{alias_index}");
+        let merge_paths = Self::collect_merge_paths(shape_group);
+        let representations_variable_name =
+            self.get_or_create_representations_var(representative, &merge_paths);
+
+        self.operation_selection_items
+            .push(SelectionItem::Field(FieldSelection {
+                name: "_entities".to_string(),
+                selections: representative.entities_selection.clone(),
+                alias: Some(alias.clone()),
+                arguments: Some(
+                    (
+                        "representations".to_string(),
+                        Value::Variable(representations_variable_name.clone()),
+                    )
+                        .into(),
+                ),
+                skip_if: None,
+                include_if: None,
+            }));
+
+        self.batched_aliases.push(EntityBatchAlias {
+            alias,
+            representations_variable_name,
+            merge_paths,
+            requires: representative.requires.clone(),
+            input_rewrites: representative.input_rewrites.clone(),
+            output_rewrites: representative.output_rewrites.clone(),
+        });
+
+        Ok(())
+    }
+
+    fn collect_merge_paths(shape_group: &[EntityFetch]) -> Vec<FlattenNodePath> {
+        let mut merge_paths = Vec::with_capacity(shape_group.len());
+        let mut seen_merge_paths = HashSet::with_capacity(shape_group.len());
+
+        for candidate in shape_group {
+            let path = candidate.flatten_path.clone();
+            if seen_merge_paths.insert(path.clone()) {
+                merge_paths.push(path);
+            }
+        }
+
+        merge_paths
+    }
+
+    fn get_or_create_representations_var(
+        &mut self,
+        representative: &EntityFetch,
+        merge_paths: &[FlattenNodePath],
+    ) -> String {
+        let representations_input_key = RepresentationsInputKey {
+            requires: representative.requires.clone(),
+            input_rewrites: representative.input_rewrites.clone(),
+            merge_paths: merge_paths.to_vec(),
+        };
+
+        if let Some(existing_name) = self
+            .representations_var_by_input_key
+            .get(&representations_input_key)
+        {
+            return existing_name.clone();
+        }
+
+        let name = next_unique_representations_var_name(
+            &mut self.used_variable_names,
+            &mut self.representations_var_index,
+        );
+
+        self.operation_variable_definitions
+            .push(VariableDefinition {
+                name: name.clone(),
+                // [_Any!]!
+                variable_type: TypeNode::NonNull(
+                    // [
+                    Box::new(TypeNode::List(
+                        Box::new(TypeNode::NonNull(
+                            // _Any
+                            Box::new(TypeNode::Named("_Any".to_string())),
+                        )),
+                        // !
+                    )), // ]
+                ), // !
+                default_value: None,
+            });
+
+        self.representations_var_by_input_key
+            .insert(representations_input_key, name.clone());
+
+        name
+    }
+
+    fn finish(
+        mut self,
+        first_candidate: &EntityFetch,
+        supergraph: &SupergraphState,
+    ) -> Result<BatchFetchNode, QueryPlanError> {
+        self.operation_variable_definitions
+            .extend(self.merged_non_representation_variables.iter().cloned());
+
+        let operation_definition = OperationDefinition {
+            name: None,
+            operation_kind: Some(OperationKind::Query),
+            selection_set: SelectionSet {
+                items: self.operation_selection_items,
+            },
+            variable_definitions: Some(self.operation_variable_definitions),
+        };
+
+        let document = minify_operation(operation_definition, supergraph).map_err(|error| {
+            QueryPlanError::Internal(format!(
+                "Failed to minify batched entities operation: {error}"
+            ))
+        })?;
+
+        let document_str = document.to_string();
+        let hash = hash_minified_query(&document_str);
+
+        Ok(BatchFetchNode {
+            id: first_candidate.fetch_node_id,
+            service_name: first_candidate.service_name.clone(),
+            variable_usages: if self.variable_usages.is_empty() {
+                None
+            } else {
+                Some(self.variable_usages)
+            },
+            operation_kind: Some(OperationKind::Query),
+            operation_name: None,
+            operation: SubgraphFetchOperation {
+                document,
+                document_str,
+                hash,
+            },
+            entity_batch: EntityBatch {
+                aliases: self.batched_aliases,
+            },
+        })
+    }
+}
+
+/// One extractable entity fetch for batching analysis.
+///
+/// It represents a node like:
+/// ```ignore
+/// Flatten(path: "products.@") {
+///   Fetch(query { _entities(representations: $representations) { ... } })
+/// }
+/// ```
+///
+/// It contains all data we need to decide if this fetch can be batched
+/// with other fetches to the same subgraph.
+#[derive(Clone)]
+struct EntityFetch {
+    /// Original index in the Parallel block (for stable ordering).
+    index: usize,
+    fetch_node_id: i64,
+    service_name: String,
+    flatten_path: FlattenNodePath,
+    variable_usages: Option<BTreeSet<String>>,
+    requires: SelectionSet,
+    entities_selection: SelectionSet,
+    input_rewrites: Option<Vec<FetchRewrite>>,
+    output_rewrites: Option<Vec<FetchRewrite>>,
+    shape_key: ShapeKey,
+    non_representations_variable_definitions: Vec<VariableDefinition>,
+}
+
+impl EntityFetch {
+    /// Exact shape comparison after hash key match.
+    ///
+    /// We verify all parts are identical, not only the hash value.
+    fn eq_shape(&self, right: &EntityFetch) -> bool {
+        self.shape_key == right.shape_key
+            && self.requires == right.requires
+            && self.entities_selection == right.entities_selection
+            && self.input_rewrites == right.input_rewrites
+            && self.output_rewrites == right.output_rewrites
+    }
+
+    fn from_node(index: usize, node: &PlanNode) -> Result<Option<Self>, QueryPlanError> {
+        // We only batch Flatten(Fetch) as those represent the entity calls
+        let PlanNode::Flatten(flatten_node) = node else {
+            return Ok(None);
+        };
+
+        let PlanNode::Fetch(fetch_node) = flatten_node.node.as_ref() else {
+            return Ok(None);
+        };
+
+        let Some(entities_field) = fetch_node
+            .operation
+            .document
+            .operation
+            .selection_set
+            .entities_field()
+        else {
+            return Ok(None);
+        };
+
+        let Some(representations_var) = entities_field.representations_variable_name() else {
+            return Ok(None);
+        };
+
+        let Some(requires) = fetch_node.requires.clone() else {
+            return Ok(None);
+        };
+
+        let requires =
+            requires.inline_fragment_spreads(&fetch_node.operation.document.fragments)?;
+        let entities_selection = entities_field
+            .selections
+            .inline_fragment_spreads(&fetch_node.operation.document.fragments)?;
+        let input_rewrites = fetch_node.input_rewrites.clone();
+        let output_rewrites = fetch_node.output_rewrites.clone();
+        let non_representations_variable_definitions = fetch_node
+            .operation
+            .document
+            .operation
+            .variable_definitions
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|var| var.name != representations_var)
+            .collect::<Vec<_>>();
+
+        let fragments = &fetch_node.operation.document.fragments;
+
+        // Compute the order-independent hash for `requires`
+        let mut hasher = Xxh3::new();
+        let shape_context = SemanticShapeHashContext::new(fragments);
+        requires.semantic_shape_hash(&mut hasher, &shape_context);
+        let requires_hash = hasher.finish();
+
+        // Compute the order-independent hash for `_entities`
+        let mut hasher = Xxh3::new();
+        let shape_context = SemanticShapeHashContext::new(fragments);
+        entities_selection.semantic_shape_hash(&mut hasher, &shape_context);
+        let entities_selection_hash = hasher.finish();
+
+        let shape_key = ShapeKey {
+            requires_hash,
+            entities_selection_hash,
+            input_rewrites_hash: fetch_rewrites_hash(input_rewrites.as_deref()),
+            output_rewrites_hash: fetch_rewrites_hash(output_rewrites.as_deref()),
+        };
+
+        Ok(Some(EntityFetch {
+            index,
+            fetch_node_id: fetch_node.id,
+            service_name: fetch_node.service_name.clone(),
+            flatten_path: flatten_node.path.clone(),
+            variable_usages: fetch_node.variable_usages.clone(),
+            requires,
+            entities_selection,
+            input_rewrites,
+            output_rewrites,
+            shape_key,
+            non_representations_variable_definitions,
+        }))
+    }
+}
+
+/// Candidates that can share non-representations variables.
+///
+/// Two fetches can be batched only when variables with the same name
+/// also have the same type and default value.
+///
+/// This struct contains:
+/// - `candidates`: fetches in this compatible group
+/// - `variables`: merged variable definitions for the group
+#[derive(Clone)]
+struct VariableCompatibleGroup {
+    candidates: Vec<EntityFetch>,
+    variables: Vec<VariableDefinition>,
+}
+
+pub(super) fn optimize_top_level_sequence(nodes: Vec<PlanNode>) -> Vec<PlanNode> {
+    optimize_plan_sequence(nodes)
+}
+
+pub(super) fn optimize_root_node(
+    node: PlanNode,
+    supergraph: &SupergraphState,
+) -> Result<PlanNode, QueryPlanError> {
+    // Single entry point for optimizer rewrites.
+    PlanOptimizer { supergraph }.optimize_node(node)
+}
+
+struct PlanOptimizer<'a> {
+    supergraph: &'a SupergraphState,
+}
+
+impl PlanOptimizer<'_> {
+    fn optimize_node(&self, node: PlanNode) -> Result<PlanNode, QueryPlanError> {
+        match node {
+            PlanNode::Fetch(_) | PlanNode::BatchFetch(_) => Ok(node),
+            PlanNode::Flatten(flatten_node) => {
+                if !matches!(flatten_node.node.as_ref(), PlanNode::Fetch(_)) {
+                    return Err(QueryPlanError::Internal(format!(
+                        "FlattenNode is expected to wrap a FetchNode, got {:?}",
+                        flatten_node.node.as_ref()
+                    )));
+                }
+
+                Ok(PlanNode::Flatten(flatten_node))
+            }
+            PlanNode::Sequence(mut sequence_node) => {
+                sequence_node.nodes = self.optimize_children(sequence_node.nodes)?;
+                sequence_node.nodes = optimize_plan_sequence(sequence_node.nodes);
+                Ok(PlanNode::sequence(sequence_node.nodes))
+            }
+            PlanNode::Parallel(parallel_node) => {
+                // If all children are fetching nodes, skip recursive optimize walk.
+                let optimized_nodes = if parallel_node
+                    .nodes
+                    .iter()
+                    .all(|node| node.is_fetching_node())
+                {
+                    parallel_node.nodes
+                } else {
+                    self.optimize_children(parallel_node.nodes)?
+                };
+
+                let optimized_nodes = PlanNode::flatten_parallel(optimized_nodes);
+                let optimized_nodes = optimize_parallel_node(optimized_nodes, self.supergraph)?;
+
+                Ok(PlanNode::parallel(optimized_nodes))
+            }
+            PlanNode::Condition(mut condition_node) => {
+                self.optimize_optional_child(&mut condition_node.if_clause)?;
+                self.optimize_optional_child(&mut condition_node.else_clause)?;
+                Ok(PlanNode::Condition(condition_node))
+            }
+            PlanNode::Subscription(mut subscription_node) => {
+                subscription_node.primary =
+                    Box::new(self.optimize_node(*subscription_node.primary)?);
+                Ok(PlanNode::Subscription(subscription_node))
+            }
+            PlanNode::Defer(mut defer_node) => {
+                self.optimize_optional_child(&mut defer_node.primary.node)?;
+
+                for deferred in defer_node.deferred.iter_mut() {
+                    self.optimize_optional_child(&mut deferred.node)?;
+                }
+
+                Ok(PlanNode::Defer(defer_node))
+            }
+        }
+    }
+
+    fn optimize_children(&self, nodes: Vec<PlanNode>) -> Result<Vec<PlanNode>, QueryPlanError> {
+        nodes
+            .into_iter()
+            .map(|node| self.optimize_node(node))
+            .collect()
+    }
+
+    fn optimize_optional_child(
+        &self,
+        node: &mut Option<Box<PlanNode>>,
+    ) -> Result<(), QueryPlanError> {
+        if let Some(current_node) = node.take() {
+            *node = Some(Box::new(self.optimize_node(*current_node)?));
+        }
+
+        Ok(())
+    }
+}
+
+/// Merge entity fetches in a `Parallel` block into `BatchFetch` nodes
+fn optimize_parallel_node(
+    nodes: Vec<PlanNode>,
+    supergraph: &SupergraphState,
+) -> Result<Vec<PlanNode>, QueryPlanError> {
+    // Find all `Flatten(Fetch)` candidates
+    // and group by subgraph.
+    let candidates_by_subgraph = partition_by_subgraph(&nodes)?;
+
+    let mut batch_node_replacements: HashMap<usize, PlanNode> = HashMap::new();
+    let mut removed_indices: HashSet<usize> = HashSet::new();
+
+    for candidates in candidates_by_subgraph.into_values() {
+        if candidates.len() < 2 {
+            continue;
+        }
+
+        // Split groups by variable compatibility
+        for variable_group in partition_by_variables_compatibility(candidates) {
+            if variable_group.candidates.len() < 2 {
+                continue;
+            }
+
+            // Split groups by fetch shape
+            let shape_groups = partition_by_shape(variable_group.candidates);
+
+            let Some(first_group) = shape_groups.first() else {
+                continue;
+            };
+            let Some(first_candidate) = first_group.first() else {
+                continue;
+            };
+
+            // For each merged group, we keep the first node position and remove the rest.
+            // This keeps sibling order stable and deterministic.
+            let first_index = first_candidate.index;
+
+            // Build one `BatchFetch` node from each final group
+            let batch_fetch_node =
+                build_batched_fetch_node(&shape_groups, &variable_group.variables, supergraph)?;
+
+            batch_node_replacements.insert(first_index, PlanNode::BatchFetch(batch_fetch_node));
+
+            for group in &shape_groups {
+                for candidate in group {
+                    // Remove all but the first candidate from the group
+                    if candidate.index != first_index {
+                        removed_indices.insert(candidate.index);
+                    }
+                }
+            }
+        }
+    }
+
+    if batch_node_replacements.is_empty() {
+        // Nothing to replace, return the original nodes
+        return Ok(nodes);
+    }
+
+    let mut optimized_nodes = Vec::with_capacity(nodes.len() - removed_indices.len());
+
+    for (index, node) in nodes.into_iter().enumerate() {
+        // If we have a replacement for this index, use it
+        if let Some(replacement) = batch_node_replacements.remove(&index) {
+            optimized_nodes.push(replacement);
+            continue;
+        }
+
+        // Skip nodes that were merged into another batch node
+        if removed_indices.contains(&index) {
+            continue;
+        }
+
+        // Otherwise keep the original node
+        optimized_nodes.push(node);
+    }
+
+    Ok(optimized_nodes)
+}
+
+fn partition_by_subgraph(
+    nodes: &[PlanNode],
+) -> Result<HashMap<String, Vec<EntityFetch>>, QueryPlanError> {
+    let mut candidates_by_subgraph: HashMap<String, Vec<EntityFetch>> = HashMap::new();
+
+    for (index, node) in nodes.iter().enumerate() {
+        if let Some(candidate) = EntityFetch::from_node(index, node)? {
+            candidates_by_subgraph
+                .entry(candidate.service_name.clone())
+                .or_default()
+                .push(candidate);
+        }
+    }
+
+    Ok(candidates_by_subgraph)
+}
+
+fn fetch_rewrites_hash(rewrites: Option<&[FetchRewrite]>) -> u64 {
+    let mut hasher = Xxh3::new();
+
+    if let Some(rewrites) = rewrites {
+        true.hash(&mut hasher);
+        rewrites.hash(&mut hasher);
+    } else {
+        false.hash(&mut hasher);
+    }
+
+    hasher.finish()
+}
+
+fn next_unique_representations_var_name(
+    used_variable_names: &mut HashSet<String>,
+    next_index: &mut usize,
+) -> String {
+    loop {
+        let name = format!("__batch_reps_{next_index}");
+        *next_index += 1;
+
+        if used_variable_names.insert(name.clone()) {
+            return name;
+        }
+    }
+}
+
+/// Group candidates by identical shape.
+///
+/// Shape = requires + entities_selection + input_rewrites + output_rewrites.
+///
+/// Same shape means the GraphQL query structure is the same,
+/// so candidates can share one alias in a batched fetch.
+///
+/// We first group by hash key, then verify full equality.
+/// This handles hash collisions safely.
+///
+/// Group insertion order is stable, so alias naming is stable too.
+fn partition_by_shape(candidates: Vec<EntityFetch>) -> Vec<Vec<EntityFetch>> {
+    let mut groups: Vec<Vec<EntityFetch>> = Vec::new();
+    let mut by_key: HashMap<ShapeKey, Vec<usize>> = HashMap::new();
+
+    'candidates_loop: for candidate in candidates {
+        if let Some(indices) = by_key.get(&candidate.shape_key) {
+            for &group_index in indices {
+                // Compare against the first element in the group,
+                // since all elements in a group have the same shape.
+                if groups[group_index][0].eq_shape(&candidate) {
+                    groups[group_index].push(candidate);
+                    continue 'candidates_loop;
+                }
+            }
+        }
+
+        // Create a new group, as it's the first time we see this exact shape
+        let group_index = groups.len();
+        groups.push(vec![candidate]);
+        by_key
+            .entry(groups[group_index][0].shape_key)
+            .or_default()
+            .push(group_index);
+    }
+
+    groups
+}
+
+/// Group candidates by variable compatibility.
+///
+/// Rule: if two fetches use the same variable name,
+/// that variable must have the same type and default value.
+///
+/// Example:
+/// ```ignore
+///   $locale: String + $locale: String     → compatible (same type)
+///   $locale: String + $locale: String!    → NOT compatible (different types)
+/// ```
+///
+/// Grouping is deterministic and follows fetch order.
+/// Each candidate joins the first compatible group.
+/// If none is compatible, it starts a new group.
+///
+/// Each group also stores merged variable definitions (set union).
+fn partition_by_variables_compatibility(
+    candidates: Vec<EntityFetch>,
+) -> Vec<VariableCompatibleGroup> {
+    // Rule: same variable name must keep same type/default.
+    // Example:
+    //   valid:   $locale: String  + $locale: String
+    //   invalid: $locale: String  + $locale: String!
+    let mut groups: Vec<VariableCompatibleGroup> = Vec::new();
+
+    for candidate in candidates {
+        let candidate_variables = &candidate.non_representations_variable_definitions;
+        let chosen_group = groups.iter().position(|group| {
+            can_merge_variable_definitions(&group.variables, candidate_variables)
+        });
+
+        if let Some(group_index) = chosen_group {
+            let group = &mut groups[group_index];
+            merge_variable_definitions(&mut group.variables, candidate_variables);
+            group.candidates.push(candidate);
+            continue;
+        }
+
+        groups.push(VariableCompatibleGroup {
+            variables: candidate_variables.clone(),
+            candidates: vec![candidate],
+        });
+    }
+
+    groups
+}
+
+fn can_merge_variable_definitions(
+    merged_variables: &[VariableDefinition],
+    other_variables: &[VariableDefinition],
+) -> bool {
+    for other_variable in other_variables {
+        let existing_variable = merged_variables
+            .iter()
+            .find(|v| v.name == other_variable.name);
+
+        let Some(existing_variable) = existing_variable else {
+            continue;
+        };
+
+        if !existing_variable.can_merge(other_variable) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn merge_variable_definitions(
+    merged_variables: &mut Vec<VariableDefinition>,
+    other_variables: &[VariableDefinition],
+) {
+    for variable in other_variables {
+        if merged_variables
+            .iter()
+            .any(|existing| existing.name == variable.name)
+        {
+            continue;
+        }
+
+        merged_variables.push(variable.clone());
+    }
+}
+
+/// Build one `BatchFetchNode` from shape groups.
+///
+/// Each shape group becomes one alias in the batched operation.
+/// One alias can fill multiple merge paths in the final response.
+///
+/// # Example
+///
+/// Given shape groups:
+/// ```ignore
+/// ShapeGroup1: [EntityFetch{path: "products.@"}, EntityFetch{path: "users.@"}]
+/// ShapeGroup2: [EntityFetch{path: "reviews.@"}]
+/// ```
+///
+/// Resulting BatchFetch:
+/// ```ignore
+/// BatchFetch {
+///   operation: query($__batch_reps_0: [[_Any!]!]!, $__batch_reps_1: [[_Any!]!]!) {
+///     _entities(representations: $__batch_reps_0) { ... }
+///     _entities(representations: $__batch_reps_1) { ... }
+///   }
+///   entityBatch {
+///     aliases: [
+///       { alias: "_e0", paths: ["products.@", "users.@"], ... },    // ShapeGroup1
+///       { alias: "_e1", paths: ["reviews.@"], ... },                // ShapeGroup2
+///     ]
+///   }
+/// }
+/// ```
+///
+/// The executor calls `_entities` once per alias.
+/// Then it spreads results to all paths covered by that alias.
+fn build_batched_fetch_node(
+    shape_groups: &[Vec<EntityFetch>],
+    merged_non_representation_variables: &[VariableDefinition],
+    supergraph: &SupergraphState,
+) -> Result<BatchFetchNode, QueryPlanError> {
+    let first_candidate = shape_groups
+        .first()
+        .and_then(|group| group.first())
+        .ok_or_else(|| {
+            QueryPlanError::Internal("Batched entities candidates were empty".to_string())
+        })?;
+
+    let mut builder =
+        BatchFetchBuilder::new(merged_non_representation_variables, shape_groups.len());
+
+    for (index, shape_group) in shape_groups.iter().enumerate() {
+        builder.add_shape_group(index, shape_group)?;
+    }
+
+    builder.finish(first_candidate, supergraph)
+}
+
+fn optimize_plan_sequence(nodes: Vec<PlanNode>) -> Vec<PlanNode> {
+    // Flatten nested Sequence nodes.
+    // If a Sequence contains another Sequence, we can inline inner nodes,
+    // because execution order stays the same.
+    let mut flattened_nodes = Vec::with_capacity(nodes.len());
+
+    for node in nodes {
+        match node {
+            PlanNode::Sequence(sequence_node) => {
+                flattened_nodes.extend(sequence_node.nodes);
+            }
+            other => flattened_nodes.push(other),
+        }
+    }
+
+    // Merge consecutive compatible Condition nodes.
+    // We check if current condition can be merged into the previous one.
+    flattened_nodes
+        .into_iter()
+        .fold(Vec::new(), |mut acc, current_node| {
+            match (acc.last_mut(), current_node) {
+                // Merge adjacent compatible Condition nodes.
+                (Some(PlanNode::Condition(last_cond)), PlanNode::Condition(current_cond))
+                    if last_cond.can_merge_with(&current_cond) =>
+                {
+                    last_cond.merge(current_cond);
+                }
+                (_, current_node) => {
+                    acc.push(current_node);
+                }
+            }
+            acc
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeSet, HashSet},
+        fs,
+        path::PathBuf,
+    };
+
+    use graphql_tools::parser::query as query_ast;
+
+    use crate::{
+        ast::{
+            document::Document,
+            merge_path::{MergePath, Segment},
+            operation::SubgraphFetchOperation,
+        },
+        planner::plan_nodes::{
+            hash_minified_query, FetchNode, FetchNodePathSegment, FetchRewrite, FlattenNode,
+            FlattenNodePath, PlanNode, QueryPlan, ValueSetter,
+        },
+        state::supergraph_state::{OperationKind, SupergraphState},
+        utils::parsing::{parse_operation, parse_schema},
+    };
+
+    use super::{next_unique_representations_var_name, optimize_root_node};
+
+    #[test]
+    fn next_unique_representations_variable_name_skips_used_values() {
+        let mut used = HashSet::from(["__batch_reps_0".to_string(), "__batch_reps_2".to_string()]);
+        let mut next_index = 0;
+
+        let first = next_unique_representations_var_name(&mut used, &mut next_index);
+        let second = next_unique_representations_var_name(&mut used, &mut next_index);
+
+        assert_eq!(first, "__batch_reps_1");
+        assert_eq!(second, "__batch_reps_3");
+    }
+
+    /// Two compatible entity fetches should become one BatchFetch
+    /// and must keep node order stable
+    #[test]
+    fn optimize_parallel_node_batches_compatible_fetches_and_keeps_order() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let passthrough = PlanNode::Fetch(non_entity_fetch_node(100, "products"));
+        let candidate_a =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, &entities_query);
+        let candidate_b =
+            flatten_entity_fetch_node(2, "inventory", "products", requires_query, &entities_query);
+
+        let nodes = vec![passthrough.clone(), candidate_a, candidate_b];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          Parallel {
+            Fetch(service: "products") {
+              {
+                products {
+                  upc
+                }
+              }
+            },
+            BatchFetch(service: "inventory") {
+              {
+                _e0 {
+                  paths: [
+                    "products.@"
+                  ]
+                  {
+                    ... on Product {
+                      upc
+                    }
+                  }
+                }
+              }
+              {
+                _e0: _entities(representations: $__batch_reps_0) {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              }
+            },
+          },
+        },
+        "#);
+    }
+
+    /// Same variable name with incompatible types should block batching,
+    /// as merging incompatible variable definitions produces invalid operations.
+    ///
+    /// This case is not really a possible scenario,
+    /// as the variables are coming from the original query,
+    /// so there won't be any conflicting variable names.
+    ///
+    /// It's worth asserting this anyway, to ensure the optimizer behaves correctly.
+    #[test]
+    fn optimize_parallel_node_does_not_batch_incompatible_variables() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+
+        // String vs String!
+        let entities_query_a = "
+          query($representations:[_Any!]!, $locale: String)  {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+        let entities_query_b = "
+          query($representations:[_Any!]!, $locale: String!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let candidate_a = flatten_entity_fetch_node(
+            1,
+            "inventory",
+            "products",
+            requires_query,
+            &entities_query_a,
+        );
+        let candidate_b = flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "products",
+            requires_query,
+            &entities_query_b,
+        );
+
+        let nodes = vec![candidate_a, candidate_b];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          Parallel {
+            Flatten(path: "products.@") {
+              Fetch(service: "inventory") {
+                {
+                  ... on Product {
+                    upc
+                  }
+                } =>
+                ($locale:String) {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              },
+            },
+            Flatten(path: "products.@") {
+              Fetch(service: "inventory") {
+                {
+                  ... on Product {
+                    upc
+                  }
+                } =>
+                ($locale:String!) {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              },
+            },
+          },
+        },
+        "#);
+    }
+
+    /// Generated `__batch_reps_*` variable must skip already-used operation variables,
+    /// to avoid collision that would make the generated query invalid.
+    #[test]
+    fn optimize_parallel_node_avoids_representations_variable_collision() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!, $__batch_reps_0: String) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let candidate_a =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, &entities_query);
+        let candidate_b =
+            flatten_entity_fetch_node(2, "inventory", "products", requires_query, &entities_query);
+
+        let nodes = vec![candidate_a, candidate_b];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            ($__batch_reps_0:String) {
+              _e0: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  shippingEstimate
+                }
+              }
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Compatible entity fetches from different subgraphs must not be batched.
+    #[test]
+    fn optimize_parallel_node_does_not_batch_across_subgraphs() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let inventory_candidate = flatten_entity_fetch_node(
+            1,
+            "inventory", // different subgraph
+            "products",
+            requires_query,
+            entities_query,
+        );
+        let products_candidate = flatten_entity_fetch_node(
+            2,
+            "products", // different subgraph
+            "products",
+            requires_query,
+            entities_query,
+        );
+
+        let nodes = vec![inventory_candidate, products_candidate];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          Parallel {
+            Flatten(path: "products.@") {
+              Fetch(service: "inventory") {
+                {
+                  ... on Product {
+                    upc
+                  }
+                } =>
+                {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              },
+            },
+            Flatten(path: "products.@") {
+              Fetch(service: "products") {
+                {
+                  ... on Product {
+                    upc
+                  }
+                } =>
+                {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              },
+            },
+          },
+        },
+        "#);
+    }
+
+    /// Candidates with the same shape should batch even when merge paths differ.
+    #[test]
+    fn optimize_parallel_node_batches_same_shape_with_different_merge_paths() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let products_candidate = flatten_entity_fetch_node(
+            1,
+            "inventory",
+            "products", // different merge paths
+            requires_query,
+            entities_query,
+        );
+        let top_products_candidate = flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts", // different merge paths
+            requires_query,
+            entities_query,
+        );
+
+        let nodes = vec![products_candidate, top_products_candidate];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  shippingEstimate
+                }
+              }
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different entities selections should not be merged into the same alias.
+    /// They should still be batched in one BatchFetch with multiple aliases.
+    #[test]
+    fn optimize_parallel_node_splits_aliases_when_entities_query_differs() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let shipping_estimate_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+        let in_stock_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { inStock }
+            }
+          }
+        ";
+
+        let products_candidate = flatten_entity_fetch_node(
+            1,
+            "inventory",
+            "products",
+            requires_query,
+            shipping_estimate_query,
+        );
+        let top_products_candidate = flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts",
+            requires_query,
+            in_stock_query,
+        );
+
+        let nodes = vec![products_candidate, top_products_candidate];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  shippingEstimate
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  inStock
+                }
+              }
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Aliases with same input side and same paths can share one representations variable.
+    #[test]
+    fn optimize_parallel_node_shares_representations_variable_when_input_and_paths_match() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let shipping_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+        let in_stock_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { inStock }
+            }
+          }
+        ";
+
+        let a =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, shipping_query);
+        let b =
+            flatten_entity_fetch_node(2, "inventory", "products", requires_query, in_stock_query);
+
+        let optimized = optimize_root_node(PlanNode::parallel(vec![a, b]), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  shippingEstimate
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  inStock
+                }
+              }
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different requires should prevent sharing the representations variable.
+    #[test]
+    fn optimize_parallel_node_does_not_share_representations_variable_when_requires_differs() {
+        let supergraph = test_supergraph_state();
+        let requires_upc = "query { ... on Product { upc } }";
+        let requires_name = "query { ... on Product { name } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let a = flatten_entity_fetch_node(1, "inventory", "products", requires_upc, entities_query);
+        let b =
+            flatten_entity_fetch_node(2, "inventory", "products", requires_name, entities_query);
+
+        let optimized = optimize_root_node(PlanNode::parallel(vec![a, b]), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    name
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  ...a
+                }
+              }
+            }
+            fragment a on Product {
+              shippingEstimate
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different input rewrites should prevent sharing the representations variable.
+    #[test]
+    fn optimize_parallel_node_does_not_share_representations_variable_when_input_rewrites_differ() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let base =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query);
+        let with_rewrite = with_input_rewrite(flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "products",
+            requires_query,
+            entities_query,
+        ));
+
+        let optimized =
+            optimize_root_node(PlanNode::parallel(vec![base, with_rewrite]), &supergraph)
+                .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  ...a
+                }
+              }
+            }
+            fragment a on Product {
+              shippingEstimate
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different requires selections should split aliases, even with same entities query.
+    #[test]
+    fn optimize_parallel_node_splits_aliases_when_requires_differs() {
+        let supergraph = test_supergraph_state();
+        let requires_upc = "query { ... on Product { upc } }";
+        let requires_name = "query { ... on Product { name } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let a = flatten_entity_fetch_node(1, "inventory", "products", requires_upc, entities_query);
+        let b =
+            flatten_entity_fetch_node(2, "inventory", "topProducts", requires_name, entities_query);
+
+        let nodes = vec![a, b];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    name
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  ...a
+                }
+              }
+            }
+            fragment a on Product {
+              shippingEstimate
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different input rewrites should split aliases.
+    #[test]
+    fn optimize_parallel_node_splits_aliases_when_input_rewrites_differ() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let base =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query);
+        let with_rewrite = with_input_rewrite(flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts",
+            requires_query,
+            entities_query,
+        ));
+
+        let nodes = vec![base, with_rewrite];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        // TODO: make sure rewrites are preserved
+        let batch_node = optimized
+            .as_batch_fetch()
+            .expect("optimized should be BatchFetch node");
+        let base_node = batch_node
+            .entity_batch
+            .aliases
+            .get(0)
+            .expect("BatchFetch node should have two aliases");
+        let rewrite_node = batch_node
+            .entity_batch
+            .aliases
+            .get(1)
+            .expect("BatchFetch node should have two aliases");
+
+        assert!(
+            base_node.input_rewrites.is_none(),
+            "base node should not have input rewrites"
+        );
+        assert!(
+            rewrite_node.input_rewrites.is_some(),
+            "rewrite node should have input rewrites"
+        );
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  ...a
+                }
+              }
+            }
+            fragment a on Product {
+              shippingEstimate
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different output rewrites should split aliases.
+    #[test]
+    fn optimize_parallel_node_splits_aliases_when_output_rewrites_differ() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let base =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query);
+        let with_rewrite = with_output_rewrite(flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts",
+            requires_query,
+            entities_query,
+        ));
+
+        let nodes = vec![base, with_rewrite];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  ...a
+                }
+              }
+            }
+            fragment a on Product {
+              shippingEstimate
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Different output rewrites split aliases, but input-equivalent aliases
+    /// should still share one representations variable.
+    #[test]
+    fn optimize_parallel_node_shares_representations_variable_when_only_output_rewrites_differ() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let base =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query);
+        let with_output_rewrite = with_output_rewrite(flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "products",
+            requires_query,
+            entities_query,
+        ));
+
+        let nodes = vec![base, with_output_rewrite];
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "products.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ...a
+                }
+              }
+            }
+            fragment a on Product {
+              shippingEstimate
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Alias assignment should be stable and follow first-seen shape order.
+    #[test]
+    fn optimize_parallel_node_alias_order_is_deterministic() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let shipping_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+        let in_stock_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { inStock }
+            }
+          }
+        ";
+
+        let shape_a_first =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, shipping_query);
+        let shape_b = flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts",
+            requires_query,
+            in_stock_query,
+        );
+        let shape_a_second =
+            flatten_entity_fetch_node(3, "inventory", "products2", requires_query, shipping_query);
+
+        let nodes = vec![shape_a_first, shape_b, shape_a_second];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                  "products2.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+              _e1 {
+                paths: [
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  shippingEstimate
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
+                ... on Product {
+                  inStock
+                }
+              }
+            }
+          },
+        },
+        "#);
+    }
+
+    /// Entities queries with fragment spreads should still batch correctly.
+    #[test]
+    fn optimize_parallel_node_batches_entities_query_with_fragment_spread() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        // Fragment names are different, but shape is the same.
+        let entities_query_a = "
+          fragment A on Product { shippingEstimate }
+
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { ...A }
+            }
+          }
+        ";
+        let entities_query_b = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { ...B }
+            }
+          }
+          fragment B on Product { shippingEstimate }
+        ";
+
+        let with_fragment_a =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query_a);
+        let with_fragment_b = flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts",
+            requires_query,
+            entities_query_b,
+        );
+
+        let nodes = vec![with_fragment_a, with_fragment_b];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          BatchFetch(service: "inventory") {
+            {
+              _e0 {
+                paths: [
+                  "products.@"
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    upc
+                  }
+                }
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              }
+            }
+          },
+        },
+        "#);
+    }
+
+    /// If there are no entity candidates, optimizer must keep the original nodes.
+    #[test]
+    fn optimize_parallel_node_returns_original_when_no_entity_candidates() {
+        let supergraph = test_supergraph_state();
+
+        let first = PlanNode::Fetch(non_entity_fetch_node(1, "products"));
+        let second = PlanNode::Fetch(non_entity_fetch_node(2, "inventory"));
+
+        let nodes = vec![first, second];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          Parallel {
+            Fetch(service: "products") {
+              {
+                products {
+                  upc
+                }
+              }
+            },
+            Fetch(service: "inventory") {
+              {
+                products {
+                  upc
+                }
+              }
+            },
+          },
+        },
+        "#);
+    }
+
+    /// One candidate in a service cannot form a batch.
+    #[test]
+    fn optimize_parallel_node_does_not_batch_single_candidate() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let candidate =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query);
+
+        let nodes = vec![candidate];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          Flatten(path: "products.@") {
+            Fetch(service: "inventory") {
+              {
+                ... on Product {
+                  upc
+                }
+              } =>
+              {
+                ... on Product {
+                  shippingEstimate
+                }
+              }
+            },
+          },
+        },
+        "#);
+    }
+
+    /// Optimizer can create separate BatchFetch nodes for different services.
+    #[test]
+    fn optimize_parallel_node_creates_multiple_batch_nodes_for_multiple_services() {
+        let supergraph = test_supergraph_state();
+        let requires_query = "query { ... on Product { upc } }";
+        let entities_query = "
+          query($representations:[_Any!]!) {
+            _entities(representations: $representations) {
+              ... on Product { shippingEstimate }
+            }
+          }
+        ";
+
+        let inventory_a =
+            flatten_entity_fetch_node(1, "inventory", "products", requires_query, entities_query);
+        let inventory_b = flatten_entity_fetch_node(
+            2,
+            "inventory",
+            "topProducts",
+            requires_query,
+            entities_query,
+        );
+        let products_a =
+            flatten_entity_fetch_node(3, "products", "products", requires_query, entities_query);
+        let products_b =
+            flatten_entity_fetch_node(4, "products", "topProducts", requires_query, entities_query);
+
+        let nodes = vec![inventory_a, inventory_b, products_a, products_b];
+
+        let optimized = optimize_root_node(PlanNode::parallel(nodes), &supergraph)
+            .expect("optimize should work");
+
+        let query_plan = QueryPlan {
+            kind: "QueryPlan",
+            node: Some(optimized),
+        };
+
+        insta::assert_snapshot!(format!("{query_plan}"), @r#"
+        QueryPlan {
+          Parallel {
+            BatchFetch(service: "inventory") {
+              {
+                _e0 {
+                  paths: [
+                    "products.@"
+                    "topProducts.@"
+                  ]
+                  {
+                    ... on Product {
+                      upc
+                    }
+                  }
+                }
+              }
+              {
+                _e0: _entities(representations: $__batch_reps_0) {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              }
+            },
+            BatchFetch(service: "products") {
+              {
+                _e0 {
+                  paths: [
+                    "products.@"
+                    "topProducts.@"
+                  ]
+                  {
+                    ... on Product {
+                      upc
+                    }
+                  }
+                }
+              }
+              {
+                _e0: _entities(representations: $__batch_reps_0) {
+                  ... on Product {
+                    shippingEstimate
+                  }
+                }
+              }
+            },
+          },
+        },
+        "#);
+    }
+
+    fn test_supergraph_state() -> SupergraphState {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture/tests/simple-requires.supergraph.graphql");
+        let sdl = fs::read_to_string(path).expect("fixture should be readable");
+        let schema = parse_schema(&sdl);
+        SupergraphState::new(&schema)
+    }
+
+    fn flatten_entity_fetch_node(
+        id: i64,
+        service_name: &str,
+        root_path_field: &str,
+        requires_query: &str,
+        entities_query: &str,
+    ) -> PlanNode {
+        let requires = parse_document(requires_query).operation.selection_set;
+        let entities_document = parse_document(entities_query);
+        let non_representation_variable_names = {
+            let representations_var = entities_document
+                .operation
+                .selection_set
+                .entities_field()
+                .and_then(|field| field.representations_variable_name())
+                .expect("entities query should define representations variable");
+
+            let usages: BTreeSet<String> = entities_document
+                .operation
+                .variable_definitions
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|var| var.name != representations_var)
+                .map(|var| var.name)
+                .collect();
+
+            if usages.is_empty() {
+                None
+            } else {
+                Some(usages)
+            }
+        };
+
+        let operation = build_subgraph_fetch_operation(entities_document);
+
+        let fetch_node = FetchNode {
+            id,
+            service_name: service_name.to_string(),
+            variable_usages: non_representation_variable_names,
+            operation_kind: Some(OperationKind::Query),
+            operation_name: None,
+            operation,
+            requires: Some(requires),
+            input_rewrites: None,
+            output_rewrites: None,
+        };
+
+        let path = FlattenNodePath::from(&MergePath::new(vec![
+            Segment::Field(root_path_field.to_string(), 0, None),
+            Segment::List,
+        ]));
+
+        PlanNode::Flatten(FlattenNode {
+            path,
+            node: Box::new(PlanNode::Fetch(fetch_node)),
+        })
+    }
+
+    fn with_input_rewrite(node: PlanNode) -> PlanNode {
+        with_fetch_rewrite(node, RewriteTarget::Input)
+    }
+
+    fn with_output_rewrite(node: PlanNode) -> PlanNode {
+        with_fetch_rewrite(node, RewriteTarget::Output)
+    }
+
+    enum RewriteTarget {
+        Input,
+        Output,
+    }
+
+    fn with_fetch_rewrite(node: PlanNode, target: RewriteTarget) -> PlanNode {
+        let PlanNode::Flatten(mut flatten_node) = node else {
+            panic!("expected Flatten node")
+        };
+        let PlanNode::Fetch(mut fetch_node) = *flatten_node.node else {
+            panic!("expected Flatten(Fetch)")
+        };
+
+        let rewrite = FetchRewrite::ValueSetter(ValueSetter {
+            path: vec![FetchNodePathSegment::Key("upc".to_string())],
+            set_value_to: "constant".to_string(),
+        });
+
+        match target {
+            RewriteTarget::Input => fetch_node.input_rewrites = Some(vec![rewrite]),
+            RewriteTarget::Output => fetch_node.output_rewrites = Some(vec![rewrite]),
+        }
+
+        flatten_node.node = Box::new(PlanNode::Fetch(fetch_node));
+        PlanNode::Flatten(flatten_node)
+    }
+
+    fn non_entity_fetch_node(id: i64, service_name: &str) -> FetchNode {
+        let operation =
+            build_subgraph_fetch_operation(parse_document("query { products { upc } }"));
+
+        FetchNode {
+            id,
+            service_name: service_name.to_string(),
+            variable_usages: None,
+            operation_kind: Some(OperationKind::Query),
+            operation_name: None,
+            operation,
+            requires: None,
+            input_rewrites: None,
+            output_rewrites: None,
+        }
+    }
+
+    fn parse_document(query: &str) -> Document {
+        let document = parse_operation(query);
+        let mut operation = None;
+        let mut fragments = Vec::new();
+
+        for definition in document.definitions {
+            match definition {
+                query_ast::Definition::Operation(current_operation) => {
+                    if operation.is_none() {
+                        operation = Some(current_operation.into());
+                    }
+                }
+                query_ast::Definition::Fragment(fragment) => {
+                    fragments.push(fragment.into());
+                }
+            }
+        }
+
+        Document {
+            operation: operation.expect("operation definition should exist"),
+            fragments,
+        }
+    }
+
+    fn build_subgraph_fetch_operation(document: Document) -> SubgraphFetchOperation {
+        let document_str = document.to_string();
+
+        SubgraphFetchOperation {
+            hash: hash_minified_query(&document_str),
+            document,
+            document_str,
+        }
+    }
+}

--- a/lib/query-planner/src/tests/arguments.rs
+++ b/lib/query-planner/src/tests/arguments.rs
@@ -43,9 +43,12 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
             }
           }
         },
-        Parallel {
-          Flatten(path: "products.@") {
-            Fetch(service: "a") {
+        BatchFetch(service: "a") {
+          {
+            _e0 {
+              paths: [
+                "products.@"
+              ]
               {
                 ... on Product {
                   __typename
@@ -56,17 +59,12 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
                   price: _internal_qp_alias_0
                   weight
                 }
-              } =>
-              {
-                ... on Product {
-                  isExpensiveCategory
-                  shippingEstimateEUR
-                }
               }
-            },
-          },
-          Flatten(path: "products.@") {
-            Fetch(service: "a") {
+            }
+            _e1 {
+              paths: [
+                "products.@"
+              ]
               {
                 ... on Product {
                   __typename
@@ -74,14 +72,22 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
                   weight
                   upc
                 }
-              } =>
-              {
-                ... on Product {
-                  shippingEstimate
-                }
               }
-            },
-          },
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Product {
+                isExpensiveCategory
+                shippingEstimateEUR
+              }
+            }
+            _e1: _entities(representations: $__batch_reps_1) {
+              ... on Product {
+                shippingEstimate
+              }
+            }
+          }
         },
       },
     },
@@ -100,21 +106,23 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
             "operation": "{products{__typename upc name price(currency: \"USD\") weight _internal_qp_alias_0: price(currency: \"EUR\") category{averagePrice(currency: \"USD\")}}}"
           },
           {
-            "kind": "Parallel",
-            "nodes": [
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "products"
-                  },
-                  "@"
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{isExpensiveCategory shippingEstimateEUR}}}",
+            "kind": "BatchFetch",
+            "serviceName": "a",
+            "operationKind": "query",
+            "operation": "query($__batch_reps_0:[_Any!]!, $__batch_reps_1:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{isExpensiveCategory shippingEstimateEUR}} _e1: _entities(representations: $__batch_reps_1){...on Product{shippingEstimate}}}",
+            "entityBatch": {
+              "aliases": [
+                {
+                  "alias": "_e0",
+                  "representationsVariableName": "__batch_reps_0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "products"
+                      },
+                      "@"
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -150,21 +158,18 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
                       ]
                     }
                   ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "products"
-                  },
-                  "@"
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{shippingEstimate}}}",
+                },
+                {
+                  "alias": "_e1",
+                  "representationsVariableName": "__batch_reps_1",
+                  "paths": [
+                    [
+                      {
+                        "Field": "products"
+                      },
+                      "@"
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -190,8 +195,8 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
                     }
                   ]
                 }
-              }
-            ]
+              ]
+            }
           }
         ]
       }
@@ -934,39 +939,45 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
             }
           },
         },
-        Parallel {
-          Flatten(path: "test") {
-            Fetch(service: "a") {
+        BatchFetch(service: "a") {
+          {
+            _e0 {
+              paths: [
+                "test"
+              ]
               {
                 ... on Test {
                   __typename
                   otherField: _internal_qp_alias_0
                   id
                 }
-              } =>
-              {
-                ... on Test {
-                  anotherWithRequiresAndArgs
-                }
               }
-            },
-          },
-          Flatten(path: "test") {
-            Fetch(service: "a") {
+            }
+            _e1 {
+              paths: [
+                "test"
+              ]
               {
                 ... on Test {
                   __typename
                   otherField
                   id
                 }
-              } =>
-              {
-                ... on Test {
-                  fieldWithRequiresAndArgs
-                }
               }
-            },
-          },
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Test {
+                anotherWithRequiresAndArgs
+              }
+            }
+            _e1: _entities(representations: $__batch_reps_1) {
+              ... on Test {
+                fieldWithRequiresAndArgs
+              }
+            }
+          }
         },
       },
     },
@@ -1015,20 +1026,22 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
             }
           },
           {
-            "kind": "Parallel",
-            "nodes": [
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "test"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Test{anotherWithRequiresAndArgs}}}",
+            "kind": "BatchFetch",
+            "serviceName": "a",
+            "operationKind": "query",
+            "operation": "query($__batch_reps_0:[_Any!]!, $__batch_reps_1:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Test{anotherWithRequiresAndArgs}} _e1: _entities(representations: $__batch_reps_1){...on Test{fieldWithRequiresAndArgs}}}",
+            "entityBatch": {
+              "aliases": [
+                {
+                  "alias": "_e0",
+                  "representationsVariableName": "__batch_reps_0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "test"
+                      }
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -1050,20 +1063,17 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
                       ]
                     }
                   ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "test"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Test{fieldWithRequiresAndArgs}}}",
+                },
+                {
+                  "alias": "_e1",
+                  "representationsVariableName": "__batch_reps_1",
+                  "paths": [
+                    [
+                      {
+                        "Field": "test"
+                      }
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -1085,8 +1095,8 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
                     }
                   ]
                 }
-              }
-            ]
+              ]
+            }
           }
         ]
       }
@@ -1147,39 +1157,45 @@ fn multiple_plain_field_and_requires_with_args_that_conflicts() -> Result<(), Bo
             }
           },
         },
-        Parallel {
-          Flatten(path: "test") {
-            Fetch(service: "a") {
+        BatchFetch(service: "a") {
+          {
+            _e0 {
+              paths: [
+                "test"
+              ]
               {
                 ... on Test {
                   __typename
                   otherField: _internal_qp_alias_0
                   id
                 }
-              } =>
-              {
-                ... on Test {
-                  anotherWithRequiresAndArgs
-                }
               }
-            },
-          },
-          Flatten(path: "test") {
-            Fetch(service: "a") {
+            }
+            _e1 {
+              paths: [
+                "test"
+              ]
               {
                 ... on Test {
                   __typename
                   otherField: _internal_qp_alias_1
                   id
                 }
-              } =>
-              {
-                ... on Test {
-                  fieldWithRequiresAndArgs
-                }
               }
-            },
-          },
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Test {
+                anotherWithRequiresAndArgs
+              }
+            }
+            _e1: _entities(representations: $__batch_reps_1) {
+              ... on Test {
+                fieldWithRequiresAndArgs
+              }
+            }
+          }
         },
       },
     },
@@ -1228,20 +1244,22 @@ fn multiple_plain_field_and_requires_with_args_that_conflicts() -> Result<(), Bo
             }
           },
           {
-            "kind": "Parallel",
-            "nodes": [
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "test"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Test{anotherWithRequiresAndArgs}}}",
+            "kind": "BatchFetch",
+            "serviceName": "a",
+            "operationKind": "query",
+            "operation": "query($__batch_reps_0:[_Any!]!, $__batch_reps_1:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Test{anotherWithRequiresAndArgs}} _e1: _entities(representations: $__batch_reps_1){...on Test{fieldWithRequiresAndArgs}}}",
+            "entityBatch": {
+              "aliases": [
+                {
+                  "alias": "_e0",
+                  "representationsVariableName": "__batch_reps_0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "test"
+                      }
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -1263,20 +1281,17 @@ fn multiple_plain_field_and_requires_with_args_that_conflicts() -> Result<(), Bo
                       ]
                     }
                   ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "test"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Test{fieldWithRequiresAndArgs}}}",
+                },
+                {
+                  "alias": "_e1",
+                  "representationsVariableName": "__batch_reps_1",
+                  "paths": [
+                    [
+                      {
+                        "Field": "test"
+                      }
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -1299,8 +1314,8 @@ fn multiple_plain_field_and_requires_with_args_that_conflicts() -> Result<(), Bo
                     }
                   ]
                 }
-              }
-            ]
+              ]
+            }
           }
         ]
       }
@@ -1868,32 +1883,48 @@ fn arguments_with_aliases() -> Result<(), Box<dyn Error>> {
           }
         },
         Parallel {
-          Flatten(path: "secondProduct") {
-            Fetch(service: "a") {
-              {
-                ... on Product {
-                  __typename
-                  id
+          BatchFetch(service: "a") {
+            {
+              _e0 {
+                paths: [
+                  "secondProduct"
+                  "firstProduct"
+                ]
+                {
+                  ... on Product {
+                    __typename
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on Product {
                   category {
                     details
                   }
                 }
               }
-            },
+            }
           },
-          Flatten(path: "secondProduct") {
-            Fetch(service: "b") {
-              {
-                ... on Product {
-                  __typename
-                  id
+          BatchFetch(service: "b") {
+            {
+              _e0 {
+                paths: [
+                  "secondProduct"
+                  "firstProduct"
+                ]
+                {
+                  ... on Product {
+                    __typename
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on Product {
                   category {
                     __typename
@@ -1901,75 +1932,31 @@ fn arguments_with_aliases() -> Result<(), Box<dyn Error>> {
                   }
                 }
               }
-            },
-          },
-          Flatten(path: "firstProduct") {
-            Fetch(service: "a") {
-              {
-                ... on Product {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on Product {
-                  category {
-                    details
-                  }
-                }
-              }
-            },
-          },
-          Flatten(path: "firstProduct") {
-            Fetch(service: "b") {
-              {
-                ... on Product {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on Product {
-                  category {
-                    __typename
-                    id
-                  }
-                }
-              }
-            },
+            }
           },
         },
-        Parallel {
-          Flatten(path: "secondProduct.category") {
-            Fetch(service: "c") {
+        BatchFetch(service: "c") {
+          {
+            _e0 {
+              paths: [
+                "secondProduct.category"
+                "firstProduct.category"
+              ]
               {
                 ... on Category {
                   __typename
                   id
                 }
-              } =>
-              {
-                ... on Category {
-                  name
-                }
               }
-            },
-          },
-          Flatten(path: "firstProduct.category") {
-            Fetch(service: "c") {
-              {
-                ... on Category {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on Category {
-                  name
-                }
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Category {
+                name
               }
-            },
-          },
+            }
+          }
         },
       },
     },
@@ -2027,32 +2014,48 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
           }
         },
         Parallel {
-          Flatten(path: "secondProduct") {
-            Fetch(service: "a") {
-              {
-                ... on Product {
-                  __typename
-                  id
+          BatchFetch(service: "a") {
+            {
+              _e0 {
+                paths: [
+                  "secondProduct"
+                  "firstProduct"
+                ]
+                {
+                  ... on Product {
+                    __typename
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on Product {
                   category {
                     details
                   }
                 }
               }
-            },
+            }
           },
-          Flatten(path: "secondProduct") {
-            Fetch(service: "b") {
-              {
-                ... on Product {
-                  __typename
-                  id
+          BatchFetch(service: "b") {
+            {
+              _e0 {
+                paths: [
+                  "secondProduct"
+                  "firstProduct"
+                ]
+                {
+                  ... on Product {
+                    __typename
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on Product {
                   category {
                     __typename
@@ -2060,75 +2063,31 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
                   }
                 }
               }
-            },
-          },
-          Flatten(path: "firstProduct") {
-            Fetch(service: "a") {
-              {
-                ... on Product {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on Product {
-                  category {
-                    details
-                  }
-                }
-              }
-            },
-          },
-          Flatten(path: "firstProduct") {
-            Fetch(service: "b") {
-              {
-                ... on Product {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on Product {
-                  category {
-                    __typename
-                    id
-                  }
-                }
-              }
-            },
+            }
           },
         },
-        Parallel {
-          Flatten(path: "secondProduct.category") {
-            Fetch(service: "c") {
+        BatchFetch(service: "c") {
+          {
+            _e0 {
+              paths: [
+                "secondProduct.category"
+                "firstProduct.category"
+              ]
               {
                 ... on Category {
                   __typename
                   id
                 }
-              } =>
-              {
-                ... on Category {
-                  name
-                }
               }
-            },
-          },
-          Flatten(path: "firstProduct.category") {
-            Fetch(service: "c") {
-              {
-                ... on Category {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on Category {
-                  name
-                }
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Category {
+                name
               }
-            },
-          },
+            }
+          }
         },
       },
     },
@@ -2153,29 +2112,41 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
             "kind": "Parallel",
             "nodes": [
               {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "secondProduct"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{category{details}}}}",
-                  "requires": [
+                "kind": "BatchFetch",
+                "serviceName": "a",
+                "operationKind": "query",
+                "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{category{details}}}}",
+                "entityBatch": {
+                  "aliases": [
                     {
-                      "kind": "InlineFragment",
-                      "typeCondition": "Product",
-                      "selections": [
+                      "alias": "_e0",
+                      "representationsVariableName": "__batch_reps_0",
+                      "paths": [
+                        [
+                          {
+                            "Field": "secondProduct"
+                          }
+                        ],
+                        [
+                          {
+                            "Field": "firstProduct"
+                          }
+                        ]
+                      ],
+                      "requires": [
                         {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
+                          "kind": "InlineFragment",
+                          "typeCondition": "Product",
+                          "selections": [
+                            {
+                              "kind": "Field",
+                              "name": "__typename"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "id"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -2183,89 +2154,41 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
                 }
               },
               {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "secondProduct"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "b",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{category{__typename id}}}}",
-                  "requires": [
+                "kind": "BatchFetch",
+                "serviceName": "b",
+                "operationKind": "query",
+                "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{category{__typename id}}}}",
+                "entityBatch": {
+                  "aliases": [
                     {
-                      "kind": "InlineFragment",
-                      "typeCondition": "Product",
-                      "selections": [
+                      "alias": "_e0",
+                      "representationsVariableName": "__batch_reps_0",
+                      "paths": [
+                        [
+                          {
+                            "Field": "secondProduct"
+                          }
+                        ],
+                        [
+                          {
+                            "Field": "firstProduct"
+                          }
+                        ]
+                      ],
+                      "requires": [
                         {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "firstProduct"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{category{details}}}}",
-                  "requires": [
-                    {
-                      "kind": "InlineFragment",
-                      "typeCondition": "Product",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "firstProduct"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "b",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{category{__typename id}}}}",
-                  "requires": [
-                    {
-                      "kind": "InlineFragment",
-                      "typeCondition": "Product",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
+                          "kind": "InlineFragment",
+                          "typeCondition": "Product",
+                          "selections": [
+                            {
+                              "kind": "Field",
+                              "name": "__typename"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "id"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -2275,23 +2198,33 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
             ]
           },
           {
-            "kind": "Parallel",
-            "nodes": [
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "secondProduct"
-                  },
-                  {
-                    "Field": "category"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "c",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Category{name}}}",
+            "kind": "BatchFetch",
+            "serviceName": "c",
+            "operationKind": "query",
+            "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Category{name}}}",
+            "entityBatch": {
+              "aliases": [
+                {
+                  "alias": "_e0",
+                  "representationsVariableName": "__batch_reps_0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "secondProduct"
+                      },
+                      {
+                        "Field": "category"
+                      }
+                    ],
+                    [
+                      {
+                        "Field": "firstProduct"
+                      },
+                      {
+                        "Field": "category"
+                      }
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -2309,41 +2242,8 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
                     }
                   ]
                 }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "firstProduct"
-                  },
-                  {
-                    "Field": "category"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "c",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Category{name}}}",
-                  "requires": [
-                    {
-                      "kind": "InlineFragment",
-                      "typeCondition": "Category",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
+              ]
+            }
           }
         ]
       }

--- a/lib/query-planner/src/tests/interface.rs
+++ b/lib/query-planner/src/tests/interface.rs
@@ -635,9 +635,13 @@ fn requires_on_field_with_args_test() -> Result<(), Box<dyn Error>> {
             size
           }
         },
-        Parallel {
-          Flatten(path: "magazine.@") {
-            Fetch(service: "inventory") {
+        BatchFetch(service: "inventory") {
+          {
+            _e0 {
+              paths: [
+                "magazine.@"
+                "book.@"
+              ]
               {
                 ... on Book {
                   __typename
@@ -655,63 +659,29 @@ fn requires_on_field_with_args_test() -> Result<(), Box<dyn Error>> {
                   }
                   id
                 }
-              } =>
-              {
-                ... on Book {
-                  delivery(zip: "1234") {
-                    ...a
-                  }
-                }
-                ... on Magazine {
-                  delivery(zip: "1234") {
-                    ...a
-                  }
+              }
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Book {
+                delivery(zip: "1234") {
+                  ...a
                 }
               }
-              fragment a on DeliveryEstimates {
-                fastestDelivery
-                estimatedDelivery
-              }
-            },
-          },
-          Flatten(path: "book.@") {
-            Fetch(service: "inventory") {
-              {
-                ... on Book {
-                  __typename
-                  dimensions {
-                    size
-                    weight
-                  }
-                  id
-                }
-                ... on Magazine {
-                  __typename
-                  dimensions {
-                    size
-                    weight
-                  }
-                  id
-                }
-              } =>
-              {
-                ... on Book {
-                  delivery(zip: "1234") {
-                    ...a
-                  }
-                }
-                ... on Magazine {
-                  delivery(zip: "1234") {
-                    ...a
-                  }
+              ... on Magazine {
+                delivery(zip: "1234") {
+                  ...a
                 }
               }
-              fragment a on DeliveryEstimates {
-                fastestDelivery
-                estimatedDelivery
-              }
-            },
-          },
+            }
+          }
+          fragment a on DeliveryEstimates {
+            ... on DeliveryEstimates {
+              fastestDelivery
+              estimatedDelivery
+            }
+          }
         },
       },
     },

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -61,37 +61,43 @@ fn issue_281_test() -> Result<(), Box<dyn Error>> {
             id
           }
         },
-        Parallel {
-          Flatten(path: "viewer.review|[UserReview].product") {
-            Fetch(service: "b") {
+        BatchFetch(service: "b") {
+          {
+            _e0 {
+              paths: [
+                "viewer.review|[UserReview].product"
+              ]
               {
                 ... on Product {
                   __typename
                   id
                 }
-              } =>
-              {
-                ... on Product {
-                  pid
-                }
               }
-            },
-          },
-          Flatten(path: "viewer.review|[AnonymousReview].product") {
-            Fetch(service: "b") {
+            }
+            _e1 {
+              paths: [
+                "viewer.review|[AnonymousReview].product"
+              ]
               {
                 ... on Product {
                   __typename
                   id
                 }
-              } =>
-              {
-                ... on Product {
-                  b
-                }
               }
-            },
-          },
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Product {
+                pid
+              }
+            }
+            _e1: _entities(representations: $__batch_reps_1) {
+              ... on Product {
+                b
+              }
+            }
+          }
         },
         Flatten(path: "viewer.review|[UserReview].product") {
           Fetch(service: "c") {

--- a/lib/query-planner/src/tests/mod.rs
+++ b/lib/query-planner/src/tests/mod.rs
@@ -34,7 +34,7 @@ fn test_bench_operation() -> Result<(), Box<dyn std::error::Error>> {
     );
     let query_plan = build_query_plan("../../bench/supergraph.graphql", document)?;
 
-    insta::assert_snapshot!(format!("{}", query_plan), @r###"
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
       Sequence {
         Parallel {
@@ -79,46 +79,40 @@ fn test_bench_operation() -> Result<(), Box<dyn std::error::Error>> {
               }
             },
           },
-          Flatten(path: "topProducts.@") {
-            Fetch(service: "reviews") {
-              {
-                ... on Product {
-                  __typename
-                  upc
-                }
-              } =>
-              {
-                ... on Product {
-                  reviews {
-                    id
-                    body
-                    author {
-                      __typename
-                      id
-                      reviews {
-                        id
-                        body
-                        product {
-                          __typename
-                          upc
-                        }
-                      }
-                      username
-                    }
+          BatchFetch(service: "reviews") {
+            {
+              _e0 {
+                paths: [
+                  "topProducts.@"
+                ]
+                {
+                  ... on Product {
+                    __typename
+                    upc
                   }
                 }
               }
-            },
-          },
-          Flatten(path: "users.@") {
-            Fetch(service: "reviews") {
-              {
-                ... on User {
-                  __typename
-                  id
+              _e1 {
+                paths: [
+                  "users.@"
+                ]
+                {
+                  ... on User {
+                    __typename
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
+                ... on Product {
+                  reviews {
+                    ...a
+                  }
+                }
+              }
+              _e1: _entities(representations: $__batch_reps_1) {
                 ... on User {
                   reviews {
                     id
@@ -127,115 +121,91 @@ fn test_bench_operation() -> Result<(), Box<dyn std::error::Error>> {
                       __typename
                       upc
                       reviews {
-                        id
-                        body
-                        author {
-                          __typename
-                          id
-                          reviews {
-                            id
-                            body
-                            product {
-                              __typename
-                              upc
-                            }
-                          }
-                          username
-                        }
+                        ...a
                       }
                     }
                   }
                 }
               }
-            },
+            }
+            fragment a on Review {
+              id
+              body
+              author {
+                __typename
+                id
+                reviews {
+                  id
+                  body
+                  product {
+                    __typename
+                    upc
+                  }
+                }
+                username
+              }
+            }
           },
         },
         Parallel {
-          Flatten(path: "topProducts.@.reviews.@.author.reviews.@.product") {
-            Fetch(service: "products") {
-              {
-                ... on Product {
-                  __typename
-                  upc
+          BatchFetch(service: "products") {
+            {
+              _e0 {
+                paths: [
+                  "topProducts.@.reviews.@.author.reviews.@.product"
+                  "users.@.reviews.@.product"
+                  "users.@.reviews.@.product.reviews.@.author.reviews.@.product"
+                ]
+                {
+                  ... on Product {
+                    __typename
+                    upc
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on Product {
                   price
                   weight
                   name
                 }
               }
-            },
+            }
           },
-          Flatten(path: "topProducts.@.reviews.@.author") {
-            Fetch(service: "accounts") {
-              {
-                ... on User {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on User {
-                  name
+          BatchFetch(service: "accounts") {
+            {
+              _e0 {
+                paths: [
+                  "topProducts.@.reviews.@.author"
+                  "users.@.reviews.@.product.reviews.@.author"
+                ]
+                {
+                  ... on User {
+                    __typename
+                    id
+                  }
                 }
               }
-            },
-          },
-          Flatten(path: "users.@.reviews.@.product") {
-            Fetch(service: "products") {
-              {
-                ... on Product {
-                  __typename
-                  upc
-                }
-              } =>
-              {
-                ... on Product {
-                  price
-                  weight
-                  name
-                }
-              }
-            },
-          },
-          Flatten(path: "users.@.reviews.@.product.reviews.@.author.reviews.@.product") {
-            Fetch(service: "products") {
-              {
-                ... on Product {
-                  __typename
-                  upc
-                }
-              } =>
-              {
-                ... on Product {
-                  price
-                  weight
-                  name
-                }
-              }
-            },
-          },
-          Flatten(path: "users.@.reviews.@.product.reviews.@.author") {
-            Fetch(service: "accounts") {
-              {
-                ... on User {
-                  __typename
-                  id
-                }
-              } =>
-              {
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on User {
                   name
                 }
               }
-            },
+            }
           },
         },
-        Parallel {
-          Flatten(path: "topProducts.@.reviews.@.author.reviews.@.product") {
-            Fetch(service: "inventory") {
+        BatchFetch(service: "inventory") {
+          {
+            _e0 {
+              paths: [
+                "topProducts.@.reviews.@.author.reviews.@.product"
+                "users.@.reviews.@.product"
+                "users.@.reviews.@.product.reviews.@.author.reviews.@.product"
+              ]
               {
                 ... on Product {
                   __typename
@@ -243,55 +213,21 @@ fn test_bench_operation() -> Result<(), Box<dyn std::error::Error>> {
                   price
                   weight
                 }
-              } =>
-              {
-                ... on Product {
-                  inStock
-                  shippingEstimate
-                }
               }
-            },
-          },
-          Flatten(path: "users.@.reviews.@.product") {
-            Fetch(service: "inventory") {
-              {
-                ... on Product {
-                  __typename
-                  upc
-                  price
-                  weight
-                }
-              } =>
-              {
-                ... on Product {
-                  inStock
-                  shippingEstimate
-                }
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Product {
+                inStock
+                shippingEstimate
               }
-            },
-          },
-          Flatten(path: "users.@.reviews.@.product.reviews.@.author.reviews.@.product") {
-            Fetch(service: "inventory") {
-              {
-                ... on Product {
-                  __typename
-                  upc
-                  price
-                  weight
-                }
-              } =>
-              {
-                ... on Product {
-                  inStock
-                  shippingEstimate
-                }
-              }
-            },
-          },
+            }
+          }
         },
       },
     },
-    "###);
+    "#);
 
     Ok(())
 }

--- a/lib/query-planner/src/tests/override_requires.rs
+++ b/lib/query-planner/src/tests/override_requires.rs
@@ -66,20 +66,28 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
           },
         },
         Parallel {
-          Flatten(path: "userInC") {
-            Fetch(service: "b") {
-              {
-                ... on User {
-                  __typename
-                  id
+          BatchFetch(service: "b") {
+            {
+              _e0 {
+                paths: [
+                  "userInC"
+                  "userInA"
+                ]
+                {
+                  ... on User {
+                    __typename
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on User {
                   name
                 }
               }
-            },
+            }
           },
           Flatten(path: "userInB") {
             Fetch(service: "c") {
@@ -109,90 +117,59 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
               {
                 ... on User {
                   aName
-                }
-              }
-            },
-          },
-          Flatten(path: "userInA") {
-            Fetch(service: "b") {
-              {
-                ... on User {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on User {
-                  name
                 }
               }
             },
           },
         },
         Parallel {
-          Flatten(path: "userInC") {
-            Fetch(service: "c") {
-              {
-                ... on User {
-                  __typename
-                  name
-                  id
+          BatchFetch(service: "c") {
+            {
+              _e0 {
+                paths: [
+                  "userInC"
+                  "userInA"
+                ]
+                {
+                  ... on User {
+                    __typename
+                    name
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on User {
                   cName
                 }
               }
-            },
+            }
           },
-          Flatten(path: "userInC") {
-            Fetch(service: "a") {
-              {
-                ... on User {
-                  __typename
-                  name
-                  id
+          BatchFetch(service: "a") {
+            {
+              _e0 {
+                paths: [
+                  "userInC"
+                  "userInA"
+                ]
+                {
+                  ... on User {
+                    __typename
+                    name
+                    id
+                  }
                 }
-              } =>
-              {
+              }
+            }
+            {
+              _e0: _entities(representations: $__batch_reps_0) {
                 ... on User {
                   aName
                 }
               }
-            },
-          },
-          Flatten(path: "userInA") {
-            Fetch(service: "c") {
-              {
-                ... on User {
-                  __typename
-                  name
-                  id
-                }
-              } =>
-              {
-                ... on User {
-                  cName
-                }
-              }
-            },
-          },
-          Flatten(path: "userInA") {
-            Fetch(service: "a") {
-              {
-                ... on User {
-                  __typename
-                  name
-                  id
-                }
-              } =>
-              {
-                ... on User {
-                  aName
-                }
-              }
-            },
+            }
           },
         },
       },
@@ -231,29 +208,41 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
             "kind": "Parallel",
             "nodes": [
               {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "userInC"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "b",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{name}}}",
-                  "requires": [
+                "kind": "BatchFetch",
+                "serviceName": "b",
+                "operationKind": "query",
+                "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on User{name}}}",
+                "entityBatch": {
+                  "aliases": [
                     {
-                      "kind": "InlineFragment",
-                      "typeCondition": "User",
-                      "selections": [
+                      "alias": "_e0",
+                      "representationsVariableName": "__batch_reps_0",
+                      "paths": [
+                        [
+                          {
+                            "Field": "userInC"
+                          }
+                        ],
+                        [
+                          {
+                            "Field": "userInA"
+                          }
+                        ]
+                      ],
+                      "requires": [
                         {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
+                          "kind": "InlineFragment",
+                          "typeCondition": "User",
+                          "selections": [
+                            {
+                              "kind": "Field",
+                              "name": "__typename"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "id"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -318,36 +307,6 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
                         {
                           "kind": "Field",
                           "name": "name"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "userInA"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "b",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{name}}}",
-                  "requires": [
-                    {
-                      "kind": "InlineFragment",
-                      "typeCondition": "User",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": "__typename"
                         },
                         {
                           "kind": "Field",
@@ -364,33 +323,45 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
             "kind": "Parallel",
             "nodes": [
               {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "userInC"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "c",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{cName}}}",
-                  "requires": [
+                "kind": "BatchFetch",
+                "serviceName": "c",
+                "operationKind": "query",
+                "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on User{cName}}}",
+                "entityBatch": {
+                  "aliases": [
                     {
-                      "kind": "InlineFragment",
-                      "typeCondition": "User",
-                      "selections": [
+                      "alias": "_e0",
+                      "representationsVariableName": "__batch_reps_0",
+                      "paths": [
+                        [
+                          {
+                            "Field": "userInC"
+                          }
+                        ],
+                        [
+                          {
+                            "Field": "userInA"
+                          }
+                        ]
+                      ],
+                      "requires": [
                         {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "name"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
+                          "kind": "InlineFragment",
+                          "typeCondition": "User",
+                          "selections": [
+                            {
+                              "kind": "Field",
+                              "name": "__typename"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "name"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "id"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -398,101 +369,45 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
                 }
               },
               {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "userInC"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{aName}}}",
-                  "requires": [
+                "kind": "BatchFetch",
+                "serviceName": "a",
+                "operationKind": "query",
+                "operation": "query($__batch_reps_0:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on User{aName}}}",
+                "entityBatch": {
+                  "aliases": [
                     {
-                      "kind": "InlineFragment",
-                      "typeCondition": "User",
-                      "selections": [
+                      "alias": "_e0",
+                      "representationsVariableName": "__batch_reps_0",
+                      "paths": [
+                        [
+                          {
+                            "Field": "userInC"
+                          }
+                        ],
+                        [
+                          {
+                            "Field": "userInA"
+                          }
+                        ]
+                      ],
+                      "requires": [
                         {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "name"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "userInA"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "c",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{cName}}}",
-                  "requires": [
-                    {
-                      "kind": "InlineFragment",
-                      "typeCondition": "User",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "name"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "userInA"
-                  }
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "a",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on User{aName}}}",
-                  "requires": [
-                    {
-                      "kind": "InlineFragment",
-                      "typeCondition": "User",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": "__typename"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "name"
-                        },
-                        {
-                          "kind": "Field",
-                          "name": "id"
+                          "kind": "InlineFragment",
+                          "typeCondition": "User",
+                          "selections": [
+                            {
+                              "kind": "Field",
+                              "name": "__typename"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "name"
+                            },
+                            {
+                              "kind": "Field",
+                              "name": "id"
+                            }
+                          ]
                         }
                       ]
                     }

--- a/lib/query-planner/src/tests/requires.rs
+++ b/lib/query-planner/src/tests/requires.rs
@@ -48,39 +48,45 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
             }
           },
         },
-        Parallel {
-          Flatten(path: "products.@") {
-            Fetch(service: "inventory") {
+        BatchFetch(service: "inventory") {
+          {
+            _e0 {
+              paths: [
+                "products.@"
+              ]
               {
                 ... on Product {
                   __typename
                   price: _internal_qp_alias_0
                   upc
                 }
-              } =>
-              {
-                ... on Product {
-                  reducedPrice
-                }
               }
-            },
-          },
-          Flatten(path: "products.@") {
-            Fetch(service: "inventory") {
+            }
+            _e1 {
+              paths: [
+                "products.@"
+              ]
               {
                 ... on Product {
                   __typename
                   price
                   upc
                 }
-              } =>
-              {
-                ... on Product {
-                  isExpensive
-                }
               }
-            },
-          },
+            }
+          }
+          {
+            _e0: _entities(representations: $__batch_reps_0) {
+              ... on Product {
+                reducedPrice
+              }
+            }
+            _e1: _entities(representations: $__batch_reps_1) {
+              ... on Product {
+                isExpensive
+              }
+            }
+          }
         },
       },
     },
@@ -129,21 +135,23 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
             }
           },
           {
-            "kind": "Parallel",
-            "nodes": [
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "products"
-                  },
-                  "@"
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "inventory",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{reducedPrice}}}",
+            "kind": "BatchFetch",
+            "serviceName": "inventory",
+            "operationKind": "query",
+            "operation": "query($__batch_reps_0:[_Any!]!, $__batch_reps_1:[_Any!]!){_e0: _entities(representations: $__batch_reps_0){...on Product{reducedPrice}} _e1: _entities(representations: $__batch_reps_1){...on Product{isExpensive}}}",
+            "entityBatch": {
+              "aliases": [
+                {
+                  "alias": "_e0",
+                  "representationsVariableName": "__batch_reps_0",
+                  "paths": [
+                    [
+                      {
+                        "Field": "products"
+                      },
+                      "@"
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -165,21 +173,18 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
                       ]
                     }
                   ]
-                }
-              },
-              {
-                "kind": "Flatten",
-                "path": [
-                  {
-                    "Field": "products"
-                  },
-                  "@"
-                ],
-                "node": {
-                  "kind": "Fetch",
-                  "serviceName": "inventory",
-                  "operationKind": "query",
-                  "operation": "query($representations:[_Any!]!){_entities(representations: $representations){...on Product{isExpensive}}}",
+                },
+                {
+                  "alias": "_e1",
+                  "representationsVariableName": "__batch_reps_1",
+                  "paths": [
+                    [
+                      {
+                        "Field": "products"
+                      },
+                      "@"
+                    ]
+                  ],
                   "requires": [
                     {
                       "kind": "InlineFragment",
@@ -201,8 +206,8 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
                     }
                   ]
                 }
-              }
-            ]
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
Introduces batched entity fetches in the query plan. It allows multiple compatible entity fetches (`Flatten(Fetch)`) to be executed through a single `BatchFetch` node, while still keeping incompatible fetches separate (I will explain in detail). 
Compatibility is decided by service name, variable definitions, input and output selection sets, and rewrites, so batching happens only when the resulting plan is correct.

---

**Notes for reviewers**

To understand the behavior, I recommend to look at the tests in `lib/query-planner/src/planner/query_plan/optimize.rs` file.
I tried to cover a lot of cases there, in an easy to read format, for you to review quicker and understand it better, but also for "future me" :)

I also tried to make the diff minimal and avoid touching functions that existed (especially around plan execution :wink:).

Two big files to look closely:
- `lib/query-planner/src/planner/query_plan/optimize.rs` - where the QueryPlan is optimized and Flatten(Fetch) turned into BatchNode)
- `lib/executor/src/execution/plan.rs` - where the execution happens.

I added top-level descriptions to files to explain the algorithm (what and why), and I also added comments with visualisations and examples to make "future me (and you)" happier.

---

For example, if the plan has two compatible entity fetches to `inventory` service, one for `products.@` and one for `topProducts.@`, the planner now produces one BatchFetch alias that serves both paths. In simple terms, the router sends one _entities request and then applies the returned entities to both places in the response. If the two fetches are not compatible, for example because they select different entity fields, the planner still creates one `BatchFetch` node but splits them into different aliases so behavior remains correct.

Here's a visual:

```graphql
Parallel {
  Flatten(path: "products.@") {
    Fetch(service: "inventory") {
      {
        ... on Product {
          upc
        }
      } =>
      {
        ... on Product {
          shippingEstimate
        }
      }
    }
  }
  Flatten(path: "topProducts.@") {
    Fetch(service: "inventory") {
      {
        ... on Product {
          upc
        }
      } =>
      {
        ... on Product {
          shippingEstimate
        }
      }
    }
  }
}
```

is optimized into:

```graphql
BatchFetch(service: "inventory") {
  {
    _e0 {
      paths: [
        "products.@"
        "topProducts.@"
      ]
      {
        ... on Product {
          upc
        }
      }
    }
  }
  {
    _e0: _entities(representations: $__batch_reps_0) {
      ... on Product {
        shippingEstimate
      }
    }
  }
}
```

**Aliasing**

When two entity fetches go to the same subgraph but request different output fields, they are batched into one BatchFetch node with two aliases, not one alias.

```graphql
BatchFetch(service: "inventory") {
  {
    _e0 {
      paths: [
        "products.@"
      ]
      {
        ... on Product {
          upc
        }
      }
    }
    _e1 {
      paths: [
        "topProducts.@"
      ]
      {
        ... on Product {
          upc
        }
      }
    }
  }
  {
    _e0: _entities(representations: $__batch_reps_0) {
      ... on Product {
        shippingEstimate
      }
    }
    _e1: _entities(representations: $__batch_reps_1) {
      ... on Product {
        inStock
      }
    }
  }
}
```

In this example, both aliases share the same requires shape (upc), but the output selection is different (shippingEstimate vs inStock), so the planner creates two aliases (_e0, _e1) inside one batch fetch.

**Errors**

When a batched subgraph response contains errors, the router first routes each error by alias.
In batch operations, subgraph errors are usually scoped to alias paths like `_e0` or `_e1`. The router maps those aliases back to the corresponding batch alias group and rewrites the first path segment to `_entities`, because entity error normalization expects paths in that format. 
After that, each alias-scoped error is expanded to all original response paths that shared the same deduplicated representation hash, so duplicated entities receive consistent error paths. Errors that cannot be matched to any known alias are kept as unmatched and attached at the top level, so they are not lost.

**Minification of the BatchFetch query**

The `BatchFetch` operation document is minified. This keeps the generated operation compact, reduces payload size, and makes hashing/deduplication stable for equivalent operations. They are produced identically to regular `Fetch` nodes.

**Network**

This change aim to reduce number of http requests. In our benchmarked scenario it reduced downstream subgraph requests from `13` to `7` for the same operation. The number of execution waves stays the same, so query depth does not change.
HTTP overhead is much lower, as you can see. This should also reduce pressure on subgraphs, because entities are resolved in one batched subgraph call instead of being resolved across multiple incoming GraphQL requests, where the lack of DataLoader or another caching layer could otherwise cause duplicate resolution work.