### PR TITLE
chore(ci): Decrease test timeouts in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: test e2e
         run: cargo test_e2e
-        timeout-minutes: 60
+        timeout-minutes: 10
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug
@@ -55,7 +55,7 @@ jobs:
           shared-key: ${{ hashFiles('**/Cargo.lock') }}
       - name: test plugin examples
         run: cargo test_plugin_examples
-        timeout-minutes: 60
+        timeout-minutes: 10
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug


### PR DESCRIPTION
Reduced timeout for end-to-end and plugin example tests from 60 minutes to 10 minutes. E2E runs in 2 minutes on average according to github stats, but let's give it a little room.

Created this PR as I saw [a case](https://github.com/graphql-hive/router/actions/runs/23005165779/job/66799944212?pr=846) where it was running and running for 20 minutes already.