### PR TITLE
Use npm package for federation audits

### DIFF
--- a/audits/package.json
+++ b/audits/package.json
@@ -11,8 +11,9 @@
     "ci:test:graphql-over-http": "start-server-and-test start:test-router http://localhost:4000 test-junit:graphql-over-http"
   },
   "devDependencies": {
-    "graphql-federation-gateway-audit": "graphql-hive/federation-gateway-audit#bf0aa76",
+    "@graphql-hive/federation-gateway-audit": "0.0.2",
     "graphql-http": "1.22.4",
+    "graphql": "16.13.1",
     "typescript": "5.9.3",
     "start-server-and-test": "2.1.5"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
     "audits": {
       "name": "router-audits-checks",
       "devDependencies": {
-        "graphql-federation-gateway-audit": "graphql-hive/federation-gateway-audit#bf0aa76",
+        "@graphql-hive/federation-gateway-audit": "0.0.2",
+        "graphql": "16.13.1",
         "graphql-http": "1.22.4",
         "start-server-and-test": "2.1.5",
         "typescript": "5.9.3"
@@ -115,7 +116,7 @@
     },
     "lib/node-addon": {
       "name": "@graphql-hive/router-query-planner",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.2.0"
@@ -136,14 +137,14 @@
       }
     },
     "node_modules/@apollo/composition": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.13.1.tgz",
-      "integrity": "sha512-F7FUlCspipP4GgzB4sB+49IS7aztrT9SAstQhhjDJD1HFzfqg8coY9w0IwXEOlZaANnC1wUEED+AgI69IOsp/Q==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.13.2.tgz",
+      "integrity": "sha512-E44BbSKuKkDdsNBtQzSU12D9FdggiOZzNR1TghqPjSPEyB1fl9Io1m2gMP0nkwrJUaftsBSP6ZSFF3SgYJfTVg==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@apollo/federation-internals": "2.13.1",
-        "@apollo/query-graphs": "2.13.1"
+        "@apollo/federation-internals": "2.13.2",
+        "@apollo/query-graphs": "2.13.2"
       },
       "engines": {
         "node": ">=18"
@@ -153,9 +154,9 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.13.1.tgz",
-      "integrity": "sha512-3w+pEjew3xDHTjM4INvBiy0+F/Puje7NSnH0S9WkFiiSjYDu9wwHW6yw5Frx8jN1T17lGOgAGbx1S+YTosCs6Q==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.13.2.tgz",
+      "integrity": "sha512-m9waen8iZhrzn23qkemlytqBCPoKU6AMv5k3eFYnu6yzoJ5/ONh6SMGE7CvrWsECcpnOLYOinxD19igEHm6Azw==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
@@ -172,13 +173,13 @@
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.13.1.tgz",
-      "integrity": "sha512-YfcwdYMCXkq8ODgZ2vGY2d7m+5i9Sjl8UygsFkVzpJUfDJCnOA35bEcs4oRCdcz3Esc1+j8Z4ORhx+4UoPsk9Q==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.13.2.tgz",
+      "integrity": "sha512-iXb7Ut72BxOIKYT1Xbmmt5jONa/kB0iuQyWKhKIJdwIw+p8VSwJvaSFtzjDZ7tYTo/QH9l8yGzAdliJVR+/7cA==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@apollo/federation-internals": "2.13.1",
+        "@apollo/federation-internals": "2.13.2",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^1.5.4",
         "uuid": "^9.0.0"
@@ -191,14 +192,14 @@
       }
     },
     "node_modules/@apollo/subgraph": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.13.1.tgz",
-      "integrity": "sha512-SmFYNd/0uzVt9OyyofSMydgYpzDRPF2gyVY0a32xb2RTCtnNpGnCMaOd9kN9V5Tm31Zspcbqycj1l64zMu0egQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.13.2.tgz",
+      "integrity": "sha512-hNJv6kcGhtWdBfGWnSZwgfmSm4ZAJ3AoPmDFOXaloSE1wKmKz0NmPsef4nkC2/AUD9/FrQMKm5xzyBYTDrpNSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "2.13.1"
+        "@apollo/federation-internals": "2.13.2"
       },
       "engines": {
         "node": ">=14.15.0"
@@ -261,6 +262,32 @@
       "version": "3.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@graphql-hive/federation-gateway-audit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/federation-gateway-audit/-/federation-gateway-audit-0.0.2.tgz",
+      "integrity": "sha512-9+jHme3iNfUHksM20N+ODkzz3t6wkICOBTkge/w29+U7qWRirXn9VLUXs3pbOs1/PpOvoLJXVvJpE7+3mVQN1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/composition": "^2.13.2",
+        "@apollo/subgraph": "^2.13.2",
+        "async-retry": "^1.3.3",
+        "detect-port": "^2.1.0",
+        "fets": "^0.8.5",
+        "get-port": "^7.1.0",
+        "graphql-yoga": "^5.18.1",
+        "jest-diff": "^30.3.0",
+        "kill-port-process": "^4.0.2",
+        "wait-on": "^9.0.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "graphql-federation-audit": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
     },
     "node_modules/@graphql-hive/router-query-planner": {
       "resolved": "lib/node-addon",
@@ -1734,19 +1761,6 @@
       "resolved": "docs/generator",
       "link": true
     },
-    "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "dev": true,
@@ -2155,31 +2169,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-federation-gateway-audit": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/graphql-hive/federation-gateway-audit.git#bf0aa76a8a4947159d1616fa6e4d67de86ef28b0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/composition": "2.13.1",
-        "@apollo/subgraph": "2.13.1",
-        "async-retry": "1.3.3",
-        "detect-port": "2.1.0",
-        "dotenv": "17.3.1",
-        "fets": "0.8.5",
-        "get-port": "7.1.0",
-        "graphql": "16.13.1",
-        "graphql-yoga": "5.18.1",
-        "jest-diff": "30.3.0",
-        "kill-port-process": "4.0.2",
-        "wait-on": "9.0.4",
-        "yargs": "18.0.0"
-      },
-      "bin": {
-        "graphql-federation-audit": "dist/cli.js"
       }
     },
     "node_modules/graphql-yoga": {


### PR DESCRIPTION
Use npm package `@graphql-hive/federation-gateway-audit` instead of pointing to the github repository