### PR TITLE
chore(node-addon): changeset for the fixes in the query planner

### DIFF
--- a/.changeset/update-node-addon.md
+++ b/.changeset/update-node-addon.md
@@ -1,0 +1,5 @@
+---
+node-addon: patch
+---
+
+This patch includes the fixes in the query planner including the fixes for mismatch handling so conflicting fields are tracked by response key (alias-aware), and internal alias rewrites restore the original client-facing key (alias-or-name) instead of always the schema field name.


### PR DESCRIPTION
This patch includes the fixes in the query planner including the fixes for mismatch handling so conflicting fields are tracked by response key (alias-aware), and internal alias rewrites restore the original client-facing key (alias-or-name) instead of always the schema field name.