### PR TITLE
fix(executor): correct timeout error message

### DIFF
--- a/.changeset/fix_timeout_error.md
+++ b/.changeset/fix_timeout_error.md
@@ -1,0 +1,8 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Fix timeout error message to include the timeout duration instead of the endpoint URL
+
+Previously by mistake, the error message for subgraph request timeouts included the endpoint URL instead of the timeout duration like `Request to subgraph timed out after http://ACCOUNT_ENDPOINT:PORT/accounts milliseconds`. This change fixes the error message to include the timeout duration in milliseconds like `Request to subgraph timed out after 200 milliseconds`.

--- a/.changeset/fix_timeout_error.md
+++ b/.changeset/fix_timeout_error.md
@@ -5,4 +5,4 @@ hive-router: patch
 
 # Fix timeout error message to include the timeout duration instead of the endpoint URL
 
-Previously by mistake, the error message for subgraph request timeouts included the endpoint URL instead of the timeout duration like `Request to subgraph timed out after http://ACCOUNT_ENDPOINT:PORT/accounts milliseconds`. This change fixes the error message to include the timeout duration in milliseconds like `Request to subgraph timed out after 200 milliseconds`.
+Previously by mistake, the error message for subgraph request timeouts included the endpoint URL instead of the timeout duration like `Request to subgraph timed out after http://ACCOUNT_ENDPOINT:PORT/accounts milliseconds`. This change simplifies the error message like `Request to subgraph timed out`.

--- a/e2e/configs/timeout_per_subgraph_dynamic.router.yaml
+++ b/e2e/configs/timeout_per_subgraph_dynamic.router.yaml
@@ -4,7 +4,7 @@ supergraph:
   path: ../supergraph.graphql
 traffic_shaping:
   all:
-    request_timeout: 2s
+    request_timeout: 200ms
     # Disable deduplication to better hunt for deadlocks in tests
     dedupe_enabled: false
   subgraphs:
@@ -12,7 +12,7 @@ traffic_shaping:
       request_timeout:
         expression: |
           if (.request.headers."x-timeout" == "short") {
-            "10s"
+            "1s"
           } else {
             .default
           }

--- a/e2e/src/timeout_per_subgraph.rs
+++ b/e2e/src/timeout_per_subgraph.rs
@@ -56,7 +56,7 @@ mod timeout_per_subgraph_e2e_tests {
         let subgraphs = TestSubgraphs::builder()
             .with_on_request(|request| {
                 if request.path == "/accounts" {
-                    sleep(Duration::from_secs(3));
+                    sleep(SUBGRAPH_DELAY);
                 }
                 None
             })
@@ -127,7 +127,7 @@ mod timeout_per_subgraph_e2e_tests {
                   },
                   "errors": [
                     {
-                      "message": "Request to subgraph timed out after 2000 milliseconds",
+                      "message": "Request to subgraph timed out after 200 milliseconds",
                       "extensions": {
                         "code": "SUBGRAPH_REQUEST_TIMEOUT",
                         "serviceName": "accounts"

--- a/e2e/src/timeout_per_subgraph.rs
+++ b/e2e/src/timeout_per_subgraph.rs
@@ -1,8 +1,141 @@
 #[cfg(test)]
-mod override_subgraph_urls_e2e_tests {
+mod timeout_per_subgraph_e2e_tests {
+    use std::{thread::sleep, time::Duration};
+
+    use ntex::http::StatusCode;
     use sonic_rs::json;
 
     use crate::testkit::{some_header_map, ClientResponseExt, TestRouter, TestSubgraphs};
+
+    #[ntex::test]
+    async fn should_apply_static_subgraph_timeout_override() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|request| {
+                if request.path == "/accounts" {
+                    sleep(Duration::from_secs(3));
+                }
+                None
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("configs/timeout_per_subgraph_static.router.yaml")
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+
+        assert_eq!(res.status(), StatusCode::OK, "Expected 200 OK");
+        let expected_json = json!({
+          "data": {
+            "users": [
+              { "id": "1" },
+              { "id": "2" },
+              { "id": "3" },
+              { "id": "4" },
+              { "id": "5" },
+              { "id": "6" }
+            ]
+          }
+        });
+
+        let json_body = res.json_body().await;
+        assert_eq!(json_body, expected_json);
+    }
+
+    #[ntex::test]
+    async fn should_apply_dynamic_subgraph_timeout_override_and_fallback_to_default() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|request| {
+                if request.path == "/accounts" {
+                    sleep(Duration::from_secs(3));
+                }
+                None
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("configs/timeout_per_subgraph_dynamic.router.yaml")
+            .build()
+            .start()
+            .await;
+
+        let short_timeout_res = router
+            .send_graphql_request(
+                "{ users { id } }",
+                None,
+                some_header_map! {
+                        http::header::HeaderName::from_static("x-timeout") => "short"
+                },
+            )
+            .await;
+
+        assert_eq!(
+            short_timeout_res.status(),
+            StatusCode::OK,
+            "Expected 200 OK"
+        );
+
+        let expected_json = json!({
+          "data": {
+            "users": [
+              { "id": "1" },
+              { "id": "2" },
+              { "id": "3" },
+              { "id": "4" },
+              { "id": "5" },
+              { "id": "6" }
+            ]
+          }
+        });
+
+        let json_body = short_timeout_res.json_body().await;
+        assert_eq!(json_body, expected_json);
+
+        let default_timeout_res = router
+            .send_graphql_request(
+                "{ users { id } }",
+                None,
+                some_header_map! {
+                        http::header::HeaderName::from_static("x-timeout") => "long"
+                },
+            )
+            .await;
+
+        assert_eq!(
+            default_timeout_res.status(),
+            StatusCode::OK,
+            "Expected 200 OK"
+        );
+        insta::assert_snapshot!(
+                default_timeout_res.json_body_string_pretty().await,
+                @r#"
+                {
+                  "data": {
+                    "users": null
+                  },
+                  "errors": [
+                    {
+                      "message": "Request to subgraph timed out after 2000 milliseconds",
+                      "extensions": {
+                        "code": "SUBGRAPH_REQUEST_TIMEOUT",
+                        "serviceName": "accounts"
+                      }
+                    }
+                  ]
+                }
+                "#
+        );
+    }
 
     #[ntex::test]
     async fn should_not_deadlock_when_overriding_subgraph_timeout_statically() {

--- a/e2e/src/timeout_per_subgraph.rs
+++ b/e2e/src/timeout_per_subgraph.rs
@@ -7,12 +7,14 @@ mod timeout_per_subgraph_e2e_tests {
 
     use crate::testkit::{some_header_map, ClientResponseExt, TestRouter, TestSubgraphs};
 
+    const SUBGRAPH_DELAY: Duration = Duration::from_millis(300);
+
     #[ntex::test]
     async fn should_apply_static_subgraph_timeout_override() {
         let subgraphs = TestSubgraphs::builder()
             .with_on_request(|request| {
                 if request.path == "/accounts" {
-                    sleep(Duration::from_secs(3));
+                    sleep(SUBGRAPH_DELAY);
                 }
                 None
             })

--- a/e2e/src/timeout_per_subgraph.rs
+++ b/e2e/src/timeout_per_subgraph.rs
@@ -127,7 +127,7 @@ mod timeout_per_subgraph_e2e_tests {
                   },
                   "errors": [
                     {
-                      "message": "Request to subgraph timed out after 200 milliseconds",
+                      "message": "Request to subgraph timed out",
                       "extensions": {
                         "code": "SUBGRAPH_REQUEST_TIMEOUT",
                         "serviceName": "accounts"

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -40,9 +40,7 @@ pub enum SubgraphExecutorError {
     TimeoutExpressionResolution(String),
     #[error("Request to subgraph timed out")]
     #[strum(serialize = "SUBGRAPH_REQUEST_TIMEOUT")]
-    RequestTimeout {
-        timeout_duration: std::time::Duration,
-    },
+    RequestTimeout(#[from] tokio::time::error::Elapsed),
     #[error("Failed to read response body from subgraph \"{0}\": {1}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_READ_FAILURE")]
     ResponseBodyReadFailure(String, String),

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -40,7 +40,9 @@ pub enum SubgraphExecutorError {
     TimeoutExpressionResolution(String),
     #[error("Request to subgraph timed out")]
     #[strum(serialize = "SUBGRAPH_REQUEST_TIMEOUT")]
-    RequestTimeout(#[from] tokio::time::error::Elapsed),
+    RequestTimeout {
+        timeout_duration: std::time::Duration,
+    },
     #[error("Failed to read response body from subgraph \"{0}\": {1}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_READ_FAILURE")]
     ResponseBodyReadFailure(String, String),

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -40,7 +40,7 @@ pub enum SubgraphExecutorError {
     TimeoutExpressionResolution(String),
     #[error("Request to subgraph timed out after {0} milliseconds")]
     #[strum(serialize = "SUBGRAPH_REQUEST_TIMEOUT")]
-    RequestTimeout(String, u128),
+    RequestTimeout(u128),
     #[error("Failed to read response body from subgraph \"{0}\": {1}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_READ_FAILURE")]
     ResponseBodyReadFailure(String, String),

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -38,9 +38,9 @@ pub enum SubgraphExecutorError {
     #[error("Failed to resolve VRL expression for timeout for subgraph. Runtime error: {0}")]
     #[strum(serialize = "SUBGRAPH_TIMEOUT_EXPRESSION_RESOLUTION_FAILURE")]
     TimeoutExpressionResolution(String),
-    #[error("Request to subgraph timed out after {0} milliseconds")]
+    #[error("Request to subgraph timed out")]
     #[strum(serialize = "SUBGRAPH_REQUEST_TIMEOUT")]
-    RequestTimeout(u128),
+    RequestTimeout(#[from] tokio::time::error::Elapsed),
     #[error("Failed to read response body from subgraph \"{0}\": {1}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_READ_FAILURE")]
     ResponseBodyReadFailure(String, String),

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -223,9 +223,7 @@ async fn send_request<'a>(
         let res_fut = http_client.request(req);
 
         let res = if let Some(timeout_duration) = timeout {
-            tokio::time::timeout(timeout_duration, res_fut)
-                .await
-                .map_err(|_| SubgraphExecutorError::RequestTimeout(timeout_duration.as_millis()))?
+            tokio::time::timeout(timeout_duration, res_fut).await?
         } else {
             res_fut.await
         }?;

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -224,8 +224,7 @@ async fn send_request<'a>(
 
         let res = if let Some(timeout_duration) = timeout {
             tokio::time::timeout(timeout_duration, res_fut)
-                .await
-                .map_err(|_| SubgraphExecutorError::RequestTimeout { timeout_duration })?
+                .await?
         } else {
             res_fut.await
         }?;

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -223,7 +223,9 @@ async fn send_request<'a>(
         let res_fut = http_client.request(req);
 
         let res = if let Some(timeout_duration) = timeout {
-            tokio::time::timeout(timeout_duration, res_fut).await?
+            tokio::time::timeout(timeout_duration, res_fut)
+                .await
+                .map_err(|_| SubgraphExecutorError::RequestTimeout { timeout_duration })?
         } else {
             res_fut.await
         }?;

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -223,8 +223,7 @@ async fn send_request<'a>(
         let res_fut = http_client.request(req);
 
         let res = if let Some(timeout_duration) = timeout {
-            tokio::time::timeout(timeout_duration, res_fut)
-                .await?
+            tokio::time::timeout(timeout_duration, res_fut).await?
         } else {
             res_fut.await
         }?;

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -225,12 +225,7 @@ async fn send_request<'a>(
         let res = if let Some(timeout_duration) = timeout {
             tokio::time::timeout(timeout_duration, res_fut)
                 .await
-                .map_err(|_| {
-                    SubgraphExecutorError::RequestTimeout(
-                        endpoint.to_string(),
-                        timeout_duration.as_millis(),
-                    )
-                })?
+                .map_err(|_| SubgraphExecutorError::RequestTimeout(timeout_duration.as_millis()))?
         } else {
             res_fut.await
         }?;


### PR DESCRIPTION
### Fix timeout error message to include the timeout duration instead of the endpoint URL

Previously by mistake, the error message for subgraph request timeouts included the endpoint URL instead of the timeout duration like `Request to subgraph timed out after http://ACCOUNT_ENDPOINT:PORT/accounts milliseconds`. This change simplifies the error message like `Request to subgraph timed out`.