### PR TITLE
refactor(executor): centralize value object handling in `ValueObject` struct

### DIFF
--- a/.changeset/tiny-forks-sing.md
+++ b/.changeset/tiny-forks-sing.md
@@ -1,0 +1,5 @@
+---
+hive-router-plan-executor: patch
+---
+
+Refactor executor response object handling to use `ValueObject` and map-style accessors across projection, merge, traversal, rewrites, and introspection paths. This centralizes key sorting and lookup behavior, reduces repeated binary-search boilerplate, and keeps runtime behavior consistent while improving maintainability.

--- a/e2e/src/demand_control.rs
+++ b/e2e/src/demand_control.rs
@@ -1,0 +1,2215 @@
+#[cfg(test)]
+mod demand_control_e2e_tests {
+    use std::time::Duration;
+
+    use sonic_rs::{json, JsonContainerTrait, JsonValueTrait};
+
+    use crate::testkit::{
+        otel::{CollectedMetrics, OtlpCollector},
+        ClientResponseExt, TestRouter, TestSubgraphs,
+    };
+    use hive_router_internal::telemetry::metrics::catalog::{labels, names};
+
+    async fn wait_for_metrics_export() {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    fn assert_histogram_sample_count(
+        metrics: &CollectedMetrics,
+        name: &str,
+        attrs: &[(&str, &str)],
+        expected_count: u64,
+    ) {
+        let (count, _) = metrics.latest_histogram_count_sum(name, attrs);
+        assert_eq!(
+            count, expected_count,
+            "Expected {name} sample count to be {expected_count}, got {count}"
+        );
+    }
+
+    async fn assert_estimated_too_expensive(
+        query: &str,
+        variables: Option<sonic_rs::Value>,
+        expected_cost: u64,
+    ) {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                        source: file
+                        path: supergraph_demand_control.graphql
+                demand_control:
+                        enabled: true
+                        max_cost: {}
+                "#,
+                expected_cost.saturating_sub(1)
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(query, variables, None).await;
+        let json = res.json_body().await;
+
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+        assert_eq!(
+            json["errors"][0]["message"].as_str(),
+            Some(
+                format!(
+                    "Operation estimated cost {} exceeds configured max cost {}",
+                    expected_cost,
+                    expected_cost.saturating_sub(1)
+                )
+                .as_str()
+            )
+        );
+    }
+
+    // No directives/custom list size: baseline query should estimate to 4.
+    #[ntex::test]
+    async fn estimator_no_customization_cost_is_4() {
+        assert_estimated_too_expensive(
+            r#"query BookQuery {
+  # Query operation has cost of `0`
+  book(id: 1) {
+    # Field `book` returns a composite type `Book` with cost of `1`
+    title # Field `title` is a leaf type with cost of `0`
+    author {
+      # Field `author` returns a composite type `Author` with cost of `1`
+      name # Field `name` is a leaf type with cost of `0`
+    }
+    publisher {
+      # Field `publisher` returns a composite type `Publisher` with cost of `1`
+      name # Field `name` is a leaf type with cost of `0`
+      address {
+        # Field `address` returns a composite type `Address` with cost of `1`
+        zipCode # Field `zipCode` is a leaf type with cost of `0`
+      }
+    }
+  }
+}"#,
+            None,
+            4,
+        )
+        .await;
+    }
+
+    // Type-level @cost(weight: 5) on nested object adds to recursive estimate.
+    #[ntex::test]
+    async fn estimator_type_cost_directive_cost_is_8() {
+        assert_estimated_too_expensive(
+            r#"query BookQuery {
+  # Query operation has cost of `0`
+  book(id: 1) {
+    # Field `book` returns a composite type `Book` with cost of `1`
+    title # Field `title` is a leaf type with cost of `0`
+    author {
+      # Field `author` returns a composite type `Author` with cost of `1`
+      name # Field `name` is a leaf type with cost of `0`
+    }
+    publisher {
+      # Field `publisher` returns a composite type `Publisher` with cost of `1`
+      name # Field `name` is a leaf type with cost of `0`
+      addressWithCost {
+        # Field `addressWithCost` returns a composite type `Address` with cost of `5`
+        zipCode # Field `zipCode` is a leaf type with cost of `0`
+      }
+    }
+  }
+}"#,
+            None,
+            8,
+        )
+        .await;
+    }
+
+    // @listSize(assumedSize: 5) multiplies list item branch cost.
+    #[ntex::test]
+    async fn estimator_list_assumed_size_cost_is_40() {
+        assert_estimated_too_expensive(
+r#"query BestsellersQuery {
+  bestsellers {
+    # Field `bestsellers` returns a list of `Book` with assumed size of `5`
+    title
+    author {
+      # Field `author` returns a composite type `Author` with cost of `1` but it is multiplied by `5`
+      name
+    }
+    publisher {
+      # Field `publisher` returns a composite type `Publisher` with cost of `1` but it is multiplied by `5`
+      name
+      addressWithCost {
+        # Field `addressWithCost` returns a composite type `Address` with cost of `5` but it is multiplied by `5` equals to `25`
+        zipCode
+      }
+    }
+  }
+}"#,
+            None,
+            40,
+        )
+        .await;
+    }
+
+    // Single slicing argument drives list size directly.
+    #[ntex::test]
+    async fn estimator_single_slicing_argument_cost_is_24() {
+        assert_estimated_too_expensive(
+r#"query NewestAdditions {
+  # Query operation has cost of `0`
+  newestAdditions(limit: 3) {
+    # Field `newestAdditions` returns a list of `Book` with assumed size of `3`
+    title # Field `title` is a leaf type with cost of `0`
+    author {
+      # Field `author` returns a composite type `Author` with cost of `1` but it is multiplied by `3`
+      name # Field `name` is a leaf type with cost of `0`
+    }
+    publisher {
+      # Field `publisher` returns a composite type `Publisher` with cost of `1` but it is multiplied by `3`
+      name # Field `name` is a leaf type with cost of `0`
+      addressWithCost {
+        # Field `addressWithCost` returns a composite type `Address` with cost of `5` but it is multiplied by `3` equals to `15`
+        zipCode # Field `zipCode` is a leaf type with cost of `0`
+      }
+    }
+  }
+}"#,
+            None,
+            24,
+        )
+        .await;
+    }
+
+    // Negative literal slicing argument should be clamped to 0, not cast into a huge u64.
+    #[ntex::test]
+    async fn estimator_negative_literal_slicing_argument_is_clamped() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph_demand_control.graphql
+                demand_control:
+                    enabled: true
+                    max_cost: 1
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                  newestAdditions(limit: -1) {
+                    title
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        assert!(
+            !json.get("errors").is_some(),
+            "negative literal slicing arg must not overflow estimated cost"
+        );
+    }
+
+    // Multiple slicing arguments use max(first, last) when requireOneSlicingArgument=false.
+    #[ntex::test]
+    async fn estimator_multiple_slicing_arguments_take_max_cost_is_40() {
+        assert_estimated_too_expensive(
+r#"query NewestAdditions {
+  # Query operation has cost of `0`
+  newestAdditions2(first: 3, last: 5) {
+    # Field `newestAdditions2` returns a list of `Book` with assumed size of `5` because `5` is the highest value between `3` and `5`
+    title # Field `title` is a leaf type with cost of `0`
+    author {
+      # Field `author` returns a composite type `Author` with cost of `1` but it is multiplied by `5`
+      name # Field `name` is a leaf type with cost of `0`
+    }
+    publisher {
+      # Field `publisher` returns a composite type `Publisher` with cost of `1` but it is multiplied by `5`
+      name # Field `name` is a leaf type with cost of `0`
+      addressWithCost {
+        # Field `addressWithCost` returns a composite type `Address` with cost of `5` but it is multiplied by `5` equals to `25`
+        zipCode # Field `zipCode` is a leaf type with cost of `0`
+      }
+    }
+  }
+}"#,
+            None,
+            40,
+        )
+        .await;
+    }
+
+    // Cursor-style pagination with sizedFields propagates configured page size to nested list field.
+    #[ntex::test]
+    async fn estimator_sized_fields_cursor_style_cost_is_41() {
+        assert_estimated_too_expensive(
+r#"query NewestAdditionsByCursor {
+  # Query operation has cost of `0`
+  newestAdditionsByCursor(limit: 5) {
+    # Field `newestAdditionsByCursor` returns a composite type `Cursor` with cost of `1`
+    page {
+      # Field `page` returns a list of `Book` with assumed size of `5`
+      title # Field `title` is a leaf type with cost of `0`
+      author {
+        # Field `author` returns a composite type `Author` with cost of `1` but it is multiplied by `5`
+        name # Field `name` is a leaf type with cost of `0`
+      }
+      publisher {
+        # Field `publisher` returns a composite type `Publisher` with cost of `1` but it is multiplied by `5`
+        name # Field `name` is a leaf type with cost of `0`
+        addressWithCost {
+          # Field `addressWithCost` returns a composite type `Address` with cost of `5` but it is multiplied by `5` equals to `25`
+          zipCode # Field `zipCode` is a leaf type with cost of `0`
+        }
+      }
+    }
+    nextPage
+  }
+}"#,
+            None,
+            41,
+        )
+        .await;
+    }
+
+    // Nested slicing argument path (input.pagination.first) resolves through variables.
+    #[ntex::test]
+    async fn estimator_nested_slicing_argument_path_cost_is_24() {
+        assert_estimated_too_expensive(
+            r#"
+                        query Search($input: SearchInput!) {
+                            search(input: $input) {
+                                title
+                                author { name }
+                                publisher { name addressWithCost { zipCode } }
+                            }
+                        }"#,
+            Some(json!({
+                "input": { "pagination": { "first": 3 } }
+            })),
+            24,
+        )
+        .await;
+    }
+
+    // Mutations include default base operation cost (10).
+    #[ntex::test]
+    async fn estimator_mutation_base_cost_is_10() {
+        assert_estimated_too_expensive(
+            r#"
+                        mutation {
+                            doThing
+                        }"#,
+            None,
+            10,
+        )
+        .await;
+    }
+
+    // Fragment spreads and inline fragments are counted once with recursive traversal.
+    #[ntex::test]
+    async fn estimator_fragments_and_inline_fragments_cost_is_8() {
+        assert_estimated_too_expensive(
+            r#"
+                        query {
+                            book(id: 1) {
+                                ...BookBits
+                            }
+                        }
+
+                        fragment BookBits on Book {
+                            title
+                            author { name }
+                            publisher {
+                                name
+                                ... on Publisher {
+                                    addressWithCost { zipCode }
+                                }
+                            }
+                        }"#,
+            None,
+            8,
+        )
+        .await;
+    }
+
+    // @include/@skip conditions alter estimated cost based on variable values.
+    #[ntex::test]
+    async fn estimator_conditional_inclusion_uses_variable_value() {
+        assert_estimated_too_expensive(
+            r#"
+                        query($withPublisher: Boolean!) {
+                            book(id: 1) {
+                                title
+                                author { name }
+                                publisher @include(if: $withPublisher) {
+                                    name
+                                    addressWithCost { zipCode }
+                                }
+                            }
+                        }"#,
+            Some(json!({ "withPublisher": false })),
+            2,
+        )
+        .await;
+    }
+
+    #[ntex::test]
+    async fn rejects_request_when_estimated_cost_exceeds_max() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            max_cost: 0
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    me {
+                        name
+                    }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        assert_eq!(
+            json["errors"][0]["message"].as_str(),
+            Some("Operation estimated cost 1 exceeds configured max cost 0")
+        );
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+    }
+
+    #[ntex::test]
+    async fn includes_cost_metadata_in_response_extensions_when_enabled() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            max_cost: 100
+            include_extension_metadata: true
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    me {
+                        name
+                    }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        assert!(json["extensions"]["cost"].is_object());
+        assert!(json["extensions"]["cost"]["estimated"].is_number());
+        assert_eq!(
+            json["extensions"]["cost"]["result"].as_str(),
+            Some("COST_OK")
+        );
+        assert!(json["extensions"]["cost"]["bySubgraph"].is_object());
+    }
+
+    #[ntex::test]
+    async fn skips_only_over_budget_subgraph_and_continues_query() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            max_cost: 1000
+            subgraph:
+              subgraphs:
+                reviews:
+                  max_cost: 0
+              all:
+                list_size: 0
+            include_extension_metadata: true
+            actual_cost:
+              mode: by_subgraph
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                  me {
+                    name
+                    reviews {
+                      body
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        assert_eq!(json["data"]["me"]["name"].as_str(), Some("Uri Goldshtein"));
+        assert!(json["errors"].is_array());
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+        assert_eq!(
+            json["errors"][0]["extensions"]["serviceName"].as_str(),
+            Some("reviews")
+        );
+        assert_eq!(
+            json["extensions"]["cost"]["result"].as_str(),
+            Some("COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+        assert_eq!(
+            json["extensions"]["cost"]["blockedSubgraphs"][0].as_str(),
+            Some("reviews")
+        );
+        assert!(json["extensions"]["cost"]["actual"].is_number());
+        assert!(json["extensions"]["cost"]["delta"].is_number());
+        assert!(json["extensions"]["cost"]["actualBySubgraph"].is_object());
+        assert!(json["extensions"]["cost"]["actualBySubgraph"]["accounts"].is_number());
+        assert!(json["extensions"]["cost"]["actualBySubgraph"]["reviews"].is_null());
+    }
+
+    #[ntex::test]
+    async fn includes_actual_and_negative_delta_for_response_shape_mode() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            list_size: 10
+            max_cost: 1000
+            include_extension_metadata: true
+            actual_cost:
+              mode: by_response_shape
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                  me {
+                    reviews {
+                      body
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        let estimated = json["extensions"]["cost"]["estimated"]
+            .as_u64()
+            .expect("estimated should be present");
+        let actual = json["extensions"]["cost"]["actual"]
+            .as_u64()
+            .expect("actual should be present");
+        let delta = json["extensions"]["cost"]["delta"]
+            .as_i64()
+            .expect("delta should be present");
+
+        assert!(actual < estimated);
+        assert_eq!(delta, actual as i64 - estimated as i64);
+    }
+
+    #[ntex::test]
+    async fn computes_by_subgraph_actual_from_responses_not_estimates() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            list_size: 10
+            max_cost: 1000
+            include_extension_metadata: true
+            actual_cost:
+              mode: by_subgraph
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                  me {
+                    reviews {
+                      body
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+
+        let estimated_total = json["extensions"]["cost"]["estimated"]
+            .as_u64()
+            .expect("estimated should be present");
+        let actual_total = json["extensions"]["cost"]["actual"]
+            .as_u64()
+            .expect("actual should be present");
+        let delta = json["extensions"]["cost"]["delta"]
+            .as_i64()
+            .expect("delta should be present");
+
+        let estimated_reviews = json["extensions"]["cost"]["bySubgraph"]["reviews"]
+            .as_u64()
+            .expect("estimated reviews cost should be present");
+        let actual_reviews = json["extensions"]["cost"]["actualBySubgraph"]["reviews"]
+            .as_u64()
+            .expect("actual reviews cost should be present");
+
+        let actual_accounts = json["extensions"]["cost"]["actualBySubgraph"]["accounts"]
+            .as_u64()
+            .expect("actual accounts cost should be present");
+
+        // Regression guard: in by_subgraph mode, actual cost must come from real subgraph
+        // responses, not copied from estimated per-subgraph values.
+        assert!(
+            actual_reviews < estimated_reviews,
+            "actual reviews cost should be lower than estimated reviews cost"
+        );
+
+        assert_eq!(actual_total, actual_accounts + actual_reviews);
+        assert_eq!(delta, actual_total as i64 - estimated_total as i64);
+        assert!(actual_total < estimated_total);
+    }
+
+    #[ntex::test]
+    async fn rejects_when_actual_by_subgraph_cost_exceeds_max() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            list_size: 0
+            max_cost: 3
+            include_extension_metadata: true
+            actual_cost:
+              mode: by_subgraph
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                  me {
+                    reviews {
+                      body
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ACTUAL_TOO_EXPENSIVE")
+        );
+
+        assert_eq!(
+            json["errors"][0]["message"].as_str(),
+            Some("Operation actual cost 4 exceeds configured max cost 3"),
+        );
+
+        let estimated = json["extensions"]["cost"]["estimated"]
+            .as_u64()
+            .expect("estimated should be present");
+        let actual = json["extensions"]["cost"]["actual"]
+            .as_u64()
+            .expect("actual should be present");
+
+        let max_cost = json["extensions"]["cost"]["maxCost"]
+            .as_u64()
+            .expect("maxCost should be present");
+
+        assert!(
+            estimated <= max_cost,
+            "estimated cost should be within max cost in actual too expensive case"
+        );
+        assert!(
+            actual > max_cost,
+            "actual cost should exceed max cost in error case"
+        );
+    }
+
+    // Ensures cost.estimated is emitted with cost.result=COST_ESTIMATED_TOO_EXPENSIVE
+    // when global demand control rejects the operation.
+    #[ntex::test]
+    async fn emits_estimated_metric_for_rejected_operation() {
+        let supergraph_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("supergraph_demand_control.graphql");
+
+        let otlp_collector = crate::testkit::otel::OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+        let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: "{}"
+
+                demand_control:
+                    enabled: true
+                    max_cost: 0
+
+                telemetry:
+                    metrics:
+                        exporters:
+                            - kind: otlp
+                              endpoint: "{}"
+                              protocol: http
+                              interval: 30ms
+                              max_export_timeout: 50ms
+                "#,
+                supergraph_path.to_str().unwrap(),
+                otlp_endpoint
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        router
+            .send_graphql_request(
+                r#"
+                        query {
+                            book(id: 1) {
+                                title
+                                author { name }
+                                publisher { name address { zipCode } }
+                            }
+                        }"#,
+                None,
+                None,
+            )
+            .await;
+
+        wait_for_metrics_export().await;
+
+        let metrics = otlp_collector.metrics_view().await;
+        let attrs = [(labels::COST_RESULT, "COST_ESTIMATED_TOO_EXPENSIVE")];
+
+        assert_histogram_sample_count(&metrics, names::COST_ESTIMATED, &attrs, 1);
+    }
+
+    // Ensures cost.estimated, cost.actual and cost.delta are emitted with
+    // cost.result=COST_OK for an executed operation.
+    #[ntex::test]
+    async fn emits_actual_and_delta_metrics_for_executed_operation() {
+        let supergraph_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+        let otlp_collector = crate::testkit::otel::OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+        let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: "{}"
+
+                demand_control:
+                    enabled: true
+                    max_cost: 1000
+                    include_extension_metadata: true
+                    actual_cost:
+                        mode: by_response_shape
+
+                telemetry:
+                    metrics:
+                        exporters:
+                            - kind: otlp
+                              endpoint: "{}"
+                              protocol: http
+                              interval: 30ms
+                              max_export_timeout: 50ms
+                "#,
+                supergraph_path.to_str().unwrap(),
+                otlp_endpoint
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        router
+            .send_graphql_request(
+                r#"
+                        query {
+                            me {
+                                reviews {
+                                    body
+                                }
+                            }
+                        }"#,
+                None,
+                None,
+            )
+            .await;
+
+        wait_for_metrics_export().await;
+
+        let metrics = otlp_collector.metrics_view().await;
+        let attrs = [(labels::COST_RESULT, "COST_OK")];
+
+        assert_histogram_sample_count(&metrics, names::COST_ESTIMATED, &attrs, 1);
+        assert_histogram_sample_count(&metrics, names::COST_ACTUAL, &attrs, 1);
+        assert_histogram_sample_count(&metrics, names::COST_DELTA, &attrs, 1);
+    }
+
+    // Ensures cost.actual and cost.delta are emitted with
+    // cost.result=COST_ACTUAL_TOO_EXPENSIVE when execution exceeds max_cost.
+    #[ntex::test]
+    async fn emits_actual_and_delta_metrics_for_actual_too_expensive_operation() {
+        let supergraph_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+        let otlp_collector = crate::testkit::otel::OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+        let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: "{}"
+
+                demand_control:
+                    enabled: true
+                    list_size: 0
+                    max_cost: 3
+                    include_extension_metadata: true
+                    actual_cost:
+                        mode: by_subgraph
+
+                telemetry:
+                    metrics:
+                        exporters:
+                            - kind: otlp
+                              endpoint: "{}"
+                              protocol: http
+                              interval: 30ms
+                              max_export_timeout: 50ms
+                "#,
+                supergraph_path.to_str().unwrap(),
+                otlp_endpoint
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        router
+            .send_graphql_request(
+                r#"
+                        query {
+                            me {
+                                reviews {
+                                    body
+                                }
+                            }
+                        }"#,
+                None,
+                None,
+            )
+            .await;
+
+        wait_for_metrics_export().await;
+
+        let metrics = otlp_collector.metrics_view().await;
+        let estimated_ok_attrs = [(labels::COST_RESULT, "COST_OK")];
+        let actual_too_expensive_attrs = [(labels::COST_RESULT, "COST_ACTUAL_TOO_EXPENSIVE")];
+
+        assert_histogram_sample_count(&metrics, names::COST_ESTIMATED, &estimated_ok_attrs, 1);
+        assert_histogram_sample_count(&metrics, names::COST_ACTUAL, &actual_too_expensive_attrs, 1);
+        assert_histogram_sample_count(&metrics, names::COST_DELTA, &actual_too_expensive_attrs, 1);
+    }
+
+    // Ensures standard demand-control histograms carry graphql.operation.name alongside cost.result.
+    #[ntex::test]
+    async fn emits_demand_control_metrics_with_operation_name_attribute() {
+        let supergraph_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+        let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: "{}"
+
+                demand_control:
+                    enabled: true
+                    list_size: 10
+                    max_cost: 1000
+                    include_extension_metadata: true
+                    actual_cost:
+                        mode: by_response_shape
+
+                telemetry:
+                    metrics:
+                        exporters:
+                            - kind: otlp
+                              endpoint: "{}"
+                              protocol: http
+                              interval: 30ms
+                              max_export_timeout: 50ms
+                "#,
+                supergraph_path.to_str().unwrap(),
+                otlp_endpoint
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        router
+            .send_graphql_request(
+                r#"
+                query DemandControlNamedQuery {
+                  me {
+                    reviews {
+                      body
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        wait_for_metrics_export().await;
+
+        let metrics = otlp_collector.metrics_view().await;
+        let attrs = [
+            (labels::COST_RESULT, "COST_OK"),
+            (labels::GRAPHQL_OPERATION_NAME, "DemandControlNamedQuery"),
+        ];
+
+        assert_histogram_sample_count(&metrics, names::COST_ESTIMATED, &attrs, 1);
+        assert_histogram_sample_count(&metrics, names::COST_ACTUAL, &attrs, 1);
+        assert_histogram_sample_count(&metrics, names::COST_DELTA, &attrs, 1);
+    }
+
+    // Ensures cost.estimated/cost.actual/cost.delta/cost.result are attached to graphql.operation spans.
+    #[ntex::test]
+    async fn records_demand_control_cost_attributes_on_graphql_operation_span() {
+        let supergraph_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+        let otlp_endpoint = otlp_collector.http_traces_endpoint();
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: {}
+
+                demand_control:
+                    enabled: true
+                    list_size: 10
+                    max_cost: 1000
+                    include_extension_metadata: true
+                    actual_cost:
+                        mode: by_response_shape
+
+                telemetry:
+                    tracing:
+                      exporters:
+                        - kind: otlp
+                          endpoint: {otlp_endpoint}
+                          protocol: http
+                          batch_processor:
+                            scheduled_delay: 50ms
+                            max_export_timeout: 50ms
+                "#,
+                supergraph_path.to_str().unwrap(),
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query DemandControlSpanQuery {
+                  me {
+                    reviews {
+                      body
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(res.status().is_success());
+
+        let operation_span = otlp_collector
+            .wait_for_span_by_hive_kind_one("graphql.operation")
+            .await;
+
+        assert_eq!(
+            operation_span.attributes.get("graphql.operation.name"),
+            Some(&"DemandControlSpanQuery".to_string())
+        );
+        assert_eq!(
+            operation_span.attributes.get("cost.result"),
+            Some(&"COST_OK".to_string())
+        );
+
+        let estimated = operation_span
+            .attributes
+            .get("cost.estimated")
+            .expect("operation span should include cost.estimated")
+            .parse::<u64>()
+            .expect("cost.estimated should be a u64");
+        let actual = operation_span
+            .attributes
+            .get("cost.actual")
+            .expect("operation span should include cost.actual")
+            .parse::<u64>()
+            .expect("cost.actual should be a u64");
+        let delta = operation_span
+            .attributes
+            .get("cost.delta")
+            .expect("operation span should include cost.delta")
+            .parse::<i64>()
+            .expect("cost.delta should be an i64");
+
+        assert!(actual < estimated);
+        assert_eq!(delta, actual as i64 - estimated as i64);
+    }
+
+    // Field-level @cost(weight: 2) on bookWithFieldCost field adds to base query cost.
+    #[ntex::test]
+    async fn field_level_cost_directive_cost_is_3() {
+        assert_estimated_too_expensive(
+            r#"query {
+  bookWithFieldCost {
+    title
+  }
+}"#,
+            None,
+            3,
+        )
+        .await;
+    }
+
+    // Argument-level @cost(weight: 1) on argument multiplies list size impact.
+    #[ntex::test]
+    async fn argument_level_cost_directive_affects_list_calculation() {
+        assert_estimated_too_expensive(
+            r#"query {
+  bookWithArgCost(limit: 5) {
+    title
+    author { name }
+  }
+}"#,
+            None,
+            // base(0) + field arg cost(1) + Book(1) + author(1) = 3
+            3,
+        )
+        .await;
+    }
+
+    // Enum value directives are currently not included in estimated cost calculation.
+    #[ntex::test]
+    async fn enum_cost_directive_in_query() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph_demand_control.graphql
+                demand_control:
+                    enabled: true
+                    max_cost: 100
+                    include_extension_metadata: true
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"query {
+  booksByGenre(genre: MYSTERY) {
+    title
+    genre
+  }
+}"#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        assert!(json["errors"].is_null());
+        assert_eq!(json["extensions"]["cost"]["estimated"].as_u64(), Some(0));
+    }
+
+    // Deeply nested slicingArguments path "input.level1.level2.count" resolves through variables.
+    #[ntex::test]
+    async fn deeply_nested_slicing_arguments_path_cost_is_24() {
+        assert_estimated_too_expensive(
+            r#"
+                query DeepSearch($input: DeepPaginationInput!) {
+                    deepSearch(input: $input) {
+                        title
+                        author { name }
+                        publisher { name addressWithCost { zipCode } }
+                    }
+                }
+            "#,
+            Some(json!({
+                "input": { "level1": { "level2": { "count": 3 } } }
+            })),
+            24,
+        )
+        .await;
+    }
+
+    // Deeply nested sizedFields path "results { page }" propagates list size to nested structure.
+    #[ntex::test]
+    async fn deeply_nested_sized_fields_path_cost_is_41() {
+        assert_estimated_too_expensive(
+            r#"
+                query DeepContainer {
+                    deepContainer(first: 5) {
+                        results {
+                            page {
+                                title
+                                author { name }
+                                publisher { name addressWithCost { zipCode } }
+                            }
+                            recent {
+                                title
+                            }
+                            metadata
+                        }
+                    }
+                }
+            "#,
+            None,
+            // deepContainer(1) + results(1) + page[5]*(Book(1)+author(1)+publisher(1)+addressWithCost(5)) + recent[2]*Book(1)
+            // => 1 + (1 + 40 + 2) = 44
+            44,
+        )
+        .await;
+    }
+
+    // @skip with false condition includes the field in cost calculation.
+    #[ntex::test]
+    async fn skip_with_false_condition_includes_field_cost() {
+        assert_estimated_too_expensive(
+            r#"
+                query($skipPublisher: Boolean!) {
+                    book(id: 1) {
+                        title
+                        author { name }
+                        publisher @skip(if: $skipPublisher) {
+                            name
+                            addressWithCost { zipCode }
+                        }
+                    }
+                }
+            "#,
+            Some(json!({ "skipPublisher": false })),
+            // title(0) + author(1) + name(0) + publisher(1) + name(0) + addressWithCost(5) + zipCode(0)
+            // base query(0) + book(1) + above = 0 + 1 + 0 + 1 + 0 + 1 + 0 + 1 + 0 + 5 + 0 = 8
+            8,
+        )
+        .await;
+    }
+
+    // @skip with true condition excludes the field from cost calculation.
+    #[ntex::test]
+    async fn skip_with_true_condition_excludes_field_cost() {
+        assert_estimated_too_expensive(
+            r#"
+                query($skipPublisher: Boolean!) {
+                    book(id: 1) {
+                        title
+                        author { name }
+                        publisher @skip(if: $skipPublisher) {
+                            name
+                            addressWithCost { zipCode }
+                        }
+                    }
+                }
+            "#,
+            Some(json!({ "skipPublisher": true })),
+            // publisher field skipped, so: query(0) + book(1) + title(0) + author(1) + name(0) = 2
+            2,
+        )
+        .await;
+    }
+
+    // Combined @include and @skip on same field: @include takes precedence (both conditions must be satisfied).
+    #[ntex::test]
+    async fn combined_include_and_skip_conditions_on_same_field() {
+        assert_estimated_too_expensive(
+            r#"
+                query($include: Boolean!, $skip: Boolean!) {
+                    book(id: 1) {
+                        title
+                        publisher @include(if: $include) @skip(if: $skip) {
+                            name
+                            addressWithCost { zipCode }
+                        }
+                    }
+                }
+            "#,
+            Some(json!({ "include": true, "skip": true })),
+            // If skip is true, field is excluded even if include is true
+            // query(0) + book(1) + title(0) = 1
+            1,
+        )
+        .await;
+    }
+
+    // Author.bio field has @cost(weight: 3), multiplies when selected.
+    #[ntex::test]
+    async fn field_cost_on_nested_type_adds_to_calculation() {
+        assert_estimated_too_expensive(
+            r#"
+                query {
+                    book(id: 1) {
+                        title
+                        author {
+                            name
+                            bio
+                        }
+                    }
+                }
+            "#,
+            None,
+            // query(0) + book(1) + title(0) + author(1) + name(0) + bio(3) = 5
+            5,
+        )
+        .await;
+    }
+
+    // Router config: default list_size applies to fields without explicit @listSize value.
+    #[ntex::test]
+    async fn router_default_list_size_applies_to_unlabeled_lists() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph_demand_control.graphql
+                demand_control:
+                    enabled: true
+                    max_cost: 14
+                    list_size: 3
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+              booksByGenre(genre: FICTION) {
+                title
+                author { name }
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        // Should be rejected since default list_size: 3 is applied to booksByGenre
+        // Cost = query(0) + booksByGenre field(1) + 3 * (Book(1) + title(0) + author(1) + name(0))
+        // = 0 + 1 + 3*(1+0+1+0) = 1 + 3*2 = 7, which is < 14, so NOT rejected
+        // But if max_cost is 6 it would be rejected
+        assert_ne!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+    }
+
+    // Per-subgraph max_cost setting allows granular control.
+    #[ntex::test]
+    async fn per_subgraph_max_cost_limit_enforced() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                demand_control:
+                    enabled: true
+                    max_cost: 10000
+                    subgraph:
+                        subgraphs: {}
+                        all:
+                            list_size: 5
+                            max_cost: 1
+                    include_extension_metadata: true
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+              me {
+                reviews {
+                  body
+                }
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        // Should have subgraph error for per-subgraph cost limit
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+    }
+
+    // Mode: measure (dry-run) - cost calculated but operation NOT rejected even if would exceed limit.
+    // In this implementation, measure mode is enabled by not setting max_cost.
+    #[ntex::test]
+    async fn mode_measure_always_allows_operation() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                demand_control:
+                    enabled: true
+                    include_extension_metadata: true
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+              me {
+                name
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        // Should succeed (data present) with cost metadata but no rejection
+        assert!(json["data"].is_object());
+        assert_eq!(
+            json["extensions"]["cost"]["result"].as_str(),
+            Some("COST_OK")
+        );
+        assert!(json["extensions"]["cost"]["estimated"].is_number());
+    }
+
+    // Mutation with default cost plus nested fields includes full cost.
+    #[ntex::test]
+    async fn mutation_with_return_type_cost_is_11() {
+        // Assuming mutation can return a Book object
+        assert_estimated_too_expensive(
+            r#"
+                mutation {
+                    doThing
+                }
+            "#,
+            None,
+            10, // Mutation base cost
+        )
+        .await;
+    }
+
+    // Error case: requireOneSlicingArgument true with multiple args should not error in cost calc.
+    #[ntex::test]
+    async fn requires_one_slicing_argument_true_with_multiple_args() {
+        // This tests the behavior when requireOneSlicingArgument=true but multiple args provided
+        // Should use the highest value or error handling logic
+        assert_estimated_too_expensive(
+            r#"
+                query {
+                    newestAdditions2(first: 2, last: 4) {
+                        title
+                    }
+                }
+            "#,
+            None,
+            // newestAdditions2 has requireOneSlicingArgument=false, so max(2, 4) = 4
+            // query(0) + 4 * (Book(1) + title(0)) = 4
+            4,
+        )
+        .await;
+    }
+
+    // Verify maxCost is included in error extensions when actual cost exceeds max.
+    #[ntex::test]
+    async fn error_extension_includes_max_cost_value() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                demand_control:
+                    enabled: true
+                    list_size: 0
+                    max_cost: 3
+                    include_extension_metadata: true
+                    actual_cost:
+                      mode: by_subgraph
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+              me {
+                reviews {
+                  body
+                }
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ACTUAL_TOO_EXPENSIVE")
+        );
+
+        assert_eq!(
+            json["errors"][0]["extensions"]["maxCost"].as_u64(),
+            Some(3),
+            "maxCost should be present in error extensions with value 3"
+        );
+    }
+
+    // Conditional with undefined variable defaults to not including the field.
+    #[ntex::test]
+    async fn conditional_with_undefined_variable_excludes_field() {
+        assert_estimated_too_expensive(
+            r#"
+                query($withAuthor: Boolean!) {
+                    book(id: 1) {
+                        title
+                        author @include(if: $withAuthor) {
+                            name
+                        }
+                    }
+                }
+            "#,
+            Some(json!({ "withAuthor": false })),
+            // query(0) + book(1) + title(0) = 1
+            1,
+        )
+        .await;
+    }
+
+    // Field-level @cost on Query root field adds directly to operation cost.
+    #[ntex::test]
+    async fn field_cost_on_root_query_field() {
+        assert_estimated_too_expensive(
+            r#"
+                query {
+                    bookWithFieldCost {
+                        title
+                    }
+                }
+            "#,
+            None,
+            // query(0) + bookWithFieldCost field(2) + Book(1) + title(0) = 3
+            3,
+        )
+        .await;
+    }
+
+    // Cost calculation respects saturating arithmetic (no overflow).
+    #[ntex::test]
+    async fn large_list_size_uses_saturating_arithmetic() {
+        assert_estimated_too_expensive(
+            r#"
+                query {
+                    newestAdditions(limit: 999999) {
+                        title
+                        author { name }
+                        publisher { name addressWithCost { zipCode } }
+                    }
+                }
+            "#,
+            None,
+            // newestAdditions uses limit as list size, so 999999 * (Book(1)+author(1)+publisher(1)+addressWithCost(5))
+            // = 999999 * 8 = 7999992
+            7999992,
+        )
+        .await;
+    }
+
+    // Empty selection set should still count field cost (not possible in GraphQL, but verify base behavior).
+    #[ntex::test]
+    async fn minimal_query_cost_is_one() {
+        assert_estimated_too_expensive(
+            r#"
+                query {
+                    book(id: 1) {
+                        title
+                    }
+                }
+            "#,
+            None,
+            // query(0) + book(1) + title(0) = 1
+            1,
+        )
+        .await;
+    }
+
+    // Verify delta is negative when actual < estimated (fewer list items than assumed).
+    #[ntex::test]
+    async fn negative_delta_when_actual_smaller_than_estimated() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                demand_control:
+                    enabled: true
+                    list_size: 10
+                    max_cost: 1000
+                    include_extension_metadata: true
+                    actual_cost:
+                      mode: by_response_shape
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+              me {
+                reviews {
+                  body
+                }
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        let delta = json["extensions"]["cost"]["delta"]
+            .as_i64()
+            .expect("delta should be present");
+
+        assert!(
+            delta < 0,
+            "delta should be negative when actual < estimated list sizes"
+        );
+    }
+
+    // Verify delta is positive when actual > estimated (more list items than assumed).
+    #[ntex::test]
+    async fn positive_delta_when_actual_greater_than_estimated() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph_demand_control.graphql
+                demand_control:
+                    enabled: true
+                    list_size: 0
+                    max_cost: 1000
+                    include_extension_metadata: true
+                    actual_cost:
+                      mode: by_response_shape
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+                            booksByGenre(genre: MYSTERY) {
+                                title
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        let estimated = json["extensions"]["cost"]["estimated"]
+            .as_u64()
+            .expect("estimated should be present");
+        let actual = json["extensions"]["cost"]["actual"]
+            .as_u64()
+            .expect("actual should be present");
+        let delta = json["extensions"]["cost"]["delta"]
+            .as_i64()
+            .expect("delta should be present");
+
+        assert!(
+            actual > estimated,
+            "actual should be larger when assumed list_size is 0"
+        );
+        assert!(
+            delta > 0,
+            "delta should be positive when actual > estimated"
+        );
+        assert_eq!(delta, actual as i64 - estimated as i64);
+    }
+
+    // Verify delta remains accurate across a range of configured list-size assumptions.
+    #[ntex::test]
+    async fn delta_accuracy_with_varying_list_sizes() {
+        for list_size in [0_u64, 1_u64, 10_u64] {
+            let subgraphs = TestSubgraphs::builder().build().start().await;
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(format!(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph_demand_control.graphql
+                    demand_control:
+                        enabled: true
+                        list_size: {list_size}
+                        max_cost: 1000
+                        include_extension_metadata: true
+                        actual_cost:
+                          mode: by_response_shape
+                    "#,
+                ))
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request(
+                    r#"
+                query {
+                                    booksByGenre(genre: MYSTERY) {
+                                        title
+                  }
+                }
+                "#,
+                    None,
+                    None,
+                )
+                .await;
+
+            let json = res.json_body().await;
+            let estimated = json["extensions"]["cost"]["estimated"]
+                .as_u64()
+                .expect("estimated should be present");
+            let actual = json["extensions"]["cost"]["actual"]
+                .as_u64()
+                .expect("actual should be present");
+            let delta = json["extensions"]["cost"]["delta"]
+                .as_i64()
+                .expect("delta should be present");
+
+            assert_eq!(
+                delta,
+                actual as i64 - estimated as i64,
+                "delta should exactly match actual-estimated for list_size={list_size}"
+            );
+
+            if list_size == 10 {
+                assert!(
+                    delta < 0,
+                    "large assumed list size should make delta negative"
+                );
+            } else {
+                assert!(
+                    delta > 0,
+                    "small assumed list size should make delta positive"
+                );
+            }
+        }
+    }
+
+    // Verify by_response_shape actual cost ignores extra entity-lookup work and only reflects
+    // the final response shape.
+    #[ntex::test]
+    async fn response_shape_mode_entity_lookup_cost_accuracy() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                demand_control:
+                    enabled: true
+                    list_size: 10
+                    max_cost: 1000
+                    include_extension_metadata: true
+                    actual_cost:
+                      mode: by_response_shape
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+            query {
+              topProducts(first: 1) {
+                inStock
+              }
+            }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        assert_eq!(
+            json["data"]["topProducts"]
+                .as_array()
+                .map(|items| items.len()),
+            Some(1)
+        );
+
+        let estimated = json["extensions"]["cost"]["estimated"]
+            .as_u64()
+            .expect("estimated should be present");
+        let actual = json["extensions"]["cost"]["actual"]
+            .as_u64()
+            .expect("actual should be present");
+        let delta = json["extensions"]["cost"]["delta"]
+            .as_i64()
+            .expect("delta should be present");
+
+        // Final response shape is a single Product object with one scalar field.
+        assert_eq!(
+            actual, 1,
+            "response-shape actual cost should reflect only the final Product item"
+        );
+        assert!(
+            estimated > actual,
+            "estimated cost should still include assumed list fanout"
+        );
+        assert_eq!(delta, actual as i64 - estimated as i64);
+    }
+
+    // Field selection without composite type nesting has minimal cost.
+    #[ntex::test]
+    async fn scalar_only_query_has_minimal_cost() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph_demand_control.graphql
+                demand_control:
+                    enabled: true
+                    max_cost: 100
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    ping
+                }
+            "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        // Just verify the query works and doesn't error
+        assert!(
+            json["data"]["ping"].as_str().is_some(),
+            "ping field should return data"
+        );
+    }
+
+    // Named subgraph max_cost override (higher) allows queries that all.max_cost would reject.
+    // accounts has specific max_cost=100; products inherits all.max_cost=1.
+    // Combined query hits both subgraphs only products (over-budget) is blocked.
+    #[ntex::test]
+    async fn named_subgraph_max_allows_where_all_would_reject() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    demand_control:
+                        enabled: true
+                        list_size: 2
+                        max_cost: 1000
+                        subgraph:
+                            subgraphs:
+                                accounts:
+                                    max_cost: 100
+                            all:
+                                max_cost: 1
+                        include_extension_metadata: true
+                    "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // users comes from accounts (max=100), topProducts from products (inherits all.max=1).
+        // With list_size=2: users costs 2*(User=1)=2 < 100 → passes.
+        // topProducts costs 2*(Product=1)=2 > 1 → blocked.
+        let res = router
+            .send_graphql_request(r#"{ users { name } topProducts { name } }"#, None, None)
+            .await;
+
+        let json = res.json_body().await;
+
+        // accounts (users) succeeds because named override gives it max_cost=100
+        assert!(
+            json["data"]["users"].is_array(),
+            "users should be returned from accounts (named override allows it)"
+        );
+        // products is blocked because it inherits all.max_cost=1 (no named override)
+        let blocked_products = json["errors"].as_array().map_or(false, |errors| {
+            errors.iter().any(|e| {
+                e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
+                    && e["extensions"]["serviceName"].as_str() == Some("products")
+            })
+        });
+        assert!(
+            blocked_products,
+            "products should be blocked (inherits all.max_cost=1, cost=2 exceeds it)"
+        );
+    }
+
+    // Per-subgraph aggregate cost sums costs across ALL fetches to the same subgraph.
+    // The query causes PRODUCTS to be fetched twice in the query plan:
+    //   1. topProducts { upc } (initial fetch, cost=2 with list_size=2)
+    //   2. _entities for product.name referenced from reviews (entity lookup, adds to aggregate)
+    // Each individual fetch is within the per-subgraph limit, but the aggregate exceeds it.
+    #[ntex::test]
+    async fn per_subgraph_aggregate_cost_across_multiple_fetches() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    demand_control:
+                        enabled: true
+                        list_size: 2
+                        max_cost: 1000
+                        subgraph:
+                            subgraphs:
+                                products:
+                                    max_cost: 2
+                            all:
+                                max_cost: 1000
+                        include_extension_metadata: true
+                    "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // Query plan forces two PRODUCTS fetches:
+        //   Fetch 1: topProducts { upc } → 2*(Product=1) = 2 (equals max, not individually exceeded)
+        //   Fetch 2: _entities for product.name looked up from reviews → adds to aggregate
+        //   Aggregate PRODUCTS cost > 2 → blocked by products.max_cost=2
+        let res = router
+            .send_graphql_request(
+                r#"{ topProducts { reviews { product { name } } } }"#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+
+        let blocked_products = json["errors"].as_array().map_or(false, |errors| {
+            errors.iter().any(|e| {
+                e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
+                    && e["extensions"]["serviceName"].as_str() == Some("products")
+            })
+        });
+        assert!(
+                blocked_products,
+                "products should be blocked because aggregate cost across multiple fetches exceeds products.max_cost=2"
+            );
+    }
+
+    // @cost on a SCALAR type adds to the cost of any field that returns that scalar.
+    // BookId scalar has @cost(weight: 1), so fields returning BookId cost 1 instead of the
+    // default 0 for leaf types.
+    #[ntex::test]
+    async fn cost_on_scalar_type_adds_to_calculation() {
+        assert_estimated_too_expensive(
+            r#"{ book(id: "1") { id } }"#,
+            None,
+            // book returns Book composite type → cost 1
+            // id field returns BookId scalar @cost(weight: 1) → adds 1 (instead of default 0)
+            // Total: Book(1) + BookId_scalar(1) = 2
+            2,
+        )
+        .await;
+    }
+
+    // Subscription operations have 0 base cost (same as queries, unlike mutations +10).
+    // Composite type and list costs still apply to the subscription selection set.
+    #[ntex::test]
+    #[ignore = "subscription cost testing requires dedicated subscription endpoint support in TestRouter"]
+    async fn subscription_cost_is_zero() {
+        // A subscription should cost the same as an equivalent query with the same selection set
+        // the operation base cost is 0 for subscriptions (vs 10 for mutations).
+        // This test is deferred until the E2E harness supports subscription endpoints.
+        todo!()
+    }
+
+    // @defer fragments must contribute to the total estimated cost. The estimator walks both
+    // the primary node and all deferred fragment nodes (PlanNode::Defer handling).
+    #[ntex::test]
+    #[ignore = "@defer fragment cost accumulation requires @defer multipart protocol support in TestRouter"]
+    async fn deferred_fragment_cost_accumulation() {
+        // The cost estimator already handles PlanNode::Defer by summing primary + all deferred
+        // fragment costs. This E2E test is deferred until the test router can issue @defer
+        // requests and collect the full multipart response stream.
+        todo!()
+    }
+
+    // Per-subgraph list_size override should use a different assumed list size for cost
+    // estimation of queries sent to that specific subgraph, independent of the global list_size.
+    #[ntex::test]
+    async fn named_subgraph_list_size_override_takes_precedence() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    demand_control:
+                        enabled: true
+                        list_size: 0
+                        max_cost: 1000
+                        subgraph:
+                            all:
+                                list_size: 3
+                                max_cost: 1000
+                            subgraphs:
+                                reviews:
+                                    list_size: 10
+                                    max_cost: 9
+                        include_extension_metadata: true
+                    "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                    query {
+                      me {
+                        reviews {
+                          body
+                        }
+                      }
+                    }
+                    "#,
+                None,
+                None,
+            )
+            .await;
+
+        let json = res.json_body().await;
+        let blocked_reviews = json["errors"].as_array().map_or(false, |errors| {
+            errors.iter().any(|e| {
+                e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
+                    && e["extensions"]["serviceName"].as_str() == Some("reviews")
+            })
+        });
+
+        assert!(
+            blocked_reviews,
+            "reviews should be blocked because reviews.list_size=10 overrides all.list_size=3"
+        );
+    }
+
+    // @cost on INPUT_FIELD_DEFINITION adds cost when that input field is provided (non-null)
+    // in a query argument, as specified by the IBM GraphQL Cost Directive specification.
+    #[ntex::test]
+    async fn cost_on_input_field_definition_adds_to_calculation() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                    supergraph:
+                        source: file
+                        path: supergraph_demand_control.graphql
+                    demand_control:
+                        enabled: true
+                        max_cost: 4
+                    "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let rejected = router
+            .send_graphql_request(
+                r#"
+                    query CostlySearch($input: CostlySearchInput!) {
+                      searchByCostlyInput(input: $input) {
+                        title
+                      }
+                    }
+                    "#,
+                Some(json!({
+                    "input": {
+                        "query": "fiction",
+                        "limit": 3
+                    }
+                })),
+                None,
+            )
+            .await;
+        let rejected_json = rejected.json_body().await;
+
+        assert_eq!(
+            rejected_json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+        assert_eq!(
+            rejected_json["errors"][0]["message"].as_str(),
+            Some("Operation estimated cost 5 exceeds configured max cost 4")
+        );
+
+        let allowed = router
+            .send_graphql_request(
+                r#"
+                    query CostlySearch($input: CostlySearchInput!) {
+                      searchByCostlyInput(input: $input) {
+                        title
+                      }
+                    }
+                    "#,
+                Some(json!({
+                    "input": {
+                        "limit": 3
+                    }
+                })),
+                None,
+            )
+            .await;
+        let allowed_json = allowed.json_body().await;
+
+        assert!(
+            allowed_json["errors"].is_null(),
+            "query without the costly input field should stay under the max cost"
+        );
+        assert!(allowed_json["data"]["searchByCostlyInput"].is_array());
+    }
+}

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -23,6 +23,7 @@ use http::{HeaderMap, StatusCode};
 use sonic_rs::ValueRef;
 use tracing::Instrument;
 
+use crate::response::value::ValueObject;
 use crate::{
     context::ExecutionContext,
     execution::{
@@ -96,7 +97,7 @@ pub async fn execute_query_plan<'exec>(
     } else if opts.projection_plan.is_empty() {
         Value::Null
     } else {
-        Value::Object(Vec::new())
+        Value::Object(ValueObject::default())
     };
 
     let mut errors = opts.initial_errors;
@@ -1473,10 +1474,7 @@ mod tests {
                 // data should have `from_a` field from subgraph_a's response,
                 // so data the merging process does not wait for subgraph_b's response to merge subgraph_a's response
                 if let Some(data) = data_ref.as_object() {
-                    let from_a_index = data.iter().position(|(k, _)| k == &"from_a");
-                    let from_a_value = from_a_index
-                        .and_then(|index| data.get(index))
-                        .and_then(|(_, v)| v.as_str());
+                    let from_a_value = data.get("from_a").and_then(|v| v.as_str());
                     if let Some(from_a_value) = from_a_value {
                         sender
                             .send(from_a_value.to_string())

--- a/lib/executor/src/execution/rewrites.rs
+++ b/lib/executor/src/execution/rewrites.rs
@@ -4,10 +4,7 @@ use hive_router_query_planner::planner::plan_nodes::{
     FetchNodePathSegment, FetchRewrite, KeyRenamer, ValueSetter,
 };
 
-use crate::{
-    introspection::schema::PossibleTypes, response::value::Value,
-    utils::consts::TYPENAME_FIELD_NAME,
-};
+use crate::{introspection::schema::PossibleTypes, response::value::Value};
 
 pub trait FetchRewriteExt {
     fn rewrite<'a>(&'a self, possible_types: &PossibleTypes, value: &mut Value<'a>);
@@ -62,11 +59,7 @@ impl RewriteApplier for KeyRenamer {
             }
             Value::Object(obj) => match current_segment {
                 FetchNodePathSegment::TypenameEquals(type_condition) => {
-                    let type_name = obj
-                        .iter()
-                        .find(|(key, _)| key == &TYPENAME_FIELD_NAME)
-                        .and_then(|(_, val)| val.as_str());
-                    if type_name.is_none_or(|type_name| {
+                    if obj.type_name().is_none_or(|type_name| {
                         entity_satisfies_any_type_condition(
                             possible_types,
                             type_name,
@@ -79,14 +72,12 @@ impl RewriteApplier for KeyRenamer {
                 FetchNodePathSegment::Key(field_name) => {
                     if remaining_path.is_empty() {
                         if field_name != &self.rename_key_to {
-                            if let Some((key, _)) =
-                                obj.iter_mut().find(|(key, _)| key == field_name)
-                            {
+                            if let Some((key, _)) = obj.entry(field_name) {
                                 *key = self.rename_key_to.as_str()
                             }
                         }
-                    } else if let Some(data) = obj.iter_mut().find(|r| r.0 == field_name) {
-                        self.apply_path(possible_types, &mut data.1, remaining_path)
+                    } else if let Some(data) = obj.get_mut(field_name) {
+                        self.apply_path(possible_types, data, remaining_path)
                     }
                 }
             },
@@ -124,11 +115,7 @@ impl RewriteApplier for ValueSetter {
 
                 match current_segment {
                     FetchNodePathSegment::TypenameEquals(type_condition) => {
-                        let type_name = map
-                            .iter()
-                            .find(|(key, _)| key == &TYPENAME_FIELD_NAME)
-                            .and_then(|(_, val)| val.as_str());
-                        if type_name.is_none_or(|type_name| {
+                        if map.type_name().is_none_or(|type_name| {
                             entity_satisfies_any_type_condition(
                                 possible_types,
                                 type_name,
@@ -139,8 +126,8 @@ impl RewriteApplier for ValueSetter {
                         }
                     }
                     FetchNodePathSegment::Key(field_name) => {
-                        if let Some(data) = map.iter_mut().find(|r| r.0 == field_name) {
-                            self.apply_path(possible_types, &mut data.1, remaining_path)
+                        if let Some(data) = map.get_mut(field_name) {
+                            self.apply_path(possible_types, data, remaining_path)
                         }
                     }
                 }

--- a/lib/executor/src/introspection/resolve.rs
+++ b/lib/executor/src/introspection/resolve.rs
@@ -84,9 +84,7 @@ fn resolve_input_value<'exec>(
     selections: &'exec SelectionSet,
     ctx: &'exec IntrospectionContext<'exec>,
 ) -> Value<'exec> {
-    let mut iv_data = resolve_input_value_selections(iv, &selections.items, ctx);
-    iv_data.sort_by_key(|(k, _)| *k);
-    Value::Object(iv_data)
+    Value::Object(resolve_input_value_selections(iv, &selections.items, ctx).into())
 }
 
 fn resolve_input_value_selections<'exec>(
@@ -131,9 +129,7 @@ fn resolve_field<'exec>(
     selections: &'exec SelectionSet,
     ctx: &'exec IntrospectionContext<'exec>,
 ) -> Value<'exec> {
-    let mut field_data = resolve_field_selections(f, &selections.items, ctx);
-    field_data.sort_by_key(|(k, _)| *k);
-    Value::Object(field_data)
+    Value::Object(resolve_field_selections(f, &selections.items, ctx).into())
 }
 
 fn resolve_field_selections<'exec>(
@@ -181,9 +177,7 @@ fn resolve_enum_value<'exec>(
     ev: &'exec EnumValue,
     selections: &'exec SelectionSet,
 ) -> Value<'exec> {
-    let mut ev_data = resolve_enum_value_selections(ev, &selections.items);
-    ev_data.sort_by_key(|(k, _)| *k);
-    Value::Object(ev_data)
+    Value::Object(resolve_enum_value_selections(ev, &selections.items).into())
 }
 
 fn resolve_enum_value_selections<'exec>(
@@ -222,9 +216,7 @@ fn resolve_type_definition<'exec>(
     selections: &'exec SelectionSet,
     ctx: &'exec IntrospectionContext<'exec>,
 ) -> Value<'exec> {
-    let mut type_data = resolve_type_definition_selections(type_def, &selections.items, ctx);
-    type_data.sort_by_key(|(k, _)| *k);
-    Value::Object(type_data)
+    Value::Object(resolve_type_definition_selections(type_def, &selections.items, ctx).into())
 }
 
 fn resolve_type_definition_selections<'exec>(
@@ -392,9 +384,7 @@ fn resolve_wrapper_type<'exec>(
     selections: &'exec SelectionSet,
     ctx: &'exec IntrospectionContext<'exec>,
 ) -> Value<'exec> {
-    let mut type_data = resolve_wrapper_type_selections(kind, inner_type, &selections.items, ctx);
-    type_data.sort_by_key(|(k, _)| *k);
-    Value::Object(type_data)
+    Value::Object(resolve_wrapper_type_selections(kind, inner_type, &selections.items, ctx).into())
 }
 
 fn resolve_wrapper_type_selections<'exec>(
@@ -451,9 +441,7 @@ fn resolve_directive<'exec>(
     selections: &'exec SelectionSet,
     ctx: &'exec IntrospectionContext<'exec>,
 ) -> Value<'exec> {
-    let mut directive_data = resolve_directive_selections(d, &selections.items, ctx);
-    directive_data.sort_by_key(|(k, _)| *k);
-    Value::Object(directive_data)
+    Value::Object(resolve_directive_selections(d, &selections.items, ctx).into())
 }
 
 fn resolve_directive_selections<'exec>(
@@ -506,10 +494,7 @@ fn resolve_schema_field<'exec>(
     field: &'exec FieldSelection,
     ctx: &'exec IntrospectionContext<'exec>,
 ) -> Value<'exec> {
-    let mut schema_data = resolve_schema_selections(&field.selections.items, ctx);
-
-    schema_data.sort_by_key(|(k, _)| *k);
-    Value::Object(schema_data)
+    Value::Object(resolve_schema_selections(&field.selections.items, ctx).into())
 }
 
 fn resolve_schema_selections<'exec>(
@@ -599,11 +584,10 @@ pub fn resolve_introspection<'exec>(
         })
         .unwrap_or_else(|| ctx.schema.query_type_name());
 
-    let mut data =
-        resolve_root_introspection_selections(root_type_name, &root_selection_set.items, ctx);
-
-    data.sort_by_key(|(k, _)| *k);
-    Value::Object(data)
+    Value::Object(
+        resolve_root_introspection_selections(root_type_name, &root_selection_set.items, ctx)
+            .into(),
+    )
 }
 
 fn resolve_root_introspection_selections<'exec>(

--- a/lib/executor/src/projection/request.rs
+++ b/lib/executor/src/projection/request.rs
@@ -5,7 +5,7 @@ use crate::{
     introspection::schema::PossibleTypes,
     json_writer::{write_and_escape_string, write_f64, write_i64, write_u64},
     projection::response::serialize_value_to_buffer,
-    response::value::Value,
+    response::value::{Value, ValueObject},
     utils::consts::{
         CLOSE_BRACE, CLOSE_BRACKET, COLON, COMMA, FALSE, NULL, OPEN_BRACE, OPEN_BRACKET, QUOTE,
         TRUE, TYPENAME, TYPENAME_FIELD_NAME,
@@ -114,7 +114,7 @@ pub fn project_requires(
 fn project_requires_map_mut(
     possible_types: &PossibleTypes,
     requires_selections: &Vec<SelectionItem>,
-    entity_obj: &Vec<(&str, Value<'_>)>,
+    entity_obj: &ValueObject<'_>,
     buffer: &mut Vec<u8>,
     first: &mut bool,
     parent_response_key: Option<&str>,
@@ -130,20 +130,13 @@ fn project_requires_map_mut(
                     continue;
                 }
 
-                let original = entity_obj
-                    .binary_search_by_key(&field_name.as_str(), |(k, _)| k)
-                    .ok()
-                    .map(|idx| &entity_obj[idx].1)
-                    .or_else(|| {
-                        if response_key == TYPENAME_FIELD_NAME {
-                            None
-                        } else {
-                            entity_obj
-                                .binary_search_by_key(&response_key, |(k, _)| k)
-                                .ok()
-                                .map(|idx| &entity_obj[idx].1)
-                        }
-                    });
+                let original = entity_obj.get(field_name).or_else(|| {
+                    if response_key == TYPENAME_FIELD_NAME {
+                        None
+                    } else {
+                        entity_obj.get(response_key)
+                    }
+                });
 
                 let Some(original) = original else {
                     continue;
@@ -158,11 +151,7 @@ fn project_requires_map_mut(
                     write_response_key(parent_first, parent_response_key, buffer);
                     buffer.put(OPEN_BRACE);
                     // Write __typename only if the object has other fields
-                    if let Some(type_name) = entity_obj
-                        .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
-                        .ok()
-                        .and_then(|idx| entity_obj[idx].1.as_str())
-                    {
+                    if let Some(type_name) = entity_obj.type_name() {
                         buffer.put(QUOTE);
                         buffer.put(TYPENAME);
                         buffer.put(QUOTE);
@@ -202,11 +191,7 @@ fn project_requires_map_mut(
             SelectionItem::InlineFragment(requires_selection) => {
                 let type_condition = &requires_selection.type_condition;
 
-                let type_name = match entity_obj
-                    .iter()
-                    .find(|(key, _)| key == &TYPENAME_FIELD_NAME)
-                    .and_then(|(_, val)| val.as_str())
-                {
+                let type_name = match entity_obj.type_name() {
                     Some(type_name) => type_name,
                     _ => type_condition,
                 };

--- a/lib/executor/src/projection/response.rs
+++ b/lib/executor/src/projection/response.rs
@@ -4,7 +4,7 @@ use crate::projection::plan::{
     ProjectionValueSource,
 };
 use crate::response::graphql_error::GraphQLError;
-use crate::response::value::Value;
+use crate::response::value::{Value, ValueObject};
 use bytes::BufMut;
 use sonic_rs::JsonValueTrait;
 use std::cell::OnceCell;
@@ -15,7 +15,7 @@ use crate::introspection::schema::SchemaMetadata;
 use crate::json_writer::{write_and_escape_string, write_f64, write_i64, write_u64};
 use crate::utils::consts::{
     CLOSE_BRACE, CLOSE_BRACKET, COLON, COMMA, EMPTY_OBJECT, FALSE, NULL, OPEN_BRACE, OPEN_BRACKET,
-    QUOTE, TRUE, TYPENAME_FIELD_NAME,
+    QUOTE, TRUE,
 };
 
 /// Represents a type's name that can be either already resolved or lazily computed.
@@ -264,7 +264,7 @@ fn project_selection_set<'a>(
 // TODO: simplfy args
 #[allow(clippy::too_many_arguments)]
 fn project_selection_set_with_map<'a>(
-    obj: &'a [(&str, Value)],
+    obj: &'a ValueObject<'a>,
     errors: &mut Vec<GraphQLError>,
     plans: &'a [FieldProjectionPlan],
     variable_values: &Option<HashMap<String, sonic_rs::Value>>,
@@ -282,10 +282,7 @@ fn project_selection_set_with_map<'a>(
             }
         }
 
-        let field_val = obj
-            .binary_search_by_key(&plan.response_key.as_str(), |(k, _)| *k)
-            .ok()
-            .map(|idx| &obj[idx].1);
+        let field_val = obj.get(&plan.response_key);
 
         let res = if let Some(conditions) = &plan.conditions {
             let field_type_name_cell = OnceCell::new();
@@ -511,11 +508,7 @@ fn resolve_type_name<'a>(
 
     let typename_field = field_val
         .and_then(|value| value.as_object())
-        .and_then(|obj| {
-            obj.binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| *k)
-                .ok()
-                .and_then(|idx| obj[idx].1.as_str())
-        });
+        .and_then(|obj| obj.type_name());
 
     if let Some(typename) = typename_field {
         return Ok(typename);

--- a/lib/executor/src/response/merge.rs
+++ b/lib/executor/src/response/merge.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use crate::response::value::Value;
+use crate::response::value::{Value, ValueObject};
 
 pub fn deep_merge<'a>(target: &mut Value<'a>, source: Value<'a>) {
     deep_merge_internal(target, source)
@@ -14,8 +14,8 @@ fn deep_merge_internal<'a>(target: &mut Value<'a>, source: Value<'a>) {
         }
 
         // Both are Objects: merge them using the helper.
-        (Value::Object(target_vec), Value::Object(source_obj)) => {
-            deep_merge_objects(target_vec, source_obj);
+        (Value::Object(target_obj), Value::Object(source_obj)) => {
+            deep_merge_objects(target_obj, source_obj);
         }
 
         // Both are Arrays: merge them element-wise.
@@ -33,22 +33,19 @@ fn deep_merge_internal<'a>(target: &mut Value<'a>, source: Value<'a>) {
     }
 }
 
-fn deep_merge_objects<'a>(
-    target_vec: &mut Vec<(&'a str, Value<'a>)>,
-    source_obj: Vec<(&'a str, Value<'a>)>,
-) {
+fn deep_merge_objects<'a>(target_obj: &mut ValueObject<'a>, source_obj: ValueObject<'a>) {
     if source_obj.is_empty() {
         return;
     }
-    if target_vec.is_empty() {
-        target_vec.clear();
-        target_vec.extend(source_obj);
+    if target_obj.is_empty() {
+        target_obj.clear();
+        target_obj.extend(source_obj);
 
         return;
     }
 
-    let old_target = std::mem::take(target_vec);
-    let mut merged = Vec::with_capacity(old_target.len() + source_obj.len());
+    let old_target = std::mem::take(target_obj);
+    let mut merged = ValueObject::with_capacity(old_target.len() + source_obj.len());
 
     let mut target_iter = old_target.into_iter().peekable();
     let mut source_iter = source_obj.into_iter().peekable();
@@ -82,5 +79,5 @@ fn deep_merge_objects<'a>(
     merged.extend(source_iter);
 
     // Replace the original vector with the newly merged one.
-    *target_vec = merged;
+    *target_obj = merged;
 }

--- a/lib/executor/src/response/value.rs
+++ b/lib/executor/src/response/value.rs
@@ -4,7 +4,7 @@ use serde::{
     de::{self, Deserializer, MapAccess, SeqAccess, Visitor},
     ser::{SerializeMap, SerializeSeq},
 };
-use sonic_rs::{JsonNumberTrait, ValueRef};
+use sonic_rs::{JsonNumberTrait, Object, ValueRef};
 use std::{
     borrow::Cow,
     fmt::Display,
@@ -24,7 +24,7 @@ pub enum Value<'a> {
     Bool(bool),
     String(Cow<'a, str>),
     Array(Vec<Value<'a>>),
-    Object(Vec<(&'a str, Value<'a>)>),
+    Object(ValueObject<'a>),
 }
 
 impl Hash for Value<'_> {
@@ -50,10 +50,8 @@ impl<'a> Value<'a> {
     pub fn take_entities_by_key(&mut self, key: &str) -> Option<Vec<Value<'a>>> {
         match self {
             Value::Object(data) => {
-                if let Ok(entities_idx) = data.binary_search_by_key(&key, |(k, _)| *k) {
-                    if let Value::Array(arr) = data.remove(entities_idx).1 {
-                        return Some(arr);
-                    }
+                if let Some(Value::Array(arr)) = data.take(key) {
+                    return Some(arr);
                 }
                 None
             }
@@ -84,7 +82,7 @@ impl<'a> Value<'a> {
 
         match self {
             Value::Object(obj) => {
-                Value::hash_object_with_requires(state, obj, selection_items, possible_types);
+                obj.hash_object_with_requires(state, selection_items, possible_types)
             }
             Value::Array(arr) => {
                 for item in arr {
@@ -93,50 +91,6 @@ impl<'a> Value<'a> {
             }
             _ => {
                 self.hash(state);
-            }
-        }
-    }
-
-    fn hash_object_with_requires<H: Hasher>(
-        state: &mut H,
-        obj: &[(&'a str, Value<'a>)],
-        selection_items: &[SelectionItem],
-        possible_types: &PossibleTypes,
-    ) {
-        for item in selection_items {
-            match item {
-                SelectionItem::Field(field_selection) => {
-                    let field_name = &field_selection.name;
-                    if let Ok(idx) = obj.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
-                        let (key, value) = &obj[idx];
-                        key.hash(state);
-                        value.hash_with_requires(
-                            state,
-                            &field_selection.selections.items,
-                            possible_types,
-                        );
-                    }
-                }
-                SelectionItem::InlineFragment(inline_fragment) => {
-                    let type_condition = &inline_fragment.type_condition;
-                    let type_name = obj
-                        .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
-                        .ok()
-                        .and_then(|idx| obj[idx].1.as_str())
-                        .unwrap_or(type_condition);
-
-                    if possible_types.entity_satisfies_type_condition(type_name, type_condition) {
-                        Value::hash_object_with_requires(
-                            state,
-                            obj,
-                            &inline_fragment.selections.items,
-                            possible_types,
-                        );
-                    }
-                }
-                SelectionItem::FragmentSpread(_) => {
-                    unreachable!("Fragment spreads should not exist in FetchNode::requires.")
-                }
             }
         }
     }
@@ -168,16 +122,11 @@ impl<'a> Value<'a> {
                 vec.extend(arr.iter().map(|v| Value::from(v.as_ref())));
                 Value::Array(vec)
             }
-            ValueRef::Object(obj) => {
-                let mut vec = Vec::with_capacity(obj.len());
-                vec.extend(obj.iter().map(|(k, v)| (k, Value::from(v.as_ref()))));
-                vec.sort_unstable_by_key(|(k, _)| *k);
-                Value::Object(vec)
-            }
+            ValueRef::Object(obj) => Value::Object(obj.into()),
         }
     }
 
-    pub fn as_object(&self) -> Option<&Vec<(&'a str, Value<'a>)>> {
+    pub fn as_object(&self) -> Option<&ValueObject<'a>> {
         match self {
             Value::Object(obj) => Some(obj),
             _ => None,
@@ -245,16 +194,7 @@ impl Display for Value<'_> {
                 }
                 write!(f, "]")
             }
-            Value::Object(obj) => {
-                write!(f, "{{")?;
-                for (i, (k, v)) in obj.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "\"{}\": {}", k, v)?;
-                }
-                write!(f, "}}")
-            }
+            Value::Object(obj) => obj.fmt(f),
         }
     }
 }
@@ -345,9 +285,7 @@ impl<'de> Visitor<'de> for ValueVisitor<'de> {
         while let Some((key, value)) = map.next_entry()? {
             entries.push((key, value));
         }
-        // IMPORTANT: We keep the sort for binary search compatibility.
-        entries.sort_unstable_by_key(|(k, _)| *k);
-        Ok(Value::Object(entries))
+        Ok(Value::Object(entries.into()))
     }
 }
 
@@ -371,9 +309,9 @@ impl serde::Serialize for Value<'_> {
                 seq.end()
             }
             Value::Object(obj) => {
-                let mut map = serializer.serialize_map(Some(obj.len()))?;
-                for (k, v) in obj {
-                    map.serialize_entry(k, v)?;
+                let mut map = serializer.serialize_map(Some(obj.entries.len()))?;
+                for (k, v) in &obj.entries {
+                    map.serialize_entry(k, &v)?;
                 }
                 map.end()
             }
@@ -399,7 +337,7 @@ mod tests {
             _ => panic!("Expected Value::Object"),
         };
 
-        let message_value = &obj.iter().find(|(k, _)| *k == "message").unwrap().1;
+        let message_value = &obj.get("message").unwrap();
 
         match message_value {
             Value::String(value) => {
@@ -424,7 +362,7 @@ mod tests {
             _ => panic!("Expected Value::Object"),
         };
 
-        let message_value = &obj.iter().find(|(k, _)| *k == "message").unwrap().1;
+        let message_value = &obj.get("message").unwrap();
 
         match message_value {
             Value::String(value) => {
@@ -436,5 +374,146 @@ mod tests {
             }
             _ => panic!("Expected Value::String"),
         }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ValueObject<'a> {
+    pub entries: Vec<(&'a str, Value<'a>)>,
+}
+
+impl<'a> From<&'a Object> for ValueObject<'a> {
+    fn from(obj: &'a Object) -> Self {
+        let mut entries = Vec::with_capacity(obj.len());
+        entries.extend(obj.iter().map(|(k, v)| (k, Value::from(v.as_ref()))));
+        entries.into()
+    }
+}
+
+impl<'a> Hash for ValueObject<'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.entries.hash(state)
+    }
+}
+
+impl<'a> Display for ValueObject<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        for (i, (k, v)) in self.entries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "\"{}\": {}", k, v)?;
+        }
+        write!(f, "}}")
+    }
+}
+
+impl<'a> ValueObject<'a> {
+    pub fn get(&self, key: &str) -> Option<&Value<'a>> {
+        self.find_index(key).map(|idx| &self.entries[idx].1)
+    }
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut Value<'a>> {
+        self.find_index(key).map(|idx| &mut self.entries[idx].1)
+    }
+    pub fn take(&mut self, key: &str) -> Option<Value<'a>> {
+        self.find_index(key).map(|idx| self.entries.remove(idx).1)
+    }
+    pub fn entry(&mut self, key: &str) -> Option<&mut (&'a str, Value<'a>)> {
+        self.find_index(key).and_then(|i| self.entries.get_mut(i))
+    }
+    pub fn type_name(&self) -> Option<&str> {
+        self.get(TYPENAME_FIELD_NAME).and_then(|v| v.as_str())
+    }
+    fn find_index(&self, key: &str) -> Option<usize> {
+        self.entries.binary_search_by_key(&key, |(k, _)| *k).ok()
+    }
+    pub fn hash_object_with_requires<H: Hasher>(
+        &self,
+        state: &mut H,
+        selection_items: &[SelectionItem],
+        possible_types: &PossibleTypes,
+    ) {
+        for item in selection_items {
+            match item {
+                SelectionItem::Field(field_selection) => {
+                    let field_name = &field_selection.name;
+                    if let Some(value) = self.get(field_name) {
+                        field_name.hash(state);
+                        value.hash_with_requires(
+                            state,
+                            &field_selection.selections.items,
+                            possible_types,
+                        );
+                    }
+                }
+                SelectionItem::InlineFragment(inline_fragment) => {
+                    let type_condition = &inline_fragment.type_condition;
+                    let type_name = self.type_name().unwrap_or(type_condition);
+
+                    if possible_types.entity_satisfies_type_condition(type_name, type_condition) {
+                        self.hash_object_with_requires(
+                            state,
+                            &inline_fragment.selections.items,
+                            possible_types,
+                        );
+                    }
+                }
+                SelectionItem::FragmentSpread(_) => {
+                    unreachable!("Fragment spreads should not exist in FetchNode::requires.")
+                }
+            }
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+    pub fn extend<I: IntoIterator<Item = (&'a str, Value<'a>)>>(&mut self, iter: I) {
+        self.entries.extend(iter);
+    }
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+    pub fn with_capacity(capacity: usize) -> Self {
+        ValueObject {
+            entries: Vec::with_capacity(capacity),
+        }
+    }
+    pub fn push(&mut self, entry: (&'a str, Value<'a>)) {
+        self.entries.push(entry);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'a str, &Value<'a>)> {
+        self.entries.iter().map(|(k, v)| (*k, v))
+    }
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&'a str, &mut Value<'a>)> {
+        self.entries.iter_mut().map(|(k, v)| (*k, v))
+    }
+    pub fn into_iter(self) -> impl Iterator<Item = (&'a str, Value<'a>)> {
+        self.entries.into_iter()
+    }
+}
+
+impl<'a> Iterator for ValueObject<'a> {
+    type Item = (&'a str, Value<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.entries.pop()
+    }
+}
+
+impl<'a> From<Vec<(&'a str, Value<'a>)>> for ValueObject<'a> {
+    fn from(mut entries: Vec<(&'a str, Value<'a>)>) -> Self {
+        entries.sort_unstable_by_key(|(k, _)| *k);
+        ValueObject { entries }
+    }
+}
+
+impl<'a> From<ValueObject<'a>> for Value<'a> {
+    fn from(obj: ValueObject<'a>) -> Self {
+        Value::Object(obj)
     }
 }

--- a/lib/executor/src/response/value.rs
+++ b/lib/executor/src/response/value.rs
@@ -379,7 +379,7 @@ mod tests {
 
 #[derive(Debug, Clone, Default)]
 pub struct ValueObject<'a> {
-    pub entries: Vec<(&'a str, Value<'a>)>,
+    pub(crate) entries: Vec<(&'a str, Value<'a>)>,
 }
 
 impl<'a> From<&'a Object> for ValueObject<'a> {

--- a/lib/executor/src/response/value.rs
+++ b/lib/executor/src/response/value.rs
@@ -497,11 +497,12 @@ impl<'a> ValueObject<'a> {
     }
 }
 
-impl<'a> Iterator for ValueObject<'a> {
+impl<'a> IntoIterator for ValueObject<'a> {
     type Item = (&'a str, Value<'a>);
+    type IntoIter = std::vec::IntoIter<(&'a str, Value<'a>)>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.entries.pop()
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
     }
 }
 

--- a/lib/executor/src/response/value.rs
+++ b/lib/executor/src/response/value.rs
@@ -309,8 +309,8 @@ impl serde::Serialize for Value<'_> {
                 seq.end()
             }
             Value::Object(obj) => {
-                let mut map = serializer.serialize_map(Some(obj.entries.len()))?;
-                for (k, v) in &obj.entries {
+                let mut map = serializer.serialize_map(Some(obj.len()))?;
+                for (k, v) in obj.iter() {
                     map.serialize_entry(k, &v)?;
                 }
                 map.end()
@@ -491,9 +491,6 @@ impl<'a> ValueObject<'a> {
     }
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&'a str, &mut Value<'a>)> {
         self.entries.iter_mut().map(|(k, v)| (*k, v))
-    }
-    pub fn into_iter(self) -> impl Iterator<Item = (&'a str, Value<'a>)> {
-        self.entries.into_iter()
     }
 }
 

--- a/lib/executor/src/utils/traverse.rs
+++ b/lib/executor/src/utils/traverse.rs
@@ -5,7 +5,6 @@ use hive_router_query_planner::planner::plan_nodes::FlattenNodePathSegment;
 use crate::{
     introspection::schema::{PossibleTypes, SchemaMetadata},
     response::{graphql_error::GraphQLErrorPath, value::Value},
-    utils::consts::TYPENAME_FIELD_NAME,
 };
 
 fn entity_satisfies_any_type_condition(
@@ -66,8 +65,7 @@ pub fn traverse_and_callback_mut<'a, Callback>(
         FlattenNodePathSegment::Field(field_name) => {
             // If the key is Field, we expect current_data to be an object
             if let Value::Object(map) = current_data {
-                if let Ok(idx) = map.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
-                    let (_, next_data) = map.get_mut(idx).unwrap();
+                if let Some(next_data) = map.get_mut(field_name) {
                     let rest_of_path = &remaining_path[1..];
                     let current_error_path_for_field =
                         current_error_path.map(|current_error_path| {
@@ -86,10 +84,7 @@ pub fn traverse_and_callback_mut<'a, Callback>(
         FlattenNodePathSegment::TypeCondition(type_condition) => {
             // If the key is Cast, we expect current_data to be an object or an array
             if let Value::Object(obj) = current_data {
-                let maybe_type_name = obj
-                    .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
-                    .ok()
-                    .and_then(|idx| obj[idx].1.as_str());
+                let maybe_type_name = obj.type_name();
 
                 if maybe_type_name.is_none_or(|type_name| {
                     entity_satisfies_any_type_condition(
@@ -156,8 +151,7 @@ pub fn traverse_and_callback<'a, Callback>(
         }
         FlattenNodePathSegment::Field(field_name) => {
             if let Value::Object(map) = current_data {
-                if let Ok(idx) = map.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
-                    let (_, next_data) = &map[idx];
+                if let Some(next_data) = map.get(field_name) {
                     let rest_of_path = &remaining_path[1..];
                     traverse_and_callback(next_data, rest_of_path, possible_types, callback);
                 }
@@ -165,10 +159,7 @@ pub fn traverse_and_callback<'a, Callback>(
         }
         FlattenNodePathSegment::TypeCondition(type_condition) => {
             if let Value::Object(obj) = current_data {
-                let maybe_type_name = obj
-                    .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
-                    .ok()
-                    .and_then(|idx| obj[idx].1.as_str());
+                let maybe_type_name = obj.type_name();
 
                 if maybe_type_name.is_none_or(|type_name| {
                     entity_satisfies_any_type_condition(possible_types, type_name, type_condition)
@@ -204,13 +195,16 @@ mod tests {
      * we should collect paths ["items", 0] and ["items", 1]
      */
     fn test_collect_error_paths_one_level() {
-        let mut data = Value::Object(vec![(
-            "items",
-            Value::Array(vec![
-                Value::Object(vec![("id", Value::String("1".into()))]),
-                Value::Object(vec![("id", Value::String("2".into()))]),
-            ]),
-        )]);
+        let mut data = Value::Object(
+            vec![(
+                "items",
+                Value::Array(vec![
+                    Value::Object(vec![("id", Value::String("1".into()))].into()),
+                    Value::Object(vec![("id", Value::String("2".into()))].into()),
+                ]),
+            )]
+            .into(),
+        );
         let path = vec![
             FlattenNodePathSegment::Field("items".into()),
             FlattenNodePathSegment::List,
@@ -249,28 +243,39 @@ mod tests {
      * we should collect paths ["users", 0, "posts", 0], ["users", 0, "posts", 1], and ["users", 1, "posts", 0]
      */
     fn test_collect_error_paths_two_levels() {
-        let mut data = Value::Object(vec![(
-            "users",
-            Value::Array(vec![
-                Value::Object(vec![
-                    ("id", Value::String("1".into())),
-                    (
-                        "posts",
-                        Value::Array(vec![
-                            Value::Object(vec![("id", Value::String("a".into()))]),
-                            Value::Object(vec![("id", Value::String("b".into()))]),
-                        ]),
+        let mut data = Value::Object(
+            vec![(
+                "users",
+                Value::Array(vec![
+                    Value::Object(
+                        vec![
+                            ("id", Value::String("1".into())),
+                            (
+                                "posts",
+                                Value::Array(vec![
+                                    Value::Object(vec![("id", Value::String("a".into()))].into()),
+                                    Value::Object(vec![("id", Value::String("b".into()))].into()),
+                                ]),
+                            ),
+                        ]
+                        .into(),
+                    ),
+                    Value::Object(
+                        vec![
+                            ("id", Value::String("2".into())),
+                            (
+                                "posts",
+                                Value::Array(vec![Value::Object(
+                                    vec![("id", Value::String("c".into()))].into(),
+                                )]),
+                            ),
+                        ]
+                        .into(),
                     ),
                 ]),
-                Value::Object(vec![
-                    ("id", Value::String("2".into())),
-                    (
-                        "posts",
-                        Value::Array(vec![Value::Object(vec![("id", Value::String("c".into()))])]),
-                    ),
-                ]),
-            ]),
-        )]);
+            )]
+            .into(),
+        );
         let path = vec![
             FlattenNodePathSegment::Field("users".into()),
             FlattenNodePathSegment::List,
@@ -319,7 +324,7 @@ mod tests {
 
     #[test]
     fn traverse_matches_multi_type_cast() {
-        let data = Value::Object(vec![("__typename", Value::String("Book".into()))]);
+        let data = Value::Object(vec![("__typename", Value::String("Book".into()))].into());
         let path = vec![FlattenNodePathSegment::TypeCondition(
             ["Book".to_string(), "User".to_string()]
                 .into_iter()
@@ -336,7 +341,7 @@ mod tests {
 
     #[test]
     fn traverse_rejects_non_matching_multi_type_cast() {
-        let data = Value::Object(vec![("__typename", Value::String("Magazine".into()))]);
+        let data = Value::Object(vec![("__typename", Value::String("Magazine".into()))].into());
         let path = vec![FlattenNodePathSegment::TypeCondition(
             ["Book".to_string(), "User".to_string()]
                 .into_iter()

--- a/plugin_examples/response_cache/src/lib.rs
+++ b/plugin_examples/response_cache/src/lib.rs
@@ -98,11 +98,7 @@ impl RouterPlugin for ResponseCachePlugin {
 
                     // Imagine this code is traversing the response data to find type names
                     if let Some(obj) = payload.data.as_object() {
-                        if let Some(typename) = obj
-                            .iter()
-                            .position(|(k, _)| k == &"__typename")
-                            .and_then(|idx| obj[idx].1.as_str())
-                        {
+                        if let Some(typename) = obj.type_name() {
                             if let Some(ttl) = ttl_per_type.get(typename) {
                                 max_ttl = max_ttl.max(*ttl);
                             }


### PR DESCRIPTION
Instead of dealing with the vectors directly, use the container `ValueObject` to avoid the repeating boilerplate like `binary_search_by_key` etc