### PR TITLE
Prevent hang in multiple_subscriptions_in_parallel test

### DIFF
--- a/e2e/src/websocket.rs
+++ b/e2e/src/websocket.rs
@@ -168,32 +168,34 @@ mod websocket_e2e_tests {
 
         let mut count1 = 0;
         let mut count2 = 0;
+        let mut done1 = false;
+        let mut done2 = false;
 
         loop {
+            if done1 && done2 {
+                break;
+            }
+
             tokio::select! {
-                maybe_response = stream1.next() => {
+                maybe_response = stream1.next(), if !done1 => {
                     match maybe_response {
                         Some(response) => {
                             assert!(response.errors.is_none(), "Expected no errors in stream1");
                             count1 += 1;
                         }
                         None => {
-                            if count2 > 0 {
-                                break;
-                            }
+                            done1 = true;
                         }
                     }
                 }
-                maybe_response = stream2.next() => {
+                maybe_response = stream2.next(), if !done2 => {
                     match maybe_response {
                         Some(response) => {
                             assert!(response.errors.is_none(), "Expected no errors in stream2");
                             count2 += 1;
                         }
                         None => {
-                            if count1 > 0 {
-                                break;
-                            }
+                            done2 = true;
                         }
                     }
                 }


### PR DESCRIPTION
Once a stream is exhausetd, stream.next() returns None immediately and keeps being "ready". Without a `done` guard, tokio::select! kept picking the dead stream on every iteration, starving the live one and causing the test to hang indefinitely.