### PR TITLE
fix(query-planner): handle both `@skip` and `@include` directives on the same selection

### DIFF
--- a/.changeset/olive-ducks-bake.md
+++ b/.changeset/olive-ducks-bake.md
@@ -1,0 +1,22 @@
+---
+hive-router-query-planner: patch
+---
+
+Fix query planner handling for combined `@skip` and `@include` conditions.
+
+- Preserve both directives when converting inline fragment conditions into fetch step selections
+- Build the expected nested condition nodes for combined skip/include execution paths
+- Handle `SkipAndInclude` in selection matching, fetch-step rendering, and multi-type batch path hashing
+- Add regression snapshot tests for field-level and fragment-level combined conditions
+
+For example a query like this:
+
+```graphql
+query($skip: Boolean!, $include: Boolean!) {
+  user {
+    name @skip(if: $skip) @include(if: $include)
+  }
+}
+```
+
+Will now correctly generate a fetch step with an inline fragment that has both `@skip` and `@include` conditions, and the planner will properly evaluate the combined conditions when determining which selections to include in the execution plan.

--- a/.changeset/olive-ducks-bake.md
+++ b/.changeset/olive-ducks-bake.md
@@ -20,3 +20,7 @@ query($skip: Boolean!, $include: Boolean!) {
 ```
 
 Will now correctly generate a fetch step with an inline fragment that has both `@skip` and `@include` conditions, and the planner will properly evaluate the combined conditions when determining which selections to include in the execution plan.
+
+- `@skip(if: $skip)` is true, the selection will be skipped regardless of the `@include` condition.
+- `@include(if: $include)` is false, the selection will be skipped regardless of the `@skip` condition.
+- Only if `@skip(if: $skip)` is false and `@include(if: $include)` is true, the selection will be included in the execution plan.

--- a/e2e/src/conditional_directives.rs
+++ b/e2e/src/conditional_directives.rs
@@ -1,0 +1,276 @@
+#[cfg(test)]
+mod conditional_directives_e2e_tests {
+    // These tests ensure the behavior when a selection has both @skip and @include directives.
+    // The expected behavior is;
+    // 1. If @skip(if: $skip) is true, the selection should be skipped regardless of the @include directive.
+    // 2. If @skip(if: $skip) is false, the selection should be included only if @include(if: $include) is true.
+    // 3. If both @skip(if: $skip) and @include(if: $include) are false, the selection should be skipped.
+    // 4. If both @skip(if: $skip) and @include(if: $include) are true, the selection should be skipped.
+
+    use sonic_rs::{pointer, JsonValueTrait};
+
+    use crate::testkit::{ClientResponseExt, Started, TestRouter, TestSubgraphs};
+
+    async fn build_router_with_supergraph() -> (TestSubgraphs<Started>, TestRouter<Started>) {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+        (subgraphs, router)
+    }
+
+    fn check_response_includes_product_name(json_body: sonic_rs::Value, expected_included: bool) {
+        println!("Response body: {}", json_body);
+        println!(
+            "Checking if product name is {} in the response",
+            if expected_included {
+                "included"
+            } else {
+                "skipped"
+            }
+        );
+        let product_name =
+            json_body.pointer(&pointer!["data", "me", "reviews", 0, "product", "name",]);
+        if expected_included {
+            assert!(
+                product_name.is_some(),
+                "Expected product name to be included, but it was not. Response body: {}",
+                json_body
+            );
+        } else {
+            assert!(
+                product_name.is_none(),
+                "Expected product name to be skipped, but it was included. Response body: {}",
+                json_body
+            );
+        }
+    }
+
+    async fn run_test(query: &str, skip: bool, include: bool, expected_included: bool) {
+        let (_subgraphs, router) = build_router_with_supergraph().await;
+        let variables = sonic_rs::json!({
+            "include": include,
+            "skip": skip,
+        });
+        let res = router
+            .send_graphql_request(query, Some(variables), None)
+            .await;
+        let json_body = res.json_body().await;
+        check_response_includes_product_name(json_body, expected_included);
+    }
+
+    const FIELD_CONDITIONS_SKIP_THEN_INCLUDE_QUERY: &'static str = r#"
+        query($skip: Boolean!, $include: Boolean!) {
+            me {
+                name
+                reviews {
+                    product {
+                        upc 
+                        name @skip(if: $skip) @include(if: $include)
+                    }
+                }
+            }
+        }
+    "#;
+
+    const FIELD_CONDITIONS_INCLUDE_THEN_SKIP_QUERY: &'static str = r#"
+        query($skip: Boolean!, $include: Boolean!) {
+            me {
+                name
+                reviews {
+                    product {
+                        upc 
+                        name @include(if: $include) @skip(if: $skip)
+                    }
+                }
+            }
+        }
+    "#;
+
+    const INLINE_FRAGMENT_CONDITIONS_SKIP_THEN_INCLUDE_QUERY: &'static str = r#"
+        query($skip: Boolean!, $include: Boolean!) {
+            me {
+                name
+                reviews {
+                    product {
+                        upc 
+                        ... on Product @skip(if: $skip) @include(if: $include) {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    "#;
+
+    const INLINE_FRAGMENT_CONDITIONS_INCLUDE_THEN_SKIP_QUERY: &'static str = r#"
+        query($skip: Boolean!, $include: Boolean!) {
+            me {
+                name
+                reviews {
+                    product {
+                        upc 
+                        ... on Product @include(if: $include) @skip(if: $skip) {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    "#;
+
+    // If skip: true, the selection should be skipped regardless of the include value
+    #[ntex::test]
+    async fn field_skip_true_and_include_true() {
+        run_test(FIELD_CONDITIONS_SKIP_THEN_INCLUDE_QUERY, true, true, false).await;
+    }
+    #[ntex::test]
+    async fn field_skip_true_and_include_false() {
+        run_test(FIELD_CONDITIONS_SKIP_THEN_INCLUDE_QUERY, true, false, false).await;
+    }
+
+    // If skip: false, the selection should be included only if include: true
+    #[ntex::test]
+    async fn field_skip_false_and_include_true() {
+        run_test(FIELD_CONDITIONS_SKIP_THEN_INCLUDE_QUERY, false, true, true).await;
+    }
+    #[ntex::test]
+    async fn field_skip_false_and_include_false() {
+        run_test(
+            FIELD_CONDITIONS_SKIP_THEN_INCLUDE_QUERY,
+            false,
+            false,
+            false,
+        )
+        .await;
+    }
+
+    // Make sure the order of directives does not matter
+    // So this time, `@include` comes before `@skip`, but the behavior should be the same as the previous 4 tests
+    #[ntex::test]
+    async fn field_include_then_skip_skip_true_and_include_true() {
+        // In this case, `@skip` is true, so the selection should be skipped regardless of the `@include` value
+        run_test(FIELD_CONDITIONS_INCLUDE_THEN_SKIP_QUERY, true, true, false).await;
+    }
+    #[ntex::test]
+    async fn field_include_then_skip_skip_true_and_include_false() {
+        // In this case, `@skip` is true, so the selection should be skipped regardless of the `@include` value
+        run_test(FIELD_CONDITIONS_INCLUDE_THEN_SKIP_QUERY, true, false, false).await;
+    }
+    #[ntex::test]
+    async fn field_include_then_skip_skip_false_and_include_true() {
+        // In this case, `@skip` is false and `@include` is true, so the selection should be included
+        run_test(FIELD_CONDITIONS_INCLUDE_THEN_SKIP_QUERY, false, true, true).await;
+    }
+    #[ntex::test]
+    async fn field_include_then_skip_skip_false_and_include_false() {
+        // In this case, `@skip` is false but `@include` is also false, so the selection should be skipped
+        run_test(
+            FIELD_CONDITIONS_INCLUDE_THEN_SKIP_QUERY,
+            false,
+            false,
+            false,
+        )
+        .await;
+    }
+
+    // If skip: true, the selection should be skipped regardless of the include value
+    #[ntex::test]
+    async fn inline_fragment_skip_true_and_include_true() {
+        // In this case, `@skip` is true, so the selection should be skipped regardless of the `@include` value
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_SKIP_THEN_INCLUDE_QUERY,
+            true,
+            true,
+            false,
+        )
+        .await;
+    }
+    #[ntex::test]
+    async fn inline_fragment_skip_true_and_include_false() {
+        // In this case, `@skip` is true, so the selection should be skipped regardless of the `@include` value
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_SKIP_THEN_INCLUDE_QUERY,
+            true,
+            false,
+            false,
+        )
+        .await;
+    }
+    // If skip: false, the selection should be included only if include: true
+    #[ntex::test]
+    async fn inline_fragment_skip_false_and_include_true() {
+        // In this case, `@skip` is false and `@include` is true, so the selection should be included
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_SKIP_THEN_INCLUDE_QUERY,
+            false,
+            true,
+            true,
+        )
+        .await;
+    }
+    #[ntex::test]
+    async fn inline_fragment_skip_false_and_include_false() {
+        // In this case, `@skip` is false but `@include` is also false, so the selection should be skipped
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_SKIP_THEN_INCLUDE_QUERY,
+            false,
+            false,
+            false,
+        )
+        .await;
+    }
+
+    // Make sure the order of directives does not matter
+    // So this time, `@include` comes before `@skip`, but the behavior should be the same as the previous 4 tests
+    #[ntex::test]
+    async fn inline_fragment_include_then_skip_skip_true_and_include_true() {
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_INCLUDE_THEN_SKIP_QUERY,
+            true,
+            true,
+            false,
+        )
+        .await;
+    }
+    #[ntex::test]
+    async fn inline_fragment_include_then_skip_skip_true_and_include_false() {
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_INCLUDE_THEN_SKIP_QUERY,
+            true,
+            false,
+            false,
+        )
+        .await;
+    }
+    #[ntex::test]
+    async fn inline_fragment_include_then_skip_skip_false_and_include_true() {
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_INCLUDE_THEN_SKIP_QUERY,
+            false,
+            true,
+            true,
+        )
+        .await;
+    }
+    #[ntex::test]
+    async fn inline_fragment_include_then_skip_skip_false_and_include_false() {
+        run_test(
+            INLINE_FRAGMENT_CONDITIONS_INCLUDE_THEN_SKIP_QUERY,
+            false,
+            false,
+            false,
+        )
+        .await;
+    }
+}

--- a/e2e/src/conditional_directives.rs
+++ b/e2e/src/conditional_directives.rs
@@ -56,7 +56,22 @@ mod conditional_directives_e2e_tests {
         let res = router
             .send_graphql_request(query, Some(variables), None)
             .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+
         let json_body = res.json_body().await;
+        let data = json_body.pointer(&pointer!["data"]);
+        assert!(
+            data.is_some_and(|value| value.is_object()),
+            "Expected response.data to be an object. Response body: {}",
+            json_body
+        );
+        let errors = json_body.pointer(&pointer!["errors"]);
+        assert!(
+            errors.is_none_or(|value| value.is_null()),
+            "Expected response.errors to be null or missing. Response body: {}",
+            json_body
+        );
+
         check_response_includes_product_name(json_body, expected_included);
     }
 

--- a/e2e/src/conditional_directives.rs
+++ b/e2e/src/conditional_directives.rs
@@ -30,15 +30,6 @@ mod conditional_directives_e2e_tests {
     }
 
     fn check_response_includes_product_name(json_body: sonic_rs::Value, expected_included: bool) {
-        println!("Response body: {}", json_body);
-        println!(
-            "Checking if product name is {} in the response",
-            if expected_included {
-                "included"
-            } else {
-                "skipped"
-            }
-        );
         let product_name =
             json_body.pointer(&pointer!["data", "me", "reviews", 0, "product", "name",]);
         if expected_included {

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -5,6 +5,8 @@ mod authorization_directives_reject;
 #[cfg(test)]
 mod body_limit;
 #[cfg(test)]
+mod conditional_directives;
+#[cfg(test)]
 mod disable_introspection;
 #[cfg(test)]
 mod entity_batching;

--- a/lib/query-planner/src/ast/merge_path.rs
+++ b/lib/query-planner/src/ast/merge_path.rs
@@ -12,18 +12,21 @@ type SelectionIdentifier = String;
 pub enum Condition {
     Skip(String),
     Include(String),
+    SkipAndInclude { skip: String, include: String },
 }
 
 impl Condition {
     pub fn to_skip_if(&self) -> Option<String> {
         match self {
             Condition::Skip(var) => Some(var.clone()),
+            Condition::SkipAndInclude { skip, .. } => Some(skip.clone()),
             _ => None,
         }
     }
     pub fn to_include_if(&self) -> Option<String> {
         match self {
             Condition::Include(var) => Some(var.clone()),
+            Condition::SkipAndInclude { include, .. } => Some(include.clone()),
             _ => None,
         }
     }
@@ -34,45 +37,52 @@ impl Display for Condition {
         match self {
             Self::Skip(condition) => write!(f, "@skip(if: ${})", condition),
             Self::Include(condition) => write!(f, "@include(if: ${})", condition),
+            Self::SkipAndInclude { skip, include } => {
+                write!(f, "@skip(if: ${}) @include(if: ${})", skip, include)
+            }
         }
     }
 }
 
 impl From<&FieldSelection> for Option<Condition> {
     fn from(field: &FieldSelection) -> Self {
-        if let Some(variable) = &field.skip_if {
-            return Some(Condition::Skip(variable.clone()));
+        match (&field.skip_if, &field.include_if) {
+            (Some(skip), Some(include)) => Some(Condition::SkipAndInclude {
+                skip: skip.clone(),
+                include: include.clone(),
+            }),
+            (Some(variable), None) => Some(Condition::Skip(variable.clone())),
+            (None, Some(variable)) => Some(Condition::Include(variable.clone())),
+            (None, None) => None,
         }
-        if let Some(variable) = &field.include_if {
-            return Some(Condition::Include(variable.clone()));
-        }
-        None
     }
 }
 
 impl From<&mut FieldSelection> for Option<Condition> {
     fn from(field: &mut FieldSelection) -> Self {
-        if let Some(variable) = &field.skip_if {
-            return Some(Condition::Skip(variable.clone()));
+        match (&field.skip_if, &field.include_if) {
+            (Some(skip), Some(include)) => Some(Condition::SkipAndInclude {
+                skip: skip.clone(),
+                include: include.clone(),
+            }),
+            (Some(variable), None) => Some(Condition::Skip(variable.clone())),
+            (None, Some(variable)) => Some(Condition::Include(variable.clone())),
+            (None, None) => None,
         }
-        if let Some(variable) = &field.include_if {
-            return Some(Condition::Include(variable.clone()));
-        }
-        None
     }
 }
 
 impl From<&InlineFragmentSelection> for Option<Condition> {
     fn from(fragment: &InlineFragmentSelection) -> Self {
-        if let Some(variable) = &fragment.skip_if {
-            return Some(Condition::Skip(variable.clone()));
+        match (&fragment.skip_if, &fragment.include_if) {
+            (Some(skip), Some(include)) => Some(Condition::SkipAndInclude {
+                skip: skip.clone(),
+                include: include.clone(),
+            }),
+            (Some(variable), None) => Some(Condition::Skip(variable.clone())),
+            (None, Some(variable)) => Some(Condition::Include(variable.clone())),
+            (None, None) => None,
         }
-
-        if let Some(variable) = &fragment.include_if {
-            return Some(Condition::Include(variable.clone()));
-        }
-
-        None
     }
 }
 

--- a/lib/query-planner/src/ast/selection_set.rs
+++ b/lib/query-planner/src/ast/selection_set.rs
@@ -872,4 +872,32 @@ mod tests {
 
         assert_eq!(target.items.len(), 2);
     }
+
+    #[test]
+    // TODO: rename
+    fn bug1() {
+        let cond = Some(Condition::Include("include".to_string()));
+        let field = FieldSelection {
+            name: "name".to_string(),
+            selections: SelectionSet::default(),
+            alias: None,
+            arguments: None,
+            skip_if: Some("skip".to_string()),
+            include_if: Some("include".to_string()),
+        };
+        assert!(!field_condition_equal(&cond, &field));
+    }
+
+    #[test]
+    // TODO: rename
+    fn bug2() {
+        let cond = Some(Condition::Skip("skip".to_string()));
+        let fragment = InlineFragmentSelection {
+            type_condition: "Product".to_string(),
+            selections: SelectionSet::default(),
+            skip_if: Some("skip".to_string()),
+            include_if: Some("include".to_string()),
+        };
+        assert!(!fragment_condition_equal(&cond, &fragment));
+    }
 }

--- a/lib/query-planner/src/ast/selection_set.rs
+++ b/lib/query-planner/src/ast/selection_set.rs
@@ -575,9 +575,11 @@ pub fn field_condition_equal(cond: &Option<Condition>, field: &FieldSelection) -
     match cond {
         Some(cond) => match cond {
             Condition::Include(var_name) => {
-                field.include_if.as_ref().is_some_and(|v| v == var_name)
+                field.include_if.as_ref().is_some_and(|v| v == var_name) && field.skip_if.is_none()
             }
-            Condition::Skip(var_name) => field.skip_if.as_ref().is_some_and(|v| v == var_name),
+            Condition::Skip(var_name) => {
+                field.skip_if.as_ref().is_some_and(|v| v == var_name) && field.include_if.is_none()
+            }
             Condition::SkipAndInclude { skip, include } => {
                 field.skip_if.as_ref().is_some_and(|v| v == skip)
                     && field.include_if.as_ref().is_some_and(|v| v == include)
@@ -592,8 +594,12 @@ fn fragment_condition_equal(cond: &Option<Condition>, fragment: &InlineFragmentS
         Some(cond) => match cond {
             Condition::Include(var_name) => {
                 fragment.include_if.as_ref().is_some_and(|v| v == var_name)
+                    && fragment.skip_if.is_none()
             }
-            Condition::Skip(var_name) => fragment.skip_if.as_ref().is_some_and(|v| v == var_name),
+            Condition::Skip(var_name) => {
+                fragment.skip_if.as_ref().is_some_and(|v| v == var_name)
+                    && fragment.include_if.is_none()
+            }
             Condition::SkipAndInclude { skip, include } => {
                 fragment.skip_if.as_ref().is_some_and(|v| v == skip)
                     && fragment.include_if.as_ref().is_some_and(|v| v == include)
@@ -874,9 +880,14 @@ mod tests {
     }
 
     #[test]
-    // TODO: rename
-    fn bug1() {
-        let cond = Some(Condition::Include("include".to_string()));
+    // Field Condition should only be equal to Condition::IncludeAndSkip
+    fn field_condition_skip_and_include() {
+        let skip_cond = Some(Condition::Skip("skip".to_string()));
+        let include_cond: Option<Condition> = Some(Condition::Include("include".to_string()));
+        let skip_and_include_cond = Some(Condition::SkipAndInclude {
+            skip: "skip".to_string(),
+            include: "include".to_string(),
+        });
         let field = FieldSelection {
             name: "name".to_string(),
             selections: SelectionSet::default(),
@@ -885,19 +896,28 @@ mod tests {
             skip_if: Some("skip".to_string()),
             include_if: Some("include".to_string()),
         };
-        assert!(!field_condition_equal(&cond, &field));
+        assert!(!field_condition_equal(&skip_cond, &field));
+        assert!(!field_condition_equal(&include_cond, &field));
+        assert!(field_condition_equal(&skip_and_include_cond, &field));
     }
 
     #[test]
-    // TODO: rename
-    fn bug2() {
-        let cond = Some(Condition::Skip("skip".to_string()));
+    // Fragment Condition should only be equal to Condition::IncludeAndSkip
+    fn fragment_condition_skip_and_include() {
+        let skip_cond = Some(Condition::Skip("skip".to_string()));
+        let include_cond: Option<Condition> = Some(Condition::Include("include".to_string()));
+        let skip_and_include_cond = Some(Condition::SkipAndInclude {
+            skip: "skip".to_string(),
+            include: "include".to_string(),
+        });
         let fragment = InlineFragmentSelection {
             type_condition: "Product".to_string(),
             selections: SelectionSet::default(),
             skip_if: Some("skip".to_string()),
             include_if: Some("include".to_string()),
         };
-        assert!(!fragment_condition_equal(&cond, &fragment));
+        assert!(!fragment_condition_equal(&skip_cond, &fragment));
+        assert!(!fragment_condition_equal(&include_cond, &fragment));
+        assert!(fragment_condition_equal(&skip_and_include_cond, &fragment));
     }
 }

--- a/lib/query-planner/src/ast/selection_set.rs
+++ b/lib/query-planner/src/ast/selection_set.rs
@@ -880,7 +880,7 @@ mod tests {
     }
 
     #[test]
-    // Field Condition should only be equal to Condition::IncludeAndSkip
+    // Field Condition should only be equal to Condition::SkipAndInclude
     fn field_condition_skip_and_include() {
         let skip_cond = Some(Condition::Skip("skip".to_string()));
         let include_cond: Option<Condition> = Some(Condition::Include("include".to_string()));
@@ -902,7 +902,7 @@ mod tests {
     }
 
     #[test]
-    // Fragment Condition should only be equal to Condition::IncludeAndSkip
+    // Fragment Condition should only be equal to Condition::SkipAndInclude
     fn fragment_condition_skip_and_include() {
         let skip_cond = Some(Condition::Skip("skip".to_string()));
         let include_cond: Option<Condition> = Some(Condition::Include("include".to_string()));

--- a/lib/query-planner/src/ast/selection_set.rs
+++ b/lib/query-planner/src/ast/selection_set.rs
@@ -578,6 +578,10 @@ pub fn field_condition_equal(cond: &Option<Condition>, field: &FieldSelection) -
                 field.include_if.as_ref().is_some_and(|v| v == var_name)
             }
             Condition::Skip(var_name) => field.skip_if.as_ref().is_some_and(|v| v == var_name),
+            Condition::SkipAndInclude { skip, include } => {
+                field.skip_if.as_ref().is_some_and(|v| v == skip)
+                    && field.include_if.as_ref().is_some_and(|v| v == include)
+            }
         },
         None => field.include_if.is_none() && field.skip_if.is_none(),
     }
@@ -590,6 +594,10 @@ fn fragment_condition_equal(cond: &Option<Condition>, fragment: &InlineFragmentS
                 fragment.include_if.as_ref().is_some_and(|v| v == var_name)
             }
             Condition::Skip(var_name) => fragment.skip_if.as_ref().is_some_and(|v| v == var_name),
+            Condition::SkipAndInclude { skip, include } => {
+                fragment.skip_if.as_ref().is_some_and(|v| v == skip)
+                    && fragment.include_if.as_ref().is_some_and(|v| v == include)
+            }
         },
         None => fragment.include_if.is_none() && fragment.skip_if.is_none(),
     }

--- a/lib/query-planner/src/planner/fetch/fetch_step_data.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_step_data.rs
@@ -82,6 +82,9 @@ impl<State> Display for FetchStepData<State> {
             match condition {
                 Condition::Include(var_name) => write!(f, " [@include(if: ${})]", var_name)?,
                 Condition::Skip(var_name) => write!(f, " [@skip(if: ${})]", var_name)?,
+                Condition::SkipAndInclude { skip, include } => {
+                    write!(f, " [@skip(if: ${}) @include(if: ${})]", skip, include)?
+                }
             }
         }
 

--- a/lib/query-planner/src/planner/fetch/optimize/batch_multi_type.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/batch_multi_type.rs
@@ -396,6 +396,11 @@ fn normalized_path_hash(path: &MergePath) -> u64 {
                         "Condition(Include)".hash(&mut hasher);
                         variable.hash(&mut hasher);
                     }
+                    Some(Condition::SkipAndInclude { skip, include }) => {
+                        "Condition(SkipAndInclude)".hash(&mut hasher);
+                        skip.hash(&mut hasher);
+                        include.hash(&mut hasher);
+                    }
                     None => "Condition(None)".hash(&mut hasher),
                 }
             }

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -71,10 +71,12 @@ impl From<&FetchStepSelections<MultiTypeFetchStep>> for SelectionSet {
                         include_if: match &condition {
                             Condition::Include(var_name) => Some(var_name.clone()),
                             Condition::Skip(_) => None,
+                            Condition::SkipAndInclude { include, .. } => Some(include.clone()),
                         },
                         skip_if: match &condition {
                             Condition::Skip(var_name) => Some(var_name.clone()),
                             Condition::Include(_) => None,
+                            Condition::SkipAndInclude { skip, .. } => Some(skip.clone()),
                         },
                         selections: selections_for_wrapper,
                     })
@@ -85,14 +87,14 @@ impl From<&FetchStepSelections<MultiTypeFetchStep>> for SelectionSet {
 }
 
 fn inline_fragment_condition(fragment: &InlineFragmentSelection) -> Option<Condition> {
-    // Return a condition:
     match (fragment.include_if.as_ref(), fragment.skip_if.as_ref()) {
-        // Either @include
+        (Some(include), Some(skip)) => Some(Condition::SkipAndInclude {
+            skip: skip.clone(),
+            include: include.clone(),
+        }),
         (Some(var_name), None) => Some(Condition::Include(var_name.clone())),
-        // or @skip
         (None, Some(var_name)) => Some(Condition::Skip(var_name.clone())),
-        // not when both are available
-        _ => None,
+        (None, None) => None,
     }
 }
 
@@ -329,6 +331,15 @@ impl FetchStepSelections<MultiTypeFetchStep> {
                         selections: prev,
                         skip_if: Some(var_name.clone()),
                         include_if: None,
+                    })];
+            }
+            Condition::SkipAndInclude { skip, include } => {
+                selection_set.items =
+                    vec![SelectionItem::InlineFragment(InlineFragmentSelection {
+                        type_condition: def_name.to_string(),
+                        selections: prev,
+                        skip_if: Some(skip.clone()),
+                        include_if: Some(include.clone()),
                     })];
             }
         }

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -68,16 +68,8 @@ impl From<&FetchStepSelections<MultiTypeFetchStep>> for SelectionSet {
 
                     SelectionItem::InlineFragment(InlineFragmentSelection {
                         type_condition: type_name.to_string(),
-                        include_if: match &condition {
-                            Condition::Include(var_name) => Some(var_name.clone()),
-                            Condition::Skip(_) => None,
-                            Condition::SkipAndInclude { include, .. } => Some(include.clone()),
-                        },
-                        skip_if: match &condition {
-                            Condition::Skip(var_name) => Some(var_name.clone()),
-                            Condition::Include(_) => None,
-                            Condition::SkipAndInclude { skip, .. } => Some(skip.clone()),
-                        },
+                        include_if: condition.to_include_if(),
+                        skip_if: condition.to_skip_if(),
                         selections: selections_for_wrapper,
                     })
                 })
@@ -87,15 +79,7 @@ impl From<&FetchStepSelections<MultiTypeFetchStep>> for SelectionSet {
 }
 
 fn inline_fragment_condition(fragment: &InlineFragmentSelection) -> Option<Condition> {
-    match (fragment.include_if.as_ref(), fragment.skip_if.as_ref()) {
-        (Some(include), Some(skip)) => Some(Condition::SkipAndInclude {
-            skip: skip.clone(),
-            include: include.clone(),
-        }),
-        (Some(var_name), None) => Some(Condition::Include(var_name.clone())),
-        (None, Some(var_name)) => Some(Condition::Skip(var_name.clone())),
-        (None, None) => None,
-    }
+    fragment.into()
 }
 
 /// Attempts to lift a common condition from the top-level inline fragments for

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -98,6 +98,13 @@ fn inline_fragment_condition(fragment: &InlineFragmentSelection) -> Option<Condi
     }
 }
 
+/// Attempts to lift a common condition from the top-level inline fragments for
+/// `type_name` into the wrapper `... on Type` fragment we build in `From`.
+///
+/// Lifting is valid when every top-level item is an inline fragment on the same
+/// type and they all share the same condition. That condition may be
+/// `@include`, `@skip`, or both directives together
+/// (`Condition::SkipAndInclude`).
 fn try_lift_condition(
     type_name: &str,
     selections: &SelectionSet,

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -602,6 +602,18 @@ impl PlanNode {
                     if_clause: None,
                     else_clause: Some(Box::new(node)),
                 }),
+                Condition::SkipAndInclude { skip, include } => {
+                    let include_node = PlanNode::Condition(ConditionNode {
+                        condition: include.clone(),
+                        if_clause: Some(Box::new(node)),
+                        else_clause: None,
+                    });
+                    PlanNode::Condition(ConditionNode {
+                        condition: skip.clone(),
+                        if_clause: None,
+                        else_clause: Some(Box::new(include_node)),
+                    })
+                }
             },
             None => node,
         }

--- a/lib/query-planner/src/tests/include_skip.rs
+++ b/lib/query-planner/src/tests/include_skip.rs
@@ -239,6 +239,166 @@ fn skip_basic_test() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn skip_and_include_field_condition_test() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query ($skip: Boolean = false, $include: Boolean = true) {
+          product {
+            price
+            neverCalledInclude @skip(if: $skip) @include(if: $include)
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/simple-include-skip.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          query ($include:Boolean=true,$skip:Boolean=false) {
+            product {
+              __typename
+              price
+              id
+              ... on Product @skip(if: $skip) @include(if: $include) {
+                price
+                __typename
+                id
+              }
+            }
+          }
+        },
+        Skip(if: $skip) {
+          Include(if: $include) {
+            Sequence {
+              Flatten(path: "product") {
+                Fetch(service: "b") {
+                  {
+                    ... on Product {
+                      __typename
+                      price
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Product {
+                      isExpensive
+                    }
+                  }
+                },
+              },
+              Flatten(path: "product") {
+                Fetch(service: "c") {
+                  {
+                    ... on Product {
+                      __typename
+                      isExpensive
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Product {
+                      neverCalledInclude
+                    }
+                  }
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn skip_and_include_fragment_condition_test() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query ($skip: Boolean = false, $include: Boolean = true) {
+          product {
+            price
+            ... on Product @skip(if: $skip) @include(if: $include) {
+              neverCalledInclude
+            }
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/simple-include-skip.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          query ($include:Boolean=true,$skip:Boolean=false) {
+            product {
+              price
+              ... on Product @skip(if: $skip) @include(if: $include) {
+                __typename
+                id
+                price
+              }
+            }
+          }
+        },
+        Skip(if: $skip) {
+          Include(if: $include) {
+            Sequence {
+              Flatten(path: "product|[Product]") {
+                Fetch(service: "b") {
+                  {
+                    ... on Product {
+                      __typename
+                      price
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Product {
+                      isExpensive
+                    }
+                  }
+                },
+              },
+              Flatten(path: "product|[Product]") {
+                Fetch(service: "c") {
+                  {
+                    ... on Product {
+                      __typename
+                      isExpensive
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Product {
+                      neverCalledInclude
+                    }
+                  }
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn include_at_root_fetch_test() -> Result<(), Box<dyn Error>> {
     init_logger();
     let document = parse_operation(


### PR DESCRIPTION
Fix query planner handling for combined `@skip` and `@include` conditions.

- Preserve both directives when converting inline fragment conditions into fetch step selections
- Build the expected nested condition nodes for combined skip/include execution paths
- Handle `SkipAndInclude` in selection matching, fetch-step rendering, and multi-type batch path hashing
- Add regression snapshot tests for field-level and fragment-level combined conditions

For example a query like this:

```graphql
query($skip: Boolean!, $include: Boolean!) {
  user {
    name @skip(if: $skip) @include(if: $include)
  }
}
```

Will now correctly generate a fetch step with an inline fragment that has both `@skip` and `@include` conditions, and the planner will properly evaluate the combined conditions when determining which selections to include in the execution plan.

- `@skip(if: $skip)` is true, the selection will be skipped regardless of the `@include` condition.
- `@include(if: $include)` is false, the selection will be skipped regardless of the `@skip` condition.
- Only if `@skip(if: $skip)` is false and `@include(if: $include)` is true, the selection will be included in the execution plan.