### PR TITLE
fix(node-addon): TypeScript types for `Subscription.primary`

### DIFF
--- a/.changeset/subscription-node.md
+++ b/.changeset/subscription-node.md
@@ -1,0 +1,6 @@
+---
+node-addon: patch
+---
+
+`Subscription` node's `primary` is `FetchNode` instead of `PlanNode` now, but the types were not compatible.
+This change updates the type of `Subscription.primary` to be `FetchNode` instead of `PlanNode`.

--- a/lib/node-addon/src/query-plan.d.ts
+++ b/lib/node-addon/src/query-plan.d.ts
@@ -50,7 +50,7 @@ export interface EntityBatchAlias {
 
 export interface SubscriptionNode {
   kind: "Subscription";
-  primary: PlanNode;
+  primary: FetchNode;
 }
 
 export type FetchNodePathSegment =


### PR DESCRIPTION
`Subscription` node's `primary` is `FetchNode` instead of `PlanNode` now, but the types were not compatible.
This change updates the type of `Subscription.primary` to be `FetchNode` instead of `PlanNode`.

Fixes https://github.com/graphql-hive/gateway/pull/2253/changes#diff-24a70983ec784fbc421e000030dbdec64676595d820e131c5edcb8255431d42dR1309