### PR TITLE
fix(node-addon): `Subscription.primary` type is `FetchNode`

### DIFF
--- a/.changeset/subscription-node.md
+++ b/.changeset/subscription-node.md
@@ -1,0 +1,5 @@
+---
+node-addon: patch
+---
+
+Fix `Subscription.primary` type to `FetchNode` instead of `PlanNode` in the distributed `index.d.ts` file.

--- a/lib/node-addon/dist/index.d.ts
+++ b/lib/node-addon/dist/index.d.ts
@@ -61,7 +61,7 @@ export interface EntityBatchAlias {
 
 export interface SubscriptionNode {
   kind: "Subscription";
-  primary: PlanNode;
+  primary: FetchNode;
 }
 
 export type FetchNodePathSegment =


### PR DESCRIPTION
Fix `Subscription.primary` type to `FetchNode` instead of `PlanNode` in the distributed `index.d.ts` file.
Because changing `query-plan.d.ts` wasn't enough :)