### PR TITLE
enhance(plugins): introduce `EarlyHTTPResponse` for a better API to return responses with headers

### DIFF
--- a/.changeset/expose-early-http-response.md
+++ b/.changeset/expose-early-http-response.md
@@ -1,0 +1,15 @@
+---
+hive-router-plan-executor: patch
+---
+
+Expose `EarlyHTTPResponse` instead of `PlanExecutionOutput` in the hooks that do not have internal fields like `response_headers_aggregator` etc, and it is easier to construct an HTTP response with a body, header map and status code.
+
+```rust
+payload.end_with_response(
+    EarlyHTTPResponse {
+        body,
+        headers,
+        status_code,
+    }
+);
+```

--- a/lib/executor/src/plugins/plugin_trait.rs
+++ b/lib/executor/src/plugins/plugin_trait.rs
@@ -456,10 +456,14 @@ impl From<EarlyHTTPResponse> for PlanExecutionOutput {
         } else {
             let mut entries: HashMap<HeaderName, (HeaderAggregationStrategy, Vec<HeaderValue>)> =
                 Default::default();
+            let mut last_name = None;
             for (name, value) in val.headers.into_iter() {
                 if let Some(name) = name {
+                    last_name = Some(name);
+                }
+                if let Some(name) = &last_name {
                     let aggregated_header = entries
-                        .entry(name)
+                        .entry(name.clone())
                         .or_insert_with(|| (HeaderAggregationStrategy::Append, Vec::new()));
                     aggregated_header.1.push(value);
                 }

--- a/lib/executor/src/plugins/plugin_trait.rs
+++ b/lib/executor/src/plugins/plugin_trait.rs
@@ -1,4 +1,6 @@
 use crate::{
+    execution::plan::PlanExecutionOutput,
+    headers::plan::{HeaderAggregationStrategy, ResponseHeaderAggregator},
     hooks::{
         on_execute::{OnExecuteStartHookPayload, OnExecuteStartHookResult},
         on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult},
@@ -20,6 +22,8 @@ use crate::{
     },
     response::graphql_error::GraphQLError,
 };
+use ahash::HashMap;
+use http::{HeaderName, HeaderValue};
 use serde::de::DeserializeOwned;
 use sonic_rs::json;
 
@@ -65,13 +69,13 @@ where
     }
 
     /// End the hook execution and return a response to the client immediately, skipping the rest of the execution flow.
-    fn end_with_response<'exec>(
+    fn end_with_response<'exec, TResponseInput: Into<TResponse>>(
         self,
-        output: TResponse,
+        output: TResponseInput,
     ) -> StartHookResult<'exec, Self, TEndPayload, TResponse> {
         StartHookResult {
             payload: self,
-            control_flow: StartControlFlow::EndWithResponse(output),
+            control_flow: StartControlFlow::EndWithResponse(output.into()),
         }
     }
 
@@ -164,10 +168,13 @@ where
     }
 
     /// End the hook execution and return a response to the client immediately, skipping the rest of the execution flow.
-    fn end_with_response(self, output: TResponse) -> EndHookResult<Self, TResponse> {
+    fn end_with_response<TResponseInput: Into<TResponse>>(
+        self,
+        output: TResponseInput,
+    ) -> EndHookResult<Self, TResponse> {
         EndHookResult {
             payload: self,
-            control_flow: EndControlFlow::EndWithResponse(output),
+            control_flow: EndControlFlow::EndWithResponse(output.into()),
         }
     }
 
@@ -433,4 +440,38 @@ pub type RouterPluginBoxed = Box<dyn DynRouterPlugin>;
 pub enum CacheHint {
     Hit,
     Miss,
+}
+
+#[derive(Default)]
+pub struct EarlyHTTPResponse {
+    pub body: Vec<u8>,
+    pub headers: http::HeaderMap,
+    pub status_code: http::StatusCode,
+}
+
+impl From<EarlyHTTPResponse> for PlanExecutionOutput {
+    fn from(val: EarlyHTTPResponse) -> Self {
+        let response_headers_aggregator = if val.headers.is_empty() {
+            None
+        } else {
+            let mut entries: HashMap<HeaderName, (HeaderAggregationStrategy, Vec<HeaderValue>)> =
+                Default::default();
+            for (name, value) in val.headers.into_iter() {
+                if let Some(name) = name {
+                    let aggregated_header = entries
+                        .entry(name)
+                        .or_insert_with(|| (HeaderAggregationStrategy::Append, Vec::new()));
+                    aggregated_header.1.push(value);
+                }
+            }
+
+            Some(ResponseHeaderAggregator { entries })
+        };
+        PlanExecutionOutput {
+            body: val.body,
+            response_headers_aggregator,
+            error_count: 0,
+            status_code: val.status_code,
+        }
+    }
 }

--- a/plugin_examples/response_cache/src/lib.rs
+++ b/plugin_examples/response_cache/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use hive_router::http::StatusCode;
+use hive_router::http::HeaderMap;
 use hive_router::plugins::hooks::on_execute::{
     OnExecuteEndHookPayload, OnExecuteStartHookPayload, OnExecuteStartHookResult,
 };
@@ -8,9 +8,11 @@ use hive_router::plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginI
 use hive_router::plugins::hooks::on_supergraph_load::{
     OnSupergraphLoadStartHookPayload, OnSupergraphLoadStartHookResult,
 };
-use hive_router::plugins::plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload};
+use hive_router::plugins::plugin_trait::{
+    EarlyHTTPResponse, EndHookPayload, RouterPlugin, StartHookPayload,
+};
 use hive_router::ArcSwap;
-use hive_router::{async_trait, graphql_tools, sonic_rs, PlanExecutionOutput};
+use hive_router::{async_trait, graphql_tools, sonic_rs};
 use redis::Commands;
 use serde::Deserialize;
 
@@ -70,11 +72,12 @@ impl RouterPlugin for ResponseCachePlugin {
                             key,
                             String::from_utf8_lossy(&body)
                         );
-                        return payload.end_with_response(PlanExecutionOutput {
+                        let mut headers = HeaderMap::new();
+                        headers.insert("X-Cache-Status", "HIT".parse().unwrap());
+                        return payload.end_with_response(EarlyHTTPResponse {
                             body,
-                            error_count: 0,
-                            response_headers_aggregator: None,
-                            status_code: StatusCode::OK,
+                            headers,
+                            ..Default::default()
                         });
                     }
                 }

--- a/plugin_examples/response_cache/src/lib.rs
+++ b/plugin_examples/response_cache/src/lib.rs
@@ -73,7 +73,7 @@ impl RouterPlugin for ResponseCachePlugin {
                             String::from_utf8_lossy(&body)
                         );
                         let mut headers = HeaderMap::new();
-                        headers.insert("X-Cache-Status", "HIT".parse().unwrap());
+                        headers.insert("X-Cache-Status", "HIT".parse().expect("X-Cache-Status and HIT are valid header name and value"));
                         return payload.end_with_response(EarlyHTTPResponse {
                             body,
                             headers,

--- a/plugin_examples/response_cache/src/lib.rs
+++ b/plugin_examples/response_cache/src/lib.rs
@@ -73,7 +73,12 @@ impl RouterPlugin for ResponseCachePlugin {
                             String::from_utf8_lossy(&body)
                         );
                         let mut headers = HeaderMap::new();
-                        headers.insert("X-Cache-Status", "HIT".parse().expect("X-Cache-Status and HIT are valid header name and value"));
+                        headers.insert(
+                            "X-Cache-Status",
+                            "HIT"
+                                .parse()
+                                .expect("X-Cache-Status and HIT are valid header name and value"),
+                        );
                         return payload.end_with_response(EarlyHTTPResponse {
                             body,
                             headers,


### PR DESCRIPTION
It is not a breaking change as `PlanExecutionOutput` is still the main "response" type of `on_query_plan` and `on_execute`.

- `end_with_response` now accepts any type that can be converted to `PlanExecutionOutput`, so `EarlyHTTPResponse` is one of them.
- `EarlyHTTPResponse` takes `headers` directly instead of aggregator, so plugins can send headers as `HeaderMap` directly

```rust
payload.end_with_response(
    EarlyHTTPResponse {
        body,
        headers,
        status_code,
    }
);
```