### PR TITLE
Add GraphiQL feature flag

### DIFF
--- a/.changeset/graphiql_feature_flag.md
+++ b/.changeset/graphiql_feature_flag.md
@@ -1,0 +1,12 @@
+---
+hive-router: patch
+---
+
+Adds an optional `graphiql` Cargo feature for `hive-router`.
+When enabled, the Router serves GraphiQL HTML and skips Laboratory asset generation so `npm` and `node` dependencies are not needed.
+By default, this feature is disabled and existing Laboratory behavior is unchanged.
+
+```bash
+cargo run -p hive-router --features graphiql
+cargo build -p hive-router --features graphiql
+```

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 [features]
 noop_otlp_exporter = ["hive-router-internal/noop_otlp_exporter"]
 testing = []
+graphiql = []
 
 [dependencies]
 hive-router-query-planner = { path = "../../lib/query-planner", version = "2.7.0" }

--- a/bin/router/build.rs
+++ b/bin/router/build.rs
@@ -5,6 +5,11 @@ use std::{
 };
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_GRAPHIQL");
+    if env::var_os("CARGO_FEATURE_GRAPHIQL").is_some() {
+        return;
+    }
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("missing OUT_DIR"));
     let output_file = out_dir.join("laboratory.html");

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -80,9 +80,7 @@ use tracing::{info, warn, Instrument};
 #[cfg(not(feature = "graphiql"))]
 static LABORATORY_HTML: &str = include_str!(concat!(env!("OUT_DIR"), "/laboratory.html"));
 #[cfg(feature = "graphiql")]
-static GRAPHIQL_HTML: &str = include_str!("../static/graphiql.html");
-#[cfg(feature = "graphiql")]
-static LABORATORY_HTML: &str = GRAPHIQL_HTML;
+static LABORATORY_HTML: &str = include_str!("../static/graphiql.html");
 
 struct CallbackServer(std::sync::Mutex<Option<ntex::server::Server>>);
 

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -77,7 +77,12 @@ pub use tokio;
 pub use tracing;
 use tracing::{info, warn, Instrument};
 
+#[cfg(not(feature = "graphiql"))]
 static LABORATORY_HTML: &str = include_str!(concat!(env!("OUT_DIR"), "/laboratory.html"));
+#[cfg(feature = "graphiql")]
+static GRAPHIQL_HTML: &str = include_str!("../static/graphiql.html");
+#[cfg(feature = "graphiql")]
+static LABORATORY_HTML: &str = GRAPHIQL_HTML;
 
 struct CallbackServer(std::sync::Mutex<Option<ntex::server::Server>>);
 

--- a/bin/router/static/graphiql.html
+++ b/bin/router/static/graphiql.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hive Router GraphiQL</title>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="https://the-guild.dev/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://the-guild.dev/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="https://the-guild.dev/favicon-16x16.png"
+    />
+    <link
+      rel="shortcut icon"
+      type="image/x-icon"
+      href="https://the-guild.dev/favicon.ico"
+    />
+    <link
+      crossorigin
+      rel="stylesheet"
+      href="https://unpkg.com/@graphql-yoga/graphiql/dist/graphiql.css"
+    />
+  </head>
+  <body id="body" class="no-focus-outline">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root">Loading GraphiQL...</div>
+    <script>
+      function prepareBlob(workerContent) {
+        const blob = new Blob([workerContent], {
+          type: "application/javascript",
+        });
+        return URL.createObjectURL(blob);
+      }
+      const workers = {};
+      const workerUrls = {
+        editorWorkerService:
+          "https://unpkg.com/@graphql-yoga/graphiql/dist/monacoeditorwork/editor.worker.bundle.js",
+        json: "https://unpkg.com/@graphql-yoga/graphiql/dist/monacoeditorwork/json.worker.bundle.js",
+        graphql:
+          "https://unpkg.com/@graphql-yoga/graphiql/dist/monacoeditorwork/graphql.worker..bundle.js",
+      };
+      function prepareWorkers() {
+        return Promise.all(
+          Object.entries(workerUrls).map(async ([label, url]) => {
+            const res = await fetch(url);
+            const text = await res.text();
+            workers[label] = prepareBlob(text);
+          }),
+        );
+      }
+      self["MonacoEnvironment"] = {
+        globalAPI: false,
+        getWorkerUrl: function (moduleId, label) {
+          return workers[label];
+        },
+      };
+    </script>
+    <script src="https://unpkg.com/@graphql-yoga/graphiql/dist/yoga-graphiql.umd.js"></script>
+    <script>
+      prepareWorkers().finally(() => {
+        YogaGraphiQL.renderYogaGraphiQL(root, {
+          title: "Hive Router GraphiQL",
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds an optional `graphiql` Cargo feature for `hive-router`. When enabled, the Router serves GraphiQL HTML and skips Laboratory asset generation so `npm` and `node` dependencies are not needed. By default, this feature is disabled and existing Laboratory behavior is unchanged.

```bash
cargo run -p hive-router --features graphiql
cargo build -p hive-router --features graphiql
```