### PR TITLE
fix(query-planner): avoid propagating @include/@skip conditions to unconditional fetches

### DIFF
--- a/.changeset/avoid-include-skip-condition-propagation.md
+++ b/.changeset/avoid-include-skip-condition-propagation.md
@@ -1,0 +1,12 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Avoid propagating @include/@skip conditions to unconditional fetches
+
+Fixed query planner condition propagation logic to avoid wrapping unconditional fetches
+in conditional blocks when merging steps. This ensures that fields without directives are
+not incorrectly gated by conditions from other steps, allowing for correct execution of
+queries with mixed conditional and unconditional selections.

--- a/lib/query-planner/fixture/tests/simple-include-skip.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/simple-include-skip.supergraph.graphql
@@ -78,6 +78,8 @@ type Product
   skip: Boolean! @join__field(graph: C, requires: "isExpensive")
   neverCalledInclude: Boolean! @join__field(graph: C, requires: "isExpensive")
   neverCalledSkip: Boolean! @join__field(graph: C, requires: "isExpensive")
+  name: String! @join__field(graph: B, requires: "price")
+  isCheap: Boolean! @join__field(graph: B, requires: "price")
 }
 
 type Query @join__type(graph: A) @join__type(graph: B) @join__type(graph: C) {

--- a/lib/query-planner/src/planner/fetch/optimize/utils.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/utils.rs
@@ -143,8 +143,16 @@ fn preserve_or_scope_source_condition_for_entity_target(
         return;
     }
 
-    // If type scope is unclear, keep condition at target step level.
-    target.condition = Some(condition);
+    if target.condition.as_ref() == Some(&condition) {
+        // Both have the same condition, safe to keep at the step level.
+        // We re-set it on the target as it was taken from the source.
+        target.condition = Some(condition);
+    } else {
+        // If target is unconditional, or has a different condition, we cannot
+        // apply the source's condition at the step level. Instead, we wrap only
+        // the source's output selections with its condition.
+        source.output.wrap_with_condition(condition);
+    }
 }
 
 // Return true in case an alias was applied during the merge process.

--- a/lib/query-planner/src/tests/include_skip.rs
+++ b/lib/query-planner/src/tests/include_skip.rs
@@ -757,3 +757,125 @@ fn plans_query_with_field_level_include_skip_conditions() -> Result<(), Box<dyn 
 
     Ok(())
 }
+
+#[test]
+fn qp_include_field_level() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query ($bool: Boolean) {
+          product {
+            price # graph A
+            name @include(if: $bool) # graph B
+            isCheap # graph B
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/simple-include-skip.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          query ($bool:Boolean) {
+            product {
+              __typename
+              price
+              id
+              ... on Product @include(if: $bool) {
+                price
+                __typename
+                id
+              }
+            }
+          }
+        },
+        Flatten(path: "product") {
+          Fetch(service: "b") {
+            {
+              ... on Product {
+                __typename
+                price
+                id
+              }
+            } =>
+            ($bool:Boolean) {
+              ... on Product {
+                isCheap
+                ... on Product @include(if: $bool) {
+                  name
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+    Ok(())
+}
+
+#[test]
+fn qp_skip_field_level() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query ($bool: Boolean) {
+          product {
+            price # graph A
+            name @skip(if: $bool) # graph B
+            isCheap # graph B
+          }
+        }
+      "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/simple-include-skip.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          query ($bool:Boolean) {
+            product {
+              __typename
+              price
+              id
+              ... on Product @skip(if: $bool) {
+                price
+                __typename
+                id
+              }
+            }
+          }
+        },
+        Flatten(path: "product") {
+          Fetch(service: "b") {
+            {
+              ... on Product {
+                __typename
+                price
+                id
+              }
+            } =>
+            ($bool:Boolean) {
+              ... on Product {
+                isCheap
+                ... on Product @skip(if: $bool) {
+                  name
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+    Ok(())
+}


### PR DESCRIPTION
# Query Planner Fix: Include/Skip Condition Propagation

Closes: https://github.com/graphql-hive/router/issues/949

## Problem

The query planner could incorrectly propagate `@include`/`@skip` conditions across merged fetch steps.
In mixed conditional and unconditional selections, unconditional fields could be wrapped by condition nodes and skipped at runtime.

### Example:

Given an operation like:
```graphql
query ($bool: Boolean) {
  product { # Resolved from Graph "A"
    price # Resolved from Graph "A"
    name @include(if: $bool) # Resolved in Graph "B"
    isCheap # Resolved in Graph "B"
  }
}
```

The Query Planner Generates:
```
Sequence
  Fetch(service: "a") { ... }
  Include(if: $bool) {  - - - - -> Wraps the whole fetch to service B around Include directive
    Flatten(path: "product") {
      Fetch(service: "b") {
        ... on Product { isCheap name }
      }
    }
  }
```

**Problem**: if $bool = false, the entire Include block is skipped, so `isCheap` which is unconditional is incorrectly skipped.
 
## Root Cause

During fetch step merge, condition propagation was preserved at the step level in cases where type scoping was unclear.
That allowed a condition from a conditional source selection to gate unconditional target selections.

## Fix

Updated query planner condition propagation logic so unconditional fetches are not wrapped in conditional blocks when merging steps.
Conditions are scoped to the relevant source output selections instead of being applied to the whole merged fetch step.
This keeps fields without directives from being incorrectly gated by conditions from other steps.

After the fix the query planner generates:
```
    QueryPlan {
      Sequence {
        Fetch(service: "a") {
          query ($bool:Boolean) {
            product {
              __typename
              price
              id
              ... on Product @include(if: $bool) {
                price
                __typename
                id
              }
            }
          }
        },
        Flatten(path: "product") {
          Fetch(service: "b") {
            {
              ... on Product {
                __typename
                price
                id
              }
            } =>
            ($bool:Boolean) {
              ... on Product {
                isCheap
                ... on Product @include(if: $bool) {
                  name
                }
              }
            }
          },
        },
      },
    },
```