### PR TITLE
fix fragment spread normalization across field boundaries and preserve spread directives

### DIFF
--- a/.changeset/norm_fix.md
+++ b/.changeset/norm_fix.md
@@ -1,0 +1,10 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Fix fragment handling
+
+Fix fragment handling for some queries that use reusable fragments with conditional directives

--- a/lib/query-planner/fixture/issues/939.supergraph.graphql
+++ b/lib/query-planner/fixture/issues/939.supergraph.graphql
@@ -1,0 +1,109 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+scalar join__FieldSet
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+enum join__Graph {
+  CONTENT @join__graph(name: "content", url: "")
+}
+
+type Query @join__type(graph: CONTENT) {
+  node(id: ID!): INode
+}
+
+type MyNode implements INode
+  @join__type(graph: CONTENT)
+  @join__implements(graph: CONTENT, interface: "INode") {
+  id: ID!
+  content: Content
+}
+
+type TextContent implements ITextContent
+  @join__type(graph: CONTENT)
+  @join__implements(graph: CONTENT, interface: "ITextContent") {
+  id: ID!
+  fragments: [TextContentFragment!]!
+}
+
+type TextGroupContent implements ITextContent
+  @join__type(graph: CONTENT)
+  @join__implements(graph: CONTENT, interface: "ITextContent") {
+  id: ID!
+  fragments: [TextContentFragment!]!
+}
+
+type TextContentFragment @join__type(graph: CONTENT) {
+  contentNode: MyNode!
+}
+
+interface INode @join__type(graph: CONTENT) {
+  id: ID!
+}
+
+interface ITextContent @join__type(graph: CONTENT) {
+  id: ID!
+  fragments: [TextContentFragment!]!
+}
+
+union Content
+  @join__type(graph: CONTENT)
+  @join__unionMember(graph: CONTENT, member: "TextContent")
+  @join__unionMember(graph: CONTENT, member: "TextGroupContent") =
+  | TextContent
+  | TextGroupContent

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -1407,4 +1407,492 @@ mod tests {
         "
         );
     }
+
+    #[test]
+    fn fragment_spread_on_interface_across_field_boundary_preserves_type_context() {
+        let schema_str = std::fs::read_to_string("./fixture/issues/939.supergraph.graphql")
+            .expect("Unable to read supergraph");
+        let schema = parse_schema(&schema_str);
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query SingleNode($id: ID!) {
+                          node(id: $id) {
+                            ... on MyNode {
+                              content {
+                                ... on ITextContent {
+                                  fragments {
+                                    contentNode {
+                                      content {
+                                        ...ITextContentPreview
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+
+                        fragment ITextContentPreview on ITextContent {
+                          id
+                        }
+                      "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query SingleNode($id: ID!) {
+          node(id: $id) {
+            ... on MyNode {
+              content {
+                ... on TextContent {
+                  fragments {
+                    contentNode {
+                      content {
+                        ... on TextContent {
+                          id
+                        }
+                        ... on TextGroupContent {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+                ... on TextGroupContent {
+                  fragments {
+                    contentNode {
+                      content {
+                        ... on TextContent {
+                          id
+                        }
+                        ... on TextGroupContent {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn same_type_fragment_spread_directives_are_preserved() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              account: Account
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Account implements Node {
+              id: ID!
+              name: String!
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query($cond: Boolean!) {
+                          account {
+                            ...AccountFields @include(if: $cond)
+                          }
+                        }
+
+                        fragment AccountFields on Account {
+                          name
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query($cond: Boolean!) {
+          account {
+            ... on Account @include(if: $cond) {
+              name
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn same_type_fragment_spread_skip_is_preserved() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              account: Account
+            }
+
+            type Account {
+              id: ID!
+              name: String!
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query($cond: Boolean!) {
+                          account {
+                            ...AccountFields @skip(if: $cond)
+                          }
+                        }
+
+                        fragment AccountFields on Account {
+                          name
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query($cond: Boolean!) {
+          account {
+            ... on Account @skip(if: $cond) {
+              name
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn same_type_fragment_spread_include_and_skip_are_preserved() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              account: Account
+            }
+
+            type Account {
+              id: ID!
+              name: String!
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query($include: Boolean!, $skip: Boolean!) {
+                          account {
+                            ...AccountFields @include(if: $include) @skip(if: $skip)
+                          }
+                        }
+
+                        fragment AccountFields on Account {
+                          name
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query($include: Boolean!, $skip: Boolean!) {
+          account {
+            ... on Account @skip(if: $skip) @include(if: $include) {
+              name
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn outer_same_type_fragment_spread_directive_is_preserved_through_nested_spreads() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              account: Account
+            }
+
+            type Account {
+              id: ID!
+              name: String!
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query($cond: Boolean!) {
+                          account {
+                            ...AccountFields1 @include(if: $cond)
+                          }
+                        }
+
+                        fragment AccountFields1 on Account {
+                          ...AccountFields2
+                        }
+
+                        fragment AccountFields2 on Account {
+                          name
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query($cond: Boolean!) {
+          account {
+            ... on Account @include(if: $cond) {
+              name
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn inner_same_type_fragment_spread_directive_is_preserved_through_nested_spreads() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              account: Account
+            }
+
+            type Account {
+              id: ID!
+              name: String!
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query($cond: Boolean!) {
+                          account {
+                            ...AccountFields1
+                          }
+                        }
+
+                        fragment AccountFields1 on Account {
+                          ...AccountFields2 @include(if: $cond)
+                        }
+
+                        fragment AccountFields2 on Account {
+                          name
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query($cond: Boolean!) {
+          account {
+            ... on Account @include(if: $cond) {
+              name
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn field_boundary_fragment_spread_include_is_preserved() {
+        let schema_str = std::fs::read_to_string("./fixture/issues/939.supergraph.graphql")
+            .expect("Unable to read supergraph");
+        let schema = parse_schema(&schema_str);
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query SingleNode($cond: Boolean!, $id: ID!) {
+                          node(id: $id) {
+                            ... on MyNode {
+                              content {
+                                ... on ITextContent {
+                                  fragments {
+                                    contentNode {
+                                      content {
+                                        ...ITextContentPreview @include(if: $cond)
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+
+                        fragment ITextContentPreview on ITextContent {
+                          id
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query SingleNode($cond: Boolean!, $id: ID!) {
+          node(id: $id) {
+            ... on MyNode {
+              content {
+                ... on TextContent {
+                  fragments {
+                    contentNode {
+                      content {
+                        ... on TextContent @include(if: $cond) {
+                          id
+                        }
+                        ... on TextGroupContent @include(if: $cond) {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+                ... on TextGroupContent {
+                  fragments {
+                    contentNode {
+                      content {
+                        ... on TextContent @include(if: $cond) {
+                          id
+                        }
+                        ... on TextGroupContent @include(if: $cond) {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn reusable_fragment_with_mixed_include_conditions_stays_separate() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              account: Account
+            }
+
+            type Account {
+              id: ID!
+              name: String!
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        insta::assert_snapshot!(
+            pretty_query(
+                normalize_operation(
+                    &supergraph,
+                    &parse_query(
+                        r#"
+                        query($first: Boolean!, $second: Boolean!) {
+                          account {
+                            ...AccountFields @include(if: $first)
+                            ...AccountFields @include(if: $second)
+                          }
+                        }
+
+                        fragment AccountFields on Account {
+                          name
+                        }
+                        "#,
+                    )
+                    .expect("to parse"),
+                    None,
+                )
+                .expect("to normalize")
+                .to_string()
+            ),
+            @r#"
+        query($first: Boolean!, $second: Boolean!) {
+          account {
+            ... on Account @include(if: $first) {
+              name
+            }
+            ... on Account @include(if: $second) {
+              name
+            }
+          }
+        }
+        "#
+        );
+    }
 }

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -60,7 +60,8 @@ fn handle_selection_set<'a>(
                 handle_selection_set(
                     &mut field.selection_set,
                     fragment_map,
-                    parent_type_condition,
+                    // Crossing a field boundary changes the parent type to the field's return type
+                    None,
                 )?;
                 new_items.push(Selection::Field(field));
             }
@@ -71,7 +72,12 @@ fn handle_selection_set<'a>(
                     }
                 })?;
 
-                if parent_type_condition == Some(&fragment_def.type_condition) {
+                if parent_type_condition == Some(&fragment_def.type_condition)
+                    // `...Frag @include(...)` stores `@include` on the spread itself.
+                    // In the code below, we inline the fragment's selections,
+                    // so any directives would be lost.
+                    && spread.directives.is_empty()
+                {
                     // If the fragment's type condition matches the top type condition,
                     // we can inline its selections directly.
                     let mut selection_set = fragment_def.selection_set.clone();

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -60,7 +60,7 @@ fn handle_selection_set<'a>(
                 handle_selection_set(
                     &mut field.selection_set,
                     fragment_map,
-                    // Crossing a field boundary changes the parent type to the field's return type
+                    // Crossing a field boundary resets the type condition context
                     None,
                 )?;
                 new_items.push(Selection::Field(field));

--- a/lib/query-planner/src/tests/fragments.rs
+++ b/lib/query-planner/src/tests/fragments.rs
@@ -231,7 +231,8 @@ fn parent_directive_only_on_abstract_fragment() -> Result<(), Box<dyn Error>> {
 /// Reusing the same named fragment with different `@include` conditions on the same
 /// concrete parent must preserve both conditions as separate wrappers.
 #[test]
-fn reusable_fragment_with_mixed_include_conditions_on_concrete_parent() -> Result<(), Box<dyn Error>> {
+fn reusable_fragment_with_mixed_include_conditions_on_concrete_parent() -> Result<(), Box<dyn Error>>
+{
     init_logger();
     let document = parse_operation(
         r#"
@@ -278,7 +279,8 @@ fn reusable_fragment_with_mixed_include_conditions_on_concrete_parent() -> Resul
 /// Reusing the same named fragment with different `@include` conditions under an
 /// abstract parent must keep both conditions through type expansion.
 #[test]
-fn reusable_fragment_with_mixed_include_conditions_on_abstract_parent() -> Result<(), Box<dyn Error>> {
+fn reusable_fragment_with_mixed_include_conditions_on_abstract_parent() -> Result<(), Box<dyn Error>>
+{
     init_logger();
     let document = parse_operation(
         r#"

--- a/lib/query-planner/src/tests/fragments.rs
+++ b/lib/query-planner/src/tests/fragments.rs
@@ -228,6 +228,102 @@ fn parent_directive_only_on_abstract_fragment() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Reusing the same named fragment with different `@include` conditions on the same
+/// concrete parent must preserve both conditions as separate wrappers.
+#[test]
+fn reusable_fragment_with_mixed_include_conditions_on_concrete_parent() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query ($first: Boolean!, $second: Boolean!) {
+          account(id: "a1") {
+            ...AccountFields @include(if: $first)
+            ...AccountFields @include(if: $second)
+          }
+        }
+
+        fragment AccountFields on Account {
+          username
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        query ($first:Boolean!,$second:Boolean!) {
+          account(id: "a1") {
+            ... on Account @include(if: $first) {
+              ...a
+            }
+            ... on Account @include(if: $second) {
+              ...a
+            }
+          }
+        }
+        fragment a on Account {
+          username
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+/// Reusing the same named fragment with different `@include` conditions under an
+/// abstract parent must keep both conditions through type expansion.
+#[test]
+fn reusable_fragment_with_mixed_include_conditions_on_abstract_parent() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query ($first: Boolean!, $second: Boolean!) {
+          account(id: "a1") {
+            ... on Node {
+              ...AccountFields @include(if: $first)
+              ...AccountFields @include(if: $second)
+            }
+          }
+        }
+
+        fragment AccountFields on Account {
+          username
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        query ($first:Boolean!,$second:Boolean!) {
+          account(id: "a1") {
+            ... on Account @include(if: $first) {
+              ...a
+            }
+            ... on Account @include(if: $second) {
+              ...a
+            }
+          }
+        }
+        fragment a on Account {
+          username
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
 #[test]
 fn simple_inline_fragment() -> Result<(), Box<dyn Error>> {
     init_logger();

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -258,3 +258,113 @@ fn issue_190_test() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn issue_939_test() -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let named_fragment_document = parse_operation(
+        r#"
+        query SingleNode($id: ID!) {
+          node(id: $id) {
+            ... on MyNode {
+              content {
+                ... on ITextContent {
+                  fragments {
+                    contentNode {
+                      content {
+                        ...ITextContentPreview
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        fragment ITextContentPreview on ITextContent {
+          id
+        }
+        "#,
+    );
+    let named_fragment_plan = build_query_plan(
+        "fixture/issues/939.supergraph.graphql",
+        named_fragment_document,
+    )?;
+
+    let inline_fragment_document = parse_operation(
+        r#"
+        query SingleNode($id: ID!) {
+          node(id: $id) {
+            ... on MyNode {
+              content {
+                ... on ITextContent {
+                  fragments {
+                    contentNode {
+                      content {
+                        ... on ITextContent {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let inline_fragment_plan = build_query_plan(
+        "fixture/issues/939.supergraph.graphql",
+        inline_fragment_document,
+    )?;
+
+    assert_eq!(
+        format!("{}", named_fragment_plan),
+        format!("{}", inline_fragment_plan)
+    );
+
+    insta::assert_snapshot!(format!("{}", inline_fragment_plan), @r#"
+    QueryPlan {
+      Fetch(service: "content") {
+        query ($id:ID!) {
+          node(id: $id) {
+            __typename
+            ... on MyNode {
+              content {
+                __typename
+                ... on TextContent {
+                  fragments {
+                    ...a
+                  }
+                }
+                ... on TextGroupContent {
+                  fragments {
+                    ...a
+                  }
+                }
+              }
+            }
+          }
+        }
+        fragment a on TextContentFragment {
+          contentNode {
+            content {
+              __typename
+              ... on TextContent {
+                id
+              }
+              ... on TextGroupContent {
+                id
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #939

Fixes query normalization for fragment spreads and preserves `@include` and `@skip` directives on fragment spreads.