### PR TITLE
fix: deserialize escaped keys in custom scalar object values

### DIFF
--- a/.changeset/escaped-scalar-keys.md
+++ b/.changeset/escaped-scalar-keys.md
@@ -1,0 +1,8 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+#  Fix subgraph response deserialization for custom scalar object
+
+Values whose JSON keys contain escaped characters such as `\t` are now deserialized correctly.

--- a/.changeset/raw_json_for_custom_scalars.md
+++ b/.changeset/raw_json_for_custom_scalars.md
@@ -1,0 +1,10 @@
+---
+hive-router-plan-executor: patch
+hive-router-query-planner: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Preserve custom scalars as raw JSON
+
+Custom scalar fields marked by the query planner are now preserved as raw JSON instead of being parsed and rebuilt as structured response values. This improves correctness for JSON passthrough custom scalars while avoiding performance regressions for normal response handling.

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -202,4 +202,60 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/966
+    async fn issue_966_custom_scalar_with_escaped_object_key() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.966.graphql
+                  query_planner:
+                    allow_expose: true
+                  override_subgraph_urls:
+                    labels:
+                      url: "http://{host}/labels"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let labels_mock = server
+            .mock("POST", "/labels")
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "labels": {
+                      "generic.learnMore.button\t": "Learn more"
+                    }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router.send_graphql_request("{ labels }", None, None).await;
+
+        labels_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "labels": {
+              "generic.learnMore.button\t": "Learn more"
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod issues_e2e_tests {
-    use crate::testkit::{ClientResponseExt, TestRouter};
+    use crate::testkit::{ClientResponseExt, Started, TestRouter};
 
     #[ntex::test]
     /// https://github.com/graphql-hive/router/issues/880
@@ -203,13 +203,8 @@ mod issues_e2e_tests {
         "#);
     }
 
-    #[ntex::test]
-    /// https://github.com/graphql-hive/router/issues/966
-    async fn issue_966_custom_scalar_with_escaped_object_key() {
-        let mut server = mockito::Server::new_async().await;
-        let host = server.host_with_port();
-
-        let router = TestRouter::builder()
+    async fn build_issue_966_router(host: &str) -> TestRouter<Started> {
+        TestRouter::builder()
             .inline_config(format!(
                 r#"
                   supergraph:
@@ -220,14 +215,37 @@ mod issues_e2e_tests {
                   override_subgraph_urls:
                     labels:
                       url: "http://{host}/labels"
+                    products:
+                      url: "http://{host}/products"
                   "#
             ))
             .build()
             .start()
-            .await;
+            .await
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/966
+    async fn issue_966_custom_scalar_root_and_abstract_paths() {
+        let mut server = mockito::Server::new_async().await;
+        let router = build_issue_966_router(&server.host_with_port()).await;
 
         let labels_mock = server
             .mock("POST", "/labels")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("labels")
+                    && body_str.contains("labelsArray")
+                    && body_str.contains("labelsText")
+                    && body_str.contains("labelsNumber")
+                    && body_str.contains("labelsBool")
+                    && body_str.contains("labelsNull")
+                    && body_str.contains("abstractThing")
+                    && body_str.contains("abstractThings")
+                    && body_str.contains("catalog")
+            })
             .expect(1)
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -237,6 +255,65 @@ mod issues_e2e_tests {
                   "data": {
                     "labels": {
                       "generic.learnMore.button\t": "Learn more"
+                    },
+                    "renamed": {
+                      "generic.learnMore.button\t": "Learn more"
+                    },
+                    "labelsArray": [
+                      "one",
+                      {
+                        "generic.learnMore.button\t": "Learn more"
+                      },
+                      1,
+                      true,
+                      null
+                    ],
+                    "labelsText": "plain text",
+                    "labelsNumber": 42,
+                    "labelsBool": true,
+                    "labelsNull": null,
+                    "catalog": {
+                      "metadata": {
+                        "nested.key\t": "nested value"
+                      },
+                      "renamedMetadata": {
+                        "nested.key\t": "nested value"
+                      },
+                      "metadataList": [
+                        {
+                          "list.key\t": "list value"
+                        },
+                        [
+                          "x",
+                          {
+                            "deep.key\t": "deep value"
+                          }
+                        ]
+                      ]
+                    },
+                    "abstractThing": {
+                      "__typename": "LabeledThing",
+                      "metadata": {
+                        "abstract.inline\t": "inline value"
+                      }
+                    },
+                    "abstractThings": [
+                      {
+                        "__typename": "LabeledThing",
+                        "metadata": {
+                          "abstract.list\t": "first"
+                        }
+                      },
+                      {
+                        "__typename": "PlainThing"
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "raw": {
+                        "shouldStayStructured": true
+                      }
                     }
                   }
                 }
@@ -244,7 +321,42 @@ mod issues_e2e_tests {
             )
             .create();
 
-        let res = router.send_graphql_request("{ labels }", None, None).await;
+        let res = router
+            .send_graphql_request(
+                r#"
+                {
+                  labels
+                  renamed: labels
+                  labelsArray
+                  labelsText
+                  labelsNumber
+                  labelsBool
+                  labelsNull
+                  abstractThing {
+                    __typename
+                    ...AbstractMetadata
+                  }
+                  abstractThings {
+                    __typename
+                    ... on LabeledThing {
+                      metadata
+                    }
+                  }
+                  catalog {
+                    metadata
+                    renamedMetadata: metadata
+                    metadataList
+                  }
+                }
+
+                fragment AbstractMetadata on LabeledThing {
+                  metadata
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
 
         labels_mock.assert();
 
@@ -253,6 +365,447 @@ mod issues_e2e_tests {
           "data": {
             "labels": {
               "generic.learnMore.button\t": "Learn more"
+            },
+            "renamed": {
+              "generic.learnMore.button\t": "Learn more"
+            },
+            "labelsArray": [
+              "one",
+              {
+                "generic.learnMore.button\t": "Learn more"
+              },
+              1,
+              true,
+              null
+            ],
+            "labelsText": "plain text",
+            "labelsNumber": 42,
+            "labelsBool": true,
+            "labelsNull": null,
+            "abstractThing": {
+              "__typename": "LabeledThing",
+              "metadata": {
+                "abstract.inline\t": "inline value"
+              }
+            },
+            "abstractThings": [
+              {
+                "__typename": "LabeledThing",
+                "metadata": {
+                  "abstract.list\t": "first"
+                }
+              },
+              {
+                "__typename": "PlainThing"
+              }
+            ],
+            "catalog": {
+              "metadata": {
+                "nested.key\t": "nested value"
+              },
+              "renamedMetadata": {
+                "nested.key\t": "nested value"
+              },
+              "metadataList": [
+                {
+                  "list.key\t": "list value"
+                },
+                [
+                  "x",
+                  {
+                    "deep.key\t": "deep value"
+                  }
+                ]
+              ]
+            }
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/966
+    async fn issue_966_custom_scalar_conditional_abstract_paths() {
+        let mut server = mockito::Server::new_async().await;
+        let router = build_issue_966_router(&server.host_with_port()).await;
+
+        let labels_abstract_conditional_mock = server
+            .mock("POST", "/labels")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("abstractThing")
+                    && body_str.contains("$include")
+                    && body_str.contains("$skip")
+            })
+            .expect(2)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "abstractThing": {
+                      "__typename": "LabeledThing",
+                      "metadata": {
+                        "conditional.field\t": "field value"
+                      },
+                      "gatedMetadata": {
+                        "conditional.fragment\t": "fragment value"
+                      }
+                    }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let included_res = router
+            .send_graphql_request(
+                r#"
+                query($include: Boolean!, $skip: Boolean!) {
+                  abstractThing {
+                    __typename
+                    ... on LabeledThing {
+                      metadata @skip(if: $skip) @include(if: $include)
+                    }
+                    ... on LabeledThing @skip(if: $skip) @include(if: $include) {
+                      gatedMetadata: metadata
+                    }
+                  }
+                }
+                "#,
+                Some(sonic_rs::json!({
+                    "include": true,
+                    "skip": false,
+                })),
+                None,
+            )
+            .await;
+
+        let skipped_res = router
+            .send_graphql_request(
+                r#"
+                query($include: Boolean!, $skip: Boolean!) {
+                  abstractThing {
+                    __typename
+                    ... on LabeledThing {
+                      metadata @skip(if: $skip) @include(if: $include)
+                    }
+                    ... on LabeledThing @skip(if: $skip) @include(if: $include) {
+                      gatedMetadata: metadata
+                    }
+                  }
+                }
+                "#,
+                Some(sonic_rs::json!({
+                    "include": false,
+                    "skip": false,
+                })),
+                None,
+            )
+            .await;
+
+        labels_abstract_conditional_mock.assert();
+
+        insta::assert_snapshot!(included_res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "abstractThing": {
+              "__typename": "LabeledThing",
+              "metadata": {
+                "conditional.field\t": "field value"
+              },
+              "gatedMetadata": {
+                "conditional.fragment\t": "fragment value"
+              }
+            }
+          }
+        }
+        "#);
+
+        insta::assert_snapshot!(skipped_res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "abstractThing": {
+              "__typename": "LabeledThing"
+            }
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/966
+    async fn issue_966_custom_scalar_direct_root_product_field() {
+        let mut server = mockito::Server::new_async().await;
+        let router = build_issue_966_router(&server.host_with_port()).await;
+
+        let product_query_mock = server
+            .mock("POST", "/products")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("product(id:") && !body_str.contains("_entities")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "product": {
+                      "id": "p1",
+                      "metadata": {
+                        "entity.root\t": "entity root value"
+                      }
+                    }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                {
+                  product(id: "p1") {
+                    id
+                    metadata
+                    renamedMetadata: metadata
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        product_query_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "product": {
+              "id": "p1",
+              "metadata": {
+                "entity.root\t": "entity root value"
+              },
+              "renamedMetadata": null
+            }
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/966
+    async fn issue_966_custom_scalar_single_entity_fetch() {
+        let mut server = mockito::Server::new_async().await;
+        let router = build_issue_966_router(&server.host_with_port()).await;
+
+        let labels_product_ref_mock = server
+            .mock("POST", "/labels")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("productRef(id:") && !body_str.contains("first:")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "productRef": {
+                      "__typename": "Product",
+                      "id": "p1"
+                    }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let product_entities_single_mock = server
+            .mock("POST", "/products")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("_entities")
+                    && body_str.contains("$representations")
+                    && !body_str.contains("_e0")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "_entities": [
+                      {
+                        "metadata": {
+                          "entity.root\t": "entity root value"
+                        },
+                        "renamedMetadata": {
+                          "entity.root\t": "entity root value"
+                        }
+                      }
+                    ]
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                {
+                  productRef(id: "p1") {
+                    id
+                    metadata
+                    renamedMetadata: metadata
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        labels_product_ref_mock.assert();
+        product_entities_single_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "productRef": {
+              "id": "p1",
+              "metadata": {
+                "entity.root\t": "entity root value"
+              },
+              "renamedMetadata": {
+                "entity.root\t": "entity root value"
+              }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/966
+    async fn issue_966_custom_scalar_batched_entity_fetch() {
+        let mut server = mockito::Server::new_async().await;
+        let router = build_issue_966_router(&server.host_with_port()).await;
+
+        let labels_product_ref_batch_mock = server
+            .mock("POST", "/labels")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("first: productRef(") && body_str.contains("second: productRef(")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "first": {
+                      "__typename": "Product",
+                      "id": "p1"
+                    },
+                    "second": {
+                      "__typename": "Product",
+                      "id": "p2"
+                    }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let product_entities_mock = server
+            .mock("POST", "/products")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("_entities")
+                    && body_str.contains("_e0")
+                    && body_str.contains("_e1")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "_e0": [
+                      {
+                        "renamedMetadata": {
+                          "batch.two\t": "second"
+                        }
+                      }
+                    ],
+                    "_e1": [
+                      {
+                        "metadata": {
+                          "batch.one\t": "first"
+                        }
+                      }
+                    ]
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                {
+                  first: productRef(id: "p1") {
+                    metadata
+                  }
+                  second: productRef(id: "p2") {
+                    renamedMetadata: metadata
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        labels_product_ref_batch_mock.assert();
+        product_entities_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "first": {
+              "metadata": {
+                "batch.one\t": "first"
+              }
+            },
+            "second": {
+              "renamedMetadata": {
+                "batch.two\t": "second"
+              }
             }
           }
         }

--- a/e2e/src/issues/supergraph.966.graphql
+++ b/e2e/src/issues/supergraph.966.graphql
@@ -1,0 +1,70 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  LABELS @join__graph(name: "labels", url: "http://0.0.0.0:4200/labels")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar Labels @join__type(graph: LABELS)
+
+type Query @join__type(graph: LABELS) {
+  labels: Labels @join__field(graph: LABELS)
+}

--- a/e2e/src/issues/supergraph.966.graphql
+++ b/e2e/src/issues/supergraph.966.graphql
@@ -47,6 +47,7 @@ scalar join__FieldSet
 
 enum join__Graph {
   LABELS @join__graph(name: "labels", url: "http://0.0.0.0:4200/labels")
+  PRODUCTS @join__graph(name: "products", url: "http://0.0.0.0:4200/products")
 }
 
 scalar link__Import
@@ -63,8 +64,51 @@ enum link__Purpose {
   EXECUTION
 }
 
-scalar Labels @join__type(graph: LABELS)
+scalar JSONBlob @join__type(graph: LABELS) @join__type(graph: PRODUCTS)
 
-type Query @join__type(graph: LABELS) {
-  labels: Labels @join__field(graph: LABELS)
+interface SearchResult @join__type(graph: LABELS) {
+  id: ID! @join__field(graph: LABELS)
+}
+
+type LabeledThing implements SearchResult
+  @join__type(graph: LABELS)
+  @join__implements(graph: LABELS, interface: "SearchResult") {
+  id: ID! @join__field(graph: LABELS)
+  metadata: JSONBlob @join__field(graph: LABELS)
+}
+
+type PlainThing implements SearchResult
+  @join__type(graph: LABELS)
+  @join__implements(graph: LABELS, interface: "SearchResult") {
+  id: ID! @join__field(graph: LABELS)
+  catalog: Catalog @join__field(graph: LABELS)
+  title: String @join__field(graph: LABELS)
+}
+
+type Product
+  @join__type(graph: LABELS, key: "id")
+  @join__type(graph: PRODUCTS, key: "id") {
+  id: ID!
+  metadata: JSONBlob
+    @join__field(graph: LABELS, external: true)
+    @join__field(graph: PRODUCTS)
+}
+
+type Catalog @join__type(graph: LABELS) {
+  metadata: JSONBlob @join__field(graph: LABELS)
+  metadataList: [JSONBlob!]! @join__field(graph: LABELS)
+}
+
+type Query @join__type(graph: LABELS) @join__type(graph: PRODUCTS) {
+  labels: JSONBlob @join__field(graph: LABELS)
+  labelsArray: JSONBlob @join__field(graph: LABELS)
+  labelsText: JSONBlob @join__field(graph: LABELS)
+  labelsNumber: JSONBlob @join__field(graph: LABELS)
+  labelsBool: JSONBlob @join__field(graph: LABELS)
+  labelsNull: JSONBlob @join__field(graph: LABELS)
+  catalog: Catalog @join__field(graph: LABELS)
+  abstractThing: SearchResult @join__field(graph: LABELS)
+  abstractThings: [SearchResult!]! @join__field(graph: LABELS)
+  productRef(id: ID!): Product @join__field(graph: LABELS)
+  product(id: ID!): Product @join__field(graph: PRODUCTS)
 }

--- a/e2e/src/subscriptions.rs
+++ b/e2e/src/subscriptions.rs
@@ -1601,7 +1601,7 @@ mod subscriptions_e2e_tests {
             query: query.into(),
             ..Default::default()
         };
-        let mut ws_stream = ws_client.subscribe(ws_payload).await;
+        let mut ws_stream = ws_client.subscribe(ws_payload, None).await;
 
         let (sub_sse, sub_multipart) = tokio::join!(
             router.send_graphql_request(query, None, sse_headers),
@@ -1691,7 +1691,7 @@ mod subscriptions_e2e_tests {
             query: query.into(),
             ..Default::default()
         };
-        let mut ws_stream = ws_client.subscribe(ws_payload).await;
+        let mut ws_stream = ws_client.subscribe(ws_payload, None).await;
 
         // consume 3 events from sub1 to let the source stream advance
         let response = ws_stream.next().await.unwrap();

--- a/e2e/src/websocket.rs
+++ b/e2e/src/websocket.rs
@@ -47,7 +47,7 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(execution_request).await;
+        let mut stream = client.subscribe(execution_request, None).await;
 
         let response = stream.next().await.expect("Expected a response");
 
@@ -97,7 +97,7 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload).await;
+        let mut stream = client.subscribe(subscribe_payload, None).await;
 
         let mut received_count = 0;
         while let Some(response) = stream.next().await {
@@ -150,7 +150,7 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream1 = client.subscribe(subscribe_payload1).await;
+        let mut stream1 = client.subscribe(subscribe_payload1, None).await;
 
         let subscribe_payload = SubscribePayload {
             query: r#"
@@ -164,7 +164,7 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream2 = client.subscribe(subscribe_payload).await;
+        let mut stream2 = client.subscribe(subscribe_payload, None).await;
 
         let mut count1 = 0;
         let mut count2 = 0;
@@ -265,7 +265,7 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload).await;
+        let mut stream = client.subscribe(subscribe_payload, None).await;
 
         stream.next().await.expect("Expected a response");
 
@@ -332,7 +332,7 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload).await;
+        let mut stream = client.subscribe(subscribe_payload, None).await;
 
         stream.next().await.expect("Expected a response");
 
@@ -408,7 +408,7 @@ mod websocket_e2e_tests {
         };
 
         // merging headers
-        let mut stream = client.subscribe(subscribe_payload).await;
+        let mut stream = client.subscribe(subscribe_payload, None).await;
         stream.next().await.expect("Expected a response");
 
         let subscribe_payload = SubscribePayload {
@@ -425,7 +425,7 @@ mod websocket_e2e_tests {
         };
 
         // missing headers in extensions, should've been merged
-        let mut stream = client.subscribe(subscribe_payload).await;
+        let mut stream = client.subscribe(subscribe_payload, None).await;
         stream.next().await.expect("Expected a response");
 
         let products_requests = subgraphs

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -16,6 +16,7 @@ use hive_router_internal::telemetry::traces::spans::graphql::{
     GraphQLOperationSpan, GraphQLSpanOperationIdentity, GraphQLSubgraphOperationSpan,
 };
 use hive_router_query_planner::ast::operation::SubgraphFetchOperation;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use hive_router_query_planner::planner::query_plan::QUERY_PLAN_KIND;
 use hive_router_query_planner::{
     ast::operation::OperationDefinition,
@@ -198,6 +199,7 @@ pub async fn execute_query_plan<'exec>(
             headers: headers_map,
             raw_variable_values: None,
             extensions: None,
+            custom_scalar_paths: fetch_node.custom_scalar_paths.as_ref(),
         };
 
         // TODO: otel instrumentation and stuff
@@ -595,6 +597,8 @@ struct PrepareExecutionJobOpts<'exec> {
     operation: &'exec SubgraphFetchOperation,
     // Output rewrites
     output_rewrites: Option<&'exec [FetchRewrite]>,
+    // Response paths whose values should stay raw JSON in `data`
+    custom_scalar_paths: Option<&'exec CustomScalarPaths>,
     // If the fetch job is for a flatten node, we pass the filtered representations,
     raw_variable_values: Option<Vec<(&'exec str, Vec<u8>)>>,
     // and the path to the representations in the original response for error handling and normalization
@@ -666,6 +670,7 @@ impl<'exec> Executor<'exec> {
                     operation_kind: fetch_node.operation_kind.as_ref(),
                     operation: &fetch_node.operation,
                     output_rewrites: fetch_node.output_rewrites.as_deref(),
+                    custom_scalar_paths: fetch_node.custom_scalar_paths.as_ref(),
                     raw_variable_values: None,
                     affected_path: None,
                 })
@@ -696,6 +701,7 @@ impl<'exec> Executor<'exec> {
                         operation_kind: batch_fetch_node.operation_kind.as_ref(),
                         operation: &batch_fetch_node.operation,
                         output_rewrites: None,
+                        custom_scalar_paths: batch_fetch_node.custom_scalar_paths.as_ref(),
                         raw_variable_values: Some(raw_variable_values),
                         affected_path: None,
                     })
@@ -783,6 +789,7 @@ impl<'exec> Executor<'exec> {
                         operation_kind: fetch_node.operation_kind.as_ref(),
                         operation: &fetch_node.operation,
                         output_rewrites: fetch_node.output_rewrites.as_deref(),
+                        custom_scalar_paths: fetch_node.custom_scalar_paths.as_ref(),
                         raw_variable_values: Some(vec![(
                             "representations",
                             filtered_representations,
@@ -1310,6 +1317,7 @@ impl<'exec> Executor<'exec> {
                 raw_variable_values: opts.raw_variable_values,
                 headers: headers_map,
                 extensions: None,
+                custom_scalar_paths: opts.custom_scalar_paths,
             };
 
             let client_document_hash_str = opts.operation.hash.to_string();
@@ -1765,6 +1773,7 @@ mod tests {
                                 document: dummy_doc.clone(),
                                 hash: 0,
                             },
+                            custom_scalar_paths: None,
                             operation_name: None,
                             requires: None,
                             input_rewrites: None,
@@ -1780,6 +1789,7 @@ mod tests {
                                 document: dummy_doc.clone(),
                                 hash: 0,
                             },
+                            custom_scalar_paths: None,
                             operation_name: None,
                             requires: None,
                             input_rewrites: None,

--- a/lib/executor/src/executors/common.rs
+++ b/lib/executor/src/executors/common.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use http::{HeaderMap, Uri};
 use sonic_rs::Value;
 
@@ -53,6 +54,7 @@ pub struct SubgraphExecutionRequest<'a> {
     pub headers: HeaderMap,
     pub raw_variable_values: Option<Vec<(&'a str, Vec<u8>)>>,
     pub extensions: Option<SubgraphRequestExtensions>,
+    pub custom_scalar_paths: Option<&'a CustomScalarPaths>,
 }
 
 impl SubgraphExecutionRequest<'_> {

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -18,6 +18,7 @@ use hive_router_internal::inflight::InFlightRole;
 use hive_router_internal::telemetry::metrics::catalog::values::GraphQLResponseStatus;
 use hive_router_internal::telemetry::metrics::http_client_metrics::HttpClientRequestStateCapture;
 use hive_router_internal::telemetry::TelemetryContext;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 
 use async_trait::async_trait;
 
@@ -470,7 +471,8 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             response = end_payload.response;
         }
 
-        let response_result = response.deserialize_http_response();
+        let response_result =
+            response.deserialize_http_response(execution_request.custom_scalar_paths);
         if let Some(mut http_request_capture) = http_request_capture {
             finish_capture_from_subgraph_result(
                 &mut http_request_capture.capture,
@@ -491,6 +493,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
+        let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let body = build_request_body(&execution_request)?;
 
         let mut req = hyper::Request::builder()
@@ -564,7 +567,11 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
 
             let boundary = multipart_subscribe::parse_boundary_from_header(content_type)
                 .map_err(|e| SubgraphExecutorError::MultipartBoundaryParseFailure(e.to_string()))?;
-            let stream = multipart_subscribe::parse_to_stream(boundary, body_stream);
+            let stream = multipart_subscribe::parse_to_stream(
+                boundary,
+                body_stream,
+                custom_scalar_paths.clone(),
+            );
 
             Ok(Box::pin(async_stream::stream! {
                 trace!("multipart subscription stream started");
@@ -588,7 +595,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
                 self.endpoint.to_string(),
             );
 
-            let stream = sse::parse_to_stream(body_stream);
+            let stream = sse::parse_to_stream(body_stream, custom_scalar_paths.clone());
 
             Ok(Box::pin(async_stream::stream! {
                 trace!("SSE subscription stream started");
@@ -643,8 +650,11 @@ pub struct SubgraphHttpResponse {
 }
 
 impl SubgraphHttpResponse {
-    fn deserialize_http_response<'a>(self) -> Result<SubgraphResponse<'a>, SubgraphExecutorError> {
-        SubgraphResponse::deserialize_from_bytes(self.body.clone()).map(
+    fn deserialize_http_response<'a>(
+        self,
+        custom_scalar_paths: Option<&CustomScalarPaths>,
+    ) -> Result<SubgraphResponse<'a>, SubgraphExecutorError> {
+        SubgraphResponse::deserialize_from_bytes(self.body.clone(), custom_scalar_paths).map(
             |mut resp: SubgraphResponse<'a>| {
                 // headers are under arc, zero cost clone
                 resp.headers = Some(self.headers.clone());

--- a/lib/executor/src/executors/http_callback.rs
+++ b/lib/executor/src/executors/http_callback.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use dashmap::DashMap;
 use futures::stream::BoxStream;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use http::{HeaderMap, HeaderValue};
 use http_body_util::BodyExt;
 use http_body_util::Full;
@@ -157,6 +158,8 @@ impl SubgraphExecutor for HttpCallbackSubgraphExecutor {
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
+        let custom_scalar_paths: Option<CustomScalarPaths> =
+            execution_request.custom_scalar_paths.cloned();
         let subscription_id = Ulid::new().to_string();
         let verifier = Ulid::new().to_string();
 
@@ -249,7 +252,10 @@ impl SubgraphExecutor for HttpCallbackSubgraphExecutor {
                 match msg {
                     CallbackMessage::Next { payload } => {
                         trace!(subscription_id = %subscription_id, "received next payload");
-                        match SubgraphResponse::deserialize_from_bytes(payload) {
+                        match SubgraphResponse::deserialize_from_bytes(
+                            payload,
+                            custom_scalar_paths.as_ref(),
+                        ) {
                             Ok(response) => yield Ok(response),
                             Err(e) => {
                                 error!(

--- a/lib/executor/src/executors/multipart_subscribe.rs
+++ b/lib/executor/src/executors/multipart_subscribe.rs
@@ -2,6 +2,7 @@ use std::str::Utf8Error;
 
 use bytes::{Buf, Bytes};
 use futures::stream::BoxStream;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use http_body_util::BodyExt;
 use hyper::body::Body;
 
@@ -75,6 +76,7 @@ pub fn parse_boundary_from_header(content_type: &str) -> Result<&str, ParseError
 pub fn parse_to_stream<B>(
     boundary: &str,
     body_stream: B,
+    custom_scalar_paths: Option<CustomScalarPaths>,
 ) -> BoxStream<'static, Result<SubgraphResponse<'static>, ParseError>>
 where
     B: Body + Send + Unpin + 'static,
@@ -101,7 +103,7 @@ where
                 buffer.drain(..skip_len);
 
                 if !part_bytes.is_empty() {
-                    match parse_part(&part_bytes) {
+                    match parse_part(&part_bytes, custom_scalar_paths.as_ref()) {
                         Ok(Some(response)) => {
                             yield Ok(response);
                         }
@@ -185,7 +187,10 @@ fn find_next_part(
     Some((next_delimiter_pos, skip_len, is_end))
 }
 
-fn parse_part(raw: &[u8]) -> Result<Option<SubgraphResponse<'static>>, ParseError> {
+fn parse_part(
+    raw: &[u8],
+    custom_scalar_paths: Option<&CustomScalarPaths>,
+) -> Result<Option<SubgraphResponse<'static>>, ParseError> {
     let text = std::str::from_utf8(raw)?;
     let body = extract_body_after_headers(text);
 
@@ -193,7 +198,7 @@ fn parse_part(raw: &[u8]) -> Result<Option<SubgraphResponse<'static>>, ParseErro
         return Ok(None);
     }
 
-    extract_payload(body)
+    extract_payload(body, custom_scalar_paths)
 }
 
 fn extract_body_after_headers(content: &str) -> &str {
@@ -206,7 +211,10 @@ fn extract_body_after_headers(content: &str) -> &str {
     }
 }
 
-fn extract_payload(body: &str) -> Result<Option<SubgraphResponse<'static>>, ParseError> {
+fn extract_payload(
+    body: &str,
+    custom_scalar_paths: Option<&CustomScalarPaths>,
+) -> Result<Option<SubgraphResponse<'static>>, ParseError> {
     // cheap heartbeat check: subgraphs send `{}` as a keep-alive ping
     if body == "{}" {
         return Ok(None);
@@ -222,23 +230,32 @@ fn extract_payload(body: &str) -> Result<Option<SubgraphResponse<'static>>, Pars
                 // transport error: payload is null, check for top-level errors
                 if let Ok(errors_lv) = sonic_rs::get_from_str(body, &["errors"]) {
                     let transport_err = format!(r#"{{"errors":{}}}"#, errors_lv.as_raw_str());
-                    return SubgraphResponse::deserialize_from_bytes(Bytes::from(transport_err))
-                        .map_err(ParseError::InvalidSubgraphResponse)
-                        .map(Some);
+                    return SubgraphResponse::deserialize_from_bytes(
+                        Bytes::from(transport_err),
+                        custom_scalar_paths,
+                    )
+                    .map_err(ParseError::InvalidSubgraphResponse)
+                    .map(Some);
                 }
                 return Ok(None);
             }
 
             // happy path: deserialize the raw payload substring directly - no re-serialization
-            SubgraphResponse::deserialize_from_bytes(Bytes::copy_from_slice(raw.as_bytes()))
-                .map_err(ParseError::InvalidSubgraphResponse)
-                .map(Some)
+            SubgraphResponse::deserialize_from_bytes(
+                Bytes::copy_from_slice(raw.as_bytes()),
+                custom_scalar_paths,
+            )
+            .map_err(ParseError::InvalidSubgraphResponse)
+            .map(Some)
         }
         Err(e) if e.is_not_found() => {
             // no payload wrapper, treat the whole body as a subgraph response
-            SubgraphResponse::deserialize_from_bytes(Bytes::from(body.to_owned()))
-                .map_err(ParseError::InvalidSubgraphResponse)
-                .map(Some)
+            SubgraphResponse::deserialize_from_bytes(
+                Bytes::from(body.to_owned()),
+                custom_scalar_paths,
+            )
+            .map_err(ParseError::InvalidSubgraphResponse)
+            .map(Some)
         }
         Err(e) => Err(ParseError::InvalidSubgraphResponse(
             SubgraphExecutorError::ResponseDeserializationFailure(e),
@@ -250,6 +267,7 @@ fn extract_payload(body: &str) -> Result<Option<SubgraphResponse<'static>>, Pars
 mod tests {
     use super::*;
     use bytes::Bytes;
+    use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 
     #[test]
     fn test_parse_boundary_from_header_simple() {
@@ -390,7 +408,7 @@ mod tests {
         let part_data =
             b"Content-Type: application/json\r\n\r\n{\"payload\":{\"data\":{\"reviewAdded\":{\"id\":\"1\"}}}}";
 
-        let response = parse_part(part_data)
+        let response = parse_part(part_data, None)
             .expect("Should parse valid part")
             .expect("Should have response");
 
@@ -401,7 +419,7 @@ mod tests {
     fn test_parse_part_without_headers() {
         let part_data = b"\r\n{\"payload\":{\"data\":{\"value\":1}}}";
 
-        let response = parse_part(part_data)
+        let response = parse_part(part_data, None)
             .expect("Should parse part without headers")
             .expect("Should have response");
 
@@ -412,7 +430,7 @@ mod tests {
     fn test_extract_payload_with_payload_property() {
         let body = r#"{"payload":{"data":{"reviewAdded":{"id":"1"}}}}"#;
 
-        let response = extract_payload(body)
+        let response = extract_payload(body, None)
             .expect("Should extract payload")
             .expect("Should have response");
 
@@ -423,7 +441,7 @@ mod tests {
     fn test_extract_payload_without_payload_property() {
         let body = r#"{"data":{"user":{"name":"Alice"}}}"#;
 
-        let response = extract_payload(body)
+        let response = extract_payload(body, None)
             .expect("Should extract payload")
             .expect("Should have response");
 
@@ -434,7 +452,7 @@ mod tests {
     fn test_extract_payload_heartbeat() {
         let body = "{}";
 
-        let payload = extract_payload(body).expect("Should parse heartbeat");
+        let payload = extract_payload(body, None).expect("Should parse heartbeat");
 
         assert!(payload.is_none(), "Heartbeat should return None");
     }
@@ -443,7 +461,7 @@ mod tests {
     fn test_extract_payload_transport_error() {
         let body = r#"{"payload":null,"errors":[{"message":"Connection lost"}]}"#;
 
-        let response = extract_payload(body)
+        let response = extract_payload(body, None)
             .expect("Should extract error")
             .expect("Should have error response");
 
@@ -466,7 +484,7 @@ mod tests {
         ))];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream("graphql", body);
+        let mut stream = parse_to_stream("graphql", body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -498,7 +516,7 @@ mod tests {
         ];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream("graphql", body);
+        let mut stream = parse_to_stream("graphql", body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -531,7 +549,7 @@ mod tests {
         ))];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream("graphql", body);
+        let mut stream = parse_to_stream("graphql", body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -557,7 +575,7 @@ mod tests {
         ))];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream("graphql", body);
+        let mut stream = parse_to_stream("graphql", body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -586,7 +604,7 @@ mod tests {
         ))];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream("myboundary", body);
+        let mut stream = parse_to_stream("myboundary", body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -612,7 +630,7 @@ mod tests {
         ))];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream("boundary", body);
+        let mut stream = parse_to_stream("boundary", body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -623,5 +641,28 @@ mod tests {
 
         let second = stream.next().await;
         assert!(second.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_parse_to_stream_uses_custom_scalar_paths() {
+        use futures::StreamExt;
+        use http_body_util::StreamBody;
+        use hyper::body::Frame;
+
+        let chunks: Vec<Result<Frame<Bytes>, std::convert::Infallible>> = vec![Ok(Frame::data(
+            Bytes::from(
+                "--graphql\r\nContent-Type: application/json\r\n\r\n{\"payload\":{\"data\":{\"custom\":{\"escaped.key\\t\":\"value\"}}}}\r\n--graphql--\r\n",
+            ),
+        ))];
+
+        let mut custom_scalar_paths = CustomScalarPaths::default();
+        custom_scalar_paths.insert_path(["custom"]);
+
+        let body = StreamBody::new(futures::stream::iter(chunks));
+        let mut stream = parse_to_stream("graphql", body, Some(custom_scalar_paths));
+
+        let first = stream.next().await.unwrap().unwrap();
+        let data = first.data.as_object().unwrap();
+        assert!(data[0].1.as_raw_json().is_some());
     }
 }

--- a/lib/executor/src/executors/sse.rs
+++ b/lib/executor/src/executors/sse.rs
@@ -1,5 +1,6 @@
 use bytes::{Buf, Bytes};
 use futures::stream::BoxStream;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use http_body_util::BodyExt;
 use hyper::body::Body;
 
@@ -25,6 +26,7 @@ pub enum ParseError {
 
 pub fn parse_to_stream<B>(
     body_stream: B,
+    custom_scalar_paths: Option<CustomScalarPaths>,
 ) -> BoxStream<'static, Result<SubgraphResponse<'static>, ParseError>>
 where
     B: Body + Send + Unpin + 'static,
@@ -42,7 +44,10 @@ where
                     Ok(Some(sse_event)) => {
                         match sse_event.event.as_deref() {
                             Some("next") if !sse_event.data.is_empty() => {
-                                match SubgraphResponse::deserialize_from_bytes(Bytes::from(sse_event.data.clone())) {
+                                match SubgraphResponse::deserialize_from_bytes(
+                                    Bytes::from(sse_event.data.clone()),
+                                    custom_scalar_paths.as_ref(),
+                                ) {
                                     Ok(response) => {
                                         yield Ok(response);
                                     }
@@ -174,6 +179,7 @@ fn parse(raw: &[u8]) -> Result<Option<SubgraphSseEvent>, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 
     #[test]
     fn test_parse_single_event_with_data() {
@@ -336,7 +342,7 @@ event: complete
         ];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream(body);
+        let mut stream = parse_to_stream(body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -366,7 +372,7 @@ event: complete
         ];
 
         let body = StreamBody::new(futures::stream::iter(chunks));
-        let mut stream = parse_to_stream(body);
+        let mut stream = parse_to_stream(body, None);
 
         let first = stream.next().await;
         assert!(first.is_some());
@@ -377,5 +383,29 @@ event: complete
 
         let second = stream.next().await;
         assert!(second.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_parse_to_stream_uses_custom_scalar_paths() {
+        use bytes::Bytes;
+        use futures::StreamExt;
+        use http_body_util::StreamBody;
+        use hyper::body::Frame;
+
+        let chunks: Vec<Result<Frame<Bytes>, std::convert::Infallible>> = vec![Ok(Frame::data(
+            Bytes::from(
+                "event: next\ndata: {\"data\":{\"custom\":{\"escaped.key\\t\":\"value\"}}}\n\nevent: complete\n\n",
+            ),
+        ))];
+
+        let mut custom_scalar_paths = CustomScalarPaths::default();
+        custom_scalar_paths.insert_path(["custom"]);
+
+        let body = StreamBody::new(futures::stream::iter(chunks));
+        let mut stream = parse_to_stream(body, Some(custom_scalar_paths));
+
+        let first = stream.next().await.unwrap().unwrap();
+        let data = first.data.as_object().unwrap();
+        assert!(data[0].1.as_raw_json().is_some());
     }
 }

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -50,6 +50,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let endpoint = self.endpoint.clone();
         let subgraph_name = self.subgraph_name.clone();
         let tls_config = self.tls_config.clone();
+        let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         debug!(
             "establishing WebSocket connection to subgraph {} at {}",
             subgraph_name, endpoint
@@ -93,7 +94,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                     subgraph_name, endpoint
                 );
 
-                let mut stream = client.subscribe(subscribe_payload).await;
+                let mut stream = client
+                    .subscribe(subscribe_payload, custom_scalar_paths)
+                    .await;
 
                 match stream.next().await {
                     Some(response) => Ok(response),
@@ -129,6 +132,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let endpoint = self.endpoint.clone();
         let subgraph_name = self.subgraph_name.clone();
         let tls_config = self.tls_config.clone();
+        let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
 
         let (subscribe_payload, init_payload) = build_subscribe_payload(execution_request);
 
@@ -170,7 +174,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 subgraph_name, endpoint
             );
 
-            let mut stream = client.subscribe(subscribe_payload).await;
+            let mut stream = client
+                .subscribe(subscribe_payload, custom_scalar_paths)
+                .await;
 
             while let Some(response) = stream.next().await {
                 match tx.try_send(Ok(response)) {

--- a/lib/executor/src/executors/websocket_client.rs
+++ b/lib/executor/src/executors/websocket_client.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use hyper_rustls::ConfigBuilderExt;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
@@ -128,8 +129,14 @@ pub async fn connect(
     }
 }
 
+#[derive(Clone)]
+struct ClientSubscription {
+    sender: mpsc::Sender<SubgraphResponse<'static>>,
+    custom_scalar_paths: Option<CustomScalarPaths>,
+}
+
 /// The client's WebSocket state. Its subscriptions map subscription IDs to their response senders.
-type WsStateRef = Rc<RefCell<WsState<mpsc::Sender<SubgraphResponse<'static>>>>>;
+type WsStateRef = Rc<RefCell<WsState<ClientSubscription>>>;
 
 /// GraphQL over WebSocket client implementing the graphql-transport-ws protocol.
 ///
@@ -272,15 +279,19 @@ impl WsClient {
     pub async fn subscribe(
         &mut self,
         subscribe_payload: SubscribePayload,
+        custom_scalar_paths: Option<CustomScalarPaths>,
     ) -> LocalBoxStream<'static, SubgraphResponse<'static>> {
         let subscribe_id = self.next_subscription_id();
 
         let (tx, rx) = mpsc::channel();
 
-        self.state
-            .borrow_mut()
-            .subscriptions
-            .insert(subscribe_id.clone(), tx);
+        self.state.borrow_mut().subscriptions.insert(
+            subscribe_id.clone(),
+            ClientSubscription {
+                sender: tx,
+                custom_scalar_paths,
+            },
+        );
 
         let _ = self
             .sink
@@ -380,9 +391,11 @@ async fn dispatch_loop(
                     }
                     Err(FrameNotParsedToText::Closed) => {
                         // notify all subscriptions that the connection was closed
-                        for (_, tx) in state.borrow_mut().subscriptions.drain() {
-                            let _ = tx.send(WsClientError::ConnectionClosed.into());
-                            tx.close();
+                        for (_, subscription) in state.borrow_mut().subscriptions.drain() {
+                            let _ = subscription
+                                .sender
+                                .send(WsClientError::ConnectionClosed.into());
+                            subscription.sender.close();
                         }
                         return;
                     }
@@ -407,9 +420,11 @@ struct DispatcherGuard {
 
 impl Drop for DispatcherGuard {
     fn drop(&mut self) {
-        for (_, tx) in self.state.borrow_mut().subscriptions.drain() {
-            let _ = tx.send(WsClientError::ConnectionClosed.into());
-            tx.close();
+        for (_, subscription) in self.state.borrow_mut().subscriptions.drain() {
+            let _ = subscription
+                .sender
+                .send(WsClientError::ConnectionClosed.into());
+            subscription.sender.close();
         }
     }
 }
@@ -437,9 +452,12 @@ fn handle_text_frame(text: String, state: &WsStateRef) -> Option<ws::Message> {
             None
         }
         ServerMessage::Next { id, payload } => {
-            if let Some(tx) = state.borrow().subscriptions.get(&id) {
+            if let Some(subscription) = state.borrow().subscriptions.get(&id) {
                 let payload_bytes = Bytes::from(sonic_rs::to_vec(&payload).unwrap_or_default());
-                let response = match SubgraphResponse::deserialize_from_bytes(payload_bytes) {
+                let response = match SubgraphResponse::deserialize_from_bytes(
+                    payload_bytes,
+                    subscription.custom_scalar_paths.as_ref(),
+                ) {
                     Ok(response) => response,
                     Err(e) => {
                         tracing::warn!("Failed to deserialize payload: {}", e);
@@ -447,23 +465,23 @@ fn handle_text_frame(text: String, state: &WsStateRef) -> Option<ws::Message> {
                     }
                 };
                 // TODO: should we be strict and close the connection if id did not match any subscription?
-                let _ = tx.send(response);
+                let _ = subscription.sender.send(response);
             }
             None
         }
         ServerMessage::Error { id, payload } => {
-            if let Some(tx) = state.borrow_mut().subscriptions.remove(&id) {
-                let _ = tx.send(SubgraphResponse {
+            if let Some(subscription) = state.borrow_mut().subscriptions.remove(&id) {
+                let _ = subscription.sender.send(SubgraphResponse {
                     errors: Some(payload),
                     ..Default::default()
                 });
-                tx.close();
+                subscription.sender.close();
             }
             None
         }
         ServerMessage::Complete { id } => {
-            if let Some(tx) = state.borrow_mut().subscriptions.remove(&id) {
-                tx.close();
+            if let Some(subscription) = state.borrow_mut().subscriptions.remove(&id) {
+                subscription.sender.close();
             }
             None
         }
@@ -484,3 +502,36 @@ fn text_to_server_message(text: &str) -> Result<ServerMessage, ws::Message> {
 }
 
 // TODO: hella tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn handle_text_frame_uses_subscription_custom_scalar_paths() {
+        let (ack_tx, _ack_rx) = oneshot::channel();
+        let state: WsStateRef = Rc::new(RefCell::new(WsState::new(ack_tx)));
+        let (tx, mut rx) = mpsc::channel();
+        let mut custom_scalar_paths = CustomScalarPaths::default();
+        custom_scalar_paths.insert_path(["custom"]);
+
+        state.borrow_mut().subscriptions.insert(
+            "1".to_string(),
+            ClientSubscription {
+                sender: tx,
+                custom_scalar_paths: Some(custom_scalar_paths),
+            },
+        );
+
+        let text =
+            r#"{"type":"next","id":"1","payload":{"data":{"custom":{"escaped.key\t":"value"}}}}"#
+                .to_string();
+
+        assert!(handle_text_frame(text, &state).is_none());
+
+        let response = rx.next().await.expect("response");
+        let data = response.data.as_object().unwrap();
+        assert!(data[0].1.as_raw_json().is_some());
+    }
+}

--- a/lib/executor/src/projection/request.rs
+++ b/lib/executor/src/projection/request.rs
@@ -56,6 +56,10 @@ pub fn project_requires(
             write_response_key(first, response_key, buffer);
             write_and_escape_string(buffer, s);
         }
+        Value::RawJson(raw) => {
+            write_response_key(first, response_key, buffer);
+            buffer.put_slice(raw.as_bytes());
+        }
         Value::Array(entity_array) => {
             write_response_key(first, response_key, buffer);
             buffer.put(OPEN_BRACKET);

--- a/lib/executor/src/projection/response.rs
+++ b/lib/executor/src/projection/response.rs
@@ -155,6 +155,7 @@ pub fn serialize_value_to_buffer(data: &Value, buffer: &mut Vec<u8>) {
         Value::I64(num) => write_i64(buffer, *num),
         Value::F64(num) => write_f64(buffer, *num),
         Value::String(value) => write_and_escape_string(buffer, value),
+        Value::RawJson(raw) => buffer.put_slice(raw.as_bytes()),
         Value::Object(value) => {
             buffer.put(OPEN_BRACE);
             let mut first = true;

--- a/lib/executor/src/response/subgraph_response.rs
+++ b/lib/executor/src/response/subgraph_response.rs
@@ -1,13 +1,19 @@
 use core::fmt;
 use std::sync::Arc;
 
+use bytes::Bytes;
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
+use http::HeaderMap;
+use serde::{
+    de::{self, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor},
+    Deserialize,
+};
+use sonic_rs::LazyValue;
+
 use crate::{
     executors::error::SubgraphExecutorError,
     response::{graphql_error::GraphQLError, value::Value},
 };
-use bytes::Bytes;
-use http::HeaderMap;
-use serde::de::{self, Deserializer, MapAccess, Visitor};
 
 #[derive(Debug, Default)]
 pub struct SubgraphResponse<'a> {
@@ -23,78 +29,225 @@ impl<'de> de::Deserialize<'de> for SubgraphResponse<'de> {
     where
         D: Deserializer<'de>,
     {
-        struct SubgraphResponseVisitor<'de> {
-            _marker: std::marker::PhantomData<&'de ()>,
-        }
+        deserialize_subgraph_response_with_paths(deserializer, &EMPTY_CUSTOM_SCALAR_PATHS)
+    }
+}
 
-        impl<'de> Visitor<'de> for SubgraphResponseVisitor<'de> {
-            type Value = SubgraphResponse<'de>;
+static EMPTY_CUSTOM_SCALAR_PATHS: CustomScalarPaths = CustomScalarPaths {
+    children: std::collections::BTreeMap::new(),
+    terminal: false,
+};
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter
-                    .write_str("a GraphQL response object with data, errors, and extensions fields")
-            }
+struct SubgraphResponseSeed<'a> {
+    custom_scalar_paths: &'a CustomScalarPaths,
+}
 
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
-                let mut data = None;
-                let mut errors = None;
-                let mut extensions = None;
+impl<'a, 'de> DeserializeSeed<'de> for SubgraphResponseSeed<'a> {
+    type Value = SubgraphResponse<'de>;
 
-                while let Some(key) = map.next_key::<&str>()? {
-                    match key {
-                        "data" => {
-                            if data.is_some() {
-                                return Err(de::Error::duplicate_field("data"));
-                            }
-                            // Let Value's deserializer handle the data field
-                            data = Some(map.next_value()?);
-                        }
-                        "errors" => {
-                            if errors.is_some() {
-                                return Err(de::Error::duplicate_field("errors"));
-                            }
-                            // For errors, deserialize into our new `GraphQLError` struct
-                            errors = Some(map.next_value()?);
-                        }
-                        "extensions" => {
-                            if extensions.is_some() {
-                                return Err(de::Error::duplicate_field("extensions"));
-                            }
-                            // Let Value's deserializer handle the extensions field
-                            extensions = Some(map.next_value()?);
-                        }
-                        _ => {
-                            // Skip unknown fields
-                            let _ = map.next_value::<de::IgnoredAny>()?;
-                        }
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_subgraph_response_with_paths(deserializer, self.custom_scalar_paths)
+    }
+}
+
+fn deserialize_subgraph_response_with_paths<'a, 'de, D>(
+    deserializer: D,
+    custom_scalar_paths: &'a CustomScalarPaths,
+) -> Result<SubgraphResponse<'de>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_map(SubgraphResponseVisitor {
+        custom_scalar_paths,
+    })
+}
+
+struct SubgraphResponseVisitor<'a> {
+    custom_scalar_paths: &'a CustomScalarPaths,
+}
+
+impl<'a, 'de> Visitor<'de> for SubgraphResponseVisitor<'a> {
+    type Value = SubgraphResponse<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a GraphQL response object with data, errors, and extensions fields")
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut data = None;
+        let mut errors = None;
+        let mut extensions = None;
+
+        while let Some(key) = map.next_key::<&str>()? {
+            match key {
+                "data" => {
+                    if data.is_some() {
+                        return Err(de::Error::duplicate_field("data"));
                     }
+                    data = Some(map.next_value_seed(ValueSeed {
+                        custom_scalar_paths: self.custom_scalar_paths,
+                    })?);
                 }
-
-                // Data field is required in a successful response, but might be null in case of errors
-                let data = data.unwrap_or(Value::Null);
-
-                Ok(SubgraphResponse {
-                    data,
-                    errors,
-                    extensions,
-                    headers: None,
-                    bytes: None,
-                })
+                "errors" => {
+                    if errors.is_some() {
+                        return Err(de::Error::duplicate_field("errors"));
+                    }
+                    errors = Some(map.next_value()?);
+                }
+                "extensions" => {
+                    if extensions.is_some() {
+                        return Err(de::Error::duplicate_field("extensions"));
+                    }
+                    // Extensions intentionally stay on the structured path.
+                    extensions = Some(map.next_value()?);
+                }
+                _ => {
+                    let _ = map.next_value::<de::IgnoredAny>()?;
+                }
             }
         }
 
-        deserializer.deserialize_map(SubgraphResponseVisitor {
-            _marker: std::marker::PhantomData,
+        Ok(SubgraphResponse {
+            data: data.unwrap_or(Value::Null),
+            errors,
+            extensions,
+            headers: None,
+            bytes: None,
         })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ValueSeed<'a> {
+    custom_scalar_paths: &'a CustomScalarPaths,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for ValueSeed<'a> {
+    type Value = Value<'de>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_value_with_paths(deserializer, self.custom_scalar_paths)
+    }
+}
+
+fn deserialize_value_with_paths<'a, 'de, D>(
+    deserializer: D,
+    custom_scalar_paths: &'a CustomScalarPaths,
+) -> Result<Value<'de>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if custom_scalar_paths.is_empty() {
+        return Value::deserialize(deserializer);
+    }
+
+    if custom_scalar_paths.terminal {
+        let raw = LazyValue::deserialize(deserializer)?;
+        return Ok(Value::RawJson(raw.as_raw_cow()));
+    }
+
+    deserializer.deserialize_any(PathAwareValueVisitor {
+        custom_scalar_paths,
+    })
+}
+
+struct PathAwareValueVisitor<'a> {
+    custom_scalar_paths: &'a CustomScalarPaths,
+}
+
+impl<'a, 'de> Visitor<'de> for PathAwareValueVisitor<'a> {
+    type Value = Value<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("any valid JSON value")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::I64(value))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::U64(value))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
+        Ok(Value::F64(value))
+    }
+
+    fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Value::String(value.into()))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Value::String(value.to_owned().into()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Value::String(value.into()))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut elements = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        while let Some(elem) = seq.next_element_seed(ValueSeed {
+            custom_scalar_paths: self.custom_scalar_paths,
+        })? {
+            elements.push(elem);
+        }
+        Ok(Value::Array(elements))
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut entries = Vec::with_capacity(map.size_hint().unwrap_or(0));
+        while let Some(key) = map.next_key::<&'de str>()? {
+            let value = match self.custom_scalar_paths.children.get(key) {
+                Some(child_paths) if !child_paths.is_empty() => map.next_value_seed(ValueSeed {
+                    custom_scalar_paths: child_paths,
+                })?,
+                _ => map.next_value()?,
+            };
+            entries.push((key, value));
+        }
+        entries.sort_unstable_by_key(|(key, _)| *key);
+        Ok(Value::Object(entries))
     }
 }
 
 impl<'a> SubgraphResponse<'a> {
     pub fn deserialize_from_bytes(
         bytes: Bytes,
+        custom_scalar_paths: Option<&CustomScalarPaths>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
         let bytes_ref: &[u8] = &bytes;
 
@@ -105,20 +258,38 @@ impl<'a> SubgraphResponse<'a> {
         // values that borrow from this buffer, creating a self-referential struct, which is why
         // `unsafe` is required.
         let bytes_ref: &'static [u8] = unsafe { std::mem::transmute(bytes_ref) };
+        let mut deserializer = sonic_rs::Deserializer::from_slice(bytes_ref);
 
-        sonic_rs::from_slice(bytes_ref)
-            .map_err(SubgraphExecutorError::ResponseDeserializationFailure)
-            .map(move |mut resp: SubgraphResponse<'static>| {
-                // Zero cost of cloning Bytes
-                resp.bytes = Some(bytes);
-                resp
-            })
+        SubgraphResponseSeed {
+            custom_scalar_paths: custom_scalar_paths.unwrap_or(&EMPTY_CUSTOM_SCALAR_PATHS),
+        }
+        .deserialize(&mut deserializer)
+        .map_err(SubgraphExecutorError::ResponseDeserializationFailure)
+        .and_then(|mut resp: SubgraphResponse<'static>| {
+            deserializer
+                .end()
+                .map_err(SubgraphExecutorError::ResponseDeserializationFailure)?;
+            resp.bytes = Some(bytes);
+            Ok(resp)
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // When subgraph returns an error with custom extensions but without `data` field
+    use bytes::Bytes;
+    use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
+    use hive_router_query_planner::{
+        graph::PlannerOverrideContext,
+        planner::{plan_nodes::PlanNode, Planner},
+        utils::{
+            cancellation::CancellationToken,
+            parsing::{parse_operation, parse_schema},
+        },
+    };
+
+    use crate::response::value::Value;
+
     #[test]
     fn deserialize_response_without_data_with_errors_with_extensions() {
         let json_response = r#"
@@ -147,5 +318,364 @@ mod tests {
             }
           }
         ]"###);
+    }
+
+    #[test]
+    fn deserializes_custom_scalar_data_field_as_raw_json() {
+        let mut paths = CustomScalarPaths::default();
+        paths.insert_path(["labels"]);
+
+        let response = super::SubgraphResponse::deserialize_from_bytes(
+            Bytes::from_static(br#"{"data":{"labels":{"generic.learnMore.button\t":"Learn more"}},"extensions":{"statusCode":200}}"#),
+            Some(&paths),
+        )
+        .unwrap();
+
+        let data = response.data.as_object().unwrap();
+        assert!(matches!(data[0].1, Value::RawJson(_)));
+
+        let extensions = response.extensions.unwrap();
+        assert!(matches!(extensions, Value::Object(_)));
+    }
+
+    #[test]
+    fn deserializes_mixed_sibling_paths_with_only_marked_path_as_raw_json() {
+        let mut paths = CustomScalarPaths::default();
+        paths.insert_path(["custom"]);
+
+        let response = super::SubgraphResponse::deserialize_from_bytes(
+            Bytes::from_static(
+                br#"{
+                    "data": {
+                        "custom": {
+                            "generic.learnMore.button\t": "Learn more"
+                        },
+                        "plain": {
+                            "message": "hello",
+                            "nested": {
+                                "count": 1
+                            }
+                        }
+                    }
+                }"#,
+            ),
+            Some(&paths),
+        )
+        .unwrap();
+
+        let data = response.data.as_object().unwrap();
+
+        let custom = data
+            .iter()
+            .find(|(key, _)| *key == "custom")
+            .unwrap()
+            .1
+            .as_raw_json()
+            .expect("custom path should deserialize as raw json");
+        assert!(custom.contains("\"generic.learnMore.button\\t\""));
+        assert!(custom.contains("\"Learn more\""));
+
+        let plain = data
+            .iter()
+            .find(|(key, _)| *key == "plain")
+            .unwrap()
+            .1
+            .as_object()
+            .expect("plain path should stay structured");
+        let message = plain
+            .iter()
+            .find(|(key, _)| *key == "message")
+            .unwrap()
+            .1
+            .as_str();
+        assert_eq!(message, Some("hello"));
+
+        let nested = plain
+            .iter()
+            .find(|(key, _)| *key == "nested")
+            .unwrap()
+            .1
+            .as_object()
+            .expect("nested object should stay structured");
+        assert!(matches!(nested[0].1, Value::U64(1)));
+    }
+
+    #[test]
+    fn custom_and_builtin_scalar_sharing_response_path() {
+        let schema = parse_schema(
+            r#"
+            schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+              query: Query
+            }
+
+            directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+            directive @join__field(
+              graph: join__Graph
+              requires: join__FieldSet
+              provides: join__FieldSet
+              type: String
+              external: Boolean
+              override: String
+              usedOverridden: Boolean
+            ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+            directive @join__implements(
+              graph: join__Graph!
+              interface: String!
+            ) repeatable on OBJECT | INTERFACE
+            directive @join__type(
+              graph: join__Graph!
+              key: join__FieldSet
+              extension: Boolean! = false
+              resolvable: Boolean! = true
+              isInterfaceObject: Boolean! = false
+            ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+            directive @join__unionMember(
+              graph: join__Graph!
+              member: String!
+            ) repeatable on UNION
+            directive @link(
+              url: String
+              as: String
+              for: link__Purpose
+              import: [link__Import]
+            ) repeatable on SCHEMA
+
+            scalar join__FieldSet
+            scalar link__Import
+
+            enum join__Graph {
+              TEST @join__graph(name: "test", url: "http://example.com/graphql")
+            }
+
+            enum link__Purpose {
+              SECURITY
+              EXECUTION
+            }
+
+            scalar JSONBlob @join__type(graph: TEST)
+
+            interface InterfaceThing @join__type(graph: TEST) {
+              id: ID! @join__field(graph: TEST)
+            }
+
+            type JsonInterfaceThing implements InterfaceThing
+              @join__type(graph: TEST)
+              @join__implements(graph: TEST, interface: "InterfaceThing") {
+              id: ID! @join__field(graph: TEST)
+              meta: JSONBlob @join__field(graph: TEST)
+            }
+
+            type StringInterfaceThing implements InterfaceThing
+              @join__type(graph: TEST)
+              @join__implements(graph: TEST, interface: "InterfaceThing") {
+              id: ID! @join__field(graph: TEST)
+              meta: String @join__field(graph: TEST)
+            }
+
+            type JsonUnionThing @join__type(graph: TEST) {
+              meta: JSONBlob @join__field(graph: TEST)
+            }
+
+            type StringUnionThing @join__type(graph: TEST) {
+              meta: String @join__field(graph: TEST)
+            }
+
+            union UnionThing
+              @join__type(graph: TEST)
+              @join__unionMember(graph: TEST, member: "JsonUnionThing")
+              @join__unionMember(graph: TEST, member: "StringUnionThing") = JsonUnionThing | StringUnionThing
+
+            type Query @join__type(graph: TEST) {
+              interfaceThing: InterfaceThing @join__field(graph: TEST)
+              unionThing: UnionThing @join__field(graph: TEST)
+            }
+            "#,
+        );
+        let planner = Planner::new_from_supergraph(&schema).expect("planner");
+        let operation = parse_operation(
+            r#"
+            {
+              interfaceThing {
+                __typename
+                ... on JsonInterfaceThing {
+                  meta
+                }
+                ... on StringInterfaceThing {
+                  meta
+                }
+              }
+              unionThing {
+                __typename
+                ... on JsonUnionThing {
+                  meta
+                }
+                ... on StringUnionThing {
+                  meta
+                }
+              }
+            }
+            "#,
+        );
+        let normalized = hive_router_query_planner::ast::normalization::normalize_operation(
+            &planner.supergraph,
+            &operation,
+            None,
+        )
+        .expect("normalized operation");
+        let plan = planner
+            .plan_from_normalized_operation(
+                normalized.executable_operation(),
+                PlannerOverrideContext::default(),
+                &CancellationToken::new(),
+            )
+            .expect("query plan");
+
+        insta::assert_snapshot!(format!("{}", plan), @r#"
+        QueryPlan {
+          Fetch(service: "test") {
+            {
+              interfaceThing {
+                __typename
+                ... on JsonInterfaceThing {
+                  meta
+                }
+                ... on StringInterfaceThing {
+                  _internal_qp_alias_0: meta
+                }
+              }
+              unionThing {
+                __typename
+                ... on JsonUnionThing {
+                  meta
+                }
+                ... on StringUnionThing {
+                  _internal_qp_alias_0: meta
+                }
+              }
+            }
+          },
+        },
+        "#);
+
+        let custom_scalar_paths = find_fetch_custom_scalar_paths(plan.node.as_ref(), "test")
+            .expect("custom scalar paths");
+
+        let interface_paths = custom_scalar_paths
+            .children
+            .get("interfaceThing")
+            .expect("interfaceThing paths");
+        assert!(
+            interface_paths
+                .children
+                .get("meta")
+                .is_some_and(|path| path.terminal),
+            "json interface branch should keep a terminal custom-scalar path"
+        );
+        assert!(!interface_paths
+            .children
+            .contains_key("_internal_qp_alias_0"));
+
+        let union_paths = custom_scalar_paths
+            .children
+            .get("unionThing")
+            .expect("unionThing paths");
+        assert!(
+            union_paths
+                .children
+                .get("meta")
+                .is_some_and(|path| path.terminal),
+            "json union branch should keep a terminal custom-scalar path"
+        );
+        assert!(!union_paths.children.contains_key("_internal_qp_alias_0"));
+
+        let response = super::SubgraphResponse::deserialize_from_bytes(
+            Bytes::from_static(
+                br#"{
+                    "data": {
+                        "interfaceThing": {
+                            "__typename": "StringInterfaceThing",
+                            "_internal_qp_alias_0": "interface string"
+                        },
+                        "unionThing": {
+                            "__typename": "JsonUnionThing",
+                            "meta": {
+                                "union.key\t": "union value"
+                            }
+                        }
+                    }
+                }"#,
+            ),
+            Some(custom_scalar_paths),
+        )
+        .unwrap();
+
+        let data = response.data.as_object().unwrap();
+
+        let interface_thing = data
+            .iter()
+            .find(|(key, _)| *key == "interfaceThing")
+            .unwrap()
+            .1
+            .as_object()
+            .expect("interfaceThing should stay structured");
+        let interface_meta = interface_thing
+            .iter()
+            .find(|(key, _)| *key == "_internal_qp_alias_0")
+            .unwrap()
+            .1
+            .as_str();
+        assert_eq!(interface_meta, Some("interface string"));
+
+        let union_thing = data
+            .iter()
+            .find(|(key, _)| *key == "unionThing")
+            .unwrap()
+            .1
+            .as_object()
+            .expect("unionThing should stay structured");
+        let union_meta = union_thing
+            .iter()
+            .find(|(key, _)| *key == "meta")
+            .unwrap()
+            .1
+            .as_raw_json()
+            .expect("json union branch should deserialize as raw json");
+        assert!(union_meta.contains("union.key\\t"));
+    }
+
+    fn find_fetch_custom_scalar_paths<'a>(
+        node: Option<&'a PlanNode>,
+        service_name: &str,
+    ) -> Option<&'a CustomScalarPaths> {
+        match node? {
+            PlanNode::Fetch(fetch) if fetch.service_name == service_name => {
+                fetch.custom_scalar_paths.as_ref()
+            }
+            PlanNode::BatchFetch(fetch) if fetch.service_name == service_name => {
+                fetch.custom_scalar_paths.as_ref()
+            }
+            PlanNode::Sequence(sequence) => sequence
+                .nodes
+                .iter()
+                .find_map(|node| find_fetch_custom_scalar_paths(Some(node), service_name)),
+            PlanNode::Parallel(parallel) => parallel
+                .nodes
+                .iter()
+                .find_map(|node| find_fetch_custom_scalar_paths(Some(node), service_name)),
+            PlanNode::Flatten(flatten) => {
+                find_fetch_custom_scalar_paths(Some(&flatten.node), service_name)
+            }
+            PlanNode::Condition(condition) => find_fetch_custom_scalar_paths(
+                condition
+                    .if_clause
+                    .as_deref()
+                    .or(condition.else_clause.as_deref()),
+                service_name,
+            ),
+            _ => None,
+        }
     }
 }

--- a/lib/executor/src/response/value.rs
+++ b/lib/executor/src/response/value.rs
@@ -23,6 +23,7 @@ pub enum Value<'a> {
     U64(u64),
     Bool(bool),
     String(Cow<'a, str>),
+    RawJson(Cow<'a, str>),
     Array(Vec<Value<'a>>),
     Object(Vec<(&'a str, Value<'a>)>),
 }
@@ -42,6 +43,7 @@ impl Hash for Value<'_> {
             Value::U64(u) => u.hash(state),
             Value::Bool(b) => b.hash(state),
             Value::String(s) => s.hash(state),
+            Value::RawJson(raw) => raw.hash(state),
             Value::Array(arr) => arr.hash(state),
             Value::Object(obj) => obj.hash(state),
         }
@@ -197,6 +199,13 @@ impl<'a> Value<'a> {
         }
     }
 
+    pub fn as_raw_json(&self) -> Option<&str> {
+        match self {
+            Value::RawJson(raw) => Some(raw),
+            _ => None,
+        }
+    }
+
     pub fn is_null(&self) -> bool {
         matches!(self, Value::Null)
     }
@@ -238,6 +247,7 @@ impl Display for Value<'_> {
             Value::Null => write!(f, "null"),
             Value::Bool(b) => write!(f, "{}", b),
             Value::String(s) => write!(f, "\"{}\"", s),
+            Value::RawJson(raw) => write!(f, "{}", raw),
             Value::F64(n) => write!(f, "{}", n),
             Value::U64(n) => write!(f, "{}", n),
             Value::I64(n) => write!(f, "{}", n),
@@ -369,6 +379,11 @@ impl serde::Serialize for Value<'_> {
             Value::U64(n) => serializer.serialize_u64(*n),
             Value::F64(n) => serializer.serialize_f64(*n),
             Value::String(s) => serializer.serialize_str(s),
+            Value::RawJson(raw) => {
+                let value: sonic_rs::LazyValue =
+                    sonic_rs::from_str(raw).map_err(serde::ser::Error::custom)?;
+                value.serialize(serializer)
+            }
             Value::Array(arr) => {
                 let mut seq = serializer.serialize_seq(Some(arr.len()))?;
                 for v in arr {
@@ -398,6 +413,9 @@ impl From<&Value<'_>> for SonicValue {
             },
             Value::I64(n) => (*n).into(),
             Value::U64(n) => (*n).into(),
+            Value::RawJson(raw) => {
+                sonic_rs::from_str(raw).unwrap_or_else(|_| SonicValue::new_null())
+            }
             Value::Array(l) => {
                 let mut array_value = SonicValue::new_array_with(l.len());
 

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter as FmtFormatter, Result as FmtResult},
     hash::{Hash, Hasher},
 };
@@ -115,6 +115,8 @@ pub struct FetchNode {
     pub operation_name: Option<String>,
     pub operation: SubgraphFetchOperation,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_scalar_paths: Option<CustomScalarPaths>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<SelectionSet>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_rewrites: Option<Vec<FetchRewrite>>,
@@ -135,7 +137,190 @@ pub struct BatchFetchNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation_name: Option<String>,
     pub operation: SubgraphFetchOperation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_scalar_paths: Option<CustomScalarPaths>,
     pub entity_batch: EntityBatch,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomScalarPaths {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub children: BTreeMap<String, CustomScalarPaths>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub terminal: bool,
+}
+
+impl CustomScalarPaths {
+    pub fn insert_path<I, S>(&mut self, path: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut node = self;
+        for segment in path {
+            node = node
+                .children
+                .entry(segment.as_ref().to_string())
+                .or_default();
+        }
+        node.terminal = true;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.terminal && self.children.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct CustomScalarPathState {
+    children: BTreeMap<String, CustomScalarPathState>,
+    custom_scalar_seen: bool,
+    standard_scalar_seen: bool,
+}
+
+impl CustomScalarPathState {
+    fn mark_custom_scalar<I, S>(&mut self, path: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut node = self;
+        for segment in path {
+            node = node
+                .children
+                .entry(segment.as_ref().to_string())
+                .or_default();
+        }
+        node.custom_scalar_seen = true;
+    }
+
+    fn mark_standard_scalar<I, S>(&mut self, path: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut node = self;
+        for segment in path {
+            node = node
+                .children
+                .entry(segment.as_ref().to_string())
+                .or_default();
+        }
+        node.standard_scalar_seen = true;
+    }
+
+    fn into_custom_scalar_paths(self) -> Option<CustomScalarPaths> {
+        let mut children = BTreeMap::new();
+
+        for (key, child) in self.children {
+            if let Some(paths) = child.into_custom_scalar_paths() {
+                children.insert(key, paths);
+            }
+        }
+
+        let terminal = self.custom_scalar_seen && !self.standard_scalar_seen && children.is_empty();
+        let paths = CustomScalarPaths { children, terminal };
+
+        (!paths.is_empty()).then_some(paths)
+    }
+}
+
+fn collect_custom_scalar_path_state(
+    path_kinds: &mut CustomScalarPathState,
+    response_path: &mut Vec<String>,
+    parent_type_name: &str,
+    selections: &SelectionSet,
+    supergraph: &SupergraphState,
+) {
+    let Some(parent_def) = supergraph.definitions.get(parent_type_name) else {
+        return;
+    };
+
+    let parent_fields = parent_def.fields();
+
+    for item in &selections.items {
+        match item {
+            SelectionItem::Field(field) => {
+                let Some(field_def) = parent_fields.get(&field.name) else {
+                    continue;
+                };
+
+                let response_key = field.selection_identifier();
+                let field_type_name = field_def.field_type.inner_type();
+
+                response_path.push(response_key.to_string());
+
+                if supergraph.is_custom_scalar_type(field_type_name) {
+                    path_kinds.mark_custom_scalar(response_path.iter().map(String::as_str));
+                } else {
+                    path_kinds.mark_standard_scalar(response_path.iter().map(String::as_str));
+
+                    if !field.selections.is_empty() {
+                        collect_custom_scalar_path_state(
+                            path_kinds,
+                            response_path,
+                            field_type_name,
+                            &field.selections,
+                            supergraph,
+                        );
+                    }
+                }
+
+                response_path.pop();
+            }
+            SelectionItem::InlineFragment(fragment) => {
+                collect_custom_scalar_path_state(
+                    path_kinds,
+                    response_path,
+                    &fragment.type_condition,
+                    &fragment.selections,
+                    supergraph,
+                );
+            }
+            SelectionItem::FragmentSpread(_) => {}
+        }
+    }
+}
+
+fn custom_scalar_paths_from_fetch_output(
+    output: &FetchStepSelections<MultiTypeFetchStep>,
+    supergraph: &SupergraphState,
+    entities_root_key: Option<&str>,
+) -> Option<CustomScalarPaths> {
+    let mut state = CustomScalarPathState::default();
+
+    for (type_name, selection_set) in output.iter_selections() {
+        let mut response_path = entities_root_key
+            .map(|root| vec![root.to_string()])
+            .unwrap_or_default();
+        collect_custom_scalar_path_state(
+            &mut state,
+            &mut response_path,
+            type_name,
+            selection_set,
+            supergraph,
+        );
+    }
+
+    state.into_custom_scalar_paths()
+}
+
+pub fn custom_scalar_paths_for_type_selection(
+    type_name: &str,
+    selection_set: &SelectionSet,
+    supergraph: &SupergraphState,
+) -> Option<CustomScalarPaths> {
+    let mut state = CustomScalarPathState::default();
+    let mut response_path = Vec::new();
+    collect_custom_scalar_path_state(
+        &mut state,
+        &mut response_path,
+        type_name,
+        selection_set,
+        supergraph,
+    );
+    state.into_custom_scalar_paths()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -537,6 +722,11 @@ impl FetchNode {
                 operation_kind: Some(OperationKind::Query),
                 operation_name: None,
                 operation: create_output_operation(step, supergraph),
+                custom_scalar_paths: custom_scalar_paths_from_fetch_output(
+                    &step.output,
+                    supergraph,
+                    Some("_entities"),
+                ),
                 requires: Some(create_input_selection_set(&step.input)),
                 input_rewrites: step.input_rewrites.clone(),
                 output_rewrites: step.output_rewrites.clone(),
@@ -564,6 +754,11 @@ impl FetchNode {
                         document_str,
                         hash,
                     },
+                    custom_scalar_paths: custom_scalar_paths_from_fetch_output(
+                        &step.output,
+                        supergraph,
+                        None,
+                    ),
                     requires: None,
                     input_rewrites: step.input_rewrites.clone(),
                     output_rewrites: step.output_rewrites.clone(),
@@ -805,4 +1000,67 @@ pub fn hash_minified_query(minified_query: &str) -> u64 {
     let mut hasher = Xxh3::new();
     minified_query.hash(&mut hasher);
     hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        planner::fetch::{selections::FetchStepSelections, state::SingleTypeFetchStep},
+        state::supergraph_state::SupergraphState,
+        utils::parsing::parse_schema,
+    };
+
+    use super::{custom_scalar_paths_from_fetch_output, SelectionSet};
+
+    fn selection_set_for_field(field_name: &str) -> SelectionSet {
+        let selection = format!("{{ {field_name} }}");
+
+        graphql_tools::parser::parse_query(&selection)
+            .unwrap()
+            .into_static()
+            .definitions
+            .into_iter()
+            .find_map(|definition| match definition {
+                graphql_tools::parser::query::Definition::Operation(
+                    graphql_tools::parser::query::OperationDefinition::SelectionSet(selection_set),
+                ) => Some(selection_set.into()),
+                _ => None,
+            })
+            .expect("selection set")
+    }
+
+    #[test]
+    fn custom_scalar_paths_do_not_mark_custom_scalar_vs_builtin_scalar_collision() {
+        let schema = parse_schema(
+            r#"
+            scalar JSONBlob
+
+            type TypeA {
+              meta: JSONBlob
+            }
+
+            type TypeB {
+              meta: String
+            }
+
+            type Query {
+              root: String
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        let mut output = FetchStepSelections::<SingleTypeFetchStep>::new_empty().into_multi_type();
+        output.declare_known_type("TypeA");
+        output.declare_known_type("TypeB");
+        *output.selections_for_definition_mut("TypeA").unwrap() = selection_set_for_field("meta");
+        *output.selections_for_definition_mut("TypeB").unwrap() = selection_set_for_field("meta");
+
+        let paths = custom_scalar_paths_from_fetch_output(&output, &supergraph, Some("_entities"));
+
+        assert!(
+            paths.is_none(),
+            "custom-scalar vs built-in-scalar collision must not emit a terminal custom scalar path"
+        );
+    }
 }

--- a/lib/query-planner/src/planner/query_plan/optimize.rs
+++ b/lib/query-planner/src/planner/query_plan/optimize.rs
@@ -69,8 +69,8 @@ use crate::{
     },
     planner::error::QueryPlanError,
     planner::plan_nodes::{
-        hash_minified_query, BatchFetchNode, EntityBatch, EntityBatchAlias, FetchRewrite,
-        FlattenNodePath, PlanNode,
+        custom_scalar_paths_for_type_selection, hash_minified_query, BatchFetchNode,
+        CustomScalarPaths, EntityBatch, EntityBatchAlias, FetchRewrite, FlattenNodePath, PlanNode,
     },
     state::supergraph_state::{OperationKind, SupergraphState, TypeNode},
 };
@@ -105,6 +105,7 @@ struct BatchFetchBuilder<'a> {
     representations_var_index: usize,
     variable_usages: BTreeSet<String>,
     representations_var_by_input_key: HashMap<RepresentationsInputKey, String>,
+    custom_scalar_paths: CustomScalarPaths,
 }
 
 impl<'a> BatchFetchBuilder<'a> {
@@ -126,6 +127,7 @@ impl<'a> BatchFetchBuilder<'a> {
             representations_var_index: 0,
             variable_usages: BTreeSet::new(),
             representations_var_by_input_key: HashMap::new(),
+            custom_scalar_paths: CustomScalarPaths::default(),
         }
     }
 
@@ -133,6 +135,7 @@ impl<'a> BatchFetchBuilder<'a> {
         &mut self,
         alias_index: usize,
         shape_group: &[EntityFetch],
+        supergraph: &SupergraphState,
     ) -> Result<(), QueryPlanError> {
         let representative = shape_group.first().ok_or_else(|| {
             QueryPlanError::Internal("Batched entities shape group cannot be empty".to_string())
@@ -166,6 +169,16 @@ impl<'a> BatchFetchBuilder<'a> {
                 include_if: None,
                 omit_from_response: false,
             }));
+
+        if let Some(alias_paths) = custom_scalar_paths_for_type_selection(
+            &representative.type_name,
+            &representative.entities_selection,
+            supergraph,
+        ) {
+            self.custom_scalar_paths
+                .children
+                .insert(alias.clone(), alias_paths);
+        }
 
         self.batched_aliases.push(EntityBatchAlias {
             alias,
@@ -280,6 +293,8 @@ impl<'a> BatchFetchBuilder<'a> {
                 document_str,
                 hash,
             },
+            custom_scalar_paths: (!self.custom_scalar_paths.is_empty())
+                .then_some(self.custom_scalar_paths),
             entity_batch: EntityBatch {
                 aliases: self.batched_aliases,
             },
@@ -306,6 +321,7 @@ struct EntityFetch {
     service_name: String,
     flatten_path: FlattenNodePath,
     variable_usages: Option<BTreeSet<String>>,
+    type_name: String,
     requires: SelectionSet,
     entities_selection: SelectionSet,
     input_rewrites: Option<Vec<FetchRewrite>>,
@@ -399,6 +415,16 @@ impl EntityFetch {
             service_name: fetch_node.service_name.clone(),
             flatten_path: flatten_node.path.clone(),
             variable_usages: fetch_node.variable_usages.clone(),
+            type_name: entities_selection
+                .items
+                .iter()
+                .find_map(|item| match item {
+                    SelectionItem::InlineFragment(fragment) => {
+                        Some(fragment.type_condition.clone())
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| "Query".to_string()),
             requires,
             entities_selection,
             input_rewrites,
@@ -809,7 +835,7 @@ fn build_batched_fetch_node(
         BatchFetchBuilder::new(merged_non_representation_variables, shape_groups.len());
 
     for (index, shape_group) in shape_groups.iter().enumerate() {
-        builder.add_shape_group(index, shape_group)?;
+        builder.add_shape_group(index, shape_group, supergraph)?;
     }
 
     builder.finish(first_candidate, supergraph)
@@ -2261,6 +2287,7 @@ mod tests {
             operation_kind: Some(OperationKind::Query),
             operation_name: None,
             operation,
+            custom_scalar_paths: None,
             requires: Some(requires),
             input_rewrites: None,
             output_rewrites: None,
@@ -2323,6 +2350,7 @@ mod tests {
             operation_kind: Some(OperationKind::Query),
             operation_name: None,
             operation,
+            custom_scalar_paths: None,
             requires: None,
             input_rewrites: None,
             output_rewrites: None,

--- a/lib/query-planner/src/state/supergraph_state.rs
+++ b/lib/query-planner/src/state/supergraph_state.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::subgraph_state::SubgraphState;
 
-static BUILDIB_SCALARS: [&str; 5] = ["String", "Int", "Float", "Boolean", "ID"];
+static BUILTIN_SCALARS: [&str; 5] = ["String", "Int", "Float", "Boolean", "ID"];
 
 pub type SchemaDocument = input::Document<'static, String>;
 
@@ -217,11 +217,15 @@ impl SupergraphState {
     }
 
     pub fn is_scalar_type(&self, type_name: &str) -> bool {
-        if BUILDIB_SCALARS.contains(&type_name) {
+        if BUILTIN_SCALARS.contains(&type_name) {
             return true;
         }
 
         self.known_scalars.contains(type_name)
+    }
+
+    pub fn is_custom_scalar_type(&self, type_name: &str) -> bool {
+        !BUILTIN_SCALARS.contains(&type_name) && self.known_scalars.contains(type_name)
     }
 
     pub fn is_interface_object_in_subgraph(&self, type_name: &str, graph_id: &str) -> bool {
@@ -289,7 +293,7 @@ impl SupergraphState {
             }
         }
 
-        for builtin in BUILDIB_SCALARS {
+        for builtin in BUILTIN_SCALARS {
             set.insert(builtin.to_string());
         }
 


### PR DESCRIPTION
Closes #966 

This fixes subgraph response deserialization when a custom scalar returns an object value whose JSON keys contain escaped characters such as `\t`. The executor now stores response object keys as `Cow<'a, str>`, which allows escaped keys to be owned when borrowing is not possible.