### PR TITLE
feat(router): allow overriding number of HTTP server workers

### DIFF
--- a/.changeset/configurable-http-workers.md
+++ b/.changeset/configurable-http-workers.md
@@ -5,9 +5,9 @@ hive-router-config: minor
 
 # Allow overriding number of HTTP server workers
 
-Adds a new `http.workers` configuration option (and `WORKERS` environment variable) to control the number of HTTP server worker threads.
+Adds a new `http.workers` configuration option (and `ROUTER_HTTP_WORKERS` environment variable) to control the number of HTTP server worker threads.
 
-By default, the router spawns one worker per physical CPU core. In containerized environments such as Kubernetes the number of physical cores reported by the OS is often higher than the CPU limit assigned to the container, which leads to oversubscribed worker threads. Set `http.workers` (or `WORKERS`) to match the container's CPU limit to avoid this.
+By default, the router spawns one worker per physical CPU core. In containerized environments such as Kubernetes the number of physical cores reported by the OS is often higher than the CPU limit assigned to the container, which leads to oversubscribed worker threads. Set `http.workers` (or `ROUTER_HTTP_WORKERS`) to match the container's CPU limit to avoid this.
 
 ```yaml
 http:

--- a/.changeset/configurable-http-workers.md
+++ b/.changeset/configurable-http-workers.md
@@ -1,6 +1,6 @@
 ---
-hive-router: patch
-hive-router-config: patch
+hive-router: minor
+hive-router-config: minor
 ---
 
 # Allow overriding number of HTTP server workers

--- a/.changeset/configurable-http-workers.md
+++ b/.changeset/configurable-http-workers.md
@@ -1,6 +1,6 @@
 ---
-hive-router: minor
-hive-router-config: minor
+hive-router: patch
+hive-router-config: patch
 ---
 
 # Allow overriding number of HTTP server workers

--- a/.changeset/configurable-http-workers.md
+++ b/.changeset/configurable-http-workers.md
@@ -1,0 +1,15 @@
+---
+hive-router: minor
+hive-router-config: minor
+---
+
+# Allow overriding number of HTTP server workers
+
+Adds a new `http.workers` configuration option (and `WORKERS` environment variable) to control the number of HTTP server worker threads.
+
+By default, the router spawns one worker per physical CPU core. In containerized environments such as Kubernetes the number of physical cores reported by the OS is often higher than the CPU limit assigned to the container, which leads to oversubscribed worker threads. Set `http.workers` (or `WORKERS`) to match the container's CPU limit to avoid this.
+
+```yaml
+http:
+  workers: 4
+```

--- a/.github/workflows/build-router.yaml
+++ b/.github/workflows/build-router.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          token: ${{ github.ref == 'refs/heads/main' && secrets.BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
       - name: setup rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
       - name: generate config schema

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -241,6 +241,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     let graphql_path = router_config.graphql_path().to_string();
     let websocket_path = router_config.websocket_path().map(|p| p.to_string());
     let callback_conf = router_config.callback_conf().cloned();
+    let workers = router_config.workers();
     let mut bg_tasks_manager = background_tasks::BackgroundTasksManager::new();
     let (shared_state, schema_state) = configure_app_from_config(
         router_config,
@@ -264,16 +265,24 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             let cb_path = path.to_string();
             let cb_addr = listen.to_string();
             let cb_subs = callback_subscriptions_for_handler.clone();
-            let cb_server = web::HttpServer::new(async move || {
+            let mut cb_server_builder = web::HttpServer::new(async move || {
                 let cb_subs = cb_subs.clone();
                 let cb_path = cb_path.clone();
                 web::App::new()
                     .state(cb_subs)
                     .configure(move |m| add_callback_handler(m, &cb_path))
-            })
-            .bind(&cb_addr)
-            .map_err(|err| RouterInitError::HttpCallbackServerBindError(cb_addr, err))?
-            .run();
+            });
+            if let Some(workers) = workers {
+                info!(
+                    "configuring HTTP callback server with {} worker(s)",
+                    workers
+                );
+                cb_server_builder = cb_server_builder.workers(workers.get());
+            }
+            let cb_server = cb_server_builder
+                .bind(&cb_addr)
+                .map_err(|err| RouterInitError::HttpCallbackServerBindError(cb_addr, err))?
+                .run();
 
             bg_tasks_manager.register_task(CallbackServer::from(cb_server));
 
@@ -291,7 +300,6 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     let long_lived_client_limit_service =
         LongLivedClientLimitService::new(&shared_state.router_config);
 
-    let workers = shared_state_clone.router_config.workers();
     let mut server = web::HttpServer::new(async move || {
         let landing_page_path = graphql_path.clone();
         let prometheus = prometheus.clone();
@@ -319,7 +327,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     });
     if let Some(workers) = workers {
         info!("configuring HTTP server with {} worker(s)", workers);
-        server = server.workers(workers);
+        server = server.workers(workers.get());
     }
 
     let tls_config = shared_state_clone

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -291,7 +291,8 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     let long_lived_client_limit_service =
         LongLivedClientLimitService::new(&shared_state.router_config);
 
-    let server = web::HttpServer::new(async move || {
+    let workers = shared_state_clone.router_config.workers();
+    let mut server = web::HttpServer::new(async move || {
         let landing_page_path = graphql_path.clone();
         let prometheus = prometheus.clone();
         let long_lived_client_limit_service = long_lived_client_limit_service.clone();
@@ -316,6 +317,10 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 landing_page_handler(landing_page_path.clone())
             }))
     });
+    if let Some(workers) = workers {
+        info!("configuring HTTP server with {} worker(s)", workers);
+        server = server.workers(workers);
+    }
 
     let tls_config = shared_state_clone
         .router_config

--- a/docs/README.md
+++ b/docs/README.md
@@ -1781,6 +1781,7 @@ Configuration for the HTTP server/listener.
 |**graphql\_endpoint**|`string`|The endpoint to serve GraphQL requests. By default, `/graphql` is used.<br/>Default: `"/graphql"`<br/>||
 |**host**|`string`|The host address to bind the HTTP server to.<br/><br/>Can also be set via the `HOST` environment variable.<br/>Default: `"0.0.0.0"`<br/>||
 |**port**|`integer`|The port to bind the HTTP server to.<br/><br/>Can also be set via the `PORT` environment variable.<br/><br/>If you are running the router inside a Docker container, please ensure that the port is exposed correctly using `-p <host_port>:<container_port>` flag.<br/>Default: `4000`<br/>Format: `"uint16"`<br/>Minimum: `0`<br/>Maximum: `65535`<br/>||
+|**workers**|`integer`, `null`|The number of worker threads to use for the HTTP server. Must be at least `1`.<br/><br/>Defaults to the number of physical CPU cores available to the process.<br/><br/>Useful in containerized environments (e.g., Kubernetes) where the number of<br/>physical cores reported by the OS is higher than the actual CPU limit<br/>assigned to the container. In such cases, you should set this to match the<br/>container's CPU limit to avoid oversubscribing worker threads.<br/><br/>Can also be set via the `ROUTER_HTTP_WORKERS` environment variable.<br/>Format: `"uint"`<br/>Minimum: `1`<br/>||
 
 **Additional Properties:** not allowed  
 **Example**

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -32,7 +32,7 @@ pub struct EnvVarOverrides {
     #[envconfig(from = "HOST")]
     pub http_host: Option<String>,
     #[envconfig(from = "WORKERS")]
-    pub http_workers: Option<u64>,
+    pub http_workers: Option<usize>,
 
     // Supergraph overrides
     #[envconfig(from = "SUPERGRAPH_FILE_PATH")]
@@ -93,7 +93,9 @@ impl EnvVarOverrides {
 
         if let Some(http_workers) = self.http_workers.take() {
             debug!("[config-override] 'http.workers' = {}", http_workers);
-            config = config.set_override("http.workers", http_workers)?;
+            // cast to u64 because the `config` crate doesn't implement `Into<Value>` for `usize`;
+            // the value is then deserialized into `Option<NonZeroUsize>`, which rejects `0`.
+            config = config.set_override("http.workers", http_workers as u64)?;
         }
 
         if self.supergraph_file_path.is_some() && self.hive_console_cdn_endpoint.is_some() {

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -31,7 +31,7 @@ pub struct EnvVarOverrides {
     pub http_port: Option<u64>,
     #[envconfig(from = "HOST")]
     pub http_host: Option<String>,
-    #[envconfig(from = "WORKERS")]
+    #[envconfig(from = "ROUTER_HTTP_WORKERS")]
     pub http_workers: Option<usize>,
 
     // Supergraph overrides

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -31,6 +31,8 @@ pub struct EnvVarOverrides {
     pub http_port: Option<u64>,
     #[envconfig(from = "HOST")]
     pub http_host: Option<String>,
+    #[envconfig(from = "WORKERS")]
+    pub http_workers: Option<u64>,
 
     // Supergraph overrides
     #[envconfig(from = "SUPERGRAPH_FILE_PATH")]
@@ -87,6 +89,11 @@ impl EnvVarOverrides {
         if let Some(http_host) = self.http_host.take() {
             debug!("[config-override] 'http.host' = {}", http_host);
             config = config.set_override("http.host", http_host)?;
+        }
+
+        if let Some(http_workers) = self.http_workers.take() {
+            debug!("[config-override] 'http.workers' = {}", http_workers);
+            config = config.set_override("http.workers", http_workers)?;
         }
 
         if self.supergraph_file_path.is_some() && self.hive_console_cdn_endpoint.is_some() {

--- a/lib/router-config/src/http_server.rs
+++ b/lib/router-config/src/http_server.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +24,7 @@ pub struct HttpServerConfig {
     #[serde(default = "http_server_port_default")]
     pub port: u16,
 
-    /// The number of worker threads to use for the HTTP server.
+    /// The number of worker threads to use for the HTTP server. Must be at least `1`.
     ///
     /// Defaults to the number of physical CPU cores available to the process.
     ///
@@ -33,7 +35,7 @@ pub struct HttpServerConfig {
     ///
     /// Can also be set via the `WORKERS` environment variable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workers: Option<usize>,
+    pub workers: Option<NonZeroUsize>,
 }
 
 impl Default for HttpServerConfig {

--- a/lib/router-config/src/http_server.rs
+++ b/lib/router-config/src/http_server.rs
@@ -21,6 +21,19 @@ pub struct HttpServerConfig {
     /// If you are running the router inside a Docker container, please ensure that the port is exposed correctly using `-p <host_port>:<container_port>` flag.
     #[serde(default = "http_server_port_default")]
     pub port: u16,
+
+    /// The number of worker threads to use for the HTTP server.
+    ///
+    /// Defaults to the number of physical CPU cores available to the process.
+    ///
+    /// Useful in containerized environments (e.g., Kubernetes) where the number of
+    /// physical cores reported by the OS is higher than the actual CPU limit
+    /// assigned to the container. In such cases, you should set this to match the
+    /// container's CPU limit to avoid oversubscribing worker threads.
+    ///
+    /// Can also be set via the `WORKERS` environment variable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workers: Option<usize>,
 }
 
 impl Default for HttpServerConfig {
@@ -29,6 +42,7 @@ impl Default for HttpServerConfig {
             host: http_server_host_default(),
             port: http_server_port_default(),
             graphql_endpoint: graphql_endpoint_default(),
+            workers: None,
         }
     }
 }

--- a/lib/router-config/src/http_server.rs
+++ b/lib/router-config/src/http_server.rs
@@ -33,7 +33,7 @@ pub struct HttpServerConfig {
     /// assigned to the container. In such cases, you should set this to match the
     /// container's CPU limit to avoid oversubscribing worker threads.
     ///
-    /// Can also be set via the `WORKERS` environment variable.
+    /// Can also be set via the `ROUTER_HTTP_WORKERS` environment variable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workers: Option<NonZeroUsize>,
 }

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -185,7 +185,7 @@ impl HiveRouterConfig {
         self.http.port
     }
 
-    pub fn workers(&self) -> Option<usize> {
+    pub fn workers(&self) -> Option<std::num::NonZeroUsize> {
         self.http.workers
     }
 

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -185,6 +185,10 @@ impl HiveRouterConfig {
         self.http.port
     }
 
+    pub fn workers(&self) -> Option<usize> {
+        self.http.workers
+    }
+
     pub fn graphql_path(&self) -> &str {
         &self.http.graphql_endpoint
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
     },
     "lib/node-addon": {
       "name": "@graphql-hive/router-query-planner",
-      "version": "0.0.24",
+      "version": "0.0.26",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "3.5.1",
@@ -1845,6 +1845,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2053,6 +2054,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }


### PR DESCRIPTION
Add an `http.workers` config option (and `WORKERS` env var) so the number of HTTP server worker threads can be set explicitly. By default ntex spawns one worker per physical CPU core, which oversubscribes workers in containerized environments (e.g. Kubernetes) where the container's CPU limit is lower than the host's physical core count.