### PR TITLE
feat: `cors.preflight_response_headers`

### DIFF
--- a/.changeset/cors-cache-control.md
+++ b/.changeset/cors-cache-control.md
@@ -1,0 +1,21 @@
+---
+hive-router-config: minor
+hive-router: minor
+---
+
+# Add `cors.preflight_response_headers` to attach headers to CORS preflight (OPTIONS) responses
+
+Adds a new optional `preflight_response_headers` map to the `cors` configuration block, and to each entry under `cors.policies`. The map allows attaching arbitrary headers (e.g. `Cache-Control`, `Server-Timing`, custom `X-*` headers) to CORS preflight (OPTIONS) responses.
+
+This is useful because the `headers` configuration block does not affect preflight responses (they are returned early by the CORS layer), so there was previously no way to control headers like `Cache-Control` for `OPTIONS` requests.
+
+Example:
+
+```yaml
+cors:
+  enabled: true
+  allow_any_origin: true
+  max_age: 86400
+  preflight_response_headers:
+    Cache-Control: "public, max-age=86400"
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ dependencies = [
  "config",
  "envconfig",
  "http",
+ "http-serde",
  "human-size",
  "humantime",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ async-trait = "0.1.88"
 futures = "0.3.31"
 humantime = "2.3.0"
 http = "1.3.1"
+http-serde = "2.1.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.6.0" }
 thiserror = "2.0.14"

--- a/bin/router/src/pipeline/cors.rs
+++ b/bin/router/src/pipeline/cors.rs
@@ -267,9 +267,7 @@ fn merge_preflight_headers(
         return global.clone();
     }
     let mut out = global.clone();
-    for (name, value) in overrides {
-        out.insert(name.clone(), value.into());
-    }
+    out.extend(overrides.iter().map(|(k, v)| (k.clone(), v.clone())));
     out
 }
 

--- a/bin/router/src/pipeline/cors.rs
+++ b/bin/router/src/pipeline/cors.rs
@@ -164,7 +164,7 @@ impl CompiledOriginRule {
 }
 
 pub enum Cors {
-    AllowAll { policy: CompiledCORSPolicy },
+    AllowAll { policy: Box<CompiledCORSPolicy> },
     ByOrigin { rules: Vec<CompiledOriginRule> },
 }
 
@@ -191,7 +191,9 @@ impl Cors {
         };
 
         if config.allow_any_origin {
-            return Ok(Some(Cors::AllowAll { policy: global }));
+            return Ok(Some(Cors::AllowAll {
+                policy: global.into(),
+            }));
         }
 
         // Resolve all origin rules
@@ -255,7 +257,7 @@ fn header_value_from_list(vec: &Option<Vec<String>>) -> Option<HeaderValue> {
     }
 }
 
-/// Merge global preflight headers with a policy override map. 
+/// Merge global preflight headers with a policy override map.
 /// Policy keys win on conflict; global-only keys are preserved.
 fn merge_preflight_headers(
     global: &http::HeaderMap,

--- a/bin/router/src/pipeline/cors.rs
+++ b/bin/router/src/pipeline/cors.rs
@@ -1,7 +1,7 @@
 use hive_router_config::cors::{CORSConfig, CORSPolicyConfig};
 use http::{header, StatusCode};
 use ntex::{
-    http::{header::HeaderValue, HeaderMap},
+    http::{header::HeaderValue, HeaderMap, Method},
     web::{self, HttpRequest},
 };
 // use regex::Regex;
@@ -22,6 +22,8 @@ pub struct CompiledCORSPolicy {
     expose_headers_value: Option<HeaderValue>,
     allow_credentials_value: Option<HeaderValue>,
     max_age_value: Option<HeaderValue>,
+    /// Extra headers applied to preflight (OPTIONS) responses.
+    preflight_response_headers: http::HeaderMap,
 }
 
 impl CompiledCORSPolicy {
@@ -43,6 +45,10 @@ impl CompiledCORSPolicy {
             } else {
                 global.max_age_value.clone()
             },
+            preflight_response_headers: merge_preflight_headers(
+                &global.preflight_response_headers,
+                &policy_config.preflight_response_headers,
+            ),
         }
     }
 
@@ -89,6 +95,16 @@ impl CompiledCORSPolicy {
         }
         if let Some(v) = &self.max_age_value {
             response_headers.insert(header::ACCESS_CONTROL_MAX_AGE, v.clone());
+        }
+
+        // User-provided preflight headers. Applied last so they override any
+        // CORS-managed default (e.g. `Cache-Control`, `Access-Control-Max-Age`,
+        // even `Access-Control-Allow-Origin`) for users who explicitly opt in.
+        // Only used on OPTIONS responses.
+        if req.method() == Method::OPTIONS {
+            for (name, value) in &self.preflight_response_headers {
+                response_headers.insert(name.into(), value.into());
+            }
         }
     }
 }
@@ -171,6 +187,7 @@ impl Cors {
             max_age_value: config
                 .max_age
                 .and_then(|v| HeaderValue::from_str(&v.to_string()).ok()),
+            preflight_response_headers: config.preflight_response_headers.clone(),
         };
 
         if config.allow_any_origin {
@@ -236,6 +253,22 @@ fn header_value_from_list(vec: &Option<Vec<String>>) -> Option<HeaderValue> {
         None | Some([]) => None,
         Some(v) => HeaderValue::from_str(&v.join(", ")).ok(),
     }
+}
+
+/// Merge global preflight headers with a policy override map. 
+/// Policy keys win on conflict; global-only keys are preserved.
+fn merge_preflight_headers(
+    global: &http::HeaderMap,
+    overrides: &http::HeaderMap,
+) -> http::HeaderMap {
+    if overrides.is_empty() {
+        return global.clone();
+    }
+    let mut out = global.clone();
+    for (name, value) in overrides {
+        out.insert(name.clone(), value.into());
+    }
+    out
 }
 
 fn append_vary(headers: &mut HeaderMap, token: &str) {
@@ -459,6 +492,192 @@ mod tests {
             assert_eq!(
                 headers.get("vary").unwrap(),
                 "Origin, Access-Control-Request-Headers"
+            );
+        }
+    }
+
+    mod preflight_response_headers {
+        use super::*;
+
+        fn create_http_header_map(entries: &[(&'static str, &'static str)]) -> http::HeaderMap {
+            let mut map = http::HeaderMap::new();
+            for (k, v) in entries {
+                map.insert(
+                    http::HeaderName::from_static(k),
+                    http::HeaderValue::from_static(v),
+                );
+            }
+            map
+        }
+
+        #[test]
+        fn extra_headers_are_set_on_preflight_response() {
+            let cors_config = CORSConfig {
+                enabled: true,
+                allow_any_origin: true,
+                preflight_response_headers: create_http_header_map(&[
+                    ("cache-control", "public, max-age=86400"),
+                    ("x-custom", "hello"),
+                ]),
+                ..CORSConfig::default()
+            };
+            let cors = Cors::from_config(&cors_config).unwrap().unwrap();
+            let req = TestRequest::with_uri("/graphql")
+                .method(Method::OPTIONS)
+                .header(header::ORIGIN, "https://example.com")
+                .to_http_request();
+            let mut headers = header::HeaderMap::new();
+            cors.set_headers(&req, &mut headers);
+            assert_eq!(
+                headers.get(header::CACHE_CONTROL).unwrap(),
+                "public, max-age=86400"
+            );
+            assert_eq!(headers.get("x-custom").unwrap(), "hello");
+        }
+
+        #[test]
+        fn extra_headers_are_not_set_on_non_preflight_response() {
+            let cors_config = CORSConfig {
+                enabled: true,
+                allow_any_origin: true,
+                preflight_response_headers: create_http_header_map(&[(
+                    "cache-control",
+                    "public, max-age=86400",
+                )]),
+                ..CORSConfig::default()
+            };
+            let cors = Cors::from_config(&cors_config).unwrap().unwrap();
+            let req = TestRequest::with_uri("/graphql")
+                .method(Method::POST)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::ORIGIN, "https://example.com")
+                .to_http_request();
+            let mut headers = header::HeaderMap::new();
+            cors.set_headers(&req, &mut headers);
+            assert!(headers.get(header::CACHE_CONTROL).is_none());
+        }
+
+        #[test]
+        fn no_extra_headers_when_unconfigured() {
+            let cors_config = CORSConfig {
+                enabled: true,
+                allow_any_origin: true,
+                ..CORSConfig::default()
+            };
+            let cors = Cors::from_config(&cors_config).unwrap().unwrap();
+            let req = TestRequest::with_uri("/graphql")
+                .method(Method::OPTIONS)
+                .header(header::ORIGIN, "https://example.com")
+                .to_http_request();
+            let mut headers = header::HeaderMap::new();
+            cors.set_headers(&req, &mut headers);
+            assert!(headers.get(header::CACHE_CONTROL).is_none());
+        }
+
+        #[test]
+        fn user_values_override_cors_managed_defaults() {
+            let cors_config = CORSConfig {
+                enabled: true,
+                allow_any_origin: true,
+                max_age: Some(60),
+                preflight_response_headers: create_http_header_map(&[
+                    ("access-control-allow-origin", "https://override.example"),
+                    ("access-control-max-age", "3600"),
+                ]),
+                ..CORSConfig::default()
+            };
+            let cors = Cors::from_config(&cors_config).unwrap().unwrap();
+            let req = TestRequest::with_uri("/graphql")
+                .method(Method::OPTIONS)
+                .header(header::ORIGIN, "https://example.com")
+                .to_http_request();
+            let mut headers = header::HeaderMap::new();
+            cors.set_headers(&req, &mut headers);
+            assert_eq!(
+                headers.get(header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+                "https://override.example"
+            );
+            assert_eq!(headers.get(header::ACCESS_CONTROL_MAX_AGE).unwrap(), "3600");
+        }
+
+        #[test]
+        fn policy_extra_headers_merge_with_global() {
+            let cors_config = CORSConfig {
+                enabled: true,
+                allow_any_origin: false,
+                preflight_response_headers: create_http_header_map(&[
+                    ("cache-control", "public, max-age=60"),
+                    ("x-global", "g"),
+                ]),
+                policies: vec![
+                    CORSPolicyConfig {
+                        origins: Some(vec!["https://example.com".to_string()]),
+                        preflight_response_headers: create_http_header_map(&[
+                            ("cache-control", "public, max-age=3600"),
+                            ("x-policy", "p"),
+                        ]),
+                        ..Default::default()
+                    },
+                    CORSPolicyConfig {
+                        origins: Some(vec!["https://another.com".to_string()]),
+                        ..Default::default()
+                    },
+                ],
+                ..CORSConfig::default()
+            };
+            let cors = Cors::from_config(&cors_config).unwrap().unwrap();
+
+            // First origin: policy overrides Cache-Control, keeps global X-Global, adds X-Policy.
+            let req = TestRequest::with_uri("/graphql")
+                .method(Method::OPTIONS)
+                .header(header::ORIGIN, "https://example.com")
+                .to_http_request();
+            let mut headers = header::HeaderMap::new();
+            cors.set_headers(&req, &mut headers);
+            assert_eq!(
+                headers.get(header::CACHE_CONTROL).unwrap(),
+                "public, max-age=3600"
+            );
+            assert_eq!(headers.get("x-global").unwrap(), "g");
+            assert_eq!(headers.get("x-policy").unwrap(), "p");
+
+            // Second origin: inherits global preflight headers untouched.
+            let req = TestRequest::with_uri("/graphql")
+                .method(Method::OPTIONS)
+                .header(header::ORIGIN, "https://another.com")
+                .to_http_request();
+            let mut headers = header::HeaderMap::new();
+            cors.set_headers(&req, &mut headers);
+            assert_eq!(
+                headers.get(header::CACHE_CONTROL).unwrap(),
+                "public, max-age=60"
+            );
+            assert_eq!(headers.get("x-global").unwrap(), "g");
+            assert!(headers.get("x-policy").is_none());
+        }
+
+        #[test]
+        fn invalid_header_entries_fail_to_deserialize() {
+            // Invalid header names/values no longer fail silently at runtime:
+            // they're rejected by serde at config-load time.
+            let bad_name = r#"{
+                "enabled": true,
+                "allow_any_origin": true,
+                "preflight_response_headers": { "invalid header name": "ok" }
+            }"#;
+            assert!(
+                serde_json::from_str::<CORSConfig>(bad_name).is_err(),
+                "expected invalid-header-name to fail deserialization"
+            );
+
+            let bad_value = r#"{
+                "enabled": true,
+                "allow_any_origin": true,
+                "preflight_response_headers": { "X-Custom": "line1\nline2" }
+            }"#;
+            assert!(
+                serde_json::from_str::<CORSConfig>(bad_value).is_err(),
+                "expected invalid-header-value to fail deserialization"
             );
         }
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@ cors:
     - origins:
         - https://example.com
         - https://another.com
+  preflight_response_headers:
+    cache-control: public, max-age=86400
 csrf:
   enabled: true
   required_headers:
@@ -578,6 +580,7 @@ Configuration for CORS (Cross-Origin Resource Sharing).
 |**max\_age**|`integer`, `null`|The maximum time (in seconds) that the results of a preflight request can be cached by the client.<br/>This will set the `Access-Control-Max-Age` header.<br/>If not set, the browser will not cache the preflight response.<br/>Example: 86400 (24 hours)<br/>Format: `"uint64"`<br/>Minimum: `0`<br/>|no|
 |[**methods**](#corsmethods)|`string[]`|List of methods that the server allows for cross-origin requests.<br/>|no|
 |[**policies**](#corspolicies)|`object[]`|List of CORS policies. The first policy that matches the request origin will be applied.<br/>|yes|
+|[**preflight\_response\_headers**](#corspreflight_response_headers)|`object`|Additional headers to set on CORS preflight (OPTIONS) responses.<br/>|no|
 
 **Example**
 
@@ -594,6 +597,8 @@ policies:
   - origins:
       - https://example.com
       - https://another.com
+preflight_response_headers:
+  cache-control: public, max-age=86400
 
 ```
 
@@ -682,6 +687,8 @@ Here's a breakdown of how inheritance works for each field:
   - If `methods` is not specified at all (`null`), the policy inherits the global methods.
   - If an empty list (`[]`) is provided, no methods are allowed for that policy.
   - If the list contains specific methods (e.g., `["GET", "POST"]`), only those methods are used, overriding the global list.
+- `preflight_response_headers`: Per-policy entries are merged on top of the global map.
+  Keys defined in the policy override the global ones, while keys defined only globally are still applied.
 
 
 **Items**
@@ -697,11 +704,12 @@ Here's a breakdown of how inheritance works for each field:
 |**max\_age**|`integer`, `null`|The maximum time (in seconds) that the results of a preflight request can be cached by the client.<br/>This will set the `Access-Control-Max-Age` header.<br/>If not set, the browser will not cache the preflight response.<br/>Example: 86400 (24 hours)<br/>Format: `"uint64"`<br/>Minimum: `0`<br/>||
 |[**methods**](#corspoliciesmethods)|`string[]`|List of methods that the server allows for cross-origin requests.<br/>||
 |[**origins**](#corspoliciesorigins)|`string[]`|List of allowed origins. If `allow_any_origin` is true, this field is ignored.<br/>||
+|[**preflight\_response\_headers**](#corspoliciespreflight_response_headers)|`object`|Additional headers to set on CORS preflight (OPTIONS) responses for this policy.<br/>||
 
 **Example**
 
 ```yaml
-- {}
+- preflight_response_headers: {}
 
 ```
 
@@ -765,6 +773,53 @@ Example: "https://example.com", "http://localhost:3000"
 **Items**
 
 **Item Type:** `string`  
+<a name="corspoliciespreflight_response_headers"></a>
+#### cors\.policies\[\]\.preflight\_response\_headers: object
+
+Additional headers to set on CORS preflight (OPTIONS) responses for this policy.
+
+Entries are merged on top of the global `cors.preflight_response_headers` map.
+Keys defined here override the global value for the same key, while keys defined only
+globally still apply.
+
+See `cors.preflight_response_headers` for details and caveats.
+
+
+**Additional Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**Additional Properties**|`string`|||
+
+<a name="corspreflight_response_headers"></a>
+### cors\.preflight\_response\_headers: object
+
+Additional headers to set on CORS preflight (OPTIONS) responses.
+
+The `headers` configuration block does not affect preflight responses
+because they are returned early by the CORS layer. This map provides a
+first-class way to attach arbitrary headers (e.g. `Cache-Control`,
+`Server-Timing`, `X-*` custom headers) to those preflight responses.
+
+Keys must be valid HTTP header names (RFC 7230) and values must be
+valid HTTP header values.
+
+The headers provided here are applied after the CORS engine's managed headers
+(`Access-Control-*`, `Vary`) and therefore override them when keys collide.
+
+Example:
+```yaml
+preflight_response_headers:
+  Cache-Control: "public, max-age=86400"
+```
+
+
+**Additional Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**Additional Properties**|`string`|||
+
 <a name="csrf"></a>
 ## csrf: object
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -683,9 +683,9 @@ Here's a breakdown of how inheritance works for each field:
 - `allow_headers` and `expose_headers`: A policy's behavior for these header lists depends on the value provided:
   - If a list with specific headers is provided (e.g., `["Content-Type"]`), it completely overrides the global list.
   - If an empty list (`[]`) is provided, the policy will inherit the headers from the global configuration.
-- `methods`: This setting has three distinct states for inheritance:
-  - If `methods` is not specified at all (`null`), the policy inherits the global methods.
-  - If an empty list (`[]`) is provided, no methods are allowed for that policy.
+- `methods`: A policy's behavior for this header list depends on the value provided:
+  - If `methods` is not specified at all (`null`) or set to an empty list (`[]`),
+    the policy inherits the methods from the global configuration.
   - If the list contains specific methods (e.g., `["GET", "POST"]`), only those methods are used, overriding the global list.
 - `preflight_response_headers`: Per-policy entries are merged on top of the global map.
   Keys defined in the policy override the global ones, while keys defined only globally are still applied.

--- a/lib/router-config/Cargo.toml
+++ b/lib/router-config/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 http = { workspace = true }
+http-serde = { workspace = true }
 tonic = { workspace = true }
 jsonwebtoken = { workspace = true }
 retry-policies = { workspace = true}

--- a/lib/router-config/src/cors.rs
+++ b/lib/router-config/src/cors.rs
@@ -1,5 +1,6 @@
-use std::vec;
+use std::{collections::HashMap, vec};
 
+use http::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -51,6 +52,8 @@ pub struct CORSConfig {
     ///   - If `methods` is not specified at all (`null`), the policy inherits the global methods.
     ///   - If an empty list (`[]`) is provided, no methods are allowed for that policy.
     ///   - If the list contains specific methods (e.g., `["GET", "POST"]`), only those methods are used, overriding the global list.
+    /// - `preflight_response_headers`: Per-policy entries are merged on top of the global map.
+    ///   Keys defined in the policy override the global ones, while keys defined only globally are still applied.
     pub policies: Vec<CORSPolicyConfig>,
 
     /// Set to true to allow credentials (cookies, authorization headers, or TLS client certificates) in cross-origin requests.
@@ -85,6 +88,32 @@ pub struct CORSConfig {
     /// Example: 86400 (24 hours)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_age: Option<u64>,
+
+    /// Additional headers to set on CORS preflight (OPTIONS) responses.
+    ///
+    /// The `headers` configuration block does not affect preflight responses
+    /// because they are returned early by the CORS layer. This map provides a
+    /// first-class way to attach arbitrary headers (e.g. `Cache-Control`,
+    /// `Server-Timing`, `X-*` custom headers) to those preflight responses.
+    ///
+    /// Keys must be valid HTTP header names (RFC 7230) and values must be
+    /// valid HTTP header values.
+    ///
+    /// The headers provided here are applied after the CORS engine's managed headers
+    /// (`Access-Control-*`, `Vary`) and therefore override them when keys collide.
+    ///
+    /// Example:
+    /// ```yaml
+    /// preflight_response_headers:
+    ///   Cache-Control: "public, max-age=86400"
+    /// ```
+    #[serde(
+        default,
+        with = "http_serde::header_map",
+        skip_serializing_if = "HeaderMap::is_empty"
+    )]
+    #[schemars(with = "HashMap<String, String>")]
+    pub preflight_response_headers: HeaderMap,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
@@ -135,6 +164,21 @@ pub struct CORSPolicyConfig {
     /// Example: 86400 (24 hours)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_age: Option<u64>,
+
+    /// Additional headers to set on CORS preflight (OPTIONS) responses for this policy.
+    ///
+    /// Entries are merged on top of the global `cors.preflight_response_headers` map.
+    /// Keys defined here override the global value for the same key, while keys defined only
+    /// globally still apply.
+    ///
+    /// See `cors.preflight_response_headers` for details and caveats.
+    #[serde(
+        default,
+        with = "http_serde::header_map",
+        skip_serializing_if = "HeaderMap::is_empty"
+    )]
+    #[schemars(with = "HashMap<String, String>")]
+    pub preflight_response_headers: HeaderMap,
 }
 
 fn default_cors_enabled() -> bool {
@@ -169,6 +213,14 @@ fn cors_example_1() -> CORSConfig {
         ]),
         expose_headers: None,
         max_age: Some(120),
+        preflight_response_headers: {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                http::header::CACHE_CONTROL,
+                http::HeaderValue::from_static("public, max-age=86400"),
+            );
+            headers
+        },
     }
 }
 fn cors_example_2() -> CORSConfig {

--- a/lib/router-config/src/cors.rs
+++ b/lib/router-config/src/cors.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, vec};
+use std::collections::HashMap;
 
 use http::HeaderMap;
 use schemars::JsonSchema;
@@ -48,9 +48,9 @@ pub struct CORSConfig {
     /// - `allow_headers` and `expose_headers`: A policy's behavior for these header lists depends on the value provided:
     ///   - If a list with specific headers is provided (e.g., `["Content-Type"]`), it completely overrides the global list.
     ///   - If an empty list (`[]`) is provided, the policy will inherit the headers from the global configuration.
-    /// - `methods`: This setting has three distinct states for inheritance:
-    ///   - If `methods` is not specified at all (`null`), the policy inherits the global methods.
-    ///   - If an empty list (`[]`) is provided, no methods are allowed for that policy.
+    /// - `methods`: A policy's behavior for this header list depends on the value provided:
+    ///   - If `methods` is not specified at all (`null`) or set to an empty list (`[]`),
+    ///     the policy inherits the methods from the global configuration.
     ///   - If the list contains specific methods (e.g., `["GET", "POST"]`), only those methods are used, overriding the global list.
     /// - `preflight_response_headers`: Per-policy entries are merged on top of the global map.
     ///   Keys defined in the policy override the global ones, while keys defined only globally are still applied.
@@ -97,7 +97,7 @@ pub struct CORSConfig {
     /// `Server-Timing`, `X-*` custom headers) to those preflight responses.
     ///
     /// Keys must be valid HTTP header names (RFC 7230) and values must be
-    /// valid HTTP header values.
+   /// valid HTTP header values.
     ///
     /// The headers provided here are applied after the CORS engine's managed headers
     /// (`Access-Control-*`, `Vary`) and therefore override them when keys collide.

--- a/lib/router-config/src/cors.rs
+++ b/lib/router-config/src/cors.rs
@@ -97,7 +97,7 @@ pub struct CORSConfig {
     /// `Server-Timing`, `X-*` custom headers) to those preflight responses.
     ///
     /// Keys must be valid HTTP header names (RFC 7230) and values must be
-   /// valid HTTP header values.
+    /// valid HTTP header values.
     ///
     /// The headers provided here are applied after the CORS engine's managed headers
     /// (`Access-Control-*`, `Vary`) and therefore override them when keys collide.


### PR DESCRIPTION
Closes https://github.com/graphql-hive/router/issues/972

Adds a new optional `preflight_response_headers` map to the `cors` configuration block, and to each entry under `cors.policies`. The map allows attaching arbitrary headers (e.g. `Cache-Control`, `Server-Timing`, custom `X-*` headers) to CORS preflight (OPTIONS) responses.

This is useful because the `headers` configuration block does not affect preflight responses (they are returned early by the CORS layer), so there was previously no way to control headers like `Cache-Control` for `OPTIONS` requests.

Example:

```yaml
cors:
  enabled: true
  allow_any_origin: true
  max_age: 86400
  preflight_response_headers:
    Cache-Control: "public, max-age=86400"
```