### PR TITLE
fix: escape inline string values in the AST per GraphQL spec

### DIFF
--- a/.changeset/escape-inline-string-arguments.md
+++ b/.changeset/escape-inline-string-arguments.md
@@ -1,0 +1,11 @@
+---
+hive-router-query-planner: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Escape inline string arguments when emitting subgraph operations
+
+Fixes a bug where string values inlined as arguments in subgraph operations were not re-escaped per the GraphQL spec. When an incoming operation contained a string literal whose decoded value carried a quote or backslash (for example `value: "\"aValue\""`), the router forwarded the argument to the subgraph as `value: ""aValue""`, producing invalid GraphQL. The same went for newlines, tabs, and other control characters.
+
+Now the characters are escaped properly per GraphQL spec [here](https://spec.graphql.org/draft/#StringCharacter).

--- a/.changeset/escape-inline-string-arguments.md
+++ b/.changeset/escape-inline-string-arguments.md
@@ -6,6 +6,6 @@ node-addon: patch
 
 # Escape inline string arguments when emitting subgraph operations
 
-Fixes a bug where string values inlined as arguments in subgraph operations were not re-escaped per the GraphQL spec. When an incoming operation contained a string literal whose decoded value carried a quote or backslash (for example `value: "\"aValue\""`), the router forwarded the argument to the subgraph as `value: ""aValue""`, producing invalid GraphQL. The same went for newlines, tabs, and other control characters.
+Fixes a bug where string values inlined as arguments in subgraph operations were not re-escaped per the GraphQL spec. When an incoming operation contained a string literal whose decoded value carried a quote or backslash (for example `payload: "\"quoted\""`), the router forwarded the argument to the subgraph as `payload: ""quoted""`, producing invalid GraphQL. The same went for newlines, tabs, and other control characters.
 
-Now the characters are escaped properly per GraphQL spec [here](https://spec.graphql.org/draft/#StringCharacter).
+Now the characters are escaped properly per the [GraphQL spec](https://spec.graphql.org/draft/#StringCharacter).

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -811,4 +811,112 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    /// Inline string arguments must be re-escaped per the GraphQL spec when
+    /// the router emits the operation to a subgraph. A value such as
+    /// `"\"quoted\""` is decoded to `"quoted"` while parsing the incoming
+    /// operation; if it is re-emitted bare, the subgraph receives the invalid
+    /// literal `payload: ""quoted""`.
+    async fn escape_inline_string_arguments_for_subgraph() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.escape-string-arguments.graphql
+                  override_subgraph_urls:
+                    entries:
+                      url: "http://{host}/entries"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let entries_mock = server
+            .mock("POST", "/entries")
+            .match_request(|r| {
+                use sonic_rs::JsonValueTrait;
+
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                let parsed: sonic_rs::Value =
+                    sonic_rs::from_slice(body).expect("subgraph body must be valid JSON");
+                let query = parsed
+                    .get(&"query")
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                    .expect("subgraph body must contain a `query` string");
+
+                let has_escaped = query.contains(r#"payload: "\"quoted\"""#);
+                let has_unescaped = query.contains(r#"payload: ""quoted"""#);
+
+                assert!(
+                    has_escaped,
+                    "expected escaped string literal in subgraph query, got: {body_str}"
+                );
+                assert!(
+                    !has_unescaped,
+                    "subgraph query must not contain unescaped quotes, got: {body_str}"
+                );
+
+                true
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "writeEntry": { "id": "primary" }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                mutation {
+                  writeEntry(
+                    bucket: "primary"
+                    attempt: 1
+                    entries: [
+                      {
+                        upsert: {
+                          schemaKey: "Entry"
+                          attributes: [
+                            { key: "field-1", payload: "\"quoted\"" }
+                          ]
+                        }
+                      }
+                    ]
+                  ) {
+                    id
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        entries_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "writeEntry": {
+              "id": "primary"
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/supergraph.escape-string-arguments.graphql
+++ b/e2e/src/issues/supergraph.escape-string-arguments.graphql
@@ -1,0 +1,84 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ENTRIES @join__graph(name: "entries", url: "http://0.0.0.0:4200/entries")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: ENTRIES) {
+  entry(id: String!): Entry
+}
+
+type Mutation @join__type(graph: ENTRIES) {
+  writeEntry(bucket: String!, attempt: Int!, entries: [EntryAction!]!): Entry
+}
+
+type Entry @join__type(graph: ENTRIES) {
+  id: String!
+}
+
+input EntryAction @join__type(graph: ENTRIES) {
+  upsert: UpsertEntry
+}
+
+input UpsertEntry @join__type(graph: ENTRIES) {
+  schemaKey: String!
+  attributes: [EntryAttribute!]!
+}
+
+input EntryAttribute @join__type(graph: ENTRIES) {
+  key: String!
+  payload: String!
+}

--- a/lib/query-planner/src/ast/arguments.rs
+++ b/lib/query-planner/src/ast/arguments.rs
@@ -120,17 +120,73 @@ mod tests {
 
     #[test]
     fn arguments_map_display_escapes_string_values() {
-        // Reproduces the issue where a string field whose decoded value contains
-        // a quote character would be re-emitted as invalid GraphQL because the
-        // surrounding quotes weren't escaped (e.g. `value: ""aValue""`).
+        // Decoded string values that carry GraphQL-special characters (such as
+        // a quote) must be re-escaped on output, otherwise the rendered query
+        // is invalid GraphQL (e.g. `payload: ""quoted""` instead of the proper
+        // `payload: "\"quoted\""`).
         let args = ArgumentsMap::from(vec![
-            ("name".to_string(), Value::String("cF-2".to_string())),
-            ("value".to_string(), Value::String("\"aValue\"".to_string())),
+            ("label".to_string(), Value::String("plain".to_string())),
+            (
+                "payload".to_string(),
+                Value::String("\"quoted\"".to_string()),
+            ),
         ]);
 
         insta::assert_snapshot!(
             args.to_string(),
-            @r#"name: "cF-2", value: "\"aValue\"""#
+            @r#"label: "plain", payload: "\"quoted\"""#
+        );
+    }
+
+    #[test]
+    fn parse_and_render_mutation_with_escaped_string_argument() {
+        // End-to-end check that a string argument whose decoded value contains
+        // GraphQL-special characters (quotes, backslashes, newlines) round-trips
+        // through parse + render without losing its escapes on the way out.
+        use crate::ast::operation::OperationDefinition;
+        use crate::utils::parsing::parse_operation;
+        use graphql_tools::parser::query::Definition;
+
+        let input = r#"
+            mutation {
+              writeEntry(
+                bucket: "primary"
+                attempt: 1
+                entries: [
+                  {
+                    upsert: {
+                      schemaKey: "Entry"
+                      attributes: [
+                        { key: "field-1", payload: "\"quoted\"" }
+                      ]
+                    }
+                  }
+                ]
+              ) { id }
+            }
+        "#;
+
+        let document = parse_operation(input);
+        let op_def = document
+            .definitions
+            .into_iter()
+            .find_map(|def| match def {
+                Definition::Operation(op) => Some(OperationDefinition::from(op)),
+                _ => None,
+            })
+            .expect("mutation operation");
+
+        let rendered = op_def.to_string();
+
+        // The inner string `"quoted"` must come out as `\"quoted\"` so the
+        // resulting GraphQL is well-formed when forwarded to a subgraph.
+        assert!(
+            rendered.contains(r#"payload: "\"quoted\"""#),
+            "expected rendered query to keep escaped quotes, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains(r#"payload: ""quoted"""#),
+            "rendered query must not contain unescaped quotes, got: {rendered}"
         );
     }
 }

--- a/lib/query-planner/src/ast/arguments.rs
+++ b/lib/query-planner/src/ast/arguments.rs
@@ -113,3 +113,24 @@ impl Display for ArgumentsMap {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arguments_map_display_escapes_string_values() {
+        // Reproduces the issue where a string field whose decoded value contains
+        // a quote character would be re-emitted as invalid GraphQL because the
+        // surrounding quotes weren't escaped (e.g. `value: ""aValue""`).
+        let args = ArgumentsMap::from(vec![
+            ("name".to_string(), Value::String("cF-2".to_string())),
+            ("value".to_string(), Value::String("\"aValue\"".to_string())),
+        ]);
+
+        insta::assert_snapshot!(
+            args.to_string(),
+            @r#"name: "cF-2", value: "\"aValue\"""#
+        );
+    }
+}

--- a/lib/query-planner/src/ast/value.rs
+++ b/lib/query-planner/src/ast/value.rs
@@ -279,8 +279,8 @@ mod tests {
 
         // String containing a quote: must be escaped as \"
         insta::assert_snapshot!(
-          Value::String("\"aValue\"".to_string()),
-          @r#""\"aValue\"""#);
+          Value::String("\"quoted\"".to_string()),
+          @r#""\"quoted\"""#);
 
         // String containing a backslash: must be escaped as \\
         insta::assert_snapshot!(

--- a/lib/query-planner/src/ast/value.rs
+++ b/lib/query-planner/src/ast/value.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fmt::Display,
+    fmt::{Display, Write},
     hash::Hash,
     mem,
 };
@@ -197,13 +197,37 @@ impl From<&mut Value> for SonicValue {
     }
 }
 
+/// Writes a string as a GraphQL string literal, escaping special characters
+/// per the GraphQL spec (https://spec.graphql.org/draft/#StringCharacter).
+///
+/// The string contents are decoded values (e.g. parsed from `"\"aValue\""` into
+/// `"aValue"`), so we must re-escape `"`, `\`, and control characters when
+/// re-emitting them as a GraphQL literal.
+fn write_graphql_string_literal(f: &mut std::fmt::Formatter<'_>, s: &str) -> std::fmt::Result {
+    f.write_char('"')?;
+    for c in s.chars() {
+        match c {
+            '"' => f.write_str("\\\"")?,
+            '\\' => f.write_str("\\\\")?,
+            '\n' => f.write_str("\\n")?,
+            '\r' => f.write_str("\\r")?,
+            '\t' => f.write_str("\\t")?,
+            '\u{0008}' => f.write_str("\\b")?,
+            '\u{000C}' => f.write_str("\\f")?,
+            c if (c as u32) < 0x20 => write!(f, "\\u{:04x}", c as u32)?,
+            c => f.write_char(c)?,
+        }
+    }
+    f.write_char('"')
+}
+
 impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Value::Variable(name) => write!(f, "${}", name),
             Value::Int(i) => write!(f, "{}", i),
             Value::Float(fl) => write!(f, "{}", fl),
-            Value::String(s) => write!(f, "\"{}\"", s),
+            Value::String(s) => write_graphql_string_literal(f, s),
             Value::Boolean(b) => write!(f, "{}", b),
             Value::Null => write!(f, "null"),
             Value::Enum(e) => write!(f, "{}", e),
@@ -252,6 +276,26 @@ mod tests {
         insta::assert_snapshot!(
           Value::String("test".to_string()),
           @r#""test""#);
+
+        // String containing a quote: must be escaped as \"
+        insta::assert_snapshot!(
+          Value::String("\"aValue\"".to_string()),
+          @r#""\"aValue\"""#);
+
+        // String containing a backslash: must be escaped as \\
+        insta::assert_snapshot!(
+          Value::String("a\\b".to_string()),
+          @r#""a\\b""#);
+
+        // String containing common control characters: must be escaped
+        insta::assert_snapshot!(
+          Value::String("line1\nline2\t\r".to_string()),
+          @r#""line1\nline2\t\r""#);
+
+        // String containing a less common control character: must be \u escaped
+        insta::assert_snapshot!(
+          Value::String("\x01".to_string()),
+          @r#""\u0001""#);
 
         insta::assert_snapshot!(
           Value::Boolean(false),

--- a/lib/query-planner/src/ast/value.rs
+++ b/lib/query-planner/src/ast/value.rs
@@ -200,24 +200,43 @@ impl From<&mut Value> for SonicValue {
 /// Writes a string as a GraphQL string literal, escaping special characters
 /// per the GraphQL spec (https://spec.graphql.org/draft/#StringCharacter).
 ///
-/// The string contents are decoded values (e.g. parsed from `"\"aValue\""` into
-/// `"aValue"`), so we must re-escape `"`, `\`, and control characters when
+/// The string contents are decoded values (e.g. parsed from `"\"quoted\""` into
+/// `"quoted"`), so we must re-escape `"`, `\`, and control characters when
 /// re-emitting them as a GraphQL literal.
+///
+/// Strings without any escapable characters are written in a single
+/// `write_str` call; otherwise we flush the run of safe bytes preceding each
+/// escape sequence in one go, which is significantly cheaper than emitting
+/// every character individually through the formatter.
 fn write_graphql_string_literal(f: &mut std::fmt::Formatter<'_>, s: &str) -> std::fmt::Result {
     f.write_char('"')?;
-    for c in s.chars() {
-        match c {
-            '"' => f.write_str("\\\"")?,
-            '\\' => f.write_str("\\\\")?,
-            '\n' => f.write_str("\\n")?,
-            '\r' => f.write_str("\\r")?,
-            '\t' => f.write_str("\\t")?,
-            '\u{0008}' => f.write_str("\\b")?,
-            '\u{000C}' => f.write_str("\\f")?,
-            c if (c as u32) < 0x20 => write!(f, "\\u{:04x}", c as u32)?,
-            c => f.write_char(c)?,
-        }
+    let mut last = 0;
+    for (i, c) in s.char_indices() {
+        let esc = match c {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            '\u{0008}' => "\\b",
+            '\u{000C}' => "\\f",
+            // ASCII C0 control characters (< 0x20) and DEL (0x7F) are escaped
+            // defensively. DEL is technically a valid SourceCharacter per the
+            // GraphQL spec, but emitting it bare can trip strict downstream
+            // parsers.
+            c if (c as u32) < 0x20 || (c as u32) == 0x7F => {
+                f.write_str(&s[last..i])?;
+                write!(f, "\\u{:04x}", c as u32)?;
+                last = i + c.len_utf8();
+                continue;
+            }
+            _ => continue,
+        };
+        f.write_str(&s[last..i])?;
+        f.write_str(esc)?;
+        last = i + c.len_utf8();
     }
+    f.write_str(&s[last..])?;
     f.write_char('"')
 }
 
@@ -296,6 +315,16 @@ mod tests {
         insta::assert_snapshot!(
           Value::String("\x01".to_string()),
           @r#""\u0001""#);
+
+        // String containing the DEL control character (U+007F): escaped \u007f
+        insta::assert_snapshot!(
+          Value::String("\u{007F}".to_string()),
+          @r#""\u007f""#);
+
+        // String with mixed safe/escapable runs: safe runs are emitted in bulk
+        insta::assert_snapshot!(
+          Value::String("hello \"world\"\nbye".to_string()),
+          @r#""hello \"world\"\nbye""#);
 
         insta::assert_snapshot!(
           Value::Boolean(false),


### PR DESCRIPTION
Ref ROUTER-322

Fixes a bug where string values inlined as arguments in subgraph operations were not re-escaped per the GraphQL spec. When an incoming operation contained a string literal whose decoded value carried a quote or backslash (for example `value: "\"myValue\""`), the router forwarded the argument to the subgraph as `value: ""myValue""`, producing invalid GraphQL. The same went for newlines, tabs, and other control characters.

Now the characters are escaped properly per GraphQL spec [here](https://spec.graphql.org/draft/#StringCharacter).