### PR TITLE
chore(release): added missing changeset for dynamic exclusion in apollo-router hive fork/plugin

### DIFF
--- a/.changeset/dynamic-exclusions.md
+++ b/.changeset/dynamic-exclusions.md
@@ -1,0 +1,19 @@
+---
+apollo-router-hive-fork: minor
+---
+
+# Dynamic Exclusions in Apollo-Router
+
+As in Hive Router, Apollo Router used to support only operation name based exclusions. 
+
+With the new dynamic exclusions feature available in the Hive fork of Apollo-Router, you can now specify custom logic to exclude requests from usage reporting.
+
+```yaml
+# legacy format
+exclude:
+  - ExcludedOp
+
+# dynamic expression format
+exclude:
+  expression: '.request.operation.name == "ExcludedOp"'
+```

--- a/knope.toml
+++ b/knope.toml
@@ -46,6 +46,7 @@ changelog = "lib/node-addon/CHANGELOG.md"
 
 [packages.apollo-router-hive-fork]
 versioned_files = ["apollo-router-workspace/bin/router/Cargo.toml", "apollo-router-workspace/Cargo.lock"]
+changelog = "apollo-router-workspace/bin/router/CHANGELOG.md"
 
 # "release" pipeline that prepares the release and pushes a release PR
 [[workflows]]


### PR DESCRIPTION


It was missing in https://github.com/graphql-hive/router/pull/932 

also, fixed knope config so it will update the changelog 