### PR TITLE
fix(router): warn about debug binary in production use

### DIFF
--- a/.changeset/warn_about_debug_binary.md
+++ b/.changeset/warn_about_debug_binary.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+# Warn about debug binary in production use 
+
+Added a warning message to the router binary to warn users about using a debug binary in production use.
+
+This is intended to prevent cases where users accidentally use a debug binary in production, which can lead to performance issues.

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -229,6 +229,14 @@ async fn graphql_endpoint_dispatch(
 }
 
 pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), RouterInitError> {
+    if cfg!(debug_assertions) && std::env::var("CARGO").is_err() {
+        eprintln!("WARNING: You are running Hive Router using a debug binary, which is not recommended for production use.");
+        eprintln!("  Please consider to use the official binary / Docker image instead:");
+        eprintln!("    https://the-guild.dev/graphql/hive/docs/router/getting-started");
+        eprintln!("  Or, if you are building with custom plugins, refer to the documentation for building from source:");
+        eprintln!("    https://the-guild.dev/graphql/hive/docs/router/customizations/plugin-system/usage#build-your-router");
+    }
+
     let config_path = std::env::var("ROUTER_CONFIG_FILE_PATH").ok();
     let router_config = load_config(config_path)?;
     let telemetry = telemetry::Telemetry::init_global(&router_config)?;


### PR DESCRIPTION
Added a warning message to the router binary to warn users about using a debug binary in production use.

This is intended to prevent cases where users accidentally use a debug binary in production, which can lead to performance issues.
