### PR TITLE
feat(router): introduce storages and s3, and supergraph source for loading from storage 

### DIFF
--- a/.changeset/_external_storage_support_eg_s3.md
+++ b/.changeset/_external_storage_support_eg_s3.md
@@ -1,0 +1,48 @@
+---
+hive-router: minor
+hive-router-config: minor
+hive-router-internal: patch
+hive-router-plan-executor: patch
+---
+
+# External storage support (e.g S3)
+
+[documentation](http://the-guild.dev/graphql/hive/docs/router/configuration/storages)
+
+This release introduces a new top-level `storages` configuration and the first storage backend, s3, so the router can load external artifacts from object storage.
+
+With this change, both the `supergraph` source and `persisted_documents` manifest can be resolved from a configured storage by reference. It also adds optional polling support so the router can reload updated content from storage without restarting.
+
+Start by configuring the storage in your router config:
+
+```yaml
+storages: 
+  my-s3: # this is the storage id 
+    type: s3
+    bucket: my-bucket
+    region: eu-west-1
+    # .. additional S3 configurations 
+```
+
+Then, you can use the storage id in your `supergraph` source:
+
+```yaml
+supergraph:
+  source: storage
+  storage_id: my-s3
+  location: supergraphs/current.graphql
+  poll_interval: 30s
+```
+
+Or, you can use the storage id in your `persisted_documents` manifest:
+
+```yaml
+persisted_documents:
+  enabled: true
+  require_id: true
+  storage:
+    type: storage
+    storage_id: my-s3
+    location: persisted/manifest.json
+    poll_interval: 30s
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -50,7 +50,7 @@ dependencies = [
  "cmac",
  "ctr",
  "dbl",
- "digest",
+ "digest 0.10.7",
  "zeroize",
 ]
 
@@ -454,6 +454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +522,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -679,6 +688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +782,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -928,7 +955,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -966,7 +993,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -977,6 +1004,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codespan-reporting"
@@ -1016,7 +1049,7 @@ checksum = "48629740a3480b865d4083ff45f826a253bd5ce28db618d89359b0e95dc750c3"
 dependencies = [
  "base64",
  "hex",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -1076,6 +1109,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1201,6 +1240,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto_secretbox"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,7 +1465,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1476,7 +1552,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1539,10 +1615,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1686,6 +1774,8 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls",
+ "s3s",
+ "s3s-fs",
  "serde",
  "serde_json",
  "sonic-rs",
@@ -1706,7 +1796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1732,7 +1822,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1751,7 +1841,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2370,6 +2460,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "hive-console-sdk"
 version = "0.3.12"
 dependencies = [
@@ -2396,7 +2496,7 @@ dependencies = [
  "retry-policies 0.5.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sonic-rs",
  "thiserror 2.0.18",
  "tokio",
@@ -2451,6 +2551,7 @@ dependencies = [
  "ntex-http",
  "ntex-io",
  "ntex-net",
+ "object_store",
  "percent-encoding",
  "prometheus",
  "rand 0.10.1",
@@ -2621,7 +2722,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2630,7 +2731,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2722,6 +2832,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -3172,7 +3291,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -3181,7 +3300,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -3268,7 +3387,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3379,7 +3498,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e715bb6f273068fc89403d6c4f5eeb83708c62b74c8d43e3e8772ca73a6288"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3501,7 +3630,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -3720,7 +3849,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "uuid",
  "variadics_please",
@@ -4117,6 +4246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numeric_cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,6 +4273,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5 0.10.6",
+ "parking_lot 0.12.5",
+ "percent-encoding",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -4404,7 +4577,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4416,7 +4589,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4488,6 +4661,24 @@ name = "parse-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pathdiff"
@@ -4566,7 +4757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4991,6 +5182,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5362,12 +5573,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -5453,7 +5666,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5529,8 +5742,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5667,6 +5880,88 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "s3s"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf5572ca9bae5fd92d4e5a3e934c73793ab743bcbc761cd5e86a622c2a5e98a"
+dependencies = [
+ "arc-swap",
+ "arrayvec",
+ "async-trait",
+ "atoi",
+ "base64-simd",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "chrono",
+ "crc-fast",
+ "futures",
+ "hex-simd",
+ "hmac 0.13.0-rc.5",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httparse",
+ "hyper",
+ "itoa",
+ "md-5 0.11.0-rc.5",
+ "memchr",
+ "mime",
+ "nom 8.0.0",
+ "numeric_cast",
+ "pin-project-lite",
+ "quick-xml 0.37.5",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1 0.11.0-rc.5",
+ "sha2 0.11.0-rc.5",
+ "smallvec",
+ "std-next",
+ "subtle",
+ "sync_wrapper",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "transform-stream",
+ "url",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
+name = "s3s-fs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63879a5ec0d8d541cdac24f5fd852b57b756c34bd9c225e2ceca2b33acdb34b1"
+dependencies = [
+ "async-trait",
+ "base64-simd",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "hex-simd",
+ "mime",
+ "numeric_cast",
+ "path-absolutize",
+ "s3s",
+ "serde",
+ "serde_json",
+ "std-next",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-error",
+ "transform-stream",
+ "uuid",
+]
 
 [[package]]
 name = "salsa20"
@@ -5991,7 +6286,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6002,7 +6297,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6013,7 +6319,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6022,7 +6339,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -6067,7 +6384,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6224,6 +6541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6244,6 +6567,16 @@ name = "static_assertions_next"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
+name = "std-next"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
+dependencies = [
+ "simdutf8",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "string_cache"
@@ -6798,6 +7131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6869,6 +7212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "transform-stream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a814d25437963577f6221d33a2aaa60bfb44acc3330cdc7c334644e9832022"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6886,7 +7238,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -6924,9 +7276,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typify"
@@ -7044,7 +7396,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -7072,6 +7424,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
@@ -7158,7 +7516,7 @@ dependencies = [
  "crypto_secretbox",
  "csv",
  "ctr",
- "digest",
+ "digest 0.10.7",
  "dns-lookup",
  "domain",
  "dyn-clone",
@@ -7167,7 +7525,7 @@ dependencies = [
  "flate2",
  "grok",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "hostname",
  "iana-time-zone",
  "idna",
@@ -7180,7 +7538,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lz4_flex",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "nom-language",
  "ofb",
@@ -7209,7 +7567,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha-1",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "simdutf8",
  "snafu 0.8.9",
@@ -7363,6 +7721,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ combine = "4.6.6"
 strum = { version = "0.28.0", features = ["derive"] }
 mockito = "1.7.0"
 futures-util = "0.3.31"
-axum = "0.8.4"
+axum = "0.8.9"
 recloser = "1.3.1"
 notify = "8.2.0"
 ipnet = "2.12.0"
@@ -102,3 +102,6 @@ tracing-subscriber = { version = "0.3.22", features = [
   "json",
 ] }
 tracing-tree = "0.4.0"
+
+# Storage
+object_store = { version = "0.13.2", features = ["aws"] }

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -88,6 +88,7 @@ futures-timer = "3.0.3"
 const-str = "1.0.0"
 md5 = "0.8.0"
 bytes = { workspace = true }
+object_store = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/bin/router/src/error.rs
+++ b/bin/router/src/error.rs
@@ -4,7 +4,7 @@ use hive_router_plan_executor::executors::error::TlsCertificatesError;
 use crate::{
     jwt::jwks_manager::JwksSourceError, pipeline::usage_reporting::UsageReportingError,
     plugins::registry::PluginRegistryError, schema_state::SupergraphManagerError,
-    shared_state::SharedStateError, telemetry::TelemetryInitError,
+    shared_state::SharedStateError, storage::error::StorageError, telemetry::TelemetryInitError,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -39,4 +39,6 @@ pub enum RouterInitError {
     },
     #[error(transparent)]
     TlsCertificatesError(#[from] TlsCertificatesError),
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
 }

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pipeline;
 pub mod plugins;
 mod schema_state;
 mod shared_state;
+mod storage;
 mod supergraph;
 pub mod telemetry;
 mod utils;
@@ -43,6 +44,7 @@ use crate::{
         websocket_server::ws_index,
     },
     plugins::plugins_service::PluginService,
+    storage::StorageManager,
     telemetry::{HeaderExtractor, PrometheusAttached},
 };
 
@@ -387,6 +389,7 @@ pub async fn configure_app_from_config(
 
     let active_subscriptions =
         ActiveSubscriptions::new(router_config.subscriptions.broadcast_capacity);
+    let storage_manager = Arc::new(StorageManager::new(&router_config.storages)?);
     let router_config_arc = Arc::new(router_config);
     let telemetry_context_arc = Arc::new(telemetry_context);
     let cache_state = Arc::new(CacheState::new());
@@ -402,6 +405,7 @@ pub async fn configure_app_from_config(
         plugins_arc.clone(),
         cache_state.clone(),
         active_subscriptions.clone(),
+        storage_manager.clone(),
     )
     .await?;
     let schema_state_arc = Arc::new(schema_state);
@@ -425,6 +429,7 @@ pub async fn configure_app_from_config(
         &router_config_arc.persisted_documents,
         &router_config_arc.http.graphql_endpoint,
         bg_tasks_manager,
+        &storage_manager,
     )
     .await
     .map_err(|err| crate::shared_state::SharedStateError::PersistedDocuments(Box::new(err)))?;
@@ -450,6 +455,7 @@ pub async fn configure_app_from_config(
         plugins_arc,
         cache_state,
         active_subscriptions.clone(),
+        storage_manager,
     )?);
 
     Ok((shared_state, schema_state_arc))

--- a/bin/router/src/pipeline/persisted_documents/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/mod.rs
@@ -6,10 +6,14 @@ use hive_router_config::persisted_documents::{
 use hive_router_internal::background_tasks::BackgroundTasksManager;
 
 use crate::pipeline::persisted_documents::extract::DocumentIdResolver;
+use crate::pipeline::persisted_documents::resolve::storage::{
+    StorageManifestReloadTask, StorageResolver,
+};
 use crate::pipeline::persisted_documents::resolve::{
     FileManifestReloadTask, FileManifestResolver, HiveCDNResolver, PersistedDocumentResolver,
     PersistedDocumentResolverError,
 };
+use crate::storage::StorageManager;
 
 pub mod extract;
 pub mod resolve;
@@ -25,6 +29,7 @@ impl PersistedDocumentsRuntime {
         config: &PersistedDocumentsConfig,
         graphql_endpoint: &str,
         background_tasks_mgr: &mut BackgroundTasksManager,
+        storage_manager: &Arc<StorageManager>,
     ) -> Result<Self, PersistedDocumentResolverError> {
         let document_id_resolver = Arc::new(
             DocumentIdResolver::from_config(config, graphql_endpoint).map_err(|error| {
@@ -52,6 +57,29 @@ impl PersistedDocumentsRuntime {
                 PersistedDocumentsStorageConfig::Hive { config } => {
                     let resolver = Arc::new(HiveCDNResolver::from_storage_config(config)?);
                     Some(resolver as Arc<dyn PersistedDocumentResolver>)
+                }
+                PersistedDocumentsStorageConfig::Storage { config } => {
+                    match storage_manager.get_storage_runtime(&config.storage_id) {
+                        Some(storage) => {
+                            let resolver = Arc::new(
+                                StorageResolver::from_storage_config(config, storage).await?,
+                            );
+
+                            if let Some(poll_interval) = &config.poll_interval {
+                                background_tasks_mgr.register_task(StorageManifestReloadTask::new(
+                                    resolver.clone(),
+                                    *poll_interval,
+                                ));
+                            }
+
+                            Some(resolver as Arc<dyn PersistedDocumentResolver>)
+                        }
+                        None => {
+                            return Err(PersistedDocumentResolverError::StorageNotFound(
+                                config.storage_id.to_string(),
+                            ));
+                        }
+                    }
                 }
             }
         } else {

--- a/bin/router/src/pipeline/persisted_documents/resolve/fs.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/fs.rs
@@ -1,9 +1,6 @@
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use serde::Deserialize;
-use std::borrow::Cow;
-use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -16,24 +13,16 @@ use tracing::{info, warn};
 use hive_router_config::persisted_documents::PersistedDocumentsFileStorageConfig;
 use hive_router_internal::background_tasks::{BackgroundTask, CancellationToken};
 
+use crate::pipeline::persisted_documents::resolve::shared_file_manifest::{
+    parse_manifest, DocumentsById,
+};
+
 use super::{
     PersistedDocumentResolveInput, PersistedDocumentResolver, PersistedDocumentResolverError,
     ResolvedDocument,
 };
 
 const RELOAD_EVENT_DEBOUNCE: Duration = Duration::from_millis(150);
-
-// In-memory map used by the file manifest resolver.
-// Values are Arc-backed so lookups only clone cheap references.
-struct DocumentsById(HashMap<String, Arc<str>>);
-
-impl Deref for DocumentsById {
-    type Target = HashMap<String, Arc<str>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 #[async_trait]
 impl PersistedDocumentResolver for FileManifestResolver {
@@ -81,43 +70,10 @@ impl Deref for FileManifestReloadTask {
     }
 }
 
-#[derive(Deserialize)]
-struct ApolloPersistedQueryManifest<'a> {
-    #[serde(borrow)]
-    format: Cow<'a, str>,
-    version: u8,
-    #[serde(borrow)]
-    operations: Vec<ApolloPersistedQueryOperation<'a>>,
-}
-
-#[derive(Deserialize)]
-struct ApolloPersistedQueryOperation<'a> {
-    #[serde(borrow)]
-    id: Cow<'a, str>,
-    #[serde(borrow)]
-    body: Cow<'a, str>,
-}
-
-type KeyValueManifest<'a> = HashMap<Cow<'a, str>, Cow<'a, str>>;
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-#[serde(bound(deserialize = "'de: 'a"))]
-enum PersistedDocumentsManifest<'a> {
-    Apollo(ApolloPersistedQueryManifest<'a>),
-    KeyValue(KeyValueManifest<'a>),
-}
-
 #[derive(Debug, Error)]
 pub enum FileResolverError {
     #[error("failed to read persisted documents manifest at '{path}': {message}")]
     ReadManifest { path: String, message: String },
-    #[error("failed to parse persisted documents manifest at '{path}': {message}")]
-    ParseManifest { path: String, message: String },
-    #[error("unsupported apollo manifest format. Expected 'apollo-persisted-query-manifest', received '{format}'")]
-    UnsupportedApolloManifestFormat { format: String },
-    #[error("unsupported apollo manifest version. Expected '1', received '{version}'")]
-    UnsupportedApolloManifestVersion { version: u8 },
     #[error("failed to initialize persisted documents file watcher for '{path}': {message}")]
     WatcherInit { path: String, message: String },
     #[error("failed to watch persisted documents path '{path}': {message}")]
@@ -240,14 +196,9 @@ impl FileManifestResolver {
                     message: err.to_string(),
                 })
             })
-            .and_then(|raw| {
-                let manifest: PersistedDocumentsManifest<'_> =
-                    sonic_rs::from_slice(&raw).map_err(|err| FileResolverError::ParseManifest {
-                        path: manifest_path.to_string(),
-                        message: err.to_string(),
-                    })?;
-
-                manifest.try_into()
+            .and_then(|raw| match parse_manifest(manifest_path, &raw) {
+                Ok(manifest) => manifest.try_into(),
+                Err(err) => Err(PersistedDocumentResolverError::FileManifest(err)),
             })
     }
 }
@@ -272,55 +223,5 @@ impl BackgroundTask for FileManifestReloadTask {
                 warn!("persisted documents background reload failed: {err}");
             }
         }
-    }
-}
-
-impl<'a> TryFrom<PersistedDocumentsManifest<'a>> for DocumentsById {
-    type Error = PersistedDocumentResolverError;
-
-    fn try_from(value: PersistedDocumentsManifest<'a>) -> Result<Self, Self::Error> {
-        match value {
-            PersistedDocumentsManifest::Apollo(manifest) => manifest.try_into(),
-            PersistedDocumentsManifest::KeyValue(manifest) => Ok(manifest.into()),
-        }
-    }
-}
-
-impl<'a> TryFrom<ApolloPersistedQueryManifest<'a>> for DocumentsById {
-    type Error = PersistedDocumentResolverError;
-
-    fn try_from(manifest: ApolloPersistedQueryManifest<'a>) -> Result<Self, Self::Error> {
-        if manifest.format != "apollo-persisted-query-manifest" {
-            return Err(FileResolverError::UnsupportedApolloManifestFormat {
-                format: manifest.format.into_owned(),
-            }
-            .into());
-        }
-
-        if manifest.version != 1 {
-            return Err(FileResolverError::UnsupportedApolloManifestVersion {
-                version: manifest.version,
-            }
-            .into());
-        }
-
-        Ok(DocumentsById(
-            manifest
-                .operations
-                .into_iter()
-                .map(|op| (op.id.into_owned(), Arc::<str>::from(op.body)))
-                .collect::<HashMap<_, _>>(),
-        ))
-    }
-}
-
-impl<'a> From<KeyValueManifest<'a>> for DocumentsById {
-    fn from(manifest: KeyValueManifest<'a>) -> Self {
-        DocumentsById(
-            manifest
-                .into_iter()
-                .map(|(id, text)| (id.into_owned(), Arc::<str>::from(text)))
-                .collect(),
-        )
     }
 }

--- a/bin/router/src/pipeline/persisted_documents/resolve/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/mod.rs
@@ -2,14 +2,18 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use crate::pipeline::error::PipelineError;
+use crate::pipeline::persisted_documents::resolve::shared_file_manifest::FileManifestError;
 use crate::pipeline::persisted_documents::types::{ClientIdentity, PersistedDocumentId};
-use file::FileResolverError;
+use crate::storage::error::StorageError;
+use fs::FileResolverError;
 use hive::HiveResolverError;
 
-pub mod file;
+pub mod fs;
 pub mod hive;
+pub mod shared_file_manifest;
+pub mod storage;
 
-pub use file::{FileManifestReloadTask, FileManifestResolver};
+pub use fs::{FileManifestReloadTask, FileManifestResolver};
 pub use hive::HiveCDNResolver;
 
 #[derive(Debug, Clone, Copy)]
@@ -26,10 +30,16 @@ pub enum PersistedDocumentResolverError {
     Configuration(String),
     #[error("Persisted documents storage is not configured")]
     StorageNotConfigured,
+    #[error("Persisted documents storage with id '{0}' does not exists")]
+    StorageNotFound(String),
     #[error("Hive Storage: {0}")]
     Hive(#[from] HiveResolverError),
     #[error("File Storage: {0}")]
     File(#[from] FileResolverError),
+    #[error("Manifest error: {0}")]
+    FileManifest(#[from] FileManifestError),
+    #[error("Storage: {0}")]
+    Storage(#[from] StorageError),
 }
 
 impl From<PersistedDocumentResolverError> for PipelineError {

--- a/bin/router/src/pipeline/persisted_documents/resolve/shared_file_manifest.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/shared_file_manifest.rs
@@ -1,0 +1,114 @@
+use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
+
+use serde::Deserialize;
+
+use crate::pipeline::persisted_documents::resolve::PersistedDocumentResolverError;
+
+// In-memory map used by the file/storage manifest resolver.
+// Values are Arc-backed so lookups only clone cheap references.
+pub struct DocumentsById(HashMap<String, Arc<str>>);
+
+#[derive(Debug, thiserror::Error)]
+pub enum FileManifestError {
+    #[error("failed to parse persisted documents manifest at '{path}': {message}")]
+    ParseManifest { path: String, message: String },
+    #[error("unsupported apollo manifest format. Expected 'apollo-persisted-query-manifest', received '{format}'")]
+    UnsupportedApolloManifestFormat { format: String },
+    #[error("unsupported apollo manifest version. Expected '1', received '{version}'")]
+    UnsupportedApolloManifestVersion { version: u8 },
+}
+
+impl Deref for DocumentsById {
+    type Target = HashMap<String, Arc<str>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub type KeyValueManifest<'a> = HashMap<Cow<'a, str>, Cow<'a, str>>;
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub enum PersistedDocumentsManifest<'a> {
+    Apollo(ApolloPersistedQueryManifest<'a>),
+    KeyValue(KeyValueManifest<'a>),
+}
+
+impl<'a> TryFrom<PersistedDocumentsManifest<'a>> for DocumentsById {
+    type Error = PersistedDocumentResolverError;
+
+    fn try_from(value: PersistedDocumentsManifest<'a>) -> Result<Self, Self::Error> {
+        match value {
+            PersistedDocumentsManifest::Apollo(manifest) => manifest.try_into(),
+            PersistedDocumentsManifest::KeyValue(manifest) => Ok(manifest.into()),
+        }
+    }
+}
+
+impl<'a> TryFrom<ApolloPersistedQueryManifest<'a>> for DocumentsById {
+    type Error = PersistedDocumentResolverError;
+
+    fn try_from(manifest: ApolloPersistedQueryManifest<'a>) -> Result<Self, Self::Error> {
+        if manifest.format != "apollo-persisted-query-manifest" {
+            return Err(FileManifestError::UnsupportedApolloManifestFormat {
+                format: manifest.format.into_owned(),
+            }
+            .into());
+        }
+
+        if manifest.version != 1 {
+            return Err(FileManifestError::UnsupportedApolloManifestVersion {
+                version: manifest.version,
+            }
+            .into());
+        }
+
+        Ok(DocumentsById(
+            manifest
+                .operations
+                .into_iter()
+                .map(|op| (op.id.into_owned(), Arc::<str>::from(op.body)))
+                .collect::<HashMap<_, _>>(),
+        ))
+    }
+}
+
+impl<'a> From<KeyValueManifest<'a>> for DocumentsById {
+    fn from(manifest: KeyValueManifest<'a>) -> Self {
+        DocumentsById(
+            manifest
+                .into_iter()
+                .map(|(id, text)| (id.into_owned(), Arc::<str>::from(text)))
+                .collect(),
+        )
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ApolloPersistedQueryManifest<'a> {
+    #[serde(borrow)]
+    format: Cow<'a, str>,
+    version: u8,
+    #[serde(borrow)]
+    operations: Vec<ApolloPersistedQueryOperation<'a>>,
+}
+
+#[derive(Deserialize)]
+pub struct ApolloPersistedQueryOperation<'a> {
+    #[serde(borrow)]
+    id: Cow<'a, str>,
+    #[serde(borrow)]
+    body: Cow<'a, str>,
+}
+
+pub fn parse_manifest<'a>(
+    manifest_path: &str,
+    raw_manifest: &'a [u8],
+) -> Result<PersistedDocumentsManifest<'a>, FileManifestError> {
+    sonic_rs::from_slice(raw_manifest).map_err(|err| FileManifestError::ParseManifest {
+        path: manifest_path.to_string(),
+        message: err.to_string(),
+    })
+}

--- a/bin/router/src/pipeline/persisted_documents/resolve/storage.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/storage.rs
@@ -1,0 +1,128 @@
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use hive_router_config::persisted_documents::PersistedDocumentsStorageRefConfig;
+use hive_router_internal::background_tasks::BackgroundTask;
+use object_store::path::Path;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use crate::{
+    pipeline::persisted_documents::resolve::{
+        shared_file_manifest::{parse_manifest, DocumentsById},
+        PersistedDocumentResolveInput, PersistedDocumentResolver, PersistedDocumentResolverError,
+        ResolvedDocument,
+    },
+    storage::{StorageGetResult, StorageRuntime},
+};
+
+pub struct StorageResolver {
+    documents: ArcSwap<DocumentsById>,
+    location: Path,
+    storage: Arc<Box<dyn StorageRuntime>>,
+    last_etag: RwLock<Option<String>>,
+}
+
+impl StorageResolver {
+    pub async fn from_storage_config(
+        config: &PersistedDocumentsStorageRefConfig,
+        storage: Arc<Box<dyn StorageRuntime>>,
+    ) -> Result<Self, PersistedDocumentResolverError> {
+        let location = Path::from(config.location.as_str());
+        let (raw_manifest, etag) = storage.get(&location).await?;
+        let parsed_manifest = parse_manifest(location.as_ref(), raw_manifest.as_bytes())
+            .map_err(PersistedDocumentResolverError::FileManifest)?;
+        let documents: DocumentsById = parsed_manifest.try_into()?;
+
+        Ok(Self {
+            location,
+            storage,
+            last_etag: RwLock::new(etag),
+            documents: ArcSwap::from_pointee(documents),
+        })
+    }
+
+    pub async fn reload_if_needed(&self) -> Result<(), PersistedDocumentResolverError> {
+        let latest_etag = {
+            let guard = self.last_etag.read().await;
+            guard.clone()
+        };
+
+        let result = self
+            .storage
+            .get_if_none_changed(&self.location, latest_etag)
+            .await?;
+
+        match result {
+            StorageGetResult::NotModified => {
+                debug!("persisted documents store was not modified");
+            }
+            StorageGetResult::Modified { contents, etag } => {
+                let parsed_manifest = parse_manifest(self.location.as_ref(), contents.as_bytes())
+                    .map_err(PersistedDocumentResolverError::FileManifest)?;
+                let documents: DocumentsById = parsed_manifest.try_into()?;
+                self.documents.store(Arc::new(documents));
+                *self.last_etag.write().await = etag;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PersistedDocumentResolver for StorageResolver {
+    async fn resolve(
+        &self,
+        input: PersistedDocumentResolveInput<'_>,
+    ) -> Result<ResolvedDocument, PersistedDocumentResolverError> {
+        let text = self
+            .documents
+            .load()
+            .get(input.persisted_document_id.as_ref())
+            .cloned()
+            .ok_or_else(|| {
+                PersistedDocumentResolverError::NotFound(input.persisted_document_id.to_string())
+            })?;
+
+        Ok(ResolvedDocument { text })
+    }
+}
+
+pub struct StorageManifestReloadTask {
+    loader: Arc<StorageResolver>,
+    poll_interval: Duration,
+}
+
+impl StorageManifestReloadTask {
+    pub fn new(loader: Arc<StorageResolver>, poll_interval: Duration) -> Self {
+        Self {
+            loader,
+            poll_interval,
+        }
+    }
+}
+
+#[async_trait]
+impl BackgroundTask for StorageManifestReloadTask {
+    fn id(&self) -> &str {
+        "persisted-documents-storage-reloader"
+    }
+
+    async fn run(&self, token: CancellationToken) {
+        loop {
+            if token.is_cancelled() {
+                break;
+            }
+
+            let error = self.loader.reload_if_needed().await;
+
+            if let Err(err) = error {
+                tracing::error!(error = %err, "failed to reload persisted documents manifest from storage");
+            }
+
+            ntex::time::sleep(self.poll_interval).await;
+        }
+    }
+}

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -1,5 +1,6 @@
 use crate::pipeline::active_subscriptions::ActiveSubscriptions;
 use crate::pipeline::authorization::metadata::AuthorizationMetadataExt;
+use crate::storage::StorageManager;
 use arc_swap::{ArcSwap, Guard};
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -90,12 +91,14 @@ impl SchemaState {
         plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
         cache_state: Arc<CacheState>,
         active_subscriptions: ActiveSubscriptions,
+        storage_manager: Arc<StorageManager>,
     ) -> Result<Self, SupergraphManagerError> {
         let (tx, mut rx) = mpsc::channel::<String>(1);
         let background_loader = SupergraphBackgroundLoader::new(
             &router_config.supergraph,
             tx,
             telemetry_context.metrics.clone(),
+            storage_manager.clone(),
         )?;
         bg_tasks_manager.register_task(SupergraphBackgroundLoaderTask(Arc::new(background_loader)));
 
@@ -287,8 +290,9 @@ impl SupergraphBackgroundLoader {
         config: &SupergraphSource,
         sender: mpsc::Sender<String>,
         metrics: Arc<Metrics>,
+        storage_manager: Arc<StorageManager>,
     ) -> Result<Self, LoadSupergraphError> {
-        let loader = resolve_from_config(config)?;
+        let loader = resolve_from_config(config, storage_manager)?;
 
         Ok(Self {
             loader,

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -40,6 +40,7 @@ use crate::pipeline::persisted_documents::resolve::PersistedDocumentResolverErro
 use crate::pipeline::persisted_documents::PersistedDocumentsRuntime;
 use crate::pipeline::progressive_override::{OverrideLabelsCompileError, OverrideLabelsEvaluator};
 use crate::pipeline::sse;
+use crate::storage::StorageManager;
 
 pub type JwtClaimsCache = Cache<String, Arc<JwtTokenPayload>>;
 pub type RouterInflightRequestsMap = InFlightMap<u64, SharedRouterResponse>;
@@ -293,6 +294,8 @@ pub struct RouterSharedState {
     pub long_lived_client_count: Arc<AtomicUsize>,
     /// Tracks all active subscriptions from clients to the router.
     pub active_subscriptions: ActiveSubscriptions,
+    /// The storage manager for the router.
+    pub storage_manager: Arc<StorageManager>,
 }
 
 impl RouterSharedState {
@@ -307,6 +310,7 @@ impl RouterSharedState {
         plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
         cache_state: Arc<CacheState>,
         active_subscriptions: ActiveSubscriptions,
+        storage_manager: Arc<StorageManager>,
     ) -> Result<Self, SharedStateError> {
         let parse_cache = cache_state.parse_cache.clone();
         let coprocessor = router_config
@@ -355,6 +359,7 @@ impl RouterSharedState {
                 .into(),
             long_lived_client_count: Arc::new(AtomicUsize::new(0)),
             active_subscriptions,
+            storage_manager,
         })
     }
 }

--- a/bin/router/src/storage/error.rs
+++ b/bin/router/src/storage/error.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("failed to configure storage runtime: {0}")]
+    Configuration(String),
+    #[error("storage failure: {0}")]
+    Store(#[from] object_store::Error),
+    #[error("failed to format contents: {0}")]
+    Format(#[from] std::string::FromUtf8Error),
+}

--- a/bin/router/src/storage/mod.rs
+++ b/bin/router/src/storage/mod.rs
@@ -1,0 +1,65 @@
+use crate::storage::error::StorageError;
+use async_trait::async_trait;
+use hive_router_config::storage::{StorageConfigMap, StorageSourceConfig};
+use object_store::path::Path;
+use std::{collections::HashMap, sync::Arc};
+use tracing::debug;
+
+pub mod error;
+pub mod s3_runtime;
+pub mod utils;
+
+pub struct StorageManager {
+    storage_runtimes: HashMap<String, Arc<Box<dyn StorageRuntime>>>,
+}
+
+impl StorageManager {
+    pub fn new(config_map: &StorageConfigMap) -> Result<Self, StorageError> {
+        let mut storage_runtimes: HashMap<String, Arc<Box<dyn StorageRuntime>>> = HashMap::new();
+
+        for (id, config) in config_map {
+            debug!(storage_id = id, config = ?config, "creating storage runtime");
+
+            storage_runtimes.insert(
+                id.to_string(),
+                Arc::new(resolve_storage_config(id, config)?),
+            );
+        }
+
+        Ok(Self { storage_runtimes })
+    }
+
+    pub fn get_storage_runtime(&self, id: &str) -> Option<Arc<Box<dyn StorageRuntime>>> {
+        self.storage_runtimes.get(id).map(Arc::clone)
+    }
+}
+
+#[async_trait]
+pub trait StorageRuntime: Send + Sync + 'static {
+    fn identifier(&self) -> &str;
+    async fn get(&self, location: &Path) -> Result<(String, Option<String>), StorageError>;
+    async fn get_if_none_changed(
+        &self,
+        location: &Path,
+        if_none_match: Option<String>,
+    ) -> Result<StorageGetResult, StorageError>;
+}
+
+pub enum StorageGetResult {
+    NotModified,
+    Modified {
+        contents: String,
+        etag: Option<String>,
+    },
+}
+
+pub fn resolve_storage_config(
+    id: &str,
+    config: &StorageSourceConfig,
+) -> Result<Box<dyn StorageRuntime>, StorageError> {
+    match config {
+        StorageSourceConfig::S3(s3_config) => {
+            Ok(Box::new(s3_runtime::S3StorageRuntime::new(id, s3_config)?))
+        }
+    }
+}

--- a/bin/router/src/storage/s3_runtime.rs
+++ b/bin/router/src/storage/s3_runtime.rs
@@ -1,0 +1,211 @@
+use crate::storage::{error::StorageError, utils::resolve_value_or_expression};
+use crate::storage::{StorageGetResult, StorageRuntime};
+use async_trait::async_trait;
+use hive_router_config::storage::s3::{S3Credentials, S3StorageConfig};
+use object_store::aws::{AmazonS3, AmazonS3Builder, AmazonS3ConfigKey};
+use object_store::path::Path;
+use object_store::{GetOptions, ObjectStore, ObjectStoreExt};
+use tracing::warn;
+
+pub struct S3StorageRuntime {
+    storage_id: String,
+    client: AmazonS3,
+}
+
+impl S3StorageRuntime {
+    pub fn new(storage_id: &str, config: &S3StorageConfig) -> Result<Self, StorageError> {
+        Ok(Self {
+            client: Self::build_client(config)?,
+            storage_id: storage_id.to_string(),
+        })
+    }
+
+    fn build_client(config: &S3StorageConfig) -> Result<AmazonS3, StorageError> {
+        let mut builder = AmazonS3Builder::new()
+            .with_bucket_name(&resolve_value_or_expression(&config.bucket, "bucket")?);
+
+        if let Some(region) = &config.region {
+            builder = builder.with_region(&resolve_value_or_expression(region, "region")?);
+        }
+        if let Some(endpoint) = &config.endpoint {
+            builder = builder.with_endpoint(&resolve_value_or_expression(endpoint, "endpoint")?);
+        }
+        if let Some(v) = config.virtual_hosted_style {
+            builder = builder.with_virtual_hosted_style_request(v);
+        }
+        if let Some(allow_http) = &config.allow_http {
+            builder =
+                builder.with_allow_http(resolve_value_or_expression(allow_http, "allow_http")?);
+        }
+
+        // Credentials
+        match &config.credentials {
+            None => {
+                // Falls through to IMDSv2 at request time — fine for EC2 instance roles
+            }
+            Some(S3Credentials::Static {
+                access_key_id,
+                secret_access_key,
+                token,
+            }) => {
+                builder = builder
+                    .with_access_key_id(resolve_value_or_expression(
+                        access_key_id,
+                        "credentials.access_key_id",
+                    )?)
+                    .with_secret_access_key(resolve_value_or_expression(
+                        secret_access_key,
+                        "credentials.secret_access_key",
+                    )?);
+                if let Some(t) = token {
+                    builder =
+                        builder.with_token(resolve_value_or_expression(t, "credentials.token")?);
+                }
+            }
+            Some(S3Credentials::WebIdentity {
+                token_file,
+                role_arn,
+                session_name,
+                sts_endpoint,
+            }) => {
+                builder = builder
+                    .with_config(
+                        AmazonS3ConfigKey::WebIdentityTokenFile,
+                        resolve_value_or_expression(token_file, "credentials.token_file")?,
+                    )
+                    .with_config(
+                        AmazonS3ConfigKey::RoleArn,
+                        resolve_value_or_expression(role_arn, "credentials.role_arn")?,
+                    );
+                if let Some(s) = session_name {
+                    builder = builder.with_config(
+                        AmazonS3ConfigKey::RoleSessionName,
+                        resolve_value_or_expression(s, "credentials.session_name")?,
+                    );
+                }
+                if let Some(e) = sts_endpoint {
+                    builder = builder.with_config(
+                        AmazonS3ConfigKey::StsEndpoint,
+                        resolve_value_or_expression(e, "credentials.sts_endpoint")?,
+                    );
+                }
+            }
+            Some(S3Credentials::EcsTask { relative_uri }) => {
+                builder = builder.with_config(
+                    AmazonS3ConfigKey::ContainerCredentialsRelativeUri,
+                    resolve_value_or_expression(relative_uri, "credentials.relative_uri")?,
+                );
+            }
+            Some(S3Credentials::EksPodIdentity {
+                full_uri,
+                token_file,
+            }) => {
+                builder = builder
+                    .with_config(
+                        AmazonS3ConfigKey::ContainerCredentialsFullUri,
+                        resolve_value_or_expression(full_uri, "credentials.full_uri")?,
+                    )
+                    .with_config(
+                        AmazonS3ConfigKey::ContainerAuthorizationTokenFile,
+                        resolve_value_or_expression(token_file, "credentials.token_file")?,
+                    );
+            }
+            Some(S3Credentials::InstanceMetadata {
+                imdsv1_fallback,
+                metadata_endpoint,
+            }) => {
+                if let Some(imdsv1_fallback) = imdsv1_fallback {
+                    if resolve_value_or_expression(imdsv1_fallback, "credentials.imdsv1_fallback")?
+                    {
+                        builder = builder.with_imdsv1_fallback();
+                    }
+                }
+                if let Some(ep) = metadata_endpoint {
+                    builder = builder.with_metadata_endpoint(resolve_value_or_expression(
+                        ep,
+                        "credentials.metadata_endpoint",
+                    )?);
+                }
+                // Otherwise nothing to do — this is the default fallback anyway
+            }
+        }
+
+        // Behavior flags
+        if let Some(v) = config.skip_signature {
+            builder = builder.with_skip_signature(v);
+        }
+        if let Some(v) = config.request_payer {
+            builder = builder.with_request_payer(v);
+        }
+        if let Some(v) = config.disable_tagging {
+            builder = builder.with_disable_tagging(v);
+        }
+        if let Some(v) = config.unsigned_payload {
+            builder = builder.with_unsigned_payload(v);
+        }
+        if let Some(v) = config.s3_express {
+            builder = builder.with_s3_express(v);
+        }
+
+        Ok(builder.build()?)
+    }
+}
+
+#[async_trait]
+impl StorageRuntime for S3StorageRuntime {
+    fn identifier(&self) -> &str {
+        &self.storage_id
+    }
+
+    async fn get(&self, location: &Path) -> Result<(String, Option<String>), StorageError> {
+        let response = self.client.get(location).await;
+
+        match response {
+            Ok(result) => {
+                let etag = result.meta.e_tag.clone();
+                let bytes = result.bytes().await?;
+                let contents = String::from_utf8(bytes.to_vec())?;
+
+                Ok((contents, etag))
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to load contents from s3");
+
+                Err(e.into())
+            }
+        }
+    }
+
+    async fn get_if_none_changed(
+        &self,
+        location: &Path,
+        if_none_match: Option<String>,
+    ) -> Result<StorageGetResult, StorageError> {
+        let response = self
+            .client
+            .get_opts(
+                location,
+                GetOptions {
+                    if_none_match,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        match response {
+            Ok(result) => {
+                let etag = result.meta.e_tag.clone();
+                let bytes = result.bytes().await?;
+                let contents = String::from_utf8(bytes.to_vec())?;
+
+                Ok(StorageGetResult::Modified { contents, etag })
+            }
+            Err(object_store::Error::NotModified { .. }) => Ok(StorageGetResult::NotModified),
+            Err(e) => {
+                warn!(error = %e, "failed to load contents from s3");
+
+                Err(e.into())
+            }
+        }
+    }
+}

--- a/bin/router/src/storage/utils.rs
+++ b/bin/router/src/storage/utils.rs
@@ -1,0 +1,60 @@
+use hive_console_sdk::expressions::{CompileExpression, ExecutableProgram};
+use hive_router_config::primitives::value_or_expression::ValueOrExpression;
+use vrl::core::Value;
+
+use crate::storage::error::StorageError;
+
+pub trait FromVrlValue: Sized {
+    fn from_vrl_value(value: &Value, context: &str) -> Result<Self, StorageError>;
+}
+
+impl FromVrlValue for String {
+    fn from_vrl_value(value: &Value, context: &str) -> Result<Self, StorageError> {
+        value
+            .as_str()
+            .ok_or_else(|| {
+                StorageError::Configuration(format!("{} expression must return a string", context))
+            })
+            .map(|s| s.to_string())
+    }
+}
+
+impl FromVrlValue for bool {
+    fn from_vrl_value(value: &Value, context: &str) -> Result<Self, StorageError> {
+        value.as_boolean().ok_or_else(|| {
+            StorageError::Configuration(format!("{} expression must return a boolean", context))
+        })
+    }
+}
+
+fn evaluate_expression<T: FromVrlValue>(
+    expression: &str,
+    context: &str,
+) -> Result<T, StorageError> {
+    let value = expression
+        .compile_expression(None)
+        .map_err(|e| {
+            StorageError::Configuration(format!("Failed to compile {} expression: {}", context, e))
+        })?
+        .execute(Value::Null)
+        .map_err(|e| {
+            StorageError::Configuration(format!("Failed to execute {} expression: {}", context, e))
+        })?;
+
+    T::from_vrl_value(&value, context)
+}
+
+pub fn resolve_value_or_expression<T>(
+    value_or_expr: &ValueOrExpression<T>,
+    context: &str,
+) -> Result<T, StorageError>
+where
+    T: FromVrlValue + Clone + Default,
+{
+    match value_or_expr {
+        ValueOrExpression::Value(v) => Ok(v.clone()),
+        ValueOrExpression::Expression { expression } => {
+            evaluate_expression::<T>(expression, context)
+        }
+    }
+}

--- a/bin/router/src/supergraph/base.rs
+++ b/bin/router/src/supergraph/base.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 
+use crate::storage::error::StorageError;
+
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum LoadSupergraphError {
@@ -21,6 +23,10 @@ pub enum LoadSupergraphError {
     MissingHiveCDNEndpoint,
     #[error("Hive CDN key is missing. Please provide it via 'HIVE_CDN_KEY' environment variable or under 'supergraph.key' in the configuration.")]
     MissingHiveCDNKey,
+    #[error("Storage ID {0} is not defined in the Router configuration")]
+    StorageIdNotFound(String),
+    #[error("Storage error: {0}")]
+    StorageError(#[from] StorageError),
 }
 
 #[derive(Debug)]

--- a/bin/router/src/supergraph/mod.rs
+++ b/bin/router/src/supergraph/mod.rs
@@ -1,18 +1,26 @@
+use std::sync::Arc;
+
 use hive_router_config::supergraph::SupergraphSource;
 
-use crate::supergraph::{
-    base::{LoadSupergraphError, SupergraphLoader},
-    file::SupergraphFileLoader,
-    hive::SupergraphHiveConsoleLoader,
+use crate::{
+    storage::{utils::resolve_value_or_expression, StorageManager},
+    supergraph::{
+        base::{LoadSupergraphError, SupergraphLoader},
+        file::SupergraphFileLoader,
+        hive::SupergraphHiveConsoleLoader,
+        storage::SupergraphStorageLoader,
+    },
 };
 use tracing::debug;
 
 pub mod base;
 pub mod file;
 pub mod hive;
+pub mod storage;
 
 pub fn resolve_from_config(
     config: &SupergraphSource,
+    storage_manager: Arc<StorageManager>,
 ) -> Result<Box<dyn SupergraphLoader + Send + Sync>, LoadSupergraphError> {
     debug!(
         "Creating supergraph loader from source {}",
@@ -52,6 +60,36 @@ pub fn resolve_from_config(
                 *accept_invalid_certs,
                 retry_policy.max_retries,
             )?)
+        }
+        SupergraphSource::Storage {
+            storage_id,
+            location,
+            poll_interval,
+        } => {
+            match storage_manager.get_storage_runtime(storage_id) {
+                None => Err(LoadSupergraphError::StorageIdNotFound(
+                    storage_id.to_string(),
+                )),
+                Some(runtime) => {
+                    let location = resolve_value_or_expression(location, "supergraph.storage.key")?;
+
+                    Ok(SupergraphStorageLoader::try_new(
+                        runtime.clone(),
+                        location,
+                        *poll_interval,
+                    )?)
+                }
+            }
+
+            // Ok(SupergraphHiveConsoleLoader::try_new(
+            //     endpoint.clone().into(),
+            //     key,
+            //     *poll_interval,
+            //     *connect_timeout,
+            //     *request_timeout,
+            //     *accept_invalid_certs,
+            //     retry_policy.max_retries,
+            // )?)
         }
     }
 }

--- a/bin/router/src/supergraph/storage.rs
+++ b/bin/router/src/supergraph/storage.rs
@@ -1,0 +1,86 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use object_store::path::Path;
+use tokio::sync::RwLock;
+use tracing::error;
+
+use crate::{
+    storage::{StorageGetResult, StorageRuntime},
+    supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader},
+};
+
+pub struct SupergraphStorageLoader {
+    fetcher: SupergraphStorageFetcher,
+    poll_interval: Option<Duration>,
+}
+
+struct SupergraphStorageFetcher {
+    storage: Arc<Box<dyn StorageRuntime>>,
+    location: Path,
+    last_etag: RwLock<Option<String>>,
+}
+
+impl SupergraphStorageFetcher {
+    async fn fetch_supergraph(&self) -> Result<Option<String>, LoadSupergraphError> {
+        let etag = {
+            let read_guard = self.last_etag.read().await;
+
+            (*read_guard).clone()
+        };
+
+        let result = self
+            .storage
+            .get_if_none_changed(&self.location, etag)
+            .await?;
+
+        match result {
+            StorageGetResult::NotModified => Ok(None),
+            StorageGetResult::Modified { contents, etag } => {
+                *self.last_etag.write().await = etag;
+
+                Ok(Some(contents))
+            }
+        }
+    }
+}
+
+impl SupergraphStorageLoader {
+    pub fn try_new(
+        fetcher: Arc<Box<dyn StorageRuntime>>,
+        location: String,
+        poll_interval: Option<Duration>,
+    ) -> Result<Box<Self>, LoadSupergraphError> {
+        Ok(Box::new(Self {
+            fetcher: SupergraphStorageFetcher {
+                storage: fetcher,
+                location: Path::from(location),
+                last_etag: RwLock::new(None),
+            },
+            poll_interval,
+        }))
+    }
+}
+
+#[async_trait]
+impl SupergraphLoader for SupergraphStorageLoader {
+    async fn load(&self) -> Result<ReloadSupergraphResult, LoadSupergraphError> {
+        let fetcher_result = self.fetcher.fetch_supergraph().await;
+
+        match fetcher_result {
+            // If there was an error fetching the supergraph, propagate it
+            Err(err) => {
+                error!("Error fetching supergraph from storage: {}", err);
+                Err(err)
+            }
+            // If the supergraph has not changed, return Unchanged
+            Ok(None) => Ok(ReloadSupergraphResult::Unchanged),
+            // If there is a new supergraph SDL, return it
+            Ok(Some(sdl)) => Ok(ReloadSupergraphResult::Changed { new_sdl: sdl }),
+        }
+    }
+
+    fn reload_interval(&self) -> Option<&std::time::Duration> {
+        self.poll_interval.as_ref()
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 |[**persisted\_documents**](#persisted_documents)|`object`|Configuration for persisted documents extraction and resolution.<br/>Default: `{"enabled":false,"log_missing_id":false,"require_id":false,"selectors":null,"storage":null}`<br/>||
 |[**plugins**](#plugins)|`object`|Configuration for custom plugins<br/>||
 |[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout":"10s"}`<br/>||
+|[**storages**](#storages)|`object`|Configuration for storage sources.<br/>||
 |[**subscriptions**](#subscriptions)|`object`|Configuration for subscriptions.<br/>Default: `{"broadcast_capacity":0,"enabled":false}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>||
 |[**telemetry**](#telemetry)|`object`|Default: `{"client_identification":{"ip_header":null,"name_header":"graphql-client-name","version_header":"graphql-client-version"},"hive":null,"metrics":{"exporters":[],"instrumentation":{"common":{"histogram":{"aggregation":"explicit","bytes":{"buckets":[128,512,1024,2048,4096,8192,16384,32768,65536,131072,262144,524288,1048576,2097152,3145728,4194304,5242880],"record_min_max":false},"seconds":{"buckets":[0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10],"record_min_max":false}}},"instruments":{}}},"resource":{"attributes":{}},"tracing":{"collect":{"max_attributes_per_event":16,"max_attributes_per_link":32,"max_attributes_per_span":128,"max_events_per_span":128,"parent_based_sampler":false,"sampling":1},"exporters":[],"instrumentation":{"spans":{"mode":"spec_compliant"}},"propagation":{"b3":false,"baggage":false,"jaeger":false,"trace_context":true}}}`<br/>||
@@ -131,6 +132,7 @@ plugins: {}
 query_planner:
   allow_expose: false
   timeout: 10s
+storages: {}
 subscriptions:
   broadcast_capacity: 0
   enabled: false
@@ -2356,6 +2358,29 @@ timeout: 10s
 
 ```
 
+<a name="storages"></a>
+## storages: object
+
+Configuration for storage sources.
+
+Each key is a unique identifier for the storage source, that can later be references in other parts of the config file.
+
+Example:
+```yaml
+storages:
+  my-s3:
+    type: s3
+    bucket: my-bucket
+    region: eu-west-1
+```
+
+
+**Additional Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**Additional Properties**||||
+
 <a name="subscriptions"></a>
 ## subscriptions: object
 
@@ -2527,6 +2552,26 @@ poll_interval: 10s
 request_timeout: 1m
 retry_policy:
   max_retries: 10
+
+```
+
+
+   
+**Option 3 (alternative):** 
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**location**||The path to the supergraph file in the storage/bucket.<br/>|yes|
+|**poll\_interval**|`string`|Optional interval at which the file should be polled for changes.<br/>If not provided, the file will only be loaded once when the router starts.<br/>|no|
+|**source**|`string`|Constant Value: `"storage"`<br/>|yes|
+|**storage\_id**|`string`|The storage id as it was defined in the config file, under `storages:` field.<br/>|yes|
+
+**Additional Properties:** not allowed  
+**Example**
+
+```yaml
+poll_interval: null
 
 ```
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -48,3 +48,7 @@ tiny_http = "0.12"
 futures-util = { workspace = true }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 rcgen = "0.14.8"
+
+# Storage testing
+s3s = "0.13"
+s3s-fs = "0.13"

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -53,6 +53,8 @@ mod probes;
 #[cfg(test)]
 mod router_timeout;
 #[cfg(test)]
+mod storage;
+#[cfg(test)]
 mod subscriptions;
 #[cfg(test)]
 mod supergraph;

--- a/e2e/src/persisted_documents/mod.rs
+++ b/e2e/src/persisted_documents/mod.rs
@@ -10,3 +10,4 @@ mod policy;
 mod shared;
 mod storage_file;
 mod storage_hive;
+mod storage_s3;

--- a/e2e/src/persisted_documents/shared.rs
+++ b/e2e/src/persisted_documents/shared.rs
@@ -7,17 +7,18 @@ pub(super) const DOC_ID: &str = "sha256:abc123";
 pub(super) const PATH_DOC_ID: &str = "abc-123";
 pub(super) const DOC_QUERY: &str = "{ topProducts { name } }";
 
+pub(super) fn create_manifest() -> String {
+    sonic_rs::to_string(&json!({
+        DOC_ID: DOC_QUERY,
+        PATH_DOC_ID: DOC_QUERY,
+    }))
+    .expect("failed to serialize persisted document manifest")
+}
+
 pub(super) fn write_manifest() -> NamedTempFile {
     let file = NamedTempFile::new().expect("failed to create temp persisted document manifest");
-    std::fs::write(
-        file.path(),
-        sonic_rs::to_string(&json!({
-            DOC_ID: DOC_QUERY,
-            PATH_DOC_ID: DOC_QUERY,
-        }))
-        .expect("failed to serialize persisted document manifest"),
-    )
-    .expect("failed to write persisted document manifest");
+    std::fs::write(file.path(), create_manifest())
+        .expect("failed to write persisted document manifest");
     file
 }
 

--- a/e2e/src/persisted_documents/storage_s3.rs
+++ b/e2e/src/persisted_documents/storage_s3.rs
@@ -1,0 +1,244 @@
+use std::time::Duration;
+
+use crate::{
+    persisted_documents::shared::{assert_resolves_successfully, create_manifest, DOC_ID},
+    testkit::{s3_mock::S3Mock, ClientResponseExt, TestRouter, TestSubgraphs},
+};
+use sonic_rs::{json, JsonValueTrait};
+
+#[ntex::test]
+async fn should_load_persisted_documents_from_s3() {
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let storage = S3Mock::start("test-bucket").await;
+    let location = "persisted/manifest.json";
+    storage.set(location, create_manifest().as_bytes()).await;
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                storages:
+                  test-s3:
+                    type: s3
+                    bucket: {}
+                    endpoint: {}
+                    allow_http: true
+                    credentials:
+                      type: static
+                      access_key_id: {}
+                      secret_access_key: {}
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: storage
+                    storage_id: test-s3
+                    location: {}
+                "#,
+            storage.bucket(),
+            storage.url(),
+            storage.access_key(),
+            storage.secret_key(),
+            location
+        ))
+        .build()
+        .start()
+        .await;
+
+    let response = router
+        .send_post_request("/graphql", json!({ "documentId": DOC_ID }), None)
+        .await;
+
+    // We expect the first request to resolve successfully,
+    // because the DOC_ID is present in the manifest.
+    assert_resolves_successfully(response).await;
+}
+
+// When persisted docs store is not available at all, service startup should fail
+#[ntex::test]
+#[should_panic]
+async fn should_fail_when_store_not_available() {
+    TestRouter::builder()
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                storages:
+                  test-s3:
+                    type: s3
+                    bucket: test
+                    endpoint: http://localhost:1111
+                    allow_http: true
+                    credentials:
+                      type: static
+                      access_key_id: test
+                      secret_access_key: dummy
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: storage
+                    storage_id: test-s3
+                    location: file.json
+                "#,
+        ))
+        .build()
+        .start()
+        .await;
+}
+
+#[ntex::test]
+async fn should_reload_persisted_documents_from_s3() {
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let storage = S3Mock::start("test-bucket").await;
+    let location = "persisted/manifest.json";
+    storage.set(location, create_manifest().as_bytes()).await;
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                storages:
+                  test-s3:
+                    type: s3
+                    bucket: {}
+                    endpoint: {}
+                    allow_http: true
+                    credentials:
+                      type: static
+                      access_key_id: {}
+                      secret_access_key: {}
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: storage
+                    storage_id: test-s3
+                    location: {}
+                    poll_interval: 100ms
+                "#,
+            storage.bucket(),
+            storage.url(),
+            storage.access_key(),
+            storage.secret_key(),
+            location
+        ))
+        .build()
+        .start()
+        .await;
+
+    let response = router
+        .send_post_request("/graphql", json!({ "documentId": DOC_ID }), None)
+        .await;
+
+    // We expect the first request to resolve successfully,
+    // because the DOC_ID is present in the manifest.
+    assert_resolves_successfully(response).await;
+
+    let new_doc_id = "xyz-100";
+    storage
+        .set(
+            location,
+            sonic_rs::to_string(&json!({
+                new_doc_id: "{ me { id } }",
+            }))
+            .expect("fail to serialize string")
+            .as_bytes(),
+        )
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let response = router
+        .send_post_request("/graphql", json!({ "documentId": new_doc_id }), None)
+        .await;
+    assert!(response.status().is_success(), "expected 2xx response");
+    let body = response.json_body().await;
+    assert!(
+        body["errors"].is_null(),
+        "unexpected graphql errors: {body}"
+    );
+    assert!(
+        body["data"]["me"].is_object(),
+        "expected resolved persisted query data: {body}"
+    );
+
+    // The old ID should not work any longer because store has changed
+    let response = router
+        .send_post_request("/graphql", json!({ "documentId": DOC_ID }), None)
+        .await;
+
+    assert!(response.status().is_client_error(), "expected 4xx response");
+}
+
+#[ntex::test]
+async fn should_still_work_if_storage_failed_after() {
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let storage = S3Mock::start("test-bucket").await;
+    let location = "persisted/manifest.json";
+    storage.set(location, create_manifest().as_bytes()).await;
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                storages:
+                  test-s3:
+                    type: s3
+                    bucket: {}
+                    endpoint: {}
+                    allow_http: true
+                    credentials:
+                      type: static
+                      access_key_id: {}
+                      secret_access_key: {}
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: storage
+                    storage_id: test-s3
+                    location: {}
+                    poll_interval: 100ms
+                "#,
+            storage.bucket(),
+            storage.url(),
+            storage.access_key(),
+            storage.secret_key(),
+            location
+        ))
+        .build()
+        .start()
+        .await;
+
+    let response = router
+        .send_post_request("/graphql", json!({ "documentId": DOC_ID }), None)
+        .await;
+
+    // We expect the first request to resolve successfully,
+    // because the DOC_ID is present in the manifest.
+    assert_resolves_successfully(response).await;
+
+    // Stop the s3 service
+    drop(storage);
+
+    // Wait a bit for the poller to detect the store is unavailable
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Runnign a query should still work
+    let response = router
+        .send_post_request("/graphql", json!({ "documentId": DOC_ID }), None)
+        .await;
+
+    assert_resolves_successfully(response).await;
+}

--- a/e2e/src/storage/mod.rs
+++ b/e2e/src/storage/mod.rs
@@ -1,0 +1,52 @@
+mod s3;
+
+#[cfg(test)]
+mod storage_e2e_tests {
+    use crate::testkit::TestRouter;
+
+    /// The goal of this test is to assert that the Router panics and throws at the config level when it starts
+    /// This is needed in order to ensure config is checked statically and validated at startup
+    #[ntex::test]
+    #[should_panic(
+        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(StorageIdNotFound(\"missing\")))"
+    )]
+    async fn should_throw_when_storage_is_missing_in_supergraph() {
+        TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: storage
+                    storage_id: missing
+                    location: test
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+    }
+
+    #[ntex::test]
+    #[should_panic(
+        expected = "failed to configure hive router from config: SharedStateError(PersistedDocuments(StorageNotFound(\"missing\")))"
+    )]
+    async fn should_throw_when_storage_is_missing_in_persisted_docs() {
+        TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: storage
+                    storage_id: missing
+                    location: test.json
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+    }
+}

--- a/e2e/src/storage/s3.rs
+++ b/e2e/src/storage/s3.rs
@@ -1,0 +1,143 @@
+#[cfg(test)]
+mod storage_s3_e2e_tests {
+    use std::time::Duration;
+
+    use sonic_rs::{JsonContainerTrait, JsonValueTrait};
+
+    use crate::testkit::{s3_mock::S3Mock, ClientResponseExt, TestRouter};
+
+    #[ntex::test]
+    async fn should_load_supergraph_from_storage() {
+        let storage = S3Mock::start("test-bucket").await;
+        let first_supergraph = include_str!("../../supergraph.graphql");
+        let location = "my-dir/supergraph.graphql";
+        storage.set(location, first_supergraph.as_bytes()).await;
+
+        let config = format!(
+            r#"
+            storages:
+              test:
+                type: s3
+                bucket: {}
+                endpoint: {}
+                allow_http: true
+                credentials:
+                  type: static
+                  access_key_id: {}
+                  secret_access_key: {}
+            supergraph:
+              source: storage
+              storage_id: test
+              location: {}
+            "#,
+            storage.bucket(),
+            storage.url(),
+            storage.access_key(),
+            storage.secret_key(),
+            location
+        );
+
+        let router = TestRouter::builder()
+            .inline_config(config)
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+    }
+
+    #[ntex::test]
+    async fn should_poll_and_load_supergraph_from_storage() {
+        let storage = S3Mock::start("test-bucket").await;
+        let first_supergraph = include_str!("../../supergraph.graphql");
+        let location = "my-dir/supergraph.graphql";
+        storage.set(location, first_supergraph.as_bytes()).await;
+
+        let config = format!(
+            r#"
+            storages:
+              test:
+                type: s3
+                bucket: {}
+                endpoint: {}
+                allow_http: true
+                credentials:
+                  type: static
+                  access_key_id: {}
+                  secret_access_key: {}
+            supergraph:
+              source: storage
+              storage_id: test
+              location: {}
+              poll_interval: 100ms
+            "#,
+            storage.bucket(),
+            storage.url(),
+            storage.access_key(),
+            storage.secret_key(),
+            location
+        );
+
+        let router = TestRouter::builder()
+            .inline_config(config)
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        storage
+            .set(
+                location,
+                "type Query { dummyNew: NewType } type NewType { id: ID! }".as_bytes(),
+            )
+            .await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        let json_body = res.json_body().await;
+        let types_arr: Vec<String> = json_body
+            .get("data")
+            .unwrap()
+            .get("__schema")
+            .unwrap()
+            .get("types")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| {
+                i.as_object()
+                    .unwrap()
+                    .get(&"name")
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(
+            types_arr.contains(&"Query".to_string()),
+            true,
+            "Expected types to contain 'Query'"
+        );
+        assert_eq!(
+            types_arr.contains(&"NewType".to_string()),
+            true,
+            "Expected types to contain 'NewType'"
+        );
+    }
+}

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -1,5 +1,6 @@
 pub mod coprocessor;
 pub mod otel;
+pub mod s3_mock;
 
 use axum_server::{tls_rustls::RustlsConfig, Handle};
 use bytes::Bytes;

--- a/e2e/src/testkit/s3_mock.rs
+++ b/e2e/src/testkit/s3_mock.rs
@@ -1,0 +1,128 @@
+use std::{net::SocketAddr, path::PathBuf};
+
+use axum::http::{Response, StatusCode};
+use axum::{error_handling::HandleError, Router};
+use s3s::Body;
+use s3s::{auth::SimpleAuth, service::S3ServiceBuilder, HttpError};
+use s3s_fs::FileSystem;
+use tempfile::TempDir;
+use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
+
+pub const MOCK_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+pub const MOCK_SECRET_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+pub struct S3Mock {
+    /// The base URL of the mock service, e.g. `http://127.0.0.1:54321`.
+    url: String,
+    /// Root of the bucket on disk.
+    root: PathBuf,
+    bucket: String,
+    _temp_dir: TempDir,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server_handle: Option<JoinHandle<()>>,
+}
+
+async fn handle_s3_error(err: HttpError) -> Response<Body> {
+    tracing::error!(?err, "S3 service error");
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from("Internal Server Error".to_string()))
+        .unwrap()
+}
+
+impl S3Mock {
+    pub async fn start(bucket: &str) -> Self {
+        let temp_dir = tempfile::tempdir().expect("no temp dir available");
+        let root = temp_dir.path().to_path_buf();
+
+        let bucket_path = root.join(bucket);
+        tokio::fs::create_dir_all(&bucket_path)
+            .await
+            .expect("failed to create bucket directory");
+
+        let fs = FileSystem::new(&root).expect("failed to create s3s filesystem");
+        let auth = SimpleAuth::from_single(MOCK_ACCESS_KEY, MOCK_SECRET_KEY);
+        let s3_service = {
+            let mut b = S3ServiceBuilder::new(fs);
+            b.set_auth(auth);
+            b.build()
+        };
+
+        let s3_service = HandleError::new(s3_service, handle_s3_error);
+        let router = Router::new().fallback_service(s3_service);
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to create listener");
+        let addr: SocketAddr = listener.local_addr().expect("failed to get local addr");
+        let url = format!("http://{addr}");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("s3 mock server error");
+        });
+
+        Self {
+            url,
+            root: root.clone(),
+            bucket: bucket.to_owned(),
+            _temp_dir: temp_dir,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    pub fn access_key(&self) -> &str {
+        MOCK_ACCESS_KEY
+    }
+
+    pub fn secret_key(&self) -> &str {
+        MOCK_SECRET_KEY
+    }
+
+    pub async fn set(&self, key: &str, contents: &[u8]) {
+        let dest = self.object_path(key);
+        if let Some(parent) = dest.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .expect("failed to create parent dirs for mock object");
+        }
+        tokio::fs::write(&dest, contents)
+            .await
+            .expect("failed to write mock object");
+    }
+
+    pub async fn remove(&self, key: &str) {
+        let path = self.object_path(key);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    fn object_path(&self, key: &str) -> PathBuf {
+        let key = key.trim_start_matches('/');
+        self.root.join(&self.bucket).join(key)
+    }
+}
+
+impl Drop for S3Mock {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+
+        if let Some(handle) = self.server_handle.take() {
+            handle.abort();
+        }
+    }
+}

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -15,6 +15,7 @@ pub mod override_subgraph_urls;
 pub mod persisted_documents;
 pub mod primitives;
 pub mod query_planner;
+pub mod storage;
 pub mod subscriptions;
 pub mod supergraph;
 pub mod telemetry;
@@ -30,6 +31,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{collections::HashMap, convert::Infallible};
 
+use crate::storage::StorageConfigMap;
 use crate::{
     env_overrides::{EnvVarOverrides, EnvVarOverridesError},
     http_server::HttpServerConfig,
@@ -137,6 +139,21 @@ pub struct HiveRouterConfig {
     /// Configuration for coprocessor.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coprocessor: Option<coprocessor::CoprocessorConfig>,
+
+    /// Configuration for storage sources.
+    ///
+    /// Each key is a unique identifier for the storage source, that can later be references in other parts of the config file.
+    ///
+    /// Example:
+    /// ```yaml
+    /// storages:
+    ///   my-s3:
+    ///     type: s3
+    ///     bucket: my-bucket
+    ///     region: eu-west-1
+    /// ```
+    #[serde(default, skip_serializing_if = "StorageConfigMap::is_empty")]
+    pub storages: StorageConfigMap,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/lib/router-config/src/persisted_documents.rs
+++ b/lib/router-config/src/persisted_documents.rs
@@ -89,6 +89,10 @@ pub enum PersistedDocumentsStorageConfig {
         #[serde(flatten)]
         config: PersistedDocumentsHiveStorageConfig,
     },
+    Storage {
+        #[serde(flatten)]
+        config: PersistedDocumentsStorageRefConfig,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -97,6 +101,24 @@ pub struct PersistedDocumentsFileStorageConfig {
     pub path: FilePath,
     #[serde(default = "default_watch")]
     pub watch: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PersistedDocumentsStorageRefConfig {
+    pub storage_id: String,
+    pub location: String,
+    #[serde(
+        default = "default_storage_poll_interval",
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    #[schemars(with = "String")]
+    pub poll_interval: Option<Duration>,
+}
+
+fn default_storage_poll_interval() -> Option<Duration> {
+    None
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/router-config/src/storage/mod.rs
+++ b/lib/router-config/src/storage/mod.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::storage::s3::S3StorageConfig;
+
+pub mod s3;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, tag = "type")]
+pub enum StorageSourceConfig {
+    /// Configuration for an Amazon S3 (or S3-compatible) object storage backend.
+    ///
+    /// Credentials are optional — if omitted, the client falls back to EC2 instance
+    /// metadata (IMDSv2). For explicit credential modes see [`S3Credentials`].
+    ///
+    /// # Examples
+    ///
+    /// Minimal configuration relying on EC2 instance role:
+    /// ```yaml
+    /// bucket: my-bucket
+    /// region: eu-west-1
+    /// ```
+    ///
+    /// Localstack / MinIO:
+    /// ```yaml
+    /// bucket: my-bucket
+    /// region: us-east-1
+    /// endpoint: http://localhost:4566
+    /// allow_http: true
+    /// credentials:
+    ///   type: static
+    ///   access_key_id: test
+    ///   secret_access_key: test
+    /// ```
+    #[serde(rename = "s3")]
+    S3(S3StorageConfig),
+}
+
+pub type StorageConfigMap = HashMap<String, StorageSourceConfig>;

--- a/lib/router-config/src/storage/s3.rs
+++ b/lib/router-config/src/storage/s3.rs
@@ -1,0 +1,251 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::primitives::value_or_expression::ValueOrExpression;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct S3StorageConfig {
+    /// Name of the S3 bucket to read from.
+    pub bucket: ValueOrExpression<String>,
+
+    /// AWS region the bucket resides in, e.g. `us-east-1` or `eu-west-1`.
+    ///
+    /// When using a custom
+    /// [`endpoint`](Self::endpoint) pointing at a non-AWS service (Localstack,
+    /// MinIO, Cloudflare R2), set this to whatever region that service expects —
+    /// typically `us-east-1` or `auto` (R2).
+    pub region: Option<ValueOrExpression<String>>,
+
+    /// Custom endpoint URL for the S3 API, e.g. `http://localhost:4566` for
+    /// [Localstack](https://localstack.cloud) or `http://minio:9000` for
+    /// [MinIO](https://min.io).
+    ///
+    /// When set, the bucket name is appended as a path segment by default
+    /// (`<endpoint>/<bucket>`). If the service expects virtual-hosted-style
+    /// requests (`<bucket>.<host>`), enable [`virtual_hosted_style`](Self::virtual_hosted_style).
+    ///
+    /// HTTP endpoints also require [`allow_http`](Self::allow_http) to be `true`.
+    pub endpoint: Option<ValueOrExpression<String>>,
+
+    /// Use [virtual-hosted-style requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
+    /// (`<bucket>.<host>/key`) instead of the default path-style
+    /// (`<host>/<bucket>/key`).
+    ///
+    /// Must be consistent with [`endpoint`](Self::endpoint): if virtual-hosted
+    /// style is enabled, the endpoint should already include the bucket name in
+    /// the host.
+    ///
+    /// Defaults to `false`.
+    pub virtual_hosted_style: Option<bool>,
+
+    /// Allow plain HTTP connections in addition to HTTPS.
+    ///
+    /// **Warning:** enabling this exposes requests and credentials to
+    /// network interception. Only use for local development or fully trusted
+    /// private networks.
+    ///
+    /// Required when [`endpoint`](Self::endpoint) uses an `http://` URL, otherwise requests will fail.
+    ///
+    /// Defaults to `false`.
+    pub allow_http: Option<ValueOrExpression<bool>>,
+
+    /// Credential provider to authenticate with S3.
+    ///
+    /// When omitted, the client falls through to EC2
+    /// [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html),
+    /// which works automatically on EC2 instances with an attached IAM role.
+    ///
+    /// See [`S3Credentials`] for all supported authentication modes.
+    pub credentials: Option<S3Credentials>,
+
+    /// Skip request signing entirely.
+    ///
+    /// Useful for public buckets that reject signed requests. When `true`, no
+    /// credentials are fetched or sent.
+    ///
+    /// See [`AmazonS3Builder::with_skip_signature`](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.with_skip_signature).
+    /// Defaults to `false`.
+    pub skip_signature: Option<bool>,
+
+    /// Charge the requester (rather than the bucket owner) for request and
+    /// data transfer costs.
+    ///
+    /// Required for access to
+    /// [Requester Pays buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html).
+    /// Defaults to `false`.
+    pub request_payer: Option<bool>,
+
+    /// Disable object tagging on writes.
+    ///
+    /// Some S3-compatible services do not support the tagging API. Setting this
+    /// to `true` suppresses tagging headers on all `PUT` requests.
+    ///
+    /// Defaults to `false`.
+    pub disable_tagging: Option<bool>,
+
+    /// Use the [`UNSIGNED-PAYLOAD`](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
+    /// literal when computing request signatures, skipping body checksumming.
+    ///
+    /// Can reduce CPU overhead for large uploads at the cost of payload
+    /// integrity verification. Defaults to `false`.
+    pub unsigned_payload: Option<bool>,
+
+    /// Enable support for
+    /// [S3 Express One Zone](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-one-zone.html)
+    /// directory buckets.
+    ///
+    /// When `true`, the bucket name must follow the S3 Express naming
+    /// convention (e.g. `my-bucket--use1-az4--x-s3`). Defaults to `false`.
+    pub s3_express: Option<bool>,
+}
+
+/// Authentication mode for S3.
+///
+/// The builder resolves credentials in the following priority order:
+///
+/// 1. [`Static`](Self::Static) — explicit access key + secret
+/// 2. [`WebIdentity`](Self::WebIdentity) — EKS IRSA via STS `AssumeRoleWithWebIdentity`
+/// 3. [`EcsTask`](Self::EcsTask) — ECS task IAM role
+/// 4. [`EksPodIdentity`](Self::EksPodIdentity) — EKS Pod Identity
+/// 5. [`InstanceMetadata`](Self::InstanceMetadata) — EC2 IMDSv2 (also the implicit
+///    default when `credentials` is omitted entirely)
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum S3Credentials {
+    /// Long-lived or temporary static credentials.
+    ///
+    /// Suitable for local development, CI, or workloads outside AWS. For
+    /// temporary credentials (e.g. from `aws sts assume-role`), supply the
+    /// `token` field as well.
+    ///
+    /// ```yaml
+    /// credentials:
+    ///   type: static
+    ///   access_key_id: AKIAIOSFODNN7EXAMPLE
+    ///   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    /// ```
+    Static {
+        /// AWS access key ID, e.g. `AKIAIOSFODNN7EXAMPLE`.
+        access_key_id: ValueOrExpression<String>,
+
+        /// AWS secret access key corresponding to `access_key_id`.
+        secret_access_key: ValueOrExpression<String>,
+
+        /// Session token for temporary credentials obtained via
+        /// [`AssumeRole`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+        /// or `aws sts assume-role`. Omit for long-lived IAM user credentials.
+        token: Option<ValueOrExpression<String>>,
+    },
+
+    /// [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+    /// on EKS via `AssumeRoleWithWebIdentity`.
+    ///
+    /// The Kubernetes service account token is exchanged for temporary AWS
+    /// credentials through STS. Typically the token file and role ARN are
+    /// injected by the EKS pod identity webhook via environment variables
+    /// (`AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`).
+    ///
+    /// ```yaml
+    /// credentials:
+    ///   type: web_identity
+    ///   token_file: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+    ///   role_arn: arn:aws:iam::123456789012:role/MyServiceRole
+    /// ```
+    WebIdentity {
+        /// Path to the file containing the web identity token (a JWT issued by
+        /// the Kubernetes OIDC provider).
+        ///
+        /// Typically `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`.
+        token_file: ValueOrExpression<String>,
+
+        /// ARN of the IAM role to assume, e.g.
+        /// `arn:aws:iam::123456789012:role/MyWebIdentityRole`.
+        role_arn: ValueOrExpression<String>,
+
+        /// Name for the assumed-role session. Appears in CloudTrail logs.
+        /// Defaults to `WebIdentitySession`.
+        session_name: Option<ValueOrExpression<String>>,
+
+        /// Custom [STS](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html)
+        /// endpoint for token exchange.
+        ///
+        /// Defaults to `https://sts.<region>.amazonaws.com`. Override when
+        /// using a regional STS endpoint or a private endpoint.
+        sts_endpoint: Option<ValueOrExpression<String>>,
+    },
+
+    /// [ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+    /// credentials fetched from the ECS task metadata endpoint.
+    ///
+    /// The relative URI is normally injected by ECS into the
+    /// `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable.
+    ///
+    /// ```yaml
+    /// credentials:
+    ///   type: ecs_task
+    ///   relative_uri: /v2/credentials/abc123
+    /// ```
+    EcsTask {
+        /// Path component of the ECS credential endpoint, e.g.
+        /// `/v2/credentials/abc123`.
+        ///
+        /// Appended to the fixed ECS metadata base URL
+        /// `http://169.254.170.2`.
+        relative_uri: ValueOrExpression<String>,
+    },
+
+    /// [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
+    /// credentials, fetched from a container credential endpoint using a
+    /// Kubernetes-issued token for authentication.
+    ///
+    /// Both `full_uri` and `token_file` are normally injected by the EKS Pod
+    /// Identity agent via the `AWS_CONTAINER_CREDENTIALS_FULL_URI` and
+    /// `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` environment variables.
+    ///
+    /// ```yaml
+    /// credentials:
+    ///   type: eks_pod_identity
+    ///   full_uri: http://169.254.170.2/v2/credentials/abc123
+    ///   token_file: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+    /// ```
+    EksPodIdentity {
+        /// Full URL of the container credential endpoint, e.g.
+        /// `http://169.254.170.2/v2/credentials/abc123`.
+        full_uri: ValueOrExpression<String>,
+
+        /// Path to the file containing the bearer token used to authenticate
+        /// with the credential endpoint, e.g.
+        /// `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`.
+        token_file: ValueOrExpression<String>,
+    },
+
+    /// EC2 [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html)
+    /// credentials via an attached IAM instance role.
+    ///
+    /// This is the implicit default when `credentials` is omitted entirely.
+    /// Use this variant explicitly only when you need to tune IMDSv1 fallback
+    /// or override the metadata endpoint.
+    ///
+    /// ```yaml
+    /// credentials:
+    ///   type: instance_metadata
+    ///   imdsv1_fallback: true
+    /// ```
+    InstanceMetadata {
+        /// Fall back to [IMDSv1](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html)
+        /// if IMDSv2 returns a 403.
+        ///
+        /// IMDSv1 is disabled by default because it is vulnerable to
+        /// [SSRF attacks](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
+        /// Only enable this for environments running old tooling (e.g. kube2iam
+        /// versions that predate IMDSv2 support) that cannot be upgraded.
+        imdsv1_fallback: Option<ValueOrExpression<bool>>,
+
+        /// Override the IMDS endpoint URL.
+        ///
+        /// Defaults to the IPv4 endpoint `http://169.254.169.254`. The IPv6
+        /// alternative `http://fd00:ec2::254` can be used on dual-stack
+        /// instances.
+        metadata_endpoint: Option<ValueOrExpression<String>>,
+    },
+}

--- a/lib/router-config/src/supergraph.rs
+++ b/lib/router-config/src/supergraph.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::primitives::{
     file_path::FilePath, retry_policy::RetryPolicyConfig, single_or_multiple::SingleOrMultiple,
+    value_or_expression::ValueOrExpression,
 };
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -74,6 +75,22 @@ pub enum SupergraphSource {
         #[serde(default = "default_hive_retry_policy")]
         retry_policy: RetryPolicyConfig,
     },
+    #[serde(rename = "storage")]
+    Storage {
+        /// The storage id as it was defined in the config file, under `storages:` field.
+        storage_id: String,
+        /// The path to the supergraph file in the storage/bucket.
+        location: ValueOrExpression<String>,
+        /// Optional interval at which the file should be polled for changes.
+        /// If not provided, the file will only be loaded once when the router starts.
+        #[serde(
+            default = "default_file_poll_interval",
+            deserialize_with = "humantime_serde::deserialize",
+            serialize_with = "humantime_serde::serialize"
+        )]
+        #[schemars(with = "String")]
+        poll_interval: Option<Duration>,
+    },
 }
 
 fn default_accept_invalid_certs() -> bool {
@@ -97,6 +114,7 @@ impl SupergraphSource {
         match self {
             SupergraphSource::File { .. } => "file",
             SupergraphSource::HiveConsole { .. } => "hive",
+            SupergraphSource::Storage { storage_id, .. } => storage_id.as_str(),
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3044,6 +3044,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/507 
Docs + product update: https://github.com/graphql-hive/docs/pull/118 
Docs preview:  https://b52f9ec0-hive-platform-docs.theguild.workers.dev/graphql/hive/docs/router/configuration/storages
Product update preview: https://16378ae4-hive-platform-docs.theguild.workers.dev/graphql/hive/product-updates/2026-05-20-hive-router-storage-backends 

## Overview 

This PR introduces a new top-level storages configuration and the first storage backend, s3, so the router can load external artifacts from object storage.

With this change, both the supergraph source and persisted documents manifest can be resolved from a configured storage by reference. It also adds optional polling support so the router can reload updated content from storage without restarting.

## TODO 

- [x] new `storages` root field 
- [x] storage of kind `s3` with full s3 client
- [x] support all s3 auth methods 
- [x] supergraph source from storage
- [x] polling interval 
- [x] support for loading persisted docs for storage 
- [x] e2e tests 
- [x] documentation 

## Configurations
 
```yaml
storages: 
  my-s3: # this is the storage id 
    type: s3
    bucket: my-bucket
    region: eu-west-1
    # .. additional S3 configurations 
```

## S3

### Configuration

The new S3 storage config supports: bucket, endpoint, region which are the essentials. Also we have flags for managing credentials (all variations of S3), encryption settings, and other behavior flags that are common and available in the underlying lib (`object_store`). 

Some fields also support `ValueOrExpression`, allowing values to be resolved dynamically. This is important because usually things like tokens,endpoints, keys or certificates needs to be loaded from env. 

### integration

This PR introduces a reusable storage runtime layer in the router:

- `StorageManager` builds and stores configured storage runtimes at startup
- `StorageRuntime` defines a shared interface for reading from external storage
- `S3StorageRuntime` is the first implementation using `object_store::aws::AmazonS3` 

The S3 runtime supports:

- loading text content from S3/object storage
- conditional reloads using ETag / if-none-match
- startup-time validation for missing or invalid storage references
- centralized error handling for storage configuration and runtime failures

## Supergraph source 

This PR adds a new supergraph source named `storage`:

```yaml
supergraph:
  source: storage
  storage_id: my-s3
  location: supergraphs/current.graphql
  poll_interval: 30s
```

This makes supergraph delivery possible via S3-compatible storage, including development/test setups with custom endpoints.

## Persisted documents source 

This PR adds support for loading persisted documents manifests from a configured storage:

```yaml
persisted_documents:
  enabled: true
  require_id: true
  storage:
    type: storage
    storage_id: my-s3
    location: persisted/manifest.json
    poll_interval: 30s
``` 

> This PR also refactors manifest parsing so file-based and storage-based persisted document loaders share the same manifest parsing logic.