### PR TITLE
Forward operation names to subgraphs

### DIFF
--- a/.changeset/forward-subgraph-operation-name.md
+++ b/.changeset/forward-subgraph-operation-name.md
@@ -6,21 +6,21 @@ hive-router-plan-executor: patch
 
 # Forward operationName to subgraphs
 
-Subgraph HTTP and HTTP callback requests now include the planner-assigned `operationName` in the JSON request body by default. Added `traffic_shaping.all.strip_operation_name` and per-subgraph `traffic_shaping.subgraphs.<name>.strip_operation_name` options for deployments that need to preserve the previous omission.
+Subgraph HTTP and HTTP callback requests can now include a planner-assigned `operationName` in the JSON request body. Added the `traffic_shaping.all.forward_operation_name` and per-subgraph `traffic_shaping.subgraphs.<name>.forward_operation_name` options. The option defaults to `false`, so the previous omission remains the default behavior.
 
-Global opt-out:
+Global opt-in:
 
 ```yaml
 traffic_shaping:
   all:
-    strip_operation_name: true
+    forward_operation_name: true
 ```
 
-Per-subgraph opt-out:
+Per-subgraph opt-in:
 
 ```yaml
 traffic_shaping:
   subgraphs:
     products:
-      strip_operation_name: true
+      forward_operation_name: true
 ```

--- a/.changeset/forward-subgraph-operation-name.md
+++ b/.changeset/forward-subgraph-operation-name.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+hive-router-config: patch
+hive-router-plan-executor: patch
+---
+
+# Forward operationName to subgraphs
+
+Subgraph HTTP and HTTP callback requests now include the planner-assigned `operationName` in the JSON request body by default. Added `traffic_shaping.all.strip_operation_name` and per-subgraph `traffic_shaping.subgraphs.<name>.strip_operation_name` options for deployments that need to preserve the previous omission.

--- a/.changeset/forward-subgraph-operation-name.md
+++ b/.changeset/forward-subgraph-operation-name.md
@@ -7,3 +7,20 @@ hive-router-plan-executor: patch
 # Forward operationName to subgraphs
 
 Subgraph HTTP and HTTP callback requests now include the planner-assigned `operationName` in the JSON request body by default. Added `traffic_shaping.all.strip_operation_name` and per-subgraph `traffic_shaping.subgraphs.<name>.strip_operation_name` options for deployments that need to preserve the previous omission.
+
+Global opt-out:
+
+```yaml
+traffic_shaping:
+  all:
+    strip_operation_name: true
+```
+
+Per-subgraph opt-out:
+
+```yaml
+traffic_shaping:
+  subgraphs:
+    products:
+      strip_operation_name: true
+```

--- a/bin/router/src/pipeline/query_plan.rs
+++ b/bin/router/src/pipeline/query_plan.rs
@@ -124,9 +124,10 @@ pub async fn plan_operation_with_cache(
 
                 supergraph
                     .planner
-                    .plan_from_normalized_operation(
+                    .plan_from_normalized_operation_with_operation_names(
                         filtered_operation_for_plan,
                         (&request_override_context.clone()).into(),
+                        &supergraph.operation_name_config,
                         cancellation_token,
                     )
                     .map(Arc::new)

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -28,10 +28,11 @@ use hive_router_plan_executor::{
 };
 use hive_router_query_planner::planner::plan_nodes::QueryPlan;
 use hive_router_query_planner::{
-    planner::{Planner, PlannerError},
+    planner::{operation_name::SubgraphOperationNameConfig, Planner, PlannerError},
     utils::parsing::parse_schema,
 };
 use moka::future::Cache;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -255,6 +256,8 @@ impl SchemaState {
         let planner = Planner::new_from_supergraph(&parsed_supergraph_sdl)?;
         let metadata = Arc::new(planner.consumer_schema.schema_metadata());
         let authorization = AuthorizationMetadata::build(&planner.supergraph, &metadata)?;
+        let operation_name_config =
+            operation_name_config_from_router_config(router_config.as_ref());
         let subgraph_executor_map = Arc::new(SubgraphExecutorMap::from_http_endpoint_map(
             &planner.supergraph.subgraph_endpoint_map,
             router_config,
@@ -270,10 +273,29 @@ impl SchemaState {
             },
             metadata,
             planner,
+            operation_name_config,
             authorization,
             subgraph_executor_map,
         })
     }
+}
+
+fn operation_name_config_from_router_config(
+    router_config: &HiveRouterConfig,
+) -> SubgraphOperationNameConfig {
+    SubgraphOperationNameConfig::new(
+        router_config.traffic_shaping.all.forward_operation_name,
+        router_config
+            .traffic_shaping
+            .subgraphs
+            .iter()
+            .filter_map(|(name, config)| {
+                config
+                    .forward_operation_name
+                    .map(|forward| (name.clone(), forward))
+            })
+            .collect::<BTreeMap<_, _>>(),
+    )
 }
 
 pub struct SupergraphBackgroundLoader {

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -195,7 +195,10 @@ pub async fn execute_query_plan<'exec>(
         let mut subgraph_request = SubgraphExecutionRequest {
             query: fetch_node.operation.document_str.as_str(),
             dedupe: false,
-            operation_name: fetch_node.operation_name.as_deref(),
+            operation_name: opts.executors.operation_name_for_subgraph_request(
+                &fetch_node.service_name,
+                fetch_node.operation_name.as_deref(),
+            ),
             variables: variable_refs,
             headers: headers_map,
             raw_variable_values: None,
@@ -1309,11 +1312,14 @@ impl<'exec> Executor<'exec> {
                 affected_path: affected_path_factory,
             })?;
             let variable_refs = select_fetch_variables(self.variable_values, opts.variable_usages);
+            let operation_name = self
+                .executors
+                .operation_name_for_subgraph_request(opts.subgraph_name, opts.operation_name);
 
             let mut subgraph_request = SubgraphExecutionRequest {
                 query: &opts.operation.document_str,
                 dedupe: self.dedupe_subgraph_requests,
-                operation_name: opts.operation_name,
+                operation_name,
                 variables: variable_refs,
                 raw_variable_values: opts.raw_variable_values,
                 headers: headers_map,

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -52,6 +52,7 @@ pub struct HTTPSubgraphExecutor {
     pub header_map: HeaderMap,
     pub semaphore: Arc<Semaphore>,
     pub dedupe_enabled: bool,
+    pub strip_operation_name: bool,
     pub in_flight_requests: InflightRequestsMap,
     pub telemetry_context: Arc<TelemetryContext>,
     pub config: Arc<HiveRouterConfig>,
@@ -59,6 +60,7 @@ pub struct HTTPSubgraphExecutor {
 
 const FIRST_VARIABLE_STR: &[u8] = b",\"variables\":{";
 const FIRST_QUOTE_STR: &[u8] = b"{\"query\":";
+const OPERATION_NAME_PREFIX: &[u8] = b",\"operationName\":";
 
 pub type HttpClient = Client<HttpsConnector<HttpConnector>, Full<Bytes>>;
 
@@ -80,6 +82,10 @@ pub fn build_request_body(
     let mut body = Vec::with_capacity(4096);
     body.put(FIRST_QUOTE_STR);
     write_and_escape_string(&mut body, execution_request.query);
+    if let Some(operation_name) = execution_request.operation_name {
+        body.put(OPERATION_NAME_PREFIX);
+        write_and_escape_string(&mut body, operation_name);
+    }
     let mut first_variable = true;
     if let Some(variables) = &execution_request.variables {
         for (variable_name, variable_value) in variables {
@@ -142,6 +148,7 @@ impl HTTPSubgraphExecutor {
         http_client: Arc<HttpClient>,
         semaphore: Arc<Semaphore>,
         dedupe_enabled: bool,
+        strip_operation_name: bool,
         in_flight_requests: InflightRequestsMap,
         telemetry_context: Arc<TelemetryContext>,
         config: Arc<HiveRouterConfig>,
@@ -163,6 +170,7 @@ impl HTTPSubgraphExecutor {
             header_map,
             semaphore,
             dedupe_enabled,
+            strip_operation_name,
             in_flight_requests,
             telemetry_context,
             config,
@@ -299,6 +307,9 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
         timeout: Option<Duration>,
         plugin_req_state: Option<&'a PluginRequestState<'a>>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
+        if self.strip_operation_name {
+            execution_request.operation_name = None;
+        }
         let mut body = build_request_body(&execution_request)?;
 
         self.header_map.iter().for_each(|(key, value)| {
@@ -487,12 +498,15 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
 
     async fn subscribe<'a>(
         &self,
-        execution_request: SubgraphExecutionRequest<'a>,
+        mut execution_request: SubgraphExecutionRequest<'a>,
         connection_timeout: Option<Duration>,
     ) -> Result<
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
+        if self.strip_operation_name {
+            execution_request.operation_name = None;
+        }
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let body = build_request_body(&execution_request)?;
 
@@ -661,5 +675,71 @@ impl SubgraphHttpResponse {
                 resp
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_request<'a>(
+        query: &'a str,
+        operation_name: Option<&'a str>,
+    ) -> SubgraphExecutionRequest<'a> {
+        SubgraphExecutionRequest {
+            query,
+            dedupe: false,
+            operation_name,
+            variables: None,
+            headers: HeaderMap::new(),
+            raw_variable_values: None,
+            extensions: None,
+            custom_scalar_paths: None,
+        }
+    }
+
+    #[test]
+    fn body_includes_operation_name_when_present() {
+        let request = make_request("query Foo { __typename }", Some("Foo"));
+        let body = build_request_body(&request).unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert_eq!(
+            body_str,
+            r#"{"query":"query Foo { __typename }","operationName":"Foo"}"#
+        );
+    }
+
+    #[test]
+    fn body_omits_operation_name_when_absent() {
+        let request = make_request("query { __typename }", None);
+        let body = build_request_body(&request).unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert_eq!(body_str, r#"{"query":"query { __typename }"}"#);
+    }
+
+    #[test]
+    fn operation_name_is_json_escaped() {
+        let request = make_request("query { __typename }", Some("With\"Quote"));
+        let body = build_request_body(&request).unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert!(body_str.contains(r#""operationName":"With\"Quote""#));
+    }
+
+    #[test]
+    fn body_keeps_operation_name_with_variables_and_extensions() {
+        let mut request = make_request("query Foo($id: ID!) { node(id: $id) { id } }", Some("Foo"));
+        request.raw_variable_values = Some(vec![("id", b"1".to_vec())]);
+        request.extensions = Some(std::collections::HashMap::from([(
+            "trace".to_string(),
+            sonic_rs::json!({ "enabled": true }),
+        )]));
+
+        let body = build_request_body(&request).unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+
+        assert_eq!(
+            body_str,
+            r#"{"query":"query Foo($id: ID!) { node(id: $id) { id } }","operationName":"Foo","variables":{"id":1},"extensions":{"trace":{"enabled":true}}}"#
+        );
     }
 }

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -709,11 +709,14 @@ mod tests {
     }
 
     #[test]
-    fn operation_name_is_json_escaped() {
-        let request = make_request("query { __typename }", Some("With\"Quote"));
+    fn query_document_is_json_escaped() {
+        let request = make_request(r#"query Foo { echo(input: "quoted") }"#, Some("Foo"));
         let body = build_request_body(&request).unwrap();
         let body_str = std::str::from_utf8(&body).unwrap();
-        assert!(body_str.contains(r#""operationName":"With\"Quote""#));
+        assert_eq!(
+            body_str,
+            r#"{"query":"query Foo { echo(input: \"quoted\") }","operationName":"Foo"}"#
+        );
     }
 
     #[test]

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -52,7 +52,6 @@ pub struct HTTPSubgraphExecutor {
     pub header_map: HeaderMap,
     pub semaphore: Arc<Semaphore>,
     pub dedupe_enabled: bool,
-    pub strip_operation_name: bool,
     pub in_flight_requests: InflightRequestsMap,
     pub telemetry_context: Arc<TelemetryContext>,
     pub config: Arc<HiveRouterConfig>,
@@ -148,7 +147,6 @@ impl HTTPSubgraphExecutor {
         http_client: Arc<HttpClient>,
         semaphore: Arc<Semaphore>,
         dedupe_enabled: bool,
-        strip_operation_name: bool,
         in_flight_requests: InflightRequestsMap,
         telemetry_context: Arc<TelemetryContext>,
         config: Arc<HiveRouterConfig>,
@@ -170,7 +168,6 @@ impl HTTPSubgraphExecutor {
             header_map,
             semaphore,
             dedupe_enabled,
-            strip_operation_name,
             in_flight_requests,
             telemetry_context,
             config,
@@ -307,9 +304,6 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
         timeout: Option<Duration>,
         plugin_req_state: Option<&'a PluginRequestState<'a>>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
-        if self.strip_operation_name {
-            execution_request.operation_name = None;
-        }
         let mut body = build_request_body(&execution_request)?;
 
         self.header_map.iter().for_each(|(key, value)| {
@@ -498,15 +492,12 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
 
     async fn subscribe<'a>(
         &self,
-        mut execution_request: SubgraphExecutionRequest<'a>,
+        execution_request: SubgraphExecutionRequest<'a>,
         connection_timeout: Option<Duration>,
     ) -> Result<
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
-        if self.strip_operation_name {
-            execution_request.operation_name = None;
-        }
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let body = build_request_body(&execution_request)?;
 

--- a/lib/executor/src/executors/http_callback.rs
+++ b/lib/executor/src/executors/http_callback.rs
@@ -71,16 +71,19 @@ pub struct HttpCallbackSubgraphExecutor {
     pub header_map: HeaderMap,
     pub callback_base_url: String,
     pub heartbeat_interval_ms: u64,
+    pub strip_operation_name: bool,
     pub active_subscriptions: CallbackSubscriptionsMap,
 }
 
 impl HttpCallbackSubgraphExecutor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         subgraph_name: String,
         endpoint: http::Uri,
         http_client: Arc<HttpClient>,
         callback_base_url: String,
         heartbeat_interval_ms: u64,
+        strip_operation_name: bool,
         active_subscriptions: CallbackSubscriptionsMap,
     ) -> Self {
         let mut header_map = HeaderMap::new();
@@ -104,6 +107,7 @@ impl HttpCallbackSubgraphExecutor {
             header_map,
             callback_base_url,
             heartbeat_interval_ms,
+            strip_operation_name,
             active_subscriptions,
         }
     }
@@ -114,6 +118,10 @@ impl HttpCallbackSubgraphExecutor {
         subscription_id: &str,
         verifier: &str,
     ) -> Result<Vec<u8>, SubgraphExecutorError> {
+        if self.strip_operation_name {
+            execution_request.operation_name = None;
+        }
+
         let callback_url = format!(
             "{}/{}",
             self.callback_base_url.trim_end_matches('/'),
@@ -285,5 +293,76 @@ impl SubgraphExecutor for HttpCallbackSubgraphExecutor {
 
             trace!(subscription_id = %subscription_id, "HTTP callback subscription stream ended");
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executors::tls::build_https_connector;
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+
+    fn make_request<'a>(
+        query: &'a str,
+        operation_name: Option<&'a str>,
+    ) -> SubgraphExecutionRequest<'a> {
+        SubgraphExecutionRequest {
+            query,
+            dedupe: false,
+            operation_name,
+            variables: None,
+            headers: HeaderMap::new(),
+            raw_variable_values: None,
+            extensions: None,
+            custom_scalar_paths: None,
+        }
+    }
+
+    fn make_executor(strip_operation_name: bool) -> HttpCallbackSubgraphExecutor {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let http_client = Arc::new(
+            Client::builder(TokioExecutor::new()).build(build_https_connector(None).unwrap()),
+        );
+
+        HttpCallbackSubgraphExecutor::new(
+            "products".to_string(),
+            "http://products.example/graphql".parse().unwrap(),
+            http_client,
+            "https://router.example/callbacks/".to_string(),
+            5000,
+            strip_operation_name,
+            Arc::new(DashMap::new()),
+        )
+    }
+
+    #[test]
+    fn callback_body_includes_operation_name_and_subscription_extensions() {
+        let executor = make_executor(false);
+        let mut request = make_request("subscription OnPing { ping }", Some("OnPing"));
+
+        let body = executor
+            .build_request_body(&mut request, "sub-1", "secret")
+            .unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+
+        assert!(body_str.contains(r#""operationName":"OnPing""#));
+        assert!(body_str.contains(r#""callbackUrl":"https://router.example/callbacks/sub-1""#));
+        assert!(body_str.contains(r#""subscriptionId":"sub-1""#));
+        assert!(body_str.contains(r#""verifier":"secret""#));
+        assert!(body_str.contains(r#""heartbeatIntervalMs":5000"#));
+    }
+
+    #[test]
+    fn callback_body_omits_operation_name_when_strip_enabled() {
+        let executor = make_executor(true);
+        let mut request = make_request("subscription OnPing { ping }", Some("OnPing"));
+
+        let body = executor
+            .build_request_body(&mut request, "sub-1", "secret")
+            .unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+
+        assert!(!body_str.contains("operationName"));
+        assert!(body_str.contains(r#""subscriptionId":"sub-1""#));
     }
 }

--- a/lib/executor/src/executors/http_callback.rs
+++ b/lib/executor/src/executors/http_callback.rs
@@ -71,7 +71,6 @@ pub struct HttpCallbackSubgraphExecutor {
     pub header_map: HeaderMap,
     pub callback_base_url: String,
     pub heartbeat_interval_ms: u64,
-    pub strip_operation_name: bool,
     pub active_subscriptions: CallbackSubscriptionsMap,
 }
 
@@ -83,7 +82,6 @@ impl HttpCallbackSubgraphExecutor {
         http_client: Arc<HttpClient>,
         callback_base_url: String,
         heartbeat_interval_ms: u64,
-        strip_operation_name: bool,
         active_subscriptions: CallbackSubscriptionsMap,
     ) -> Self {
         let mut header_map = HeaderMap::new();
@@ -107,7 +105,6 @@ impl HttpCallbackSubgraphExecutor {
             header_map,
             callback_base_url,
             heartbeat_interval_ms,
-            strip_operation_name,
             active_subscriptions,
         }
     }
@@ -118,10 +115,6 @@ impl HttpCallbackSubgraphExecutor {
         subscription_id: &str,
         verifier: &str,
     ) -> Result<Vec<u8>, SubgraphExecutorError> {
-        if self.strip_operation_name {
-            execution_request.operation_name = None;
-        }
-
         let callback_url = format!(
             "{}/{}",
             self.callback_base_url.trim_end_matches('/'),
@@ -318,7 +311,7 @@ mod tests {
         }
     }
 
-    fn make_executor(strip_operation_name: bool) -> HttpCallbackSubgraphExecutor {
+    fn make_executor() -> HttpCallbackSubgraphExecutor {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let http_client = Arc::new(
             Client::builder(TokioExecutor::new()).build(build_https_connector(None).unwrap()),
@@ -330,14 +323,13 @@ mod tests {
             http_client,
             "https://router.example/callbacks/".to_string(),
             5000,
-            strip_operation_name,
             Arc::new(DashMap::new()),
         )
     }
 
     #[test]
     fn callback_body_includes_operation_name_and_subscription_extensions() {
-        let executor = make_executor(false);
+        let executor = make_executor();
         let mut request = make_request("subscription OnPing { ping }", Some("OnPing"));
 
         let body = executor
@@ -350,19 +342,5 @@ mod tests {
         assert!(body_str.contains(r#""subscriptionId":"sub-1""#));
         assert!(body_str.contains(r#""verifier":"secret""#));
         assert!(body_str.contains(r#""heartbeatIntervalMs":5000"#));
-    }
-
-    #[test]
-    fn callback_body_omits_operation_name_when_strip_enabled() {
-        let executor = make_executor(true);
-        let mut request = make_request("subscription OnPing { ping }", Some("OnPing"));
-
-        let body = executor
-            .build_request_body(&mut request, "sub-1", "secret")
-            .unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
-
-        assert!(!body_str.contains("operationName"));
-        assert!(body_str.contains(r#""subscriptionId":"sub-1""#));
     }
 }

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -93,6 +93,7 @@ struct ResolvedSubgraphConfig<'a> {
     client: Arc<HttpClient>,
     timeout_config: &'a DurationOrExpression,
     dedupe_enabled: bool,
+    strip_operation_name: bool,
 }
 
 pub type InflightRequestsMap = InFlightMap<u64, (SubgraphHttpResponse, u64)>;
@@ -563,6 +564,7 @@ impl SubgraphExecutorMap {
                     subgraph_config.client,
                     semaphore,
                     subgraph_config.dedupe_enabled,
+                    subgraph_config.strip_operation_name,
                     self.in_flight_requests.clone(),
                     self.telemetry_context.clone(),
                     self.config.clone(),
@@ -665,6 +667,7 @@ impl SubgraphExecutorMap {
                     subgraph_config.client,
                     callback_config.public_url.to_string(),
                     heartbeat_interval_ms,
+                    subgraph_config.strip_operation_name,
                     self.callback_subscriptions.clone(),
                 )
                 .to_boxed_arc();
@@ -689,6 +692,7 @@ impl SubgraphExecutorMap {
             client: self.client.clone(),
             timeout_config: &self.config.traffic_shaping.all.request_timeout,
             dedupe_enabled: self.config.traffic_shaping.all.dedupe_enabled,
+            strip_operation_name: self.config.traffic_shaping.all.strip_operation_name,
         };
 
         let Some(subgraph_config) = self.config.traffic_shaping.subgraphs.get(subgraph_name) else {
@@ -729,6 +733,10 @@ impl SubgraphExecutorMap {
 
         if let Some(custom_timeout) = &subgraph_config.request_timeout {
             config.timeout_config = custom_timeout;
+        }
+
+        if let Some(strip_operation_name) = subgraph_config.strip_operation_name {
+            config.strip_operation_name = strip_operation_name;
         }
 
         Ok(config)
@@ -891,5 +899,84 @@ pub fn compile_duration_or_expression(
             let hints = ProgramHints::from_program(&program);
             Ok(ValueOrProgram::Program(Box::new(program), hints))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hive_router_config::{
+        telemetry::tracing::TracingPropagationConfig,
+        traffic_shaping::TrafficShapingExecutorSubgraphConfig,
+    };
+
+    fn make_subgraph_config(
+        strip_operation_name: Option<bool>,
+    ) -> TrafficShapingExecutorSubgraphConfig {
+        TrafficShapingExecutorSubgraphConfig {
+            pool_idle_timeout: None,
+            dedupe_enabled: None,
+            request_timeout: None,
+            circuit_breaker: None,
+            tls: None,
+            allow_only_http2: None,
+            strip_operation_name,
+        }
+    }
+
+    fn make_map(config: HiveRouterConfig) -> SubgraphExecutorMap {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let global_timeout =
+            compile_duration_or_expression(&config.traffic_shaping.all.request_timeout, None)
+                .unwrap();
+
+        SubgraphExecutorMap::new(
+            Arc::new(config),
+            global_timeout,
+            Arc::new(TelemetryContext::from_propagation_config(
+                &TracingPropagationConfig::default(),
+            )),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn resolve_subgraph_config_uses_global_strip_operation_name() {
+        let mut config = HiveRouterConfig::default();
+        config.traffic_shaping.all.strip_operation_name = true;
+        let map = make_map(config);
+
+        let resolved = map.resolve_subgraph_config("products").unwrap();
+
+        assert!(resolved.strip_operation_name);
+    }
+
+    #[test]
+    fn resolve_subgraph_config_allows_subgraph_to_disable_global_strip_operation_name() {
+        let mut config = HiveRouterConfig::default();
+        config.traffic_shaping.all.strip_operation_name = true;
+        config
+            .traffic_shaping
+            .subgraphs
+            .insert("products".to_string(), make_subgraph_config(Some(false)));
+        let map = make_map(config);
+
+        let resolved = map.resolve_subgraph_config("products").unwrap();
+
+        assert!(!resolved.strip_operation_name);
+    }
+
+    #[test]
+    fn resolve_subgraph_config_allows_subgraph_to_enable_strip_operation_name() {
+        let mut config = HiveRouterConfig::default();
+        config
+            .traffic_shaping
+            .subgraphs
+            .insert("products".to_string(), make_subgraph_config(Some(true)));
+        let map = make_map(config);
+
+        let resolved = map.resolve_subgraph_config("products").unwrap();
+
+        assert!(resolved.strip_operation_name);
     }
 }

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -93,7 +93,6 @@ struct ResolvedSubgraphConfig<'a> {
     client: Arc<HttpClient>,
     timeout_config: &'a DurationOrExpression,
     dedupe_enabled: bool,
-    strip_operation_name: bool,
 }
 
 pub type InflightRequestsMap = InFlightMap<u64, (SubgraphHttpResponse, u64)>;
@@ -202,6 +201,19 @@ impl SubgraphExecutorMap {
     /// Returns the shared active callback subscriptions map for use by callback handlers.
     pub fn callback_subscriptions(&self) -> CallbackSubscriptionsMap {
         self.callback_subscriptions.clone()
+    }
+
+    /// Applies `forward_operation_name` before a request reaches any concrete subgraph executor.
+    pub(crate) fn operation_name_for_subgraph_request<'a>(
+        &self,
+        subgraph_name: &str,
+        operation_name: Option<&'a str>,
+    ) -> Option<&'a str> {
+        if self.should_forward_operation_name(subgraph_name) {
+            operation_name
+        } else {
+            None
+        }
     }
 
     pub async fn execute<'exec>(
@@ -564,7 +576,6 @@ impl SubgraphExecutorMap {
                     subgraph_config.client,
                     semaphore,
                     subgraph_config.dedupe_enabled,
-                    subgraph_config.strip_operation_name,
                     self.in_flight_requests.clone(),
                     self.telemetry_context.clone(),
                     self.config.clone(),
@@ -667,7 +678,6 @@ impl SubgraphExecutorMap {
                     subgraph_config.client,
                     callback_config.public_url.to_string(),
                     heartbeat_interval_ms,
-                    subgraph_config.strip_operation_name,
                     self.callback_subscriptions.clone(),
                 )
                 .to_boxed_arc();
@@ -692,7 +702,6 @@ impl SubgraphExecutorMap {
             client: self.client.clone(),
             timeout_config: &self.config.traffic_shaping.all.request_timeout,
             dedupe_enabled: self.config.traffic_shaping.all.dedupe_enabled,
-            strip_operation_name: self.config.traffic_shaping.all.strip_operation_name,
         };
 
         let Some(subgraph_config) = self.config.traffic_shaping.subgraphs.get(subgraph_name) else {
@@ -735,11 +744,16 @@ impl SubgraphExecutorMap {
             config.timeout_config = custom_timeout;
         }
 
-        if let Some(strip_operation_name) = subgraph_config.strip_operation_name {
-            config.strip_operation_name = strip_operation_name;
-        }
-
         Ok(config)
+    }
+
+    fn should_forward_operation_name(&self, subgraph_name: &str) -> bool {
+        self.config
+            .traffic_shaping
+            .subgraphs
+            .get(subgraph_name)
+            .and_then(|subgraph_config| subgraph_config.forward_operation_name)
+            .unwrap_or(self.config.traffic_shaping.all.forward_operation_name)
     }
 
     /// Compiles and registers a timeout for a specific subgraph.
@@ -911,7 +925,7 @@ mod tests {
     };
 
     fn make_subgraph_config(
-        strip_operation_name: Option<bool>,
+        forward_operation_name: Option<bool>,
     ) -> TrafficShapingExecutorSubgraphConfig {
         TrafficShapingExecutorSubgraphConfig {
             pool_idle_timeout: None,
@@ -920,7 +934,7 @@ mod tests {
             circuit_breaker: None,
             tls: None,
             allow_only_http2: None,
-            strip_operation_name,
+            forward_operation_name,
         }
     }
 
@@ -941,33 +955,46 @@ mod tests {
     }
 
     #[test]
-    fn resolve_subgraph_config_uses_global_strip_operation_name() {
-        let mut config = HiveRouterConfig::default();
-        config.traffic_shaping.all.strip_operation_name = true;
-        let map = make_map(config);
+    fn operation_name_for_subgraph_request_omits_operation_name_by_default() {
+        let map = make_map(HiveRouterConfig::default());
 
-        let resolved = map.resolve_subgraph_config("products").unwrap();
+        let operation_name =
+            map.operation_name_for_subgraph_request("products", Some("ProductsQuery"));
 
-        assert!(resolved.strip_operation_name);
+        assert_eq!(operation_name, None);
     }
 
     #[test]
-    fn resolve_subgraph_config_allows_subgraph_to_disable_global_strip_operation_name() {
+    fn operation_name_for_subgraph_request_uses_global_forward_operation_name() {
         let mut config = HiveRouterConfig::default();
-        config.traffic_shaping.all.strip_operation_name = true;
+        config.traffic_shaping.all.forward_operation_name = true;
+        let map = make_map(config);
+
+        let operation_name =
+            map.operation_name_for_subgraph_request("products", Some("ProductsQuery"));
+
+        assert_eq!(operation_name, Some("ProductsQuery"));
+    }
+
+    #[test]
+    fn operation_name_for_subgraph_request_allows_subgraph_to_disable_global_forward_operation_name(
+    ) {
+        let mut config = HiveRouterConfig::default();
+        config.traffic_shaping.all.forward_operation_name = true;
         config
             .traffic_shaping
             .subgraphs
             .insert("products".to_string(), make_subgraph_config(Some(false)));
         let map = make_map(config);
 
-        let resolved = map.resolve_subgraph_config("products").unwrap();
+        let operation_name =
+            map.operation_name_for_subgraph_request("products", Some("ProductsQuery"));
 
-        assert!(!resolved.strip_operation_name);
+        assert_eq!(operation_name, None);
     }
 
     #[test]
-    fn resolve_subgraph_config_allows_subgraph_to_enable_strip_operation_name() {
+    fn operation_name_for_subgraph_request_allows_subgraph_to_enable_forward_operation_name() {
         let mut config = HiveRouterConfig::default();
         config
             .traffic_shaping
@@ -975,8 +1002,9 @@ mod tests {
             .insert("products".to_string(), make_subgraph_config(Some(true)));
         let map = make_map(config);
 
-        let resolved = map.resolve_subgraph_config("products").unwrap();
+        let operation_name =
+            map.operation_name_for_subgraph_request("products", Some("ProductsQuery"));
 
-        assert!(resolved.strip_operation_name);
+        assert_eq!(operation_name, Some("ProductsQuery"));
     }
 }

--- a/lib/executor/src/plugins/hooks/on_supergraph_load.rs
+++ b/lib/executor/src/plugins/hooks/on_supergraph_load.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use graphql_tools::static_graphql::schema::Document;
 use hive_router_internal::authorization::metadata::AuthorizationMetadata;
-use hive_router_query_planner::planner::Planner;
+use hive_router_query_planner::planner::{operation_name::SubgraphOperationNameConfig, Planner};
 
 use crate::{
     introspection::schema::SchemaMetadata,
@@ -24,6 +24,8 @@ pub struct SupergraphData {
     pub metadata: Arc<SchemaMetadata>,
     /// The query planner instance that will be used to generate the query plan for the incoming GraphQL requests based on the supergraph schema.
     pub planner: Planner,
+    /// Configuration for generating subgraph operation names during query planning.
+    pub operation_name_config: SubgraphOperationNameConfig,
     /// The authorization metadata that will be used to authorize the incoming GraphQL requests based on the supergraph schema and the authorization rules defined in the router.
     pub authorization: AuthorizationMetadata,
     /// The map of subgraph executors that will be used to execute the query plan for the incoming GraphQL requests based on the supergraph schema.

--- a/lib/query-planner/benches/qp_benches.rs
+++ b/lib/query-planner/benches/qp_benches.rs
@@ -7,6 +7,7 @@ use hive_router_query_planner::graph::Graph;
 use hive_router_query_planner::graph::PlannerOverrideContext;
 use hive_router_query_planner::planner::best::find_best_combination;
 use hive_router_query_planner::planner::fetch::fetch_graph::build_fetch_graph_from_query_tree;
+use hive_router_query_planner::planner::operation_name::SubgraphOperationNameConfig;
 use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_graph;
 use hive_router_query_planner::planner::walker::walk_operation;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
@@ -40,6 +41,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
     let parsed_document = get_operation("../../bench/operation.graphql");
     let operation =
         get_executable_operation(&parsed_document, &supergraph_state, Some("TestQuery"));
+    let operation_name_config = SubgraphOperationNameConfig::default();
     let override_context = PlannerOverrideContext::default();
     let cancellation_token = CancellationToken::new();
 
@@ -47,6 +49,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
         b.iter(|| {
             let bb_graph = black_box(&graph);
             let bb_operation = black_box(&operation);
+            let bb_operation_name_config = black_box(&operation_name_config);
             let bb_supergraph_state = black_box(&supergraph_state);
             let bb_override_context = black_box(&override_context);
 
@@ -71,6 +74,8 @@ fn query_plan_pipeline(c: &mut Criterion) {
             let query_plan = build_query_plan_from_fetch_graph(
                 fetch_graph,
                 bb_supergraph_state,
+                bb_operation_name_config,
+                bb_operation.name.as_deref(),
                 &cancellation_token,
             )
             .unwrap();
@@ -95,6 +100,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
         b.iter(|| {
             let bb_graph = black_box(&graph);
             let bb_operation = black_box(&operation);
+            let bb_operation_name_config = black_box(&operation_name_config);
             let bb_supergraph_state = black_box(&supergraph_state);
             let bb_override_context = black_box(&override_context);
 
@@ -119,6 +125,8 @@ fn query_plan_pipeline(c: &mut Criterion) {
             let query_plan = build_query_plan_from_fetch_graph(
                 fetch_graph,
                 bb_supergraph_state,
+                bb_operation_name_config,
+                bb_operation.name.as_deref(),
                 &cancellation_token,
             )
             .unwrap();

--- a/lib/query-planner/fixture/tests/subscription.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/subscription.supergraph.graphql
@@ -1,0 +1,73 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+  subscription: Subscription
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  PINGS @join__graph(name: "pings", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary to resolve fields.
+  """
+  EXECUTION
+}
+
+type Query @join__type(graph: PINGS) {
+  _empty: String
+}
+
+type Subscription @join__type(graph: PINGS) {
+  ping: String!
+}

--- a/lib/query-planner/src/planner/mod.rs
+++ b/lib/query-planner/src/planner/mod.rs
@@ -23,6 +23,7 @@ use crate::{
 pub mod best;
 mod error;
 pub mod fetch;
+pub mod operation_name;
 pub mod plan_nodes;
 pub mod query_plan;
 pub mod tree;
@@ -79,6 +80,22 @@ impl Planner {
         override_context: PlannerOverrideContext,
         cancellation_token: &CancellationToken,
     ) -> Result<QueryPlan, PlannerError> {
+        self.plan_from_normalized_operation_with_operation_names(
+            normalized_operation,
+            override_context,
+            &operation_name::SubgraphOperationNameConfig::default(),
+            cancellation_token,
+        )
+    }
+
+    #[inline]
+    pub fn plan_from_normalized_operation_with_operation_names(
+        &self,
+        normalized_operation: &OperationDefinition,
+        override_context: PlannerOverrideContext,
+        operation_name_config: &operation_name::SubgraphOperationNameConfig,
+        cancellation_token: &CancellationToken,
+    ) -> Result<QueryPlan, PlannerError> {
         let best_paths_per_leaf = walk_operation(
             &self.graph,
             &self.supergraph,
@@ -96,8 +113,13 @@ impl Planner {
             cancellation_token,
         )?;
         add_variables_to_fetch_steps(&mut fetch_graph, &normalized_operation.variable_definitions)?;
-        let query_plan =
-            build_query_plan_from_fetch_graph(fetch_graph, &self.supergraph, cancellation_token)?;
+        let query_plan = build_query_plan_from_fetch_graph(
+            fetch_graph,
+            &self.supergraph,
+            operation_name_config,
+            normalized_operation.name.as_deref(),
+            cancellation_token,
+        )?;
 
         Ok(query_plan)
     }

--- a/lib/query-planner/src/planner/operation_name.rs
+++ b/lib/query-planner/src/planner/operation_name.rs
@@ -1,0 +1,36 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct SubgraphOperationNameConfig {
+    default_forward: bool,
+    subgraphs: BTreeMap<String, bool>,
+}
+
+impl SubgraphOperationNameConfig {
+    pub fn new(default_forward: bool, subgraphs: BTreeMap<String, bool>) -> Self {
+        Self {
+            default_forward,
+            subgraphs,
+        }
+    }
+
+    pub fn should_forward(&self, subgraph_name: &str) -> bool {
+        self.subgraphs
+            .get(subgraph_name)
+            .copied()
+            .unwrap_or(self.default_forward)
+    }
+
+    pub fn operation_name(
+        &self,
+        subgraph_name: &str,
+        client_operation_name: Option<&str>,
+        fetch_step_id: i64,
+    ) -> Option<String> {
+        if self.should_forward(subgraph_name) {
+            client_operation_name.map(|name| format!("{}_{}", name, fetch_step_id))
+        } else {
+            None
+        }
+    }
+}

--- a/lib/query-planner/src/planner/operation_name.rs
+++ b/lib/query-planner/src/planner/operation_name.rs
@@ -28,9 +28,23 @@ impl SubgraphOperationNameConfig {
         fetch_step_id: i64,
     ) -> Option<String> {
         if self.should_forward(subgraph_name) {
-            client_operation_name.map(|name| format!("{}_{}", name, fetch_step_id))
+            client_operation_name
+                .filter(|name| !name.is_empty())
+                .map(|name| format!("{}_{}", name, fetch_step_id))
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_name_is_not_generated_for_empty_client_operation_name() {
+        let config = SubgraphOperationNameConfig::new(true, BTreeMap::new());
+
+        assert_eq!(config.operation_name("products", Some(""), 7), None);
     }
 }

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -10,6 +10,7 @@ use crate::{
     planner::fetch::{
         fetch_step_data::FetchStepData, selections::FetchStepSelections, state::MultiTypeFetchStep,
     },
+    planner::operation_name::SubgraphOperationNameConfig,
     state::supergraph_state::{OperationKind, SupergraphState, TypeNode},
     utils::pretty_display::{get_indent, PrettyDisplay},
 };
@@ -650,6 +651,7 @@ fn create_input_selection_set(
 fn create_output_operation(
     step: &FetchStepData<MultiTypeFetchStep>,
     supergraph: &SupergraphState,
+    operation_name: Option<&str>,
 ) -> SubgraphFetchOperation {
     let mut variables = vec![VariableDefinition {
         name: "representations".to_string(),
@@ -664,7 +666,7 @@ fn create_output_operation(
     }
 
     let operation_def = OperationDefinition {
-        name: None,
+        name: operation_name.map(ToString::to_string),
         operation_kind: Some(OperationKind::Query),
         variable_definitions: Some(variables),
         selection_set: SelectionSet {
@@ -713,15 +715,23 @@ impl FetchNode {
     pub fn from_fetch_step(
         step: &FetchStepData<MultiTypeFetchStep>,
         supergraph: &SupergraphState,
+        operation_name_config: &SubgraphOperationNameConfig,
+        client_operation_name: Option<&str>,
     ) -> Self {
+        let operation_name = operation_name_config.operation_name(
+            &step.service_name.0,
+            client_operation_name,
+            step.id,
+        );
+
         match step.is_entity_call() {
             true => FetchNode {
                 id: step.id,
                 service_name: step.service_name.0.clone(),
                 variable_usages: step.variable_usages.clone(),
                 operation_kind: Some(OperationKind::Query),
-                operation_name: None,
-                operation: create_output_operation(step, supergraph),
+                operation_name: operation_name.clone(),
+                operation: create_output_operation(step, supergraph, operation_name.as_deref()),
                 custom_scalar_paths: custom_scalar_paths_from_fetch_output(
                     &step.output,
                     supergraph,
@@ -733,7 +743,7 @@ impl FetchNode {
             },
             false => {
                 let operation_def = OperationDefinition {
-                    name: None,
+                    name: operation_name.clone(),
                     operation_kind: Some(step.into()),
                     selection_set: (&step.output).into(),
                     variable_definitions: step.variable_definitions.clone(),
@@ -748,7 +758,7 @@ impl FetchNode {
                     service_name: step.service_name.0.clone(),
                     variable_usages: step.variable_usages.clone(),
                     operation_kind: Some(step.into()),
-                    operation_name: None,
+                    operation_name,
                     operation: SubgraphFetchOperation {
                         document,
                         document_str,
@@ -772,8 +782,15 @@ impl PlanNode {
     pub fn from_fetch_step(
         step: &FetchStepData<MultiTypeFetchStep>,
         supergraph: &SupergraphState,
+        operation_name_config: &SubgraphOperationNameConfig,
+        client_operation_name: Option<&str>,
     ) -> Self {
-        let fetch = FetchNode::from_fetch_step(step, supergraph);
+        let fetch = FetchNode::from_fetch_step(
+            step,
+            supergraph,
+            operation_name_config,
+            client_operation_name,
+        );
 
         let node = if !step.response_path.is_empty() {
             PlanNode::Flatten(FlattenNode {

--- a/lib/query-planner/src/planner/query_plan.rs
+++ b/lib/query-planner/src/planner/query_plan.rs
@@ -5,6 +5,7 @@ use petgraph::{graph::NodeIndex, visit::EdgeRef};
 use crate::{
     planner::{
         fetch::state::MultiTypeFetchStep,
+        operation_name::SubgraphOperationNameConfig,
         plan_nodes::PlanNode,
         query_plan::optimize::{optimize_root_node, optimize_top_level_sequence},
     },
@@ -85,6 +86,8 @@ pub static QUERY_PLAN_KIND: &str = "QueryPlan";
 pub fn build_query_plan_from_fetch_graph(
     fetch_graph: FetchGraph<MultiTypeFetchStep>,
     supergraph: &SupergraphState,
+    operation_name_config: &SubgraphOperationNameConfig,
+    client_operation_name: Option<&str>,
     cancellation_token: &CancellationToken,
 ) -> Result<QueryPlan, QueryPlanError> {
     let root_index = fetch_graph.root_index.ok_or(QueryPlanError::NoRoot)?;
@@ -121,7 +124,12 @@ pub fn build_query_plan_from_fetch_graph(
                 )))?;
 
             let step_data = fetch_graph.get_step_data(step_index)?;
-            current_wave_nodes.push(PlanNode::from_fetch_step(step_data, supergraph));
+            current_wave_nodes.push(PlanNode::from_fetch_step(
+                step_data,
+                supergraph,
+                operation_name_config,
+                client_operation_name,
+            ));
             planned_nodes_count += 1;
             in_degrees.mark_as_processed(step_index);
 

--- a/lib/query-planner/src/planner/query_plan/optimize.rs
+++ b/lib/query-planner/src/planner/query_plan/optimize.rs
@@ -261,7 +261,7 @@ impl<'a> BatchFetchBuilder<'a> {
             .extend(self.merged_non_representation_variables.iter().cloned());
 
         let operation_definition = OperationDefinition {
-            name: None,
+            name: first_candidate.operation_name.clone(),
             operation_kind: Some(OperationKind::Query),
             selection_set: SelectionSet {
                 items: self.operation_selection_items,
@@ -287,7 +287,7 @@ impl<'a> BatchFetchBuilder<'a> {
                 Some(self.variable_usages)
             },
             operation_kind: Some(OperationKind::Query),
-            operation_name: None,
+            operation_name: first_candidate.operation_name.clone(),
             operation: SubgraphFetchOperation {
                 document,
                 document_str,
@@ -319,6 +319,7 @@ struct EntityFetch {
     index: usize,
     fetch_node_id: i64,
     service_name: String,
+    operation_name: Option<String>,
     flatten_path: FlattenNodePath,
     variable_usages: Option<BTreeSet<String>>,
     type_name: String,
@@ -413,6 +414,7 @@ impl EntityFetch {
             index,
             fetch_node_id: fetch_node.id,
             service_name: fetch_node.service_name.clone(),
+            operation_name: fetch_node.operation_name.clone(),
             flatten_path: flatten_node.path.clone(),
             variable_usages: fetch_node.variable_usages.clone(),
             type_name: entities_selection

--- a/lib/query-planner/src/tests/root_types.rs
+++ b/lib/query-planner/src/tests/root_types.rs
@@ -137,3 +137,30 @@ fn forwarded_operation_names_include_fetch_step_id_when_enabled() -> Result<(), 
 
     Ok(())
 }
+
+#[test]
+fn forwarded_operation_names_include_fetch_step_id_for_subscriptions() -> Result<(), Box<dyn Error>>
+{
+    init_logger();
+    let document = parse_operation(
+        r#"
+        subscription OnPing {
+          ping
+        }"#,
+    );
+    let operation_name_config =
+        SubgraphOperationNameConfig::new(false, BTreeMap::from([("pings".to_string(), true)]));
+    let query_plan = build_query_plan_with_context_and_operation_names(
+        "fixture/tests/subscription.supergraph.graphql",
+        document,
+        PlannerOverrideContext::default(),
+        &operation_name_config,
+    )?;
+    let json = sonic_rs::to_string_pretty(&query_plan).unwrap_or_default();
+
+    assert!(json.contains(r#""kind": "Subscription""#));
+    assert!(json.contains(r#""operationName": "OnPing_"#));
+    assert!(json.contains(r#""operation": "subscription OnPing_"#));
+
+    Ok(())
+}

--- a/lib/query-planner/src/tests/root_types.rs
+++ b/lib/query-planner/src/tests/root_types.rs
@@ -1,7 +1,12 @@
+use crate::graph::edge::PlannerOverrideContext;
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    planner::operation_name::SubgraphOperationNameConfig,
+    tests::testkit::{
+        build_query_plan, build_query_plan_with_context_and_operation_names, init_logger,
+    },
     utils::parsing::parse_operation,
 };
+use std::collections::BTreeMap;
 use std::error::Error;
 
 #[test]
@@ -98,5 +103,37 @@ fn shared_root() -> Result<(), Box<dyn Error>> {
       }
     }
     "#);
+    Ok(())
+}
+
+#[test]
+fn forwarded_operation_names_include_fetch_step_id_when_enabled() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query GetProduct {
+          product {
+            id
+            price {
+              id
+              amount
+            }
+          }
+        }"#,
+    );
+    let operation_name_config =
+        SubgraphOperationNameConfig::new(false, BTreeMap::from([("price".to_string(), true)]));
+    let query_plan = build_query_plan_with_context_and_operation_names(
+        "fixture/tests/shared-root.supergraph.graphql",
+        document,
+        PlannerOverrideContext::default(),
+        &operation_name_config,
+    )?;
+    let json = sonic_rs::to_string_pretty(&query_plan).unwrap_or_default();
+
+    assert!(json.contains(r#""operationName": "GetProduct_"#));
+    assert!(json.contains(r#""operation": "query GetProduct_"#));
+    assert!(!json.contains(r#""operationName": "GetProduct_1""#));
+
     Ok(())
 }

--- a/lib/query-planner/src/tests/testkit.rs
+++ b/lib/query-planner/src/tests/testkit.rs
@@ -14,6 +14,7 @@ use crate::graph::Graph;
 use crate::planner::add_variables_to_fetch_steps;
 use crate::planner::best::find_best_combination;
 use crate::planner::fetch::fetch_graph::build_fetch_graph_from_query_tree;
+use crate::planner::operation_name::SubgraphOperationNameConfig;
 use crate::planner::plan_nodes::QueryPlan;
 use crate::planner::query_plan::build_query_plan_from_fetch_graph;
 use crate::planner::walker::walk_operation;
@@ -59,6 +60,20 @@ pub fn build_query_plan_with_context(
     query: query_ast::Document<'static, String>,
     override_context: PlannerOverrideContext,
 ) -> Result<QueryPlan, Box<dyn Error>> {
+    build_query_plan_with_context_and_operation_names(
+        fixture_path,
+        query,
+        override_context,
+        &SubgraphOperationNameConfig::default(),
+    )
+}
+
+pub fn build_query_plan_with_context_and_operation_names(
+    fixture_path: &str,
+    query: query_ast::Document<'static, String>,
+    override_context: PlannerOverrideContext,
+    operation_name_config: &SubgraphOperationNameConfig,
+) -> Result<QueryPlan, Box<dyn Error>> {
     let cancellation_token = CancellationToken::new();
     let schema = parse_schema(&read_supergraph(fixture_path));
     let supergraph_state = SupergraphState::new(&schema);
@@ -82,8 +97,13 @@ pub fn build_query_plan_with_context(
     )?;
     add_variables_to_fetch_steps(&mut fetch_graph, &operation.variable_definitions)?;
 
-    let plan =
-        build_query_plan_from_fetch_graph(fetch_graph, &supergraph_state, &cancellation_token)?;
+    let plan = build_query_plan_from_fetch_graph(
+        fetch_graph,
+        &supergraph_state,
+        operation_name_config,
+        operation.name.as_deref(),
+        &cancellation_token,
+    )?;
 
     Ok(plan)
 }

--- a/lib/router-config/src/traffic_shaping.rs
+++ b/lib/router-config/src/traffic_shaping.rs
@@ -109,11 +109,9 @@ pub struct TrafficShapingExecutorSubgraphConfig {
     /// and will fail if the subgraph doesn't support HTTP/2.
     pub allow_only_http2: Option<bool>,
 
-    /// When set to `true`, the router omits the `operationName` field from the JSON
-    /// body sent to this subgraph. When `false` (the default), the planner-assigned
-    /// operation name is forwarded, which makes upstream subgraph logs, traces and
-    /// APM tools much easier to correlate with the original client operation.
-    pub strip_operation_name: Option<bool>,
+    /// When set to `true`, the router forwards the planner-assigned `operationName`
+    /// field in the JSON body sent to this subgraph.
+    pub forward_operation_name: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -174,12 +172,10 @@ pub struct TrafficShapingExecutorGlobalConfig {
     #[serde(default)]
     pub allow_only_http2: bool,
 
-    /// When set to `true`, the router omits the `operationName` field from the JSON
-    /// body sent to subgraphs. When `false` (the default), the planner-assigned
-    /// operation name is forwarded, which makes upstream subgraph logs, traces and
-    /// APM tools much easier to correlate with the original client operation.
+    /// When set to `true`, the router forwards the planner-assigned `operationName`
+    /// field in JSON request bodies sent to subgraphs. Defaults to `false`.
     #[serde(default)]
-    pub strip_operation_name: bool,
+    pub forward_operation_name: bool,
 }
 
 fn default_subgraph_pool_idle_timeout() -> Option<Duration> {
@@ -213,7 +209,7 @@ impl Default for TrafficShapingExecutorGlobalConfig {
             circuit_breaker: default_circuit_breaker_config(),
             tls: None,
             allow_only_http2: false,
-            strip_operation_name: false,
+            forward_operation_name: false,
         }
     }
 }
@@ -224,35 +220,35 @@ mod tests {
     use crate::parse_yaml_config;
 
     #[test]
-    fn strip_operation_name_defaults_to_false() {
+    fn forward_operation_name_defaults_to_false() {
         let config = TrafficShapingExecutorGlobalConfig::default();
 
-        assert!(!config.strip_operation_name);
+        assert!(!config.forward_operation_name);
     }
 
     #[test]
-    fn strip_operation_name_deserializes_global_and_subgraph_values() {
+    fn forward_operation_name_deserializes_global_and_subgraph_values() {
         let config = parse_yaml_config(
             r#"
 traffic_shaping:
   all:
-    strip_operation_name: true
+    forward_operation_name: true
   subgraphs:
     products:
-      strip_operation_name: false
+      forward_operation_name: false
 "#
             .to_string(),
         )
         .unwrap();
 
-        assert!(config.traffic_shaping.all.strip_operation_name);
+        assert!(config.traffic_shaping.all.forward_operation_name);
         assert_eq!(
             config
                 .traffic_shaping
                 .subgraphs
                 .get("products")
                 .unwrap()
-                .strip_operation_name,
+                .forward_operation_name,
             Some(false)
         );
     }

--- a/lib/router-config/src/traffic_shaping.rs
+++ b/lib/router-config/src/traffic_shaping.rs
@@ -108,6 +108,12 @@ pub struct TrafficShapingExecutorSubgraphConfig {
     /// This will make the subgraph requests never fall back to HTTP/1.1,
     /// and will fail if the subgraph doesn't support HTTP/2.
     pub allow_only_http2: Option<bool>,
+
+    /// When set to `true`, the router omits the `operationName` field from the JSON
+    /// body sent to this subgraph. When `false` (the default), the planner-assigned
+    /// operation name is forwarded, which makes upstream subgraph logs, traces and
+    /// APM tools much easier to correlate with the original client operation.
+    pub strip_operation_name: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -167,6 +173,13 @@ pub struct TrafficShapingExecutorGlobalConfig {
     /// and will fail if the subgraph doesn't support HTTP/2.
     #[serde(default)]
     pub allow_only_http2: bool,
+
+    /// When set to `true`, the router omits the `operationName` field from the JSON
+    /// body sent to subgraphs. When `false` (the default), the planner-assigned
+    /// operation name is forwarded, which makes upstream subgraph logs, traces and
+    /// APM tools much easier to correlate with the original client operation.
+    #[serde(default)]
+    pub strip_operation_name: bool,
 }
 
 fn default_subgraph_pool_idle_timeout() -> Option<Duration> {
@@ -200,7 +213,48 @@ impl Default for TrafficShapingExecutorGlobalConfig {
             circuit_breaker: default_circuit_breaker_config(),
             tls: None,
             allow_only_http2: false,
+            strip_operation_name: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_yaml_config;
+
+    #[test]
+    fn strip_operation_name_defaults_to_false() {
+        let config = TrafficShapingExecutorGlobalConfig::default();
+
+        assert!(!config.strip_operation_name);
+    }
+
+    #[test]
+    fn strip_operation_name_deserializes_global_and_subgraph_values() {
+        let config = parse_yaml_config(
+            r#"
+traffic_shaping:
+  all:
+    strip_operation_name: true
+  subgraphs:
+    products:
+      strip_operation_name: false
+"#
+            .to_string(),
+        )
+        .unwrap();
+
+        assert!(config.traffic_shaping.all.strip_operation_name);
+        assert_eq!(
+            config
+                .traffic_shaping
+                .subgraphs
+                .get("products")
+                .unwrap()
+                .strip_operation_name,
+            Some(false)
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Adds opt-in forwarding of planner-assigned `operationName` values to subgraph request bodies.

When `traffic_shaping.all.forward_operation_name` or `traffic_shaping.subgraphs.<name>.forward_operation_name` is enabled, the planner generates subgraph operation names as `<ClientOperationName>_<FetchStepData.id>` and the executor forwards that value in the GraphQL-over-HTTP JSON `operationName` field.

Forwarding remains disabled by default, preserving the existing behavior of omitting `operationName` from subgraph calls. No forwarded name is generated when the client operation name is empty or absent.

The forwarding decision is applied before concrete subgraph executors receive the `SubgraphExecutionRequest`, so it works consistently for fetches and subscriptions, including HTTP callback subscription requests.

## Configuration

Global opt-in:

```yaml
traffic_shaping:
  all:
    forward_operation_name: true
```

Per-subgraph opt-in:

```yaml
traffic_shaping:
  subgraphs:
    products:
      forward_operation_name: true
```

## Validation

- `cargo fmt --check`
- `cargo check --locked -p hive-router`
- `cargo check --locked -p hive-router-query-planner -p hive-router-config -p hive-router-plan-executor`
- `cargo check --locked -p hive-router-query-planner`
- `cargo test --locked -p hive-router-config forward_operation_name`
- `cargo test --locked -p hive-router-plan-executor operation_name`
- `cargo test --locked -p hive-router-plan-executor query_document_is_json_escaped`
- `cargo test --locked -p hive-router-query-planner root_types`
- `cargo test --locked -p hive-router-query-planner operation_name_is_not_generated_for_empty_client_operation_name`
- `cargo test --locked -p hive-router-query-planner forwarded_operation_names_include_fetch_step_id_for_subscriptions`
- `git diff --check`
