### PR TITLE
feat(router): add tracing sampling env override (`TELEMETRY_TRACING_SAMPLING_RATE`)

### DIFF
--- a/.changeset/tracing-sampling-env-var.md
+++ b/.changeset/tracing-sampling-env-var.md
@@ -8,7 +8,7 @@ hive-router-config: patch
 The tracing sampling rate can now be overridden without editing the router config file:
 
 ```shell
-TRACING_SAMPLING_RATE=0.1
+TELEMETRY_TRACING_SAMPLING_RATE=0.1
 ```
 
 This sets the same value as the following YAML configuration:

--- a/.changeset/tracing-sampling-env-var.md
+++ b/.changeset/tracing-sampling-env-var.md
@@ -1,0 +1,21 @@
+---
+hive-router: patch
+hive-router-config: patch
+---
+
+# Add tracing sampling rate environment override
+
+The tracing sampling rate can now be overridden without editing the router config file:
+
+```shell
+TRACING_SAMPLING_RATE=0.1
+```
+
+This sets the same value as the following YAML configuration:
+
+```yaml
+telemetry:
+  tracing:
+    collect:
+      sampling: 0.1
+```

--- a/.changeset/tracing-sampling-env-var.md
+++ b/.changeset/tracing-sampling-env-var.md
@@ -1,6 +1,8 @@
 ---
 hive-router: patch
 hive-router-config: patch
+hive-router-internal: patch
+hive-router-plan-executor: patch
 ---
 
 # Add tracing sampling rate environment override

--- a/docs/README.md
+++ b/docs/README.md
@@ -3222,7 +3222,7 @@ propagation:
 |**max\_attributes\_per\_span**|`integer`|Default: `128`<br/>Format: `"uint32"`<br/>Minimum: `0`<br/>||
 |**max\_events\_per\_span**|`integer`|Default: `128`<br/>Format: `"uint32"`<br/>Minimum: `0`<br/>||
 |**parent\_based\_sampler**|`boolean`|Default: `false`<br/>||
-|**sampling**|`number`|Default: `1`<br/>Format: `"double"`<br/>||
+|**sampling**|`number`|Can also be set via the `TELEMETRY_TRACING_SAMPLING_RATE` environment variable.<br/>Default: `1`<br/>Format: `"double"`<br/>||
 
 **Additional Properties:** not allowed  
 **Example**

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -53,7 +53,7 @@ pub struct EnvVarOverrides {
     pub hive_usage_reporting_enabled: Option<bool>,
 
     // Tracing overrides
-    #[envconfig(from = "TRACING_SAMPLING_RATE")]
+    #[envconfig(from = "TELEMETRY_TRACING_SAMPLING_RATE")]
     pub tracing_sampling_rate: Option<f64>,
 }
 

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -4,7 +4,7 @@ use tracing::debug;
 
 use crate::log::{LogFormat, LogLevel};
 
-#[derive(Envconfig)]
+#[derive(Default, Envconfig)]
 pub struct EnvVarOverrides {
     // Logger overrides
     #[envconfig(from = "LOG_LEVEL")]
@@ -51,6 +51,10 @@ pub struct EnvVarOverrides {
     pub hive_tracing_enabled: Option<bool>,
     #[envconfig(from = "HIVE_USAGE_REPORTING_ENABLED")]
     pub hive_usage_reporting_enabled: Option<bool>,
+
+    // Tracing overrides
+    #[envconfig(from = "TRACING_SAMPLING_RATE")]
+    pub tracing_sampling_rate: Option<f64>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -149,6 +153,15 @@ impl EnvVarOverrides {
             config = config.set_override("telemetry.hive.target", hive_target)?;
         }
 
+        if let Some(tracing_sampling_rate) = self.tracing_sampling_rate.take() {
+            debug!(
+                "[config-override] 'telemetry.tracing.collect.sampling' = {}",
+                tracing_sampling_rate
+            );
+            config =
+                config.set_override("telemetry.tracing.collect.sampling", tracing_sampling_rate)?;
+        }
+
         // Laboratory overrides
         if let Some(laboratory_enabled) = self.laboratory_enabled.take() {
             config = config.set_override("laboratory.enabled", laboratory_enabled)?;
@@ -163,5 +176,58 @@ impl EnvVarOverrides {
         }
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+
+    use crate::HiveRouterConfig;
+
+    use super::*;
+
+    fn config_from_overrides(overrides: EnvVarOverrides) -> HiveRouterConfig {
+        overrides
+            .apply_overrides(Config::builder())
+            .unwrap()
+            .build()
+            .unwrap()
+            .try_deserialize::<HiveRouterConfig>()
+            .unwrap()
+    }
+
+    #[test]
+    fn tracing_sampling_rate_override_sets_tracing_collect_sampling() {
+        let config = config_from_overrides(EnvVarOverrides {
+            tracing_sampling_rate: Some(0.25),
+            ..Default::default()
+        });
+
+        assert_eq!(config.telemetry.tracing.collect.sampling, 0.25);
+    }
+
+    #[test]
+    fn tracing_sampling_rate_override_wins_over_config_file_value() {
+        let config = EnvVarOverrides {
+            tracing_sampling_rate: Some(0.1),
+            ..Default::default()
+        }
+        .apply_overrides(Config::builder().add_source(File::from_str(
+            r#"
+telemetry:
+  tracing:
+    collect:
+      sampling: 0.75
+"#,
+            FileFormat::Yaml,
+        )))
+        .unwrap()
+        .build()
+        .unwrap()
+        .try_deserialize::<HiveRouterConfig>()
+        .unwrap();
+
+        assert_eq!(config.telemetry.tracing.collect.sampling, 0.1);
     }
 }

--- a/lib/router-config/src/telemetry/tracing.rs
+++ b/lib/router-config/src/telemetry/tracing.rs
@@ -80,6 +80,7 @@ pub struct TracingCollectConfig {
     pub max_attributes_per_event: u32,
     #[serde(default = "default_max_attributes_per_link")]
     pub max_attributes_per_link: u32,
+    /// Can also be set via the `TRACING_SAMPLING_RATE` environment variable.
     #[serde(default = "default_sampling")]
     pub sampling: f64,
     #[serde(default = "default_parent_based_sampler")]

--- a/lib/router-config/src/telemetry/tracing.rs
+++ b/lib/router-config/src/telemetry/tracing.rs
@@ -80,7 +80,7 @@ pub struct TracingCollectConfig {
     pub max_attributes_per_event: u32,
     #[serde(default = "default_max_attributes_per_link")]
     pub max_attributes_per_link: u32,
-    /// Can also be set via the `TRACING_SAMPLING_RATE` environment variable.
+    /// Can also be set via the `TELEMETRY_TRACING_SAMPLING_RATE` environment variable.
     #[serde(default = "default_sampling")]
     pub sampling: f64,
     #[serde(default = "default_parent_based_sampler")]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "graphql": "16.14.0",
         "graphql-http": "1.22.4",
         "start-server-and-test": "3.0.5",
-        "typescript": "^6.0.3"
+        "typescript": "6.0.3"
       }
     },
     "bench": {
@@ -46,7 +46,7 @@
     },
     "lib/node-addon": {
       "name": "@graphql-hive/router-query-planner",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "3.5.1",
@@ -1835,6 +1835,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2043,6 +2044,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3044,6 +3046,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }


### PR DESCRIPTION
## Summary

Add `TELEMETRY_TRACING_SAMPLING_RATE` as an environment override for `telemetry.tracing.collect.sampling`.

This makes it easy to adjust trace sampling in deployments without editing the router config file. The override uses the same numeric value as the YAML config, for example `TELEMETRY_TRACING_SAMPLING_RATE=0.1` maps to `telemetry.tracing.collect.sampling: 0.1`.

## Validation

- `command cargo test --locked -p hive-router-config tracing_sampling_rate`
- `command cargo check --locked -p hive-router-config`
- `command cargo fmt`
- `git diff --check`