### PR TITLE
Add support for end_with_graphql_errors

### DIFF
--- a/.changeset/end_with_graphql_errors
+++ b/.changeset/end_with_graphql_errors
@@ -1,0 +1,8 @@
+---
+hive-router-plan-executor: minor
+hive-router: patch
+---
+
+## Add `end_with_graphql_errors(...)` to the plugin hook API.
+
+Plugin authors can now terminate execution with multiple GraphQL errors in a single response. This avoids forcing plugins to either return only one error or manually build a raw GraphQL error response when several errors should be reported together.

--- a/lib/executor/src/plugins/hooks/on_execute.rs
+++ b/lib/executor/src/plugins/hooks/on_execute.rs
@@ -190,8 +190,6 @@ impl FromGraphQLErrorsToResponse for PlanExecutionOutput {
         PlanExecutionOutput {
             body: from_graphql_errors_to_bytes(errors),
             error_count,
-            // CORS is applied later to the final HTTP response; this only skips
-            // subgraph/early-response header aggregation for plugin-generated errors.
             response_headers_aggregator: None,
             status_code,
         }

--- a/lib/executor/src/plugins/hooks/on_execute.rs
+++ b/lib/executor/src/plugins/hooks/on_execute.rs
@@ -8,8 +8,8 @@ use sonic_rs::json;
 use crate::execution::plan::PlanExecutionOutput;
 use crate::plugin_context::{PluginContext, RouterHttpRequest};
 use crate::plugin_trait::{
-    EndHookPayload, EndHookResult, FromGraphQLErrorToResponse, FromGraphQLErrorsToResponse,
-    StartHookPayload, StartHookResult,
+    from_graphql_errors_to_bytes, EndHookPayload, EndHookResult, FromGraphQLErrorToResponse,
+    FromGraphQLErrorsToResponse, StartHookPayload, StartHookResult,
 };
 use crate::request_context::RequestContextPluginApi;
 use crate::response::graphql_error::GraphQLError;
@@ -187,12 +187,11 @@ impl FromGraphQLErrorsToResponse for PlanExecutionOutput {
         status_code: http::StatusCode,
     ) -> Self {
         let error_count = errors.len();
-        let body_json = json!({
-            "errors": errors,
-        });
         PlanExecutionOutput {
-            body: sonic_rs::to_vec(&body_json).unwrap_or_default(),
+            body: from_graphql_errors_to_bytes(errors),
             error_count,
+            // CORS is applied later to the final HTTP response; this only skips
+            // subgraph/early-response header aggregation for plugin-generated errors.
             response_headers_aggregator: None,
             status_code,
         }

--- a/lib/executor/src/plugins/hooks/on_execute.rs
+++ b/lib/executor/src/plugins/hooks/on_execute.rs
@@ -8,7 +8,8 @@ use sonic_rs::json;
 use crate::execution::plan::PlanExecutionOutput;
 use crate::plugin_context::{PluginContext, RouterHttpRequest};
 use crate::plugin_trait::{
-    EndHookPayload, EndHookResult, FromGraphQLErrorToResponse, StartHookPayload, StartHookResult,
+    EndHookPayload, EndHookResult, FromGraphQLErrorToResponse, FromGraphQLErrorsToResponse,
+    StartHookPayload, StartHookResult,
 };
 use crate::request_context::RequestContextPluginApi;
 use crate::response::graphql_error::GraphQLError;
@@ -176,12 +177,22 @@ pub type OnExecuteEndHookResult<'exec> =
 
 impl FromGraphQLErrorToResponse for PlanExecutionOutput {
     fn from_graphql_error_to_response(error: GraphQLError, status_code: http::StatusCode) -> Self {
+        Self::from_graphql_errors_to_response(vec![error], status_code)
+    }
+}
+
+impl FromGraphQLErrorsToResponse for PlanExecutionOutput {
+    fn from_graphql_errors_to_response(
+        errors: Vec<GraphQLError>,
+        status_code: http::StatusCode,
+    ) -> Self {
+        let error_count = errors.len();
         let body_json = json!({
-            "errors": [error],
+            "errors": errors,
         });
         PlanExecutionOutput {
             body: sonic_rs::to_vec(&body_json).unwrap_or_default(),
-            error_count: 1,
+            error_count,
             response_headers_aggregator: None,
             status_code,
         }

--- a/lib/executor/src/plugins/hooks/on_subgraph_execute.rs
+++ b/lib/executor/src/plugins/hooks/on_subgraph_execute.rs
@@ -2,8 +2,8 @@ use crate::{
     executors::common::{SubgraphExecutionRequest, SubgraphExecutorBoxedArc},
     plugin_context::{PluginContext, RouterHttpRequest},
     plugin_trait::{
-        EndHookPayload, EndHookResult, FromGraphQLErrorToResponse, StartHookPayload,
-        StartHookResult,
+        EndHookPayload, EndHookResult, FromGraphQLErrorToResponse, FromGraphQLErrorsToResponse,
+        StartHookPayload, StartHookResult,
     },
     request_context::RequestContextPluginApi,
     response::{graphql_error::GraphQLError, subgraph_response::SubgraphResponse},
@@ -68,9 +68,18 @@ pub type OnSubgraphExecuteEndHookResult<'exec> =
     EndHookResult<OnSubgraphExecuteEndHookPayload<'exec>, SubgraphResponse<'exec>>;
 
 impl FromGraphQLErrorToResponse for SubgraphResponse<'_> {
-    fn from_graphql_error_to_response(error: GraphQLError, _status_code: http::StatusCode) -> Self {
+    fn from_graphql_error_to_response(error: GraphQLError, status_code: http::StatusCode) -> Self {
+        Self::from_graphql_errors_to_response(vec![error], status_code)
+    }
+}
+
+impl FromGraphQLErrorsToResponse for SubgraphResponse<'_> {
+    fn from_graphql_errors_to_response(
+        errors: Vec<GraphQLError>,
+        _status_code: http::StatusCode,
+    ) -> Self {
         SubgraphResponse {
-            errors: Some(vec![error]),
+            errors: Some(errors),
             ..Default::default()
         }
     }

--- a/lib/executor/src/plugins/hooks/on_subgraph_http_request.rs
+++ b/lib/executor/src/plugins/hooks/on_subgraph_http_request.rs
@@ -7,7 +7,8 @@ use crate::{
     },
     plugin_context::PluginContext,
     plugin_trait::{
-        from_graphql_error_to_bytes, EndHookPayload, FromGraphQLErrorToResponse, StartHookPayload,
+        from_graphql_errors_to_bytes, EndHookPayload, FromGraphQLErrorToResponse,
+        FromGraphQLErrorsToResponse, StartHookPayload,
     },
     request_context::RequestContextPluginApi,
     response::graphql_error::GraphQLError,
@@ -80,7 +81,16 @@ pub type OnSubgraphHttpResponseHookResult<'exec> = crate::plugin_trait::EndHookR
 
 impl FromGraphQLErrorToResponse for SubgraphHttpResponse {
     fn from_graphql_error_to_response(error: GraphQLError, status: http::StatusCode) -> Self {
-        let body_bytes = from_graphql_error_to_bytes(error);
+        Self::from_graphql_errors_to_response(vec![error], status)
+    }
+}
+
+impl FromGraphQLErrorsToResponse for SubgraphHttpResponse {
+    fn from_graphql_errors_to_response(
+        errors: Vec<GraphQLError>,
+        status: http::StatusCode,
+    ) -> Self {
+        let body_bytes = from_graphql_errors_to_bytes(errors);
         SubgraphHttpResponse {
             body: Bytes::from(body_bytes),
             status,

--- a/lib/executor/src/plugins/plugin_trait.rs
+++ b/lib/executor/src/plugins/plugin_trait.rs
@@ -113,6 +113,23 @@ where
         ))
     }
 
+    /// End the hook execution with multiple GraphQL errors,
+    /// returning a response with the appropriate error format to the client immediately, skipping the rest of the execution flow.
+    fn end_with_graphql_errors<'exec, TErrors>(
+        self,
+        errors: TErrors,
+        status_code: http::StatusCode,
+    ) -> StartHookResult<'exec, Self, TEndPayload, TResponse>
+    where
+        TErrors: IntoIterator<Item = GraphQLError>,
+        TResponse: FromGraphQLErrorsToResponse,
+    {
+        self.end_with_response(TResponse::from_graphql_errors_to_response(
+            errors.into_iter().collect(),
+            status_code,
+        ))
+    }
+
     /// Attach a callback to be executed at the end of the hook, allowing you to manipulate the end payload or response.
     /// This is useful when you want to execute some logic after the main execution of the hook
     ///
@@ -212,26 +229,150 @@ where
             status_code,
         ))
     }
+
+    /// End the hook execution with multiple GraphQL errors,
+    /// returning a response with the appropriate error format to the client immediately, skipping the rest of the execution flow.
+    fn end_with_graphql_errors<TErrors>(
+        self,
+        errors: TErrors,
+        status_code: http::StatusCode,
+    ) -> EndHookResult<Self, TResponse>
+    where
+        TErrors: IntoIterator<Item = GraphQLError>,
+        TResponse: FromGraphQLErrorsToResponse,
+    {
+        self.end_with_response(TResponse::from_graphql_errors_to_response(
+            errors.into_iter().collect(),
+            status_code,
+        ))
+    }
 }
 
 pub trait FromGraphQLErrorToResponse {
     fn from_graphql_error_to_response(error: GraphQLError, status_code: http::StatusCode) -> Self;
 }
 
+pub trait FromGraphQLErrorsToResponse: FromGraphQLErrorToResponse {
+    fn from_graphql_errors_to_response(
+        errors: Vec<GraphQLError>,
+        status_code: http::StatusCode,
+    ) -> Self;
+}
+
 pub fn from_graphql_error_to_bytes(error: GraphQLError) -> Vec<u8> {
+    from_graphql_errors_to_bytes(vec![error])
+}
+
+pub fn from_graphql_errors_to_bytes(errors: Vec<GraphQLError>) -> Vec<u8> {
     let body = json!({
-        "errors": [error]
+        "errors": errors
     });
     sonic_rs::to_vec(&body).unwrap_or_default()
 }
 
 impl FromGraphQLErrorToResponse for ntex::http::Response {
     fn from_graphql_error_to_response(error: GraphQLError, status_code: http::StatusCode) -> Self {
-        let body = from_graphql_error_to_bytes(error);
+        Self::from_graphql_errors_to_response(vec![error], status_code)
+    }
+}
+
+impl FromGraphQLErrorsToResponse for ntex::http::Response {
+    fn from_graphql_errors_to_response(
+        errors: Vec<GraphQLError>,
+        status_code: http::StatusCode,
+    ) -> Self {
+        let body = from_graphql_errors_to_bytes(errors);
         ntex::http::Response::build(ntex::http::StatusCode::OK)
             .content_type("application/json")
             .status(status_code)
             .body(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestStartPayload;
+    struct TestEndPayload;
+
+    struct TestResponse {
+        errors: Vec<GraphQLError>,
+        status_code: http::StatusCode,
+    }
+
+    impl FromGraphQLErrorToResponse for TestResponse {
+        fn from_graphql_error_to_response(
+            error: GraphQLError,
+            status_code: http::StatusCode,
+        ) -> Self {
+            Self::from_graphql_errors_to_response(vec![error], status_code)
+        }
+    }
+
+    impl FromGraphQLErrorsToResponse for TestResponse {
+        fn from_graphql_errors_to_response(
+            errors: Vec<GraphQLError>,
+            status_code: http::StatusCode,
+        ) -> Self {
+            TestResponse {
+                errors,
+                status_code,
+            }
+        }
+    }
+
+    impl StartHookPayload<TestEndPayload, TestResponse> for TestStartPayload {}
+    impl EndHookPayload<TestResponse> for TestEndPayload {}
+
+    #[test]
+    fn end_with_graphql_errors_returns_all_errors() {
+        let result = TestStartPayload.end_with_graphql_errors(
+            vec![
+                GraphQLError::from_message_and_code("First violation", "FIRST_VIOLATION"),
+                GraphQLError::from_message_and_code("Second violation", "SECOND_VIOLATION"),
+            ],
+            http::StatusCode::BAD_REQUEST,
+        );
+
+        let StartControlFlow::EndWithResponse(response) = result.control_flow else {
+            panic!("expected hook to end with response");
+        };
+
+        assert_eq!(response.status_code, http::StatusCode::BAD_REQUEST);
+        assert_eq!(response.errors.len(), 2);
+        assert_eq!(response.errors[0].message, "First violation");
+        assert_eq!(response.errors[1].message, "Second violation");
+    }
+
+    #[test]
+    fn from_graphql_errors_to_bytes_serializes_all_errors() {
+        let body = from_graphql_errors_to_bytes(vec![
+            GraphQLError::from_message_and_code("First violation", "FIRST_VIOLATION"),
+            GraphQLError::from_message_and_code("Second violation", "SECOND_VIOLATION"),
+        ]);
+
+        let body: sonic_rs::Value = sonic_rs::from_slice(&body).unwrap();
+
+        assert_eq!(
+            body,
+            json!({
+                "errors": [
+                    {
+                        "message": "First violation",
+                        "extensions": {
+                            "code": "FIRST_VIOLATION"
+                        }
+                    },
+                    {
+                        "message": "Second violation",
+                        "extensions": {
+                            "code": "SECOND_VIOLATION"
+                        }
+                    }
+                ]
+            })
+        );
     }
 }
 

--- a/plugin_examples/forbid_anonymous_operations/src/test.rs
+++ b/plugin_examples/forbid_anonymous_operations/src/test.rs
@@ -1,7 +1,43 @@
 #[cfg(test)]
 mod tests {
     use e2e::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
-    use hive_router::{http::StatusCode, ntex, sonic_rs};
+    use hive_router::plugins::{
+        hooks::{
+            on_graphql_params::{OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult},
+            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        },
+        plugin_trait::{RouterPlugin, StartHookPayload},
+    };
+    use hive_router::{async_trait, http::StatusCode, ntex, sonic_rs, GraphQLError};
+
+    #[derive(Default)]
+    struct MultipleGraphQLErrorsPlugin;
+
+    #[async_trait]
+    impl RouterPlugin for MultipleGraphQLErrorsPlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "forbid_anonymous_operations"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_graphql_params<'exec>(
+            &'exec self,
+            payload: OnGraphQLParamsStartHookPayload<'exec>,
+        ) -> OnGraphQLParamsStartHookResult<'exec> {
+            payload.end_with_graphql_errors(
+                vec![
+                    GraphQLError::from_message_and_code("First violation", "FIRST_VIOLATION"),
+                    GraphQLError::from_message_and_code("Second violation", "SECOND_VIOLATION"),
+                ],
+                StatusCode::BAD_REQUEST,
+            )
+        }
+    }
 
     #[ntex::test]
     async fn should_forbid_anonymous_operations() {
@@ -28,6 +64,44 @@ mod tests {
                         "message": "Anonymous operations are not allowed",
                         "extensions": {
                             "code": "ANONYMOUS_OPERATION"
+                        }
+                    }
+                ]
+            })
+        );
+    }
+
+    #[ntex::test]
+    async fn should_return_multiple_graphql_errors() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("../plugin_examples/forbid_anonymous_operations/router.config.yaml")
+            .register_plugin::<MultipleGraphQLErrorsPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            res.json_body().await,
+            sonic_rs::json!({
+                "errors": [
+                    {
+                        "message": "First violation",
+                        "extensions": {
+                            "code": "FIRST_VIOLATION"
+                        }
+                    },
+                    {
+                        "message": "Second violation",
+                        "extensions": {
+                            "code": "SECOND_VIOLATION"
                         }
                     }
                 ]


### PR DESCRIPTION
## What changed

- Added `end_with_graphql_errors(...)` to start and end hook payloads for response types that can represent GraphQL error lists.
- Added `FromGraphQLErrorsToResponse` plus shared JSON serialization for `{ "errors": [...] }`.
- Wired multi-error conversion through HTTP, subgraph HTTP, subgraph execution, and plan execution response types.
- Added unit coverage and a plugin example test for returning two GraphQL errors in one response.

## Why

`end_with_graphql_error(...)` only accepted one `GraphQLError`, forcing plugins to drop additional violations or manually build raw responses. GraphQL responses support an `errors` array, so the plugin API should expose that directly while preserving the existing single-error helper.

## Validation

- `cargo fmt --check`
- `cargo check -p hive-router-plan-executor --offline`
- `cargo check -p hive-router --offline`
- `cargo test -p hive-router-plan-executor end_with_graphql_errors_returns_all_errors --offline -- --nocapture`
- `cargo test -p hive-router-plan-executor from_graphql_errors_to_bytes_serializes_all_errors --offline -- --nocapture`

Note: attempted `cargo test -p forbid-anonymous-operations-plugin-example should_return_multiple_graphql_errors -- --nocapture`, but Cargo could not fetch uncached `ascii v1.1.0` because the local socket firewall rejected the TLS certificate for `static.crates.io`.