### PR TITLE
fix(console-sdk): remove dependency on ntex

### DIFF
--- a/.changeset/remove_dependency_ntex_from_console_sdk.md
+++ b/.changeset/remove_dependency_ntex_from_console_sdk.md
@@ -1,0 +1,11 @@
+---
+hive-router-plan-executor: patch
+hive-console-sdk: patch
+hive-router-internal: patch
+hive-router: patch
+hive-apollo-router-plugin: patch
+---
+
+# Remove dependency ntex from console-sdk
+
+Other pkgs are released due to minor refactor and code relocation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,6 @@ dependencies = [
  "md5",
  "mockito",
  "moka",
- "ntex",
  "recloser",
  "regex-automata",
  "regress 0.11.1",

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -1,5 +1,4 @@
 use futures::StreamExt;
-use hive_console_sdk::agent::usage_agent::RequestDetails;
 use hive_router_internal::{
     http::read_body_stream,
     telemetry::traces::spans::{
@@ -407,7 +406,7 @@ pub async fn graphql_request_handler(
                         "Expected Usage Reporting options to be present when Hive Usage Agent is initialized",
                     ),
                 shared_response.error_count(),
-                Some(RequestDetails::from(&*req)),
+                Some(usage_reporting::request_details_from_ntex_request(&*req)),
             )
             .await;
         }

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -406,7 +406,7 @@ pub async fn graphql_request_handler(
                         "Expected Usage Reporting options to be present when Hive Usage Agent is initialized",
                     ),
                 shared_response.error_count(),
-                Some(usage_reporting::request_details_from_ntex_request(&*req)),
+                Some(usage_reporting::request_details_from_ntex_request(req)),
             )
             .await;
         }

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -159,11 +159,12 @@ impl BackgroundTask for UsageAgentTask {
 pub fn request_details_from_ntex_request<'req>(
     req: &'req ntex::web::HttpRequest,
 ) -> RequestDetails<'req> {
-    let headers = req
-        .headers()
-        .iter()
-        .filter_map(|(name, value)| value.to_str().ok().map(|val_str| (name.as_str(), val_str)))
-        .collect();
+    let mut headers = Vec::with_capacity(req.headers().len());
+    for (name, value) in req.headers().iter() {
+        if let Ok(val_str) = value.to_str() {
+            headers.push((name.as_str(), val_str));
+        }
+    }
 
     RequestDetails {
         method: req.method(),

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -99,7 +99,7 @@ pub async fn collect_usage_report<'a>(
     hive_usage_agent: &UsageAgent,
     usage_config: &UsageReportingConfig,
     error_count: usize,
-    request_details: Option<RequestDetails>,
+    request_details: Option<RequestDetails<'a>>,
 ) {
     let sample_rate = usage_config.sample_rate.as_f64();
     if sample_rate < 1.0 && !rand::rng().random_bool(sample_rate) {
@@ -155,21 +155,19 @@ impl BackgroundTask for UsageAgentTask {
     }
 }
 
-pub fn request_details_from_ntex_request(req: &ntex::web::HttpRequest) -> RequestDetails {
+#[inline]
+pub fn request_details_from_ntex_request<'req>(
+    req: &'req ntex::web::HttpRequest,
+) -> RequestDetails<'req> {
     let headers = req
         .headers()
         .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|val_str| (name.to_string(), val_str.to_string()))
-        })
+        .filter_map(|(name, value)| value.to_str().ok().map(|val_str| (name.as_str(), val_str)))
         .collect();
 
     RequestDetails {
-        method: req.method().clone(),
-        url: req.uri().clone(),
+        method: req.method(),
+        url: req.uri(),
         headers,
     }
 }

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -154,3 +154,22 @@ impl BackgroundTask for UsageAgentTask {
         self.0.start_flush_interval(&token).await
     }
 }
+
+pub fn request_details_from_ntex_request(req: &ntex::web::HttpRequest) -> RequestDetails {
+    let headers = req
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|val_str| (name.to_string(), val_str.to_string()))
+        })
+        .collect();
+
+    RequestDetails {
+        method: req.method().clone(),
+        url: req.uri().clone(),
+        headers,
+    }
+}

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -524,12 +524,12 @@ async fn handle_text_frame(
                             value
                                 .to_str()
                                 .ok()
-                                .map(|val_str| (name.to_string(), val_str.to_string()))
+                                .map(|val_str| (name.as_str(), val_str))
                         })
                         .collect();
                     let request_details = RequestDetails {
-                        method: Method::POST,
-                        url: (*ws_uri).clone(),
+                        method: &Method::POST,
+                        url: ws_uri,
                         headers,
                     };
                     usage_reporting::collect_usage_report(

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -518,19 +518,16 @@ async fn handle_text_frame(
                 };
 
                 if let Some(hive_usage_agent) = &shared_state.hive_usage_agent {
-                    let headers = headers
-                        .iter()
-                        .filter_map(|(name, value)| {
-                            value
-                                .to_str()
-                                .ok()
-                                .map(|val_str| (name.as_str(), val_str))
-                        })
-                        .collect();
+                    let mut headers_vec: Vec<(&str, &str)> = Vec::with_capacity(headers.len());
+                    for (name, value) in headers.iter() {
+                        if let Ok(val_str) = value.to_str() {
+                            headers_vec.push((name.as_str(), val_str));
+                        }
+                    }
                     let request_details = RequestDetails {
                         method: &Method::POST,
                         url: ws_uri,
-                        headers,
+                        headers: headers_vec,
                     };
                     usage_reporting::collect_usage_report(
                         supergraph.supergraph_schema.clone(),

--- a/lib/executor/src/coprocessor/stages/graphql.rs
+++ b/lib/executor/src/coprocessor/stages/graphql.rs
@@ -18,6 +18,7 @@ use crate::coprocessor::stage::{
     compile_condition, evaluate_condition, CoprocessorRequest, CoprocessorRequestBody,
     CoprocessorResponseBody, HeaderMapJsonRef, Stage, StageResponsePayload,
 };
+use crate::execution::client_request_details::ntex_header_map_to_vrl_value;
 use crate::plugins::hooks::on_graphql_params::GraphQLParams;
 use crate::request_context::{SelectedRequestContext, SharedRequestContext};
 
@@ -154,7 +155,9 @@ impl Stage for GraphqlRequestStage {
             hints.context_builder(|root| {
                 root.insert_object("request", |req| {
                     req.insert_lazy("method", || input.request.method().as_str().into())
-                        .insert_lazy("headers", || input.request.headers().to_vrl_value())
+                        .insert_lazy("headers", || {
+                            ntex_header_map_to_vrl_value(input.request.headers())
+                        })
                         .insert_lazy("url", || input.request.uri().to_vrl_value())
                         .insert_object("operation", |op| {
                             op.insert_lazy("name", || {
@@ -235,7 +238,9 @@ impl Stage for GraphqlAnalysisStage {
             hints.context_builder(|root| {
                 root.insert_object("request", |req| {
                     req.insert_lazy("method", || input.request.method.as_str().into())
-                        .insert_lazy("headers", || input.request.headers.to_vrl_value())
+                        .insert_lazy("headers", || {
+                            ntex_header_map_to_vrl_value(input.request.headers)
+                        })
                         .insert_lazy("url", || input.request.uri.to_vrl_value())
                         .insert_object("operation", |op| {
                             op.insert_lazy("name", || {
@@ -315,12 +320,16 @@ impl Stage for GraphqlResponseStage {
             hints.context_builder(|root| {
                 root.insert_object("request", |req| {
                     req.insert_lazy("method", || input.request.method().as_str().into())
-                        .insert_lazy("headers", || input.request.headers().to_vrl_value())
+                        .insert_lazy("headers", || {
+                            ntex_header_map_to_vrl_value(input.request.headers())
+                        })
                         .insert_lazy("url", || input.request.uri().to_vrl_value());
                 });
                 root.insert_object("response", |res| {
-                    res.insert_lazy("headers", || input.response.headers().to_vrl_value())
-                        .insert_lazy("status_code", || input.response.status().as_u16().into());
+                    res.insert_lazy("headers", || {
+                        ntex_header_map_to_vrl_value(input.response.headers())
+                    })
+                    .insert_lazy("status_code", || input.response.status().as_u16().into());
                 });
             })
         })

--- a/lib/executor/src/coprocessor/stages/router.rs
+++ b/lib/executor/src/coprocessor/stages/router.rs
@@ -14,13 +14,16 @@ use ntex::http::{
 use ntex::util::Bytes as NtexBytes;
 use ntex::web::{self, DefaultError};
 
-use crate::coprocessor::protocol::COPROCESSOR_VERSION;
 use crate::coprocessor::stage::{
     compile_condition, evaluate_condition, CoprocessorRequest, CoprocessorRequestBody,
     CoprocessorResponseBody, HeaderMapJsonRef, Stage, StageResponsePayload,
 };
 use crate::request_context::SelectedRequestContext;
 use crate::{coprocessor::error::CoprocessorError, request_context::SharedRequestContext};
+use crate::{
+    coprocessor::protocol::COPROCESSOR_VERSION,
+    execution::client_request_details::ntex_header_map_to_vrl_value,
+};
 
 pub struct RouterRequestStage {
     condition: Option<BooleanOrProgram>,
@@ -108,7 +111,9 @@ impl Stage for RouterRequestStage {
             hints.context_builder(|root| {
                 root.insert_object("request", |req| {
                     req.insert_lazy("method", || input.request.method().as_str().into())
-                        .insert_lazy("headers", || input.request.headers().to_vrl_value())
+                        .insert_lazy("headers", || {
+                            ntex_header_map_to_vrl_value(input.request.headers())
+                        })
                         .insert_lazy("url", || input.request.uri().to_vrl_value());
                 });
             })
@@ -200,13 +205,15 @@ impl Stage for RouterResponseStage {
                         input.response.request().method().as_str().into()
                     })
                     .insert_lazy("headers", || {
-                        input.response.request().headers().to_vrl_value()
+                        ntex_header_map_to_vrl_value(input.response.request().headers())
                     })
                     .insert_lazy("url", || input.response.request().uri().to_vrl_value());
                 })
                 .insert_object("response", |res| {
-                    res.insert_lazy("headers", || input.response.headers().to_vrl_value())
-                        .insert_lazy("status_code", || input.response.status().as_u16().into());
+                    res.insert_lazy("headers", || {
+                        ntex_header_map_to_vrl_value(input.response.headers())
+                    })
+                    .insert_lazy("status_code", || input.response.status().as_u16().into());
                 });
             })
         })

--- a/lib/executor/src/execution/client_request_details.rs
+++ b/lib/executor/src/execution/client_request_details.rs
@@ -141,9 +141,24 @@ impl From<&ClientRequestDetails<'_>> for Value {
     }
 }
 
+pub fn ntex_header_map_to_vrl_value(headers: &NtexHeaderMap) -> Value {
+    let mut obj = BTreeMap::new();
+
+    for (header_name, header_value) in headers.iter() {
+        if let Ok(value) = header_value.to_str() {
+            obj.insert(
+                header_name.as_str().into(),
+                Value::Bytes(Bytes::from(value.to_owned())),
+            );
+        }
+    }
+
+    Value::Object(obj)
+}
+
 fn request_details_to_vrl_value(details: &(impl ClientRequestDetailsView + ?Sized)) -> Value {
     // .request.headers
-    let headers_value = details.headers().to_vrl_value();
+    let headers_value = ntex_header_map_to_vrl_value(details.headers());
 
     // .request.url
     let url_value = details.url().to_vrl_value();

--- a/lib/hive-console-sdk/Cargo.toml
+++ b/lib/hive-console-sdk/Cargo.toml
@@ -40,7 +40,6 @@ bytes ={ workspace = true }
 sonic-rs = { workspace = true }
 humantime = { workspace = true }
 http-serde = "2.1.1"
-ntex = { workspace = true }
 
 [dev-dependencies]
 mockito = { workspace = true }

--- a/lib/hive-console-sdk/src/agent/usage_agent.rs
+++ b/lib/hive-console-sdk/src/agent/usage_agent.rs
@@ -112,10 +112,10 @@ pub trait UsageAgentExt {
     #[deprecated(note = "use `add_report_with_request` instead")]
     async fn add_report(&self, execution_report: ExecutionReport) -> Result<(), AgentError>;
 
-    async fn add_report_with_request(
+    async fn add_report_with_request<'req>(
         &self,
         execution_report: ExecutionReport,
-        request: Option<RequestDetails>,
+        request: Option<RequestDetails<'req>>,
     ) -> Result<(), AgentError>;
 }
 
@@ -253,10 +253,10 @@ impl UsageAgentInner {
 }
 
 #[derive(Debug, Clone)]
-pub struct RequestDetails {
-    pub method: http::Method,
-    pub url: http::Uri,
-    pub headers: Vec<(String, String)>,
+pub struct RequestDetails<'req> {
+    pub method: &'req http::Method,
+    pub url: &'req http::Uri,
+    pub headers: Vec<(&'req str, &'req str)>,
 }
 
 #[async_trait::async_trait]
@@ -278,10 +278,10 @@ impl UsageAgentExt for UsageAgent {
         }
     }
 
-    async fn add_report_with_request(
+    async fn add_report_with_request<'req>(
         &self,
         execution_report: ExecutionReport,
-        request: Option<RequestDetails>,
+        request: Option<RequestDetails<'req>>,
     ) -> Result<(), AgentError> {
         let inner = self.inner();
 
@@ -314,36 +314,31 @@ impl UsageAgentExt for UsageAgent {
     }
 }
 
-impl<'req, TBody> From<&'req http::Request<TBody>> for RequestDetails {
+impl<'req, TBody> From<&'req http::Request<TBody>> for RequestDetails<'req> {
     fn from(req: &'req http::Request<TBody>) -> Self {
         let headers = req
             .headers()
             .iter()
-            .filter_map(|(name, value)| {
-                value
-                    .to_str()
-                    .ok()
-                    .map(|val_str| (name.to_string(), val_str.to_string()))
-            })
+            .filter_map(|(name, value)| value.to_str().ok().map(|val_str| (name.as_str(), val_str)))
             .collect();
 
         RequestDetails {
-            method: req.method().clone(),
-            url: req.uri().clone(),
+            method: req.method(),
+            url: req.uri(),
             headers,
         }
     }
 }
 
-impl From<RequestDetails> for VrlValue {
-    fn from(details: RequestDetails) -> Self {
+impl<'req> From<RequestDetails<'req>> for VrlValue {
+    fn from(details: RequestDetails<'req>) -> Self {
         let mut merged_headers: BTreeMap<String, String> = BTreeMap::new();
         for (header_name, header_value) in details.headers {
-            if let Some(existing_value) = merged_headers.get_mut(&header_name) {
+            if let Some(existing_value) = merged_headers.get_mut(header_name) {
                 existing_value.push_str(", ");
-                existing_value.push_str(&header_value);
+                existing_value.push_str(header_value);
             } else {
-                merged_headers.insert(header_name, header_value);
+                merged_headers.insert(header_name.into(), header_value.into());
             }
         }
 

--- a/lib/hive-console-sdk/src/agent/usage_agent.rs
+++ b/lib/hive-console-sdk/src/agent/usage_agent.rs
@@ -316,11 +316,12 @@ impl UsageAgentExt for UsageAgent {
 
 impl<'req, TBody> From<&'req http::Request<TBody>> for RequestDetails<'req> {
     fn from(req: &'req http::Request<TBody>) -> Self {
-        let headers = req
-            .headers()
-            .iter()
-            .filter_map(|(name, value)| value.to_str().ok().map(|val_str| (name.as_str(), val_str)))
-            .collect();
+        let mut headers = Vec::with_capacity(req.headers().len());
+        for (name, value) in req.headers().iter() {
+            if let Ok(val_str) = value.to_str() {
+                headers.push((name.as_str(), val_str));
+            }
+        }
 
         RequestDetails {
             method: req.method(),

--- a/lib/hive-console-sdk/src/agent/usage_agent.rs
+++ b/lib/hive-console-sdk/src/agent/usage_agent.rs
@@ -335,27 +335,6 @@ impl<'req, TBody> From<&'req http::Request<TBody>> for RequestDetails {
     }
 }
 
-impl<'req> From<&'req ntex::web::HttpRequest> for RequestDetails {
-    fn from(req: &'req ntex::web::HttpRequest) -> Self {
-        let headers = req
-            .headers()
-            .iter()
-            .filter_map(|(name, value)| {
-                value
-                    .to_str()
-                    .ok()
-                    .map(|val_str| (name.to_string(), val_str.to_string()))
-            })
-            .collect();
-
-        RequestDetails {
-            method: req.method().clone(),
-            url: req.uri().clone(),
-            headers,
-        }
-    }
-}
-
 impl From<RequestDetails> for VrlValue {
     fn from(details: RequestDetails) -> Self {
         let mut merged_headers: BTreeMap<String, String> = BTreeMap::new();

--- a/lib/hive-console-sdk/src/expressions/values/http.rs
+++ b/lib/hive-console-sdk/src/expressions/values/http.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use crate::expressions::{lib::ToVrlValue, FromVrlValue};
 use bytes::Bytes;
 use http::{HeaderMap, HeaderValue, Uri};
-use ntex::http::HeaderMap as NtexHeaderMap;
 use vrl::core::Value as VrlValue;
 
 /// Error type for HeaderValue conversion failures
@@ -63,21 +62,6 @@ impl FromVrlValue for HeaderValue {
             VrlValue::Object(_) => Err(HeaderValueConversionError::UnsupportedObject),
             VrlValue::Null => Err(HeaderValueConversionError::UnsupportedNull),
         }
-    }
-}
-
-impl ToVrlValue for NtexHeaderMap {
-    fn to_vrl_value(&self) -> VrlValue {
-        let mut obj = BTreeMap::new();
-        for (header_name, header_value) in self.iter() {
-            if let Ok(value) = header_value.to_str() {
-                obj.insert(
-                    header_name.as_str().into(),
-                    VrlValue::Bytes(Bytes::from(value.to_owned())),
-                );
-            }
-        }
-        VrlValue::Object(obj)
     }
 }
 


### PR DESCRIPTION
Console-SDK doesn't have any good reason to depend on `ntex`. 