### PR TITLE
fix(router): resolve S3 storage credentials from the environment

### DIFF
--- a/.changeset/s3_credentials_from_env
+++ b/.changeset/s3_credentials_from_env
@@ -1,0 +1,20 @@
+---
+hive-router: minor
+---
+
+## Resolve S3 storage credentials from the environment by default
+
+The S3 storage backend now seeds its client from the standard `AWS_*`
+environment variables, matching the behaviour of the AWS SDKs. This makes the
+backend work out of the box in common Kubernetes setups without an explicit
+`credentials` block:
+
+- **EKS IRSA** now works automatically — the pod identity webhook injects
+  `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN`, which are picked up directly.
+- Static credentials can be supplied via `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY` (and optional `AWS_SESSION_TOKEN`).
+- ECS task roles, EKS Pod Identity, region, and endpoint are likewise read from
+  their respective `AWS_*` variables.
+
+Explicit values in the `storages.<id>` config still take precedence over the
+environment, so existing configurations are unaffected.

--- a/bin/router/src/storage/s3_runtime.rs
+++ b/bin/router/src/storage/s3_runtime.rs
@@ -21,18 +21,42 @@ impl S3StorageRuntime {
     }
 
     fn build_client(config: &S3StorageConfig) -> Result<AmazonS3, StorageError> {
-        // Seed the builder from the standard `AWS_*` environment variables so
-        // that credentials supplied by the runtime work without any explicit
-        // configuration. Most importantly this makes EKS IRSA work out of the
-        // box — the pod identity webhook injects `AWS_WEB_IDENTITY_TOKEN_FILE`
-        // and `AWS_ROLE_ARN`, which `from_env` picks up — and it also honours
-        // plain `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`,
-        // `AWS_REGION`, `AWS_ENDPOINT`, and the ECS container-credential vars.
+        // When no credentials are configured, seed the whole builder from the
+        // standard `AWS_*` environment variables so the ambient runtime works
+        // out of the box — most importantly EKS IRSA, where the pod identity
+        // webhook injects `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN`.
         //
-        // The explicit config below is applied afterwards, so any value set in
-        // the router config takes precedence over the environment.
-        let mut builder = AmazonS3Builder::from_env()
-            .with_bucket_name(&resolve_value_or_expression(&config.bucket, "bucket")?);
+        // When credentials *are* configured explicitly we must NOT pull
+        // credentials from the environment: `from_env` would otherwise mix
+        // env-derived credentials into the configured ones — e.g. an env
+        // `AWS_SESSION_TOKEN` attaching itself to configured static keys, or
+        // env static keys taking object_store's internal precedence over a
+        // configured `web_identity` role. We still honour non-credential env
+        // vars (region, endpoint) as a fallback when they are not set in the
+        // config, so explicit credentials don't disable that convenience.
+        let mut builder = match &config.credentials {
+            None => AmazonS3Builder::from_env(),
+            Some(_) => {
+                let mut b = AmazonS3Builder::new();
+                if config.region.is_none() {
+                    if let Ok(region) = std::env::var("AWS_REGION")
+                        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+                    {
+                        b = b.with_region(region);
+                    }
+                }
+                if config.endpoint.is_none() {
+                    if let Ok(endpoint) = std::env::var("AWS_ENDPOINT_URL")
+                        .or_else(|_| std::env::var("AWS_ENDPOINT"))
+                    {
+                        b = b.with_endpoint(endpoint);
+                    }
+                }
+                b
+            }
+        };
+        builder =
+            builder.with_bucket_name(&resolve_value_or_expression(&config.bucket, "bucket")?);
 
         if let Some(region) = &config.region {
             builder = builder.with_region(&resolve_value_or_expression(region, "region")?);

--- a/bin/router/src/storage/s3_runtime.rs
+++ b/bin/router/src/storage/s3_runtime.rs
@@ -21,7 +21,17 @@ impl S3StorageRuntime {
     }
 
     fn build_client(config: &S3StorageConfig) -> Result<AmazonS3, StorageError> {
-        let mut builder = AmazonS3Builder::new()
+        // Seed the builder from the standard `AWS_*` environment variables so
+        // that credentials supplied by the runtime work without any explicit
+        // configuration. Most importantly this makes EKS IRSA work out of the
+        // box — the pod identity webhook injects `AWS_WEB_IDENTITY_TOKEN_FILE`
+        // and `AWS_ROLE_ARN`, which `from_env` picks up — and it also honours
+        // plain `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`,
+        // `AWS_REGION`, `AWS_ENDPOINT`, and the ECS container-credential vars.
+        //
+        // The explicit config below is applied afterwards, so any value set in
+        // the router config takes precedence over the environment.
+        let mut builder = AmazonS3Builder::from_env()
             .with_bucket_name(&resolve_value_or_expression(&config.bucket, "bucket")?);
 
         if let Some(region) = &config.region {

--- a/e2e/src/storage/s3.rs
+++ b/e2e/src/storage/s3.rs
@@ -100,10 +100,11 @@ mod storage_s3_e2e_tests {
         );
     }
 
-    /// Explicit credentials in the config take precedence over the environment:
-    /// bogus `AWS_*` values must be ignored when the config provides real
-    /// credentials. If precedence regressed, signing would use the bogus env
-    /// credentials, the mock would reject them, and supergraph load would fail.
+    /// Explicit credentials in the config are used verbatim and the `AWS_*`
+    /// credential environment variables are ignored entirely. This guards against
+    /// env credentials mixing into the configured ones — in particular a stray
+    /// `AWS_SESSION_TOKEN` must not attach to configured static keys (which would
+    /// break signing), and bogus env access keys must not be used at all.
     #[ntex::test]
     async fn should_prefer_config_credentials_over_env() {
         let storage = S3Mock::start("test-bucket").await;
@@ -111,10 +112,12 @@ mod storage_s3_e2e_tests {
         let location = "my-dir/supergraph.graphql";
         storage.set(location, supergraph.as_bytes()).await;
 
-        // Wrong credentials in the environment, correct ones in the config.
+        // Wrong credentials in the environment, including a session token that
+        // must not leak onto the configured token-less static credentials.
         let _env = EnvGuard::set(&[
             ("AWS_ACCESS_KEY_ID", "AKIAWRONGWRONGWRONG0"),
             ("AWS_SECRET_ACCESS_KEY", "wrong-secret-should-be-ignored"),
+            ("AWS_SESSION_TOKEN", "bogus-session-token-should-be-ignored"),
         ]);
 
         let config = format!(

--- a/e2e/src/storage/s3.rs
+++ b/e2e/src/storage/s3.rs
@@ -1,10 +1,161 @@
 #[cfg(test)]
 mod storage_s3_e2e_tests {
+    use std::sync::Mutex;
     use std::time::Duration;
 
     use sonic_rs::{JsonContainerTrait, JsonValueTrait};
 
     use crate::testkit::{s3_mock::S3Mock, ClientResponseExt, TestRouter};
+
+    /// Serializes the tests that mutate process-global `AWS_*` environment
+    /// variables. The test harness runs tests in parallel within a single
+    /// process, so without this they would clobber one another's environment.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that sets environment variables for the duration of a test and
+    /// restores their previous values on drop. Holds [`ENV_LOCK`] while alive so
+    /// no other env-mutating test runs concurrently.
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(vars: &[(&str, &str)]) -> Self {
+            // Recover from a poisoned lock so a single panicking test does not
+            // wedge the rest of the suite.
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let saved = vars
+                .iter()
+                .map(|(key, value)| {
+                    let previous = std::env::var(key).ok();
+                    std::env::set_var(key, value);
+                    (key.to_string(), previous)
+                })
+                .collect();
+            Self { _lock: lock, saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in &self.saved {
+                match previous {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    /// With no `credentials` block in the config, the backend must pick up
+    /// credentials from the standard `AWS_*` environment variables. This is the
+    /// same `from_env` mechanism that makes EKS IRSA work out of the box (the
+    /// pod identity webhook injects `AWS_WEB_IDENTITY_TOKEN_FILE`/`AWS_ROLE_ARN`).
+    #[ntex::test]
+    async fn should_load_supergraph_using_credentials_from_env() {
+        let storage = S3Mock::start("test-bucket").await;
+        let supergraph = include_str!("../../supergraph.graphql");
+        let location = "my-dir/supergraph.graphql";
+        storage.set(location, supergraph.as_bytes()).await;
+
+        // Credentials are supplied through the environment; only non-credential
+        // settings remain in the config.
+        let _env = EnvGuard::set(&[
+            ("AWS_ACCESS_KEY_ID", storage.access_key()),
+            ("AWS_SECRET_ACCESS_KEY", storage.secret_key()),
+        ]);
+
+        let config = format!(
+            r#"
+            storages:
+              test:
+                type: s3
+                bucket: {}
+                endpoint: {}
+                allow_http: true
+            supergraph:
+              source: storage
+              storage_id: test
+              location: {}
+            "#,
+            storage.bucket(),
+            storage.url(),
+            location
+        );
+
+        let router = TestRouter::builder()
+            .inline_config(config)
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+
+        assert!(
+            res.status().is_success(),
+            "Expected 200 OK when credentials are supplied via AWS_* env vars"
+        );
+    }
+
+    /// Explicit credentials in the config take precedence over the environment:
+    /// bogus `AWS_*` values must be ignored when the config provides real
+    /// credentials. If precedence regressed, signing would use the bogus env
+    /// credentials, the mock would reject them, and supergraph load would fail.
+    #[ntex::test]
+    async fn should_prefer_config_credentials_over_env() {
+        let storage = S3Mock::start("test-bucket").await;
+        let supergraph = include_str!("../../supergraph.graphql");
+        let location = "my-dir/supergraph.graphql";
+        storage.set(location, supergraph.as_bytes()).await;
+
+        // Wrong credentials in the environment, correct ones in the config.
+        let _env = EnvGuard::set(&[
+            ("AWS_ACCESS_KEY_ID", "AKIAWRONGWRONGWRONG0"),
+            ("AWS_SECRET_ACCESS_KEY", "wrong-secret-should-be-ignored"),
+        ]);
+
+        let config = format!(
+            r#"
+            storages:
+              test:
+                type: s3
+                bucket: {}
+                endpoint: {}
+                allow_http: true
+                credentials:
+                  type: static
+                  access_key_id: {}
+                  secret_access_key: {}
+            supergraph:
+              source: storage
+              storage_id: test
+              location: {}
+            "#,
+            storage.bucket(),
+            storage.url(),
+            storage.access_key(),
+            storage.secret_key(),
+            location
+        );
+
+        let router = TestRouter::builder()
+            .inline_config(config)
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+
+        assert!(
+            res.status().is_success(),
+            "Expected config credentials to override the bogus AWS_* env vars"
+        );
+    }
 
     #[ntex::test]
     async fn should_load_supergraph_from_storage() {

--- a/lib/router-config/src/storage/s3.rs
+++ b/lib/router-config/src/storage/s3.rs
@@ -66,9 +66,10 @@ pub struct S3StorageConfig {
     /// - On EC2, the client finally falls through to
     ///   [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
     ///
-    /// Set this field only to provide credentials explicitly or to override what
-    /// the environment supplies — values configured here take precedence over
-    /// the environment.
+    /// When this field **is** set, credentials are taken solely from the config:
+    /// the `AWS_*` credential environment variables are ignored entirely, so they
+    /// cannot mix into or shadow the mode you configured (only non-credential
+    /// settings such as region and endpoint still fall back to the environment).
     ///
     /// See [`S3Credentials`] for all supported authentication modes.
     pub credentials: Option<S3Credentials>,

--- a/lib/router-config/src/storage/s3.rs
+++ b/lib/router-config/src/storage/s3.rs
@@ -51,9 +51,24 @@ pub struct S3StorageConfig {
 
     /// Credential provider to authenticate with S3.
     ///
-    /// When omitted, the client falls through to EC2
-    /// [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html),
-    /// which works automatically on EC2 instances with an attached IAM role.
+    /// When omitted, credentials are resolved from the standard `AWS_*`
+    /// environment variables and the ambient runtime, matching the behaviour of
+    /// the AWS SDKs. In particular:
+    ///
+    /// - On **EKS**, [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+    ///   works out of the box: the pod identity webhook injects
+    ///   `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN`, which are picked up
+    ///   automatically — no `credentials` block required.
+    /// - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and optional
+    ///   `AWS_SESSION_TOKEN`) provide static credentials.
+    /// - ECS task roles and EKS Pod Identity are resolved from their respective
+    ///   `AWS_CONTAINER_CREDENTIALS_*` variables.
+    /// - On EC2, the client finally falls through to
+    ///   [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
+    ///
+    /// Set this field only to provide credentials explicitly or to override what
+    /// the environment supplies — values configured here take precedence over
+    /// the environment.
     ///
     /// See [`S3Credentials`] for all supported authentication modes.
     pub credentials: Option<S3Credentials>,
@@ -107,8 +122,11 @@ pub struct S3StorageConfig {
 /// 2. [`WebIdentity`](Self::WebIdentity) — EKS IRSA via STS `AssumeRoleWithWebIdentity`
 /// 3. [`EcsTask`](Self::EcsTask) — ECS task IAM role
 /// 4. [`EksPodIdentity`](Self::EksPodIdentity) — EKS Pod Identity
-/// 5. [`InstanceMetadata`](Self::InstanceMetadata) — EC2 IMDSv2 (also the implicit
-///    default when `credentials` is omitted entirely)
+/// 5. [`InstanceMetadata`](Self::InstanceMetadata) — EC2 IMDSv2
+///
+/// When `credentials` is omitted entirely, credentials are instead resolved
+/// from the `AWS_*` environment variables and the ambient runtime — see
+/// [`S3StorageConfig::credentials`].
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum S3Credentials {


### PR DESCRIPTION
The S3 storage backend built its client with `AmazonS3Builder::new()`, which ignores the standard `AWS_*` environment variables. As a result it did not work out of the box in Kubernetes/EKS and credentials could not be supplied via the environment.

Build from `AmazonS3Builder::from_env()` instead, so EKS IRSA works automatically (the pod identity webhook injects
`AWS_WEB_IDENTITY_TOKEN_FILE`/`AWS_ROLE_ARN`) and static credentials can be provided via `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Explicit config values are applied afterwards and continue to take precedence.

Adds e2e coverage for env-supplied credentials and config-over-env precedence using the in-process S3 mock.