### PR TITLE
feat(executor): invoke on_subgraph_execute on subscribe path

### DIFF
--- a/.changeset/subscription_plugin_hooks
+++ b/.changeset/subscription_plugin_hooks
@@ -1,0 +1,10 @@
+---
+hive-router-plan-executor: minor
+hive-router: patch
+---
+
+## Invoke `on_subgraph_execute` plugin hook on the subscribe path.
+
+Previously, the `on_subgraph_execute` hook was only invoked for queries and mutations; subscription registration bypassed all plugin hooks. Plugins that mutate `execution_request.headers` (for example to inject auth context) had no way of affecting the subscription registration request, so subgraphs saw an unmodified registration payload.
+
+The hook is now invoked on the subscribe path with the same loop semantics as the execute path. Only `proceed` is fully supported for now; `end_with_response` surfaces a dedicated `SUBGRAPH_SUBSCRIBE_PLUGIN_END_WITH_RESPONSE_UNSUPPORTED` error (mapping a single response into a `'static` stream still needs to be worked out), and `on_end` callbacks are dropped with a warning. Tracked upstream in [#922](https://github.com/graphql-hive/router/issues/922).

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -55,6 +55,8 @@ mod router_timeout;
 #[cfg(test)]
 mod storage;
 #[cfg(test)]
+mod subscription_plugin_hooks;
+#[cfg(test)]
 mod subscriptions;
 #[cfg(test)]
 mod supergraph;

--- a/e2e/src/subscription_plugin_hooks.rs
+++ b/e2e/src/subscription_plugin_hooks.rs
@@ -1,0 +1,215 @@
+#[cfg(test)]
+mod subscription_plugin_hooks_e2e_tests {
+
+    use crate::testkit::{some_header_map, TestRouter, TestSubgraphs};
+    use hive_router::{
+        async_trait,
+        plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        plugins::hooks::on_subgraph_execute::{
+            OnSubgraphExecuteStartHookPayload, OnSubgraphExecuteStartHookResult,
+        },
+        plugins::plugin_trait::{RouterPlugin, StartHookPayload},
+        GraphQLError,
+    };
+    use ntex::http;
+
+    const INJECTED_HEADER_NAME: &str = "x-subscription-plugin-injected";
+    const INJECTED_HEADER_VALUE: &str = "from-on-subgraph-execute";
+
+    /// Plugin that injects a marker header on every subgraph request from
+    /// `on_subgraph_execute`. The test asserts that the header reaches the
+    /// subgraph for the subscription registration request, proving that the
+    /// hook is invoked on the subscribe path.
+    #[derive(Default)]
+    struct InjectSubscriptionHeaderPlugin;
+
+    #[async_trait]
+    impl RouterPlugin for InjectSubscriptionHeaderPlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "test_inject_subscription_header"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_subgraph_execute<'exec>(
+            &'exec self,
+            mut payload: OnSubgraphExecuteStartHookPayload<'exec>,
+        ) -> OnSubgraphExecuteStartHookResult<'exec> {
+            payload.execution_request.headers.insert(
+                ::http::header::HeaderName::from_static(INJECTED_HEADER_NAME),
+                ::http::header::HeaderValue::from_static(INJECTED_HEADER_VALUE),
+            );
+            payload.proceed()
+        }
+    }
+
+    /// Subscription via SSE — verifies that `on_subgraph_execute` is invoked
+    /// for the subscribe-registration request and that header mutations from
+    /// the plugin reach the subgraph.
+    #[ntex::test]
+    async fn on_subgraph_execute_invoked_on_subscribe_sse() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_http_streaming_subscriptions_protocol(
+                subgraphs::HTTPStreamingSubscriptionProtocol::SseOnly,
+            )
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                plugins:
+                    test_inject_subscription_header:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<InjectSubscriptionHeaderPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAdded(intervalInMs: 0) {
+                        product {
+                            upc
+                        }
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+
+        // Drain the body to ensure the subscription registration actually
+        // happens and the subgraph receives the request.
+        let _body = res.body().await.unwrap();
+
+        let reviews_requests = subgraphs
+            .get_requests_log("reviews")
+            .expect("`reviews` subgraph should have received the subscription registration");
+
+        assert!(
+            !reviews_requests.is_empty(),
+            "`reviews` subgraph should have received at least one request"
+        );
+
+        let header_value = reviews_requests
+            .iter()
+            .find_map(|req| req.headers.get(INJECTED_HEADER_NAME))
+            .expect("the injected header must be present on the subgraph request");
+
+        assert_eq!(
+            header_value, INJECTED_HEADER_VALUE,
+            "the injected header value must match the value set by the plugin"
+        );
+    }
+
+    /// Plugin that always short-circuits with `end_with_response`. We use this
+    /// to verify that the explicit error surfaces to the caller on the
+    /// subscribe path instead of being silently dropped.
+    #[derive(Default)]
+    struct EndWithResponsePlugin;
+
+    #[async_trait]
+    impl RouterPlugin for EndWithResponsePlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "test_end_with_response_on_subscribe"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_subgraph_execute<'exec>(
+            &'exec self,
+            payload: OnSubgraphExecuteStartHookPayload<'exec>,
+        ) -> OnSubgraphExecuteStartHookResult<'exec> {
+            payload.end_with_graphql_error(
+                GraphQLError::from_message_and_code(
+                    "short-circuit from plugin",
+                    "TEST_PLUGIN_SHORT_CIRCUIT",
+                ),
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        }
+    }
+
+    /// `end_with_response` on the subscribe path is not yet supported. Confirm
+    /// the dedicated error code is surfaced to the client.
+    #[ntex::test]
+    async fn on_subgraph_execute_end_with_response_unsupported_on_subscribe() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_http_streaming_subscriptions_protocol(
+                subgraphs::HTTPStreamingSubscriptionProtocol::SseOnly,
+            )
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                plugins:
+                    test_end_with_response_on_subscribe:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<EndWithResponsePlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAdded(intervalInMs: 0) {
+                        product {
+                            upc
+                        }
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+
+        let body = res.body().await.unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+
+        assert!(
+            body_str.contains("SUBGRAPH_SUBSCRIBE_PLUGIN_END_WITH_RESPONSE_UNSUPPORTED"),
+            "expected the dedicated error code to be emitted in the SSE stream, got: {body_str}"
+        );
+    }
+}

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -231,6 +231,7 @@ pub async fn execute_query_plan<'exec>(
                 &fetch_node.service_name,
                 subgraph_request,
                 &opts.client_request,
+                opts.plugin_req_state.as_ref(),
             )
             .await
             .with_plan_context(LazyPlanContext {

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -105,6 +105,14 @@ pub enum SubgraphExecutorError {
     #[error("Subgraph internal server error")]
     #[strum(serialize = "SUBGRAPH_INTERNAL_SERVER_ERROR")]
     InternalServerError(Box<SubgraphResponse<'static>>),
+    #[error(
+        "Plugin returned an `end_with_response` control flow from `on_subgraph_execute` on the \
+         subscribe path. Short-circuiting a subscription with a single subgraph response is not \
+         yet supported; short-circuit from an earlier hook (e.g. `on_http_request` or \
+         `on_graphql_params`) instead."
+    )]
+    #[strum(serialize = "SUBGRAPH_SUBSCRIBE_PLUGIN_END_WITH_RESPONSE_UNSUPPORTED")]
+    SubscribePluginEndWithResponseUnsupported,
 }
 
 impl SubgraphExecutorError {

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -351,16 +351,71 @@ impl SubgraphExecutorMap {
 
     pub async fn subscribe<'exec>(
         &self,
-        subgraph_name: &str,
-        execution_request: SubgraphExecutionRequest<'exec>,
+        subgraph_name: &'exec str,
+        mut execution_request: SubgraphExecutionRequest<'exec>,
         client_request: &ClientRequestDetails<'exec>,
+        plugin_req_state: Option<&'exec PluginRequestState<'exec>>,
     ) -> Result<
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
-        let executor = self.get_or_create_subscription_executor(subgraph_name, client_request)?;
+        let mut executor =
+            self.get_or_create_subscription_executor(subgraph_name, client_request)?;
 
         let timeout = self.resolve_subgraph_timeout(subgraph_name, client_request)?;
+
+        // Invoke the `on_subgraph_execute` plugin hook for the subscribe path so
+        // plugins can observe and modify the registration request (e.g. inject
+        // auth headers) the same way they can for queries and mutations.
+        //
+        // `EndWithResponse` and `OnEnd` control flows don't yet have a clean
+        // mapping to a streamed subscription:
+        //   * `EndWithResponse` would require materialising a `SubgraphResponse<'exec>`
+        //     into the `'static` stream that subscribe returns. We surface a
+        //     dedicated error to make the limitation visible to plugin authors
+        //     rather than silently dropping the response.
+        //   * `OnEnd` callbacks are bound to `'exec` and have no well-defined
+        //     end-of-stream invocation point yet. We log a warning and drop the
+        //     callback, leaving the rest of the plugin's request mutations in place.
+        //
+        // Tracked upstream in https://github.com/graphql-hive/router/issues/922.
+        if let Some(plugin_req_state) = plugin_req_state.as_ref() {
+            let mut start_payload = OnSubgraphExecuteStartHookPayload {
+                router_http_request: &plugin_req_state.router_http_request,
+                context: &plugin_req_state.context,
+                request_context: plugin_req_state
+                    .request_context
+                    .for_plugin::<hooks::OnSubgraphExecute>(),
+                subgraph_name,
+                executor,
+                execution_request,
+            };
+            for plugin in plugin_req_state.plugins.as_ref() {
+                let result = plugin.on_subgraph_execute(start_payload).await;
+                start_payload = result.payload;
+                match result.control_flow {
+                    StartControlFlow::Proceed => {
+                        // continue to next plugin
+                    }
+                    StartControlFlow::EndWithResponse(_) => {
+                        return Err(
+                            SubgraphExecutorError::SubscribePluginEndWithResponseUnsupported,
+                        );
+                    }
+                    StartControlFlow::OnEnd(_) => {
+                        tracing::warn!(
+                            subgraph_name,
+                            "`on_subgraph_execute` `on_end` callback dropped on subscribe path; \
+                             end-of-stream callbacks for subscriptions are not yet implemented \
+                             (see https://github.com/graphql-hive/router/issues/922)"
+                        );
+                    }
+                }
+            }
+            // Give the ownership back to variables
+            execution_request = start_payload.execution_request;
+            executor = start_payload.executor;
+        }
 
         let subscribe_fut = executor.subscribe(execution_request, timeout);
 


### PR DESCRIPTION
## Summary

Closes part of #922.

`on_subgraph_execute` was only invoked on the execute path; subscription registration in `executors::map::SubgraphExecutorMap::subscribe` bypassed all plugin hooks. Plugins that mutate `execution_request.headers` (for example to inject auth or tenancy context) had no way of affecting the subscription registration request, so subgraphs received an unmodified payload.

This PR invokes the hook on the subscribe path using the same loop semantics as the execute path — same payload, same control-flow types. It plugs the gap for the most common plugin use case (request mutation) while leaving the harder lifetime work (`'exec`→`'static` materialization for `EndWithResponse`, end-of-stream semantics for `OnEnd`) for a follow-up.

## Control-flow handling on the subscribe path

| Variant | Behavior |
|---|---|
| `Proceed` | Fully supported — identical to the execute path. |
| `EndWithResponse` | Returns a dedicated `SubgraphExecutorError::SubscribePluginEndWithResponseUnsupported` (code `SUBGRAPH_SUBSCRIBE_PLUGIN_END_WITH_RESPONSE_UNSUPPORTED`). Materializing a `SubgraphResponse<'exec>` into the `'static` `BoxStream` returned by `subscribe` needs a deliberate solution (clone-into-owned for `Value<'a>`) and is intentionally deferred. |
| `OnEnd` | Logs a `tracing::warn!` and drops the callback. There is no symmetric end-of-stream invocation point yet; the rest of the plugin's request mutations still take effect. |

Both deferred variants surface explicitly to the plugin author rather than being silently dropped, so the limitation is discoverable.

## Changes

- `lib/executor/src/executors/map.rs` — `subscribe()` accepts `plugin_req_state: Option<&'exec PluginRequestState<'exec>>` and runs the hook loop before delegating to the underlying subgraph executor. Mirrors `execute()` line-for-line where the semantics line up.
- `lib/executor/src/execution/plan.rs` — single subscribe call site now passes `opts.plugin_req_state.as_ref()`.
- `lib/executor/src/executors/error.rs` — new `SubscribePluginEndWithResponseUnsupported` variant.
- `e2e/src/subscription_plugin_hooks.rs` — two e2e tests:
  - `on_subgraph_execute_invoked_on_subscribe_sse` — registers a plugin that injects a marker header, runs an SSE subscription, asserts the subgraph received the header on the registration request.
  - `on_subgraph_execute_end_with_response_unsupported_on_subscribe` — confirms the dedicated error code reaches the client when a plugin returns `EndWithResponse`.

## Out of scope

The per-event re-execution `// TODO: plugins for subscriptions are not yet supported` in `execution/plan.rs:305` is unchanged — it requires `PluginRequestState<'exec>` to be reshaped (or `Arc`-ified) so it can live across `'static` stream boundaries. Splitting that into a separate PR keeps this one reviewable.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p hive-router-plan-executor --lib` — 92 passed
- [x] `cargo test -p e2e subscription_plugin_hooks` — 2 new tests pass
- [x] `cargo test -p e2e subscriptions` — all 24 existing subscription tests pass (no regression)
- [x] `cargo test -p e2e http_callback` — 5/5 pass
- [x] `cargo test -p e2e websocket_` — 10/10 pass
- [x] `cargo test -p e2e coprocessor` — 31/31 pass

