### PR TITLE
feat(executor): invoke on_subgraph_execute on subscribe path

### DIFF
--- a/.changeset/subscription_plugin_hooks
+++ b/.changeset/subscription_plugin_hooks
@@ -1,0 +1,20 @@
+---
+hive-router-plan-executor: minor
+hive-router: patch
+---
+
+## Invoke `on_subgraph_execute` plugin hook on the subscribe path.
+
+`on_subgraph_execute` previously fired only for queries and mutations; subscription registration bypassed all subgraph plugin hooks. Plugins that mutate `execution_request.headers` had no way of affecting the subscription registration request. For example, a plugin that injects an `Authorization` header from a refreshed JWT cookie (like `plugin_examples/jwt_cookie`) now applies the same header injection when registering subscriptions with upstream subgraphs.
+
+The control-flow contract on the subscribe path is documented on `OnSubgraphExecuteStartHookPayload`:
+
+- `Proceed` — fully supported, mirrors the execute path.
+- `EndWithResponse` — returns `SUBGRAPH_SUBSCRIBE_PLUGIN_HOOK_UNSUPPORTED`. Materialising a `SubgraphResponse<'exec>` into the `'static` stream returned by `subscribe` needs a dedicated solution; short-circuit from an earlier hook (`on_http_request`, `on_graphql_params`, `on_query_plan`) instead.
+- `OnEnd` — the plugin's request-payload mutations are preserved, but the end-of-stream callback is not invoked (no symmetric end-of-stream point yet).
+
+Tracked in [#922](https://github.com/graphql-hive/router/issues/922).
+
+### Breaking change
+
+`SubgraphExecutorMap::subscribe` now takes `subgraph_name: &'exec str` (was `&str`) and an additional `plugin_req_state: Option<&'exec PluginRequestState<'exec>>` argument, matching the surface of `SubgraphExecutorMap::execute`. Callers outside the router binary need to thread `plugin_req_state` through (or pass `None`).

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -55,6 +55,8 @@ mod router_timeout;
 #[cfg(test)]
 mod storage;
 #[cfg(test)]
+mod subscription_plugin_hooks;
+#[cfg(test)]
 mod subscriptions;
 #[cfg(test)]
 mod supergraph;

--- a/e2e/src/subscription_plugin_hooks.rs
+++ b/e2e/src/subscription_plugin_hooks.rs
@@ -1,0 +1,322 @@
+#[cfg(test)]
+mod subscription_plugin_hooks_e2e_tests {
+
+    use std::time::Duration;
+
+    use crate::testkit::{some_header_map, TestRouter, TestSubgraphs};
+    use hive_router::{
+        async_trait,
+        plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        plugins::hooks::on_subgraph_execute::{
+            OnSubgraphExecuteStartHookPayload, OnSubgraphExecuteStartHookResult,
+        },
+        plugins::plugin_trait::{RouterPlugin, StartHookPayload},
+        GraphQLError,
+    };
+    use ntex::http;
+
+    const FIRST_HEADER_NAME: &str = "x-subscription-plugin-first";
+    const FIRST_HEADER_VALUE: &str = "from-first-plugin";
+    const SECOND_HEADER_NAME: &str = "x-subscription-plugin-second";
+    const SECOND_HEADER_VALUE: &str = "from-second-plugin";
+
+    /// Drains the response body with a hard timeout so the test fails fast
+    /// instead of hanging if the subgraph stub ever changes its emit cadence.
+    async fn drain_body_with_timeout(res: ntex::client::ClientResponse) -> Vec<u8> {
+        ntex::time::timeout(Duration::from_secs(5), res.body())
+            .await
+            .expect("response body should drain within 5s")
+            .expect("response body should be readable")
+            .to_vec()
+    }
+
+    macro_rules! define_header_plugin {
+        ($plugin:ident, $name:literal, $header_name:expr, $header_value:expr) => {
+            #[derive(Default)]
+            struct $plugin;
+
+            #[async_trait]
+            impl RouterPlugin for $plugin {
+                type Config = ();
+
+                fn plugin_name() -> &'static str {
+                    $name
+                }
+
+                fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+                    payload.initialize_plugin_with_defaults()
+                }
+
+                async fn on_subgraph_execute<'exec>(
+                    &'exec self,
+                    mut payload: OnSubgraphExecuteStartHookPayload<'exec>,
+                ) -> OnSubgraphExecuteStartHookResult<'exec> {
+                    payload.execution_request.headers.insert(
+                        ::http::header::HeaderName::from_static($header_name),
+                        ::http::header::HeaderValue::from_static($header_value),
+                    );
+                    payload.proceed()
+                }
+            }
+        };
+    }
+
+    define_header_plugin!(
+        InjectFirstHeaderPlugin,
+        "test_inject_first_header",
+        FIRST_HEADER_NAME,
+        FIRST_HEADER_VALUE
+    );
+    define_header_plugin!(
+        InjectSecondHeaderPlugin,
+        "test_inject_second_header",
+        SECOND_HEADER_NAME,
+        SECOND_HEADER_VALUE
+    );
+
+    /// Subscription via SSE — verifies that `on_subgraph_execute` is invoked
+    /// for the subscribe-registration request and that header mutations from
+    /// the plugin reach the subgraph.
+    #[ntex::test]
+    async fn on_subgraph_execute_invoked_on_subscribe_sse() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_http_streaming_subscriptions_protocol(
+                subgraphs::HTTPStreamingSubscriptionProtocol::SseOnly,
+            )
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                plugins:
+                    test_inject_first_header:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<InjectFirstHeaderPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAdded(intervalInMs: 0) {
+                        product {
+                            upc
+                        }
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+        let _body = drain_body_with_timeout(res).await;
+
+        let reviews_requests = subgraphs
+            .get_requests_log("reviews")
+            .expect("`reviews` subgraph should have received the subscription registration");
+
+        assert!(
+            !reviews_requests.is_empty(),
+            "`reviews` subgraph should have received at least one request"
+        );
+
+        let header_value = reviews_requests
+            .iter()
+            .find_map(|req| req.headers.get(FIRST_HEADER_NAME))
+            .expect("the injected header must be present on the subgraph request");
+
+        assert_eq!(
+            header_value, FIRST_HEADER_VALUE,
+            "the injected header value must match the value set by the plugin"
+        );
+    }
+
+    /// Two plugins both mutate `execution_request.headers` from
+    /// `on_subgraph_execute`. The subgraph should observe both header
+    /// mutations, proving the plugin loop iterates fully on the subscribe
+    /// path (not just stops after the first plugin).
+    #[ntex::test]
+    async fn on_subgraph_execute_chains_multiple_plugins_on_subscribe() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_http_streaming_subscriptions_protocol(
+                subgraphs::HTTPStreamingSubscriptionProtocol::SseOnly,
+            )
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                plugins:
+                    test_inject_first_header:
+                        enabled: true
+                    test_inject_second_header:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<InjectFirstHeaderPlugin>()
+            .register_plugin::<InjectSecondHeaderPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAdded(intervalInMs: 0) {
+                        product {
+                            upc
+                        }
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+        let _body = drain_body_with_timeout(res).await;
+
+        let reviews_requests = subgraphs
+            .get_requests_log("reviews")
+            .expect("`reviews` subgraph should have received the subscription registration");
+
+        let registration = reviews_requests
+            .iter()
+            .find(|req| req.headers.contains_key(FIRST_HEADER_NAME))
+            .expect("at least one request should carry the first plugin's header");
+
+        assert_eq!(
+            registration.headers.get(FIRST_HEADER_NAME),
+            Some(&::http::HeaderValue::from_static(FIRST_HEADER_VALUE)),
+            "first plugin's header must be present"
+        );
+        assert_eq!(
+            registration.headers.get(SECOND_HEADER_NAME),
+            Some(&::http::HeaderValue::from_static(SECOND_HEADER_VALUE)),
+            "second plugin's header must also be present (plugin loop iterates fully)"
+        );
+    }
+
+    /// Plugin that short-circuits with `end_with_response` to drive the
+    /// dedicated subscribe-path error. The status code/error code attached
+    /// here intentionally never reach the client — the assertions below
+    /// confirm we surface `SUBGRAPH_SUBSCRIBE_PLUGIN_HOOK_UNSUPPORTED`
+    /// rather than the plugin's response.
+    #[derive(Default)]
+    struct EndWithResponsePlugin;
+
+    #[async_trait]
+    impl RouterPlugin for EndWithResponsePlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "test_end_with_response_on_subscribe"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_subgraph_execute<'exec>(
+            &'exec self,
+            payload: OnSubgraphExecuteStartHookPayload<'exec>,
+        ) -> OnSubgraphExecuteStartHookResult<'exec> {
+            payload.end_with_graphql_error(
+                GraphQLError::from_message_and_code(
+                    "short-circuit from plugin",
+                    "TEST_PLUGIN_SHORT_CIRCUIT",
+                ),
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        }
+    }
+
+    /// `end_with_response` on the subscribe path is not yet supported. Confirm
+    /// the dedicated error code is surfaced to the client and the plugin's
+    /// own response payload never reaches it.
+    #[ntex::test]
+    async fn on_subgraph_execute_end_with_response_unsupported_on_subscribe() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_http_streaming_subscriptions_protocol(
+                subgraphs::HTTPStreamingSubscriptionProtocol::SseOnly,
+            )
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                plugins:
+                    test_end_with_response_on_subscribe:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<EndWithResponsePlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAdded(intervalInMs: 0) {
+                        product {
+                            upc
+                        }
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+        let body = drain_body_with_timeout(res).await;
+        let body_str = std::str::from_utf8(&body).unwrap();
+
+        assert!(
+            body_str.contains("SUBGRAPH_SUBSCRIBE_PLUGIN_HOOK_UNSUPPORTED"),
+            "expected the dedicated error code to be emitted in the SSE stream, got: {body_str}"
+        );
+        assert!(
+            !body_str.contains("TEST_PLUGIN_SHORT_CIRCUIT"),
+            "plugin's own response payload must NOT reach the client, got: {body_str}"
+        );
+    }
+}

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -231,6 +231,7 @@ pub async fn execute_query_plan<'exec>(
                 &fetch_node.service_name,
                 subgraph_request,
                 &opts.client_request,
+                opts.plugin_req_state.as_ref(),
             )
             .await
             .with_plan_context(LazyPlanContext {

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -105,6 +105,13 @@ pub enum SubgraphExecutorError {
     #[error("Subgraph internal server error")]
     #[strum(serialize = "SUBGRAPH_INTERNAL_SERVER_ERROR")]
     InternalServerError(Box<SubgraphResponse<'static>>),
+    #[error(
+        "Plugin returned `end_with_response` from `on_subgraph_execute` on the subscribe path; \
+         not supported (see `OnSubgraphExecuteStartHookPayload` docs). Short-circuit from an \
+         earlier hook (e.g. `on_http_request`, `on_graphql_params`) instead."
+    )]
+    #[strum(serialize = "SUBGRAPH_SUBSCRIBE_PLUGIN_HOOK_UNSUPPORTED")]
+    SubscribePluginHookUnsupported,
 }
 
 impl SubgraphExecutorError {

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -351,16 +351,29 @@ impl SubgraphExecutorMap {
 
     pub async fn subscribe<'exec>(
         &self,
-        subgraph_name: &str,
+        subgraph_name: &'exec str,
         execution_request: SubgraphExecutionRequest<'exec>,
         client_request: &ClientRequestDetails<'exec>,
+        plugin_req_state: Option<&'exec PluginRequestState<'exec>>,
     ) -> Result<
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
         let executor = self.get_or_create_subscription_executor(subgraph_name, client_request)?;
-
         let timeout = self.resolve_subgraph_timeout(subgraph_name, client_request)?;
+
+        // Invoke `on_subgraph_execute` so plugins can mutate the registration
+        // request (e.g. inject auth headers). See `run_subscribe_plugins` for
+        // the subscribe-path control-flow contract. Skip the helper entirely
+        // when no plugins are registered to avoid the payload construction and
+        // async state-machine overhead on the hot path.
+        let (executor, execution_request) = match plugin_req_state {
+            Some(plugin_req_state) if !plugin_req_state.plugins.is_empty() => {
+                run_subscribe_plugins(subgraph_name, executor, execution_request, plugin_req_state)
+                    .await?
+            }
+            _ => (executor, execution_request),
+        };
 
         let subscribe_fut = executor.subscribe(execution_request, timeout);
 
@@ -854,6 +867,49 @@ impl SubgraphExecutorMap {
 
         Ok(())
     }
+}
+
+/// Drives the `on_subgraph_execute` hook for the subscribe path.
+///
+/// Control-flow contract on the subscribe path (also documented on
+/// [`OnSubgraphExecuteStartHookPayload`]):
+///
+/// * `Proceed` — fully supported, mirrors the execute path.
+/// * `EndWithResponse` — returns
+///   [`SubgraphExecutorError::SubscribePluginHookUnsupported`]; materialising a
+///   `SubgraphResponse<'exec>` into the `'static` stream needs a dedicated
+///   solution and is intentionally deferred.
+/// * `OnEnd` — the plugin's request mutations are preserved, but the
+///   end-of-stream callback is **not invoked** (there is no symmetric
+///   end-of-stream point yet). Plugins that need end-of-stream behaviour for
+///   subscriptions should not register an `on_end` callback here today.
+async fn run_subscribe_plugins<'exec>(
+    subgraph_name: &'exec str,
+    executor: SubgraphExecutorBoxedArc,
+    execution_request: SubgraphExecutionRequest<'exec>,
+    plugin_req_state: &'exec PluginRequestState<'exec>,
+) -> Result<(SubgraphExecutorBoxedArc, SubgraphExecutionRequest<'exec>), SubgraphExecutorError> {
+    let mut start_payload = OnSubgraphExecuteStartHookPayload {
+        router_http_request: &plugin_req_state.router_http_request,
+        context: &plugin_req_state.context,
+        request_context: plugin_req_state
+            .request_context
+            .for_plugin::<hooks::OnSubgraphExecute>(),
+        subgraph_name,
+        executor,
+        execution_request,
+    };
+    for plugin in plugin_req_state.plugins.as_ref() {
+        let result = plugin.on_subgraph_execute(start_payload).await;
+        start_payload = result.payload;
+        match result.control_flow {
+            StartControlFlow::Proceed | StartControlFlow::OnEnd(_) => {}
+            StartControlFlow::EndWithResponse(_) => {
+                return Err(SubgraphExecutorError::SubscribePluginHookUnsupported);
+            }
+        }
+    }
+    Ok((start_payload.executor, start_payload.execution_request))
 }
 
 /// Resolves a timeout DurationOrProgram to a concrete Duration.

--- a/lib/executor/src/plugins/hooks/on_subgraph_execute.rs
+++ b/lib/executor/src/plugins/hooks/on_subgraph_execute.rs
@@ -11,6 +11,31 @@ use crate::{
 
 type RequestContextApi = RequestContextPluginApi<super::OnSubgraphExecute>;
 
+/// # Subscribe-path control-flow contract
+///
+/// `on_subgraph_execute` fires for queries, mutations **and** the subscribe
+/// registration request (since [#1072]). The subscribe path imposes two
+/// restrictions on the returned [`StartHookResult`]:
+///
+/// * [`StartControlFlow::EndWithResponse`] short-circuits the subgraph call
+///   with a `SubgraphResponse<'exec>` that does not yet have a defined
+///   materialisation into the `'static` stream returned by `subscribe`.
+///   Returning this variant on the subscribe path surfaces
+///   `SUBGRAPH_SUBSCRIBE_PLUGIN_HOOK_UNSUPPORTED` to the caller. Short-circuit
+///   from an earlier hook (`on_http_request`, `on_graphql_params`,
+///   `on_query_plan`) instead.
+/// * [`StartControlFlow::OnEnd`] callbacks are not invoked on the subscribe
+///   path — there is no symmetric end-of-stream point yet. The plugin's
+///   request-payload mutations made before returning `on_end` are still
+///   applied. Plugins that need end-of-stream behaviour for subscriptions
+///   should track it through a different hook.
+///
+/// Tracked in <https://github.com/graphql-hive/router/issues/922>.
+///
+/// [#1072]: https://github.com/graphql-hive/router/pull/1072
+/// [`StartHookResult`]: crate::plugin_trait::StartHookResult
+/// [`StartControlFlow::EndWithResponse`]: crate::plugin_trait::StartControlFlow::EndWithResponse
+/// [`StartControlFlow::OnEnd`]: crate::plugin_trait::StartControlFlow::OnEnd
 pub struct OnSubgraphExecuteStartHookPayload<'exec> {
     /// The incoming HTTP request to the router for which the GraphQL execution is happening.
     /// It includes all the details of the request such as headers, body, etc.


### PR DESCRIPTION
Plugins that mutate `execution_request.headers` from `on_subgraph_execute` (auth header injection, request tracing, and so on) had no effect on subscription-registration requests, because the hook never fired on the subscribe path. The plugin loop in `executors::map::SubgraphExecutorMap::subscribe` now mirrors `execute` — same payload, same control-flow type — so the same mutations land on subscribe-registration requests.

Refs #922 — partial fix.

## Motivation

We're evaluating Hive Router as the federation layer for our GraphQL stack. Plugin support on the subscribe path is a hard requirement for us — specifically, we need to validate user authorization for subscriptions the same way our `on_subgraph_execute` plugin already does for queries and mutations. Without the hook firing on subscribe, that's not expressible through the current plugin API.

Ran the patched build against our stage cluster and confirmed the behavior is what we need: authorized subscriptions register, unauthorized ones get rejected cleanly. That's the gate we need to start adopting Hive Router for real workloads.

## What ships

- `lib/executor/src/executors/map.rs` — `subscribe()` accepts `plugin_req_state` and runs the hook loop via a `run_subscribe_plugins` helper.
- `lib/executor/src/execution/plan.rs` — pass `plugin_req_state.as_ref()` to the subscribe call (one line).
- `lib/executor/src/executors/error.rs` — `SubscribePluginHookUnsupported` variant for the subscribe-path constraint below.
- `lib/executor/src/plugins/hooks/on_subgraph_execute.rs` — documented subscribe-path control-flow contract on `OnSubgraphExecuteStartHookPayload`.
- `e2e/src/subscription_plugin_hooks.rs` — three end-to-end tests (positive, chained plugins, negative).
- `.changeset/subscription_plugin_hooks` — release note.

## Subscribe-path control-flow contract

| Variant | Behavior |
|---|---|
| `Proceed` | Fully supported — identical to the execute path. |
| `EndWithResponse` | Returns `SUBGRAPH_SUBSCRIBE_PLUGIN_HOOK_UNSUPPORTED`. The hook hands back `SubgraphResponse<'exec>`; materialising that into the `'static` `BoxStream` returned by `subscribe` needs more thought, so for now plugin authors get an explicit error rather than a silent drop. Short-circuit from an earlier hook (`on_http_request`, `on_graphql_params`, `on_query_plan`) instead. |
| `OnEnd` | The plugin's request-payload mutations apply, but the end-of-stream callback is not invoked — no symmetric end-of-stream point exists yet. Documented on `OnSubgraphExecuteStartHookPayload`. |

## Out of scope

The per-event re-execution `// TODO: plugins for subscriptions are not yet supported` at `lib/executor/src/execution/plan.rs:305` still stands. That one wants `PluginRequestState<'exec>` reshaped (or `Arc`-ified) so it can live across `'static` stream boundaries; splitting it out keeps this PR reviewable. Same story for `on_graphql_params` not firing on the WebSocket subscribe path — separate gap, separate PR.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p hive-router-plan-executor --lib` — 92 passed
- [x] `cargo test -p e2e subscription_plugin_hooks` — 3 new tests pass (positive, chained plugins, negative)
- [x] `cargo test -p e2e subscriptions` — all 24 existing subscription tests still pass
- [x] `cargo test -p e2e http_callback` — 5/5 pass
- [x] `cargo test -p e2e websocket_` — 10/10 pass
