### PR TITLE
fix(executor): always add `__typename` to `representations`

### DIFF
--- a/.changeset/typename_in_entity_representations.md
+++ b/.changeset/typename_in_entity_representations.md
@@ -1,0 +1,8 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+## Always include `__typename` in `_entities` representations
+
+When resolving a field via `@requires`, the executor now resolves `__typename` in the entity representation using the enclosing inline fragment's type condition, even when the parent's response data did not have `__typename`. Previously, the receiving subgraph could fail with `tried to load an entity for type "undefined"` whenever the client query did not explicitly select `__typename` on the parent entity.

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -919,4 +919,140 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1070
+    ///
+    /// When resolving a field via `@requires`, the router must include
+    /// `__typename` in `_entities` representations sent to subgraphs — even
+    /// when the client query does not select `__typename` and the parent
+    /// subgraph response did not echo it back. Without `__typename` the
+    /// receiving subgraph cannot dispatch `__resolveReference` and fails with
+    /// `tried to load an entity for type "undefined"`.
+    async fn issue_1070_typename_in_entity_representations() {
+        use sonic_rs::JsonValueTrait;
+
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.1070.graphql
+                  query_planner:
+                    allow_expose: true
+                  override_subgraph_urls:
+                    search:
+                      url: "http://{host}/search"
+                    offers:
+                      url: "http://{host}/offers"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // Mock the first hop. Intentionally omit `__typename` on
+        // `productSearchResult` to simulate the failure mode from #1070,
+        // where the parent's response data does not carry `__typename`.
+        let search_mock = server
+            .mock("POST", "/search")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+                body_str.contains("productSearchResult")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "productSearchResult": {
+                      "partialCriteria": "partialCriteria",
+                      "category": "books"
+                    }
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        // The second hop is the entity fetch for `bestOffer`. Assert in the
+        // request matcher that the representation includes `__typename`.
+        let offers_mock = server
+            .mock("POST", "/offers")
+            .match_request(|r| {
+                let body_bytes = r.body().unwrap();
+                let body_str = String::from_utf8(body_bytes.clone()).unwrap();
+                if !body_str.contains("_entities") {
+                    return false;
+                }
+
+                let parsed: sonic_rs::Value = sonic_rs::from_slice(body_bytes)
+                    .expect("offers subgraph body must be valid JSON");
+                let variables = parsed
+                    .get(&"variables")
+                    .expect("subgraph body must contain `variables`");
+                let representations = variables
+                    .get(&"representations")
+                    .expect("variables must contain `representations`");
+                let first = representations
+                    .get(0)
+                    .expect("representations must have at least one entry");
+                let typename = first
+                    .get(&"__typename")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                assert_eq!(
+                    typename.as_deref(),
+                    Some("ProductSearchResultResponse"),
+                    "expected `__typename` in entity representation, got: {body_str}"
+                );
+
+                true
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "_entities": [
+                      { "bestOffer": { "price": 9.99 } }
+                    ]
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{ productSearchResult(partialCriteria: "partialCriteria") { bestOffer { price } } }"#,
+                None,
+                None,
+            )
+            .await;
+
+        search_mock.assert();
+        offers_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "productSearchResult": {
+              "bestOffer": {
+                "price": 9.99
+              }
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/supergraph.1070.graphql
+++ b/e2e/src/issues/supergraph.1070.graphql
@@ -1,0 +1,84 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+type ProductSearchResultResponse
+  @join__type(graph: SEARCH, key: "partialCriteria")
+  @join__type(graph: OFFERS, key: "partialCriteria", extension: true) {
+  partialCriteria: String!
+  category: String
+    @join__field(graph: SEARCH)
+    @join__field(graph: OFFERS, external: true)
+  bestOffer: Offer @join__field(graph: OFFERS, requires: "category")
+}
+
+type Offer @join__type(graph: OFFERS) {
+  price: Float
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SEARCH @join__graph(name: "search", url: "http://0.0.0.0:4200/search")
+  OFFERS @join__graph(name: "offers", url: "http://0.0.0.0:4200/offers")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query @join__type(graph: SEARCH) @join__type(graph: OFFERS) {
+  productSearchResult(partialCriteria: String!): ProductSearchResultResponse
+    @join__field(graph: SEARCH)
+}

--- a/lib/executor/src/introspection/schema.rs
+++ b/lib/executor/src/introspection/schema.rs
@@ -72,6 +72,22 @@ impl PossibleTypes {
         possible_types.insert(type_name.to_string());
         possible_types
     }
+
+    #[cfg(test)]
+    pub(crate) fn from_pairs<I, M>(entries: I) -> Self
+    where
+        I: IntoIterator<Item = (&'static str, M)>,
+        M: IntoIterator<Item = &'static str>,
+    {
+        let mut map: HashMap<String, HashSet<String>> = HashMap::default();
+        for (parent, members) in entries {
+            map.insert(
+                parent.to_string(),
+                members.into_iter().map(|s| s.to_string()).collect(),
+            );
+        }
+        Self { map }
+    }
 }
 
 pub trait SchemaWithMetadata {

--- a/lib/executor/src/projection/request.rs
+++ b/lib/executor/src/projection/request.rs
@@ -102,6 +102,7 @@ pub fn project_requires(
                 &mut first,
                 response_key,
                 parent_first,
+                None,
             );
             if first {
                 // If no fields were projected, "first" is still true,
@@ -115,6 +116,7 @@ pub fn project_requires(
     true
 }
 
+#[allow(clippy::too_many_arguments)]
 fn project_requires_map_mut(
     possible_types: &PossibleTypes,
     requires_selections: &Vec<SelectionItem>,
@@ -123,6 +125,7 @@ fn project_requires_map_mut(
     first: &mut bool,
     parent_response_key: Option<&str>,
     parent_first: bool,
+    current_type_name: Option<&str>,
 ) {
     for requires_selection in requires_selections {
         match &requires_selection {
@@ -162,10 +165,14 @@ fn project_requires_map_mut(
                     write_response_key(parent_first, parent_response_key, buffer);
                     buffer.put(OPEN_BRACE);
                     // Write __typename only if the object has other fields
+                    // Prefer the value existing in response data; otherwise fallback
+                    // to the enclosing inline fragment's type condition so that
+                    // entity representations always include __typename
                     if let Some(type_name) = entity_obj
                         .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
                         .ok()
                         .and_then(|idx| entity_obj[idx].1.as_str())
+                        .or(current_type_name)
                     {
                         buffer.put(QUOTE);
                         buffer.put(TYPENAME);
@@ -226,6 +233,7 @@ fn project_requires_map_mut(
                         first,
                         parent_response_key,
                         parent_first,
+                        Some(type_name),
                     );
                 }
             }
@@ -272,18 +280,24 @@ mod tests {
     }
 
     fn project_requires_pretty(requires: &str, entity_json: sonic_rs::Value) -> Option<String> {
+        project_requires_pretty_with_possible_types(
+            requires,
+            entity_json,
+            &PossibleTypes::default(),
+        )
+    }
+
+    fn project_requires_pretty_with_possible_types(
+        requires: &str,
+        entity_json: sonic_rs::Value,
+        possible_types: &PossibleTypes,
+    ) -> Option<String> {
         let requires = requires_from_str(requires);
         let entity = Value::from(entity_json.as_ref());
 
         let mut buffer = Vec::new();
-        let projected = project_requires(
-            &PossibleTypes::default(),
-            &requires,
-            &entity,
-            &mut buffer,
-            true,
-            None,
-        );
+        let projected =
+            project_requires(possible_types, &requires, &entity, &mut buffer, true, None);
 
         if !projected {
             return None;
@@ -391,5 +405,98 @@ mod tests {
 
         let pretty = project_requires_pretty("contactOptions", json!({}));
         assert_eq!(pretty, None);
+    }
+
+    /// When the parent response data lacks `__typename` (e.g. because the client
+    /// did not select it and the field came back from a previous `_entities`
+    /// response that didn't carry it), the executor must still emit
+    /// `__typename` in the entity representation, using the enclosing
+    /// `InlineFragment.type_condition` as the fallback. Without `__typename`
+    /// the receiving subgraph cannot dispatch `__resolveReference`.
+    #[test]
+    fn project_requires_injects_typename_from_inline_fragment() {
+        insta::assert_snapshot!(
+          &project_requires_pretty(
+              "... on ProductSearchResultResponse { __typename partialCriteria }",
+              json!({
+                  "partialCriteria": "partialCriteria"
+              }),
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "ProductSearchResultResponse",
+            "partialCriteria": "partialCriteria"
+          }
+        "#);
+
+        // When the entity does carry __typename, the response value still
+        // wins over the inline fragment's type_condition. Matches existing
+        // behavior (e.g. @interfaceObject input_rewrites apply earlier).
+        insta::assert_snapshot!(
+          &project_requires_pretty(
+              "... on Product { __typename upc }",
+              json!({
+                  "__typename": "Product",
+                  "upc": "abc-123"
+              }),
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "Product",
+            "upc": "abc-123"
+          }
+        "#);
+
+        // Interface case: the inline fragment uses the interface type
+        // (`Node`) but the entity's `__typename` carries the concrete object
+        // type (`Book`). The concrete __typename in the response data must
+        // win over the inline fragment's type_condition — otherwise we'd
+        // send the wrong type name to the subgraph and break dispatch.
+        let possible_types = PossibleTypes::from_pairs([("Node", ["Book", "Magazine"])]);
+        insta::assert_snapshot!(
+          &project_requires_pretty_with_possible_types(
+              "... on Node { __typename id }",
+              json!({
+                  "__typename": "Book",
+                  "id": "b-1"
+              }),
+              &possible_types,
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "Book",
+            "id": "b-1"
+          }
+        "#);
+
+        // Nested non-entity sub-objects without their own inline fragment do
+        // not get a typename fallback, because the planner does not wrap them
+        // in an InlineFragment. The fix is scoped to the entity-level
+        // representation, which is what `_entities` actually needs.
+        insta::assert_snapshot!(
+          &project_requires_pretty(
+              "... on Ad { __typename id branch { contactOptions { email } } }",
+              json!({
+                  "id": "1",
+                  "branch": {
+                      "contactOptions": { "email": "a@b.c" }
+                  }
+              }),
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "Ad",
+            "branch": {
+              "contactOptions": {
+                "email": "a@b.c"
+              }
+            },
+            "id": "1"
+          }
+        "#);
     }
 }


### PR DESCRIPTION
Fixes #1070 

When resolving a field via `@requires`, the executor now resolves `__typename` in the entity representation using the enclosing inline fragment's type condition, even when the parent's response data did not have `__typename`. Previously, the receiving subgraph could fail with `tried to load an entity for type "undefined"` whenever the client query did not explicitly select `__typename` on the parent entity.