### PR TITLE
Expose `context` in `on_graphql_error` hook

### DIFF
--- a/.changeset/on_graphql_error_request_context.md
+++ b/.changeset/on_graphql_error_request_context.md
@@ -1,0 +1,31 @@
+---
+hive-router-plan-executor: minor
+hive-router: minor
+---
+
+## Expose `context` and `request_context` on `on_graphql_error`
+
+The `on_graphql_error` plugin hook now holds the `PluginContext` and a
+`RequestContextPluginApi<OnGraphqlError>` as `context` and `request_context`, matching other request-scoped hooks (`on_http_request`, `on_execute`, etc.).
+
+### Migration
+
+`on_graphql_error` now has a generic over the request lifetime; signatures must be
+updated from:
+
+```rust
+fn on_graphql_error(&self, mut payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
+    // ...
+}
+```
+
+to:
+
+```rust
+fn on_graphql_error<'req>(
+    &'req self,
+    mut payload: OnGraphQLErrorHookPayload<'req>,
+) -> OnGraphQLErrorHookResult<'req> {
+    // ...
+}
+```

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -191,7 +191,7 @@ async fn graphql_endpoint_dispatch(
             // If the request handler returns an error, convert it to an HTTP response.
             Err(err) => {
                 write_graphql_response_metric_status(request, GraphQLResponseStatus::Error);
-                handle_pipeline_error(err, &app_state, &response_mode)
+                handle_pipeline_error(err, request, &app_state, &response_mode)
             }
         };
 
@@ -217,7 +217,7 @@ async fn graphql_endpoint_dispatch(
                 Err(error) => {
                     warn!(%error, "coprocessor graphql.response stage failed");
                     write_graphql_response_metric_status(request, GraphQLResponseStatus::Error);
-                    handle_pipeline_error(error.into(), &app_state, &response_mode)
+                    handle_pipeline_error(error.into(), request, &app_state, &response_mode)
                 }
             };
         }

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -309,7 +309,6 @@ pub fn handle_pipeline_error(
     if let Some(plugins) = &shared_state.plugins {
         let plugin_context = req.extensions().get::<Arc<PluginContext>>().cloned();
         let request_context = req.read_request_context().ok();
-
         if let (Some(plugin_context), Some(request_context)) = (plugin_context, request_context) {
             let (new_errors, new_status_code) = handle_graphql_errors_with_plugins(
                 plugins,

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -10,7 +10,8 @@ use hive_router_plan_executor::{
     },
     headers::errors::HeaderRuleRuntimeError,
     hooks::on_graphql_error::handle_graphql_errors_with_plugins,
-    request_context::RequestContextError,
+    plugin_context::PluginContext,
+    request_context::{RequestContextError, RequestContextExt},
     response::graphql_error::GraphQLError,
 };
 use hive_router_query_planner::{
@@ -20,7 +21,7 @@ use http::header;
 use http::{header::RETRY_AFTER, HeaderName, Method, StatusCode};
 use ntex::{
     http::ResponseBuilder,
-    web::{self, error::QueryPayloadError},
+    web::{self, error::QueryPayloadError, HttpRequest},
 };
 use strum::IntoStaticStr;
 
@@ -269,6 +270,7 @@ impl PipelineError {
 #[inline]
 pub fn handle_pipeline_error(
     err: PipelineError,
+    req: &HttpRequest,
     shared_state: &RouterSharedState,
     response_mode: &ResponseMode,
 ) -> web::HttpResponse {
@@ -305,10 +307,20 @@ pub fn handle_pipeline_error(
     };
 
     if let Some(plugins) = &shared_state.plugins {
-        let (new_errors, new_status_code) =
-            handle_graphql_errors_with_plugins(plugins, errors, status);
-        errors = new_errors;
-        res.status(new_status_code);
+        let plugin_context = req.extensions().get::<Arc<PluginContext>>().cloned();
+        let request_context = req.read_request_context().ok();
+
+        if let (Some(plugin_context), Some(request_context)) = (plugin_context, request_context) {
+            let (new_errors, new_status_code) = handle_graphql_errors_with_plugins(
+                plugins,
+                plugin_context.as_ref(),
+                &request_context,
+                errors,
+                status,
+            );
+            errors = new_errors;
+            res.status(new_status_code);
+        }
     }
 
     if let Some(error_recorder) = shared_state

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -921,10 +921,10 @@ async fn test_otlp_graphql_errors_total_uses_post_plugin_error_codes() {
             payload.initialize_plugin_with_defaults()
         }
 
-        fn on_graphql_error(
+        fn on_graphql_error<'req>(
             &self,
-            mut payload: OnGraphQLErrorHookPayload,
-        ) -> OnGraphQLErrorHookResult {
+            mut payload: OnGraphQLErrorHookPayload<'req>,
+        ) -> OnGraphQLErrorHookResult<'req> {
             payload.error.extensions.code = Some("PLUGIN_MAPPED_ERROR".to_string());
             payload.proceed()
         }

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -468,6 +468,8 @@ async fn execute_query_plan_with_data<'exec>(
         if let Some(plugin_req_state) = opts.plugin_req_state.as_ref() {
             let (new_errors, new_status_code) = handle_graphql_errors_with_plugins(
                 plugin_req_state.plugins.as_ref(),
+                plugin_req_state.context.as_ref(),
+                &plugin_req_state.request_context,
                 errors,
                 status_code,
             );

--- a/lib/executor/src/plugins/hooks/mod.rs
+++ b/lib/executor/src/plugins/hooks/mod.rs
@@ -24,6 +24,7 @@ pub struct OnQueryPlan;
 pub struct OnExecute;
 pub struct OnSubgraphExecute;
 pub struct OnSubgraphHttp;
+pub struct OnGraphqlError;
 
 impl sealed::Sealed for OnHttpRequest {}
 impl sealed::Sealed for OnGraphqlParams {}
@@ -33,6 +34,7 @@ impl sealed::Sealed for OnQueryPlan {}
 impl sealed::Sealed for OnExecute {}
 impl sealed::Sealed for OnSubgraphExecute {}
 impl sealed::Sealed for OnSubgraphHttp {}
+impl sealed::Sealed for OnGraphqlError {}
 
 impl HookMarker for OnHttpRequest {}
 impl HookMarker for OnGraphqlParams {}
@@ -42,3 +44,4 @@ impl HookMarker for OnQueryPlan {}
 impl HookMarker for OnExecute {}
 impl HookMarker for OnSubgraphExecute {}
 impl HookMarker for OnSubgraphHttp {}
+impl HookMarker for OnGraphqlError {}

--- a/lib/executor/src/plugins/hooks/on_graphql_error.rs
+++ b/lib/executor/src/plugins/hooks/on_graphql_error.rs
@@ -1,15 +1,24 @@
 use http::StatusCode;
 
-use crate::{plugin_trait::RouterPluginBoxed, response::graphql_error::GraphQLError};
+use crate::{
+    plugin_context::PluginContext, plugin_trait::RouterPluginBoxed,
+    request_context::RequestContextPluginApi, request_context::SharedRequestContext,
+    response::graphql_error::GraphQLError,
+};
 
-pub type OnGraphQLErrorHookResult = OnGraphQLErrorHookPayload;
+type RequestContextApi = RequestContextPluginApi<super::OnGraphqlError>;
 
-pub struct OnGraphQLErrorHookPayload {
+pub type OnGraphQLErrorHookResult<'req> = OnGraphQLErrorHookPayload<'req>;
+
+pub struct OnGraphQLErrorHookPayload<'req> {
     /// The GraphQL error that occurred during the execution of the request.
     /// The plugin can modify the error before proceeding, or it can replace it with a new error.
     /// Example:
     /// ```
-    /// fn on_graphql_error(mut payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
+    /// fn on_graphql_error<'req>(
+    ///     &'req self,
+    ///     mut payload: OnGraphQLErrorHookPayload<'req>,
+    /// ) -> OnGraphQLErrorHookResult<'req> {
     ///     // Add additional information to the error message
     ///     payload.error.message = format!("{} - Additional info from plugin", payload.error.message);
     ///     payload.proceed()
@@ -20,30 +29,46 @@ pub struct OnGraphQLErrorHookPayload {
     /// The plugin can modify the status code before proceeding.
     /// Example:
     /// ```
-    /// fn on_graphql_error(mut payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
+    /// fn on_graphql_error<'req>(
+    ///     &'req self,
+    ///     mut payload: OnGraphQLErrorHookPayload<'req>,
+    /// ) -> OnGraphQLErrorHookResult<'req> {
     ///     // Change the status code to 500 Internal Server Error
     ///     payload.status_code = StatusCode::INTERNAL_SERVER_ERROR;
     ///     payload.proceed()
     /// }
     /// ```
     pub status_code: StatusCode,
+    /// The context object that can be used to share data across different plugin hooks for the same request.
+    /// It is unique per request and is dropped after the response is sent.
+    ///
+    /// [Learn more about the context data sharing in the docs](https://the-guild.dev/graphql/hive/docs/router/extensibility/plugin_system#context-data-sharing)
+    pub context: &'req PluginContext,
+    pub request_context: RequestContextApi,
 }
 
-impl OnGraphQLErrorHookPayload {
+impl<'req> OnGraphQLErrorHookPayload<'req> {
     /// Returning this will proceed the hook with `payload.error`, and `payload.status_code`
-    pub fn proceed(self) -> OnGraphQLErrorHookResult {
+    pub fn proceed(self) -> OnGraphQLErrorHookResult<'req> {
         self
     }
 }
 
 pub fn handle_graphql_errors_with_plugins(
     plugins: &[RouterPluginBoxed],
+    context: &PluginContext,
+    request_context: &SharedRequestContext,
     errors: Vec<GraphQLError>,
     mut status_code: StatusCode,
 ) -> (Vec<GraphQLError>, StatusCode) {
     let mut new_errors = Vec::with_capacity(errors.len());
     for error in errors {
-        let mut payload = OnGraphQLErrorHookPayload { error, status_code };
+        let mut payload = OnGraphQLErrorHookPayload {
+            error,
+            status_code,
+            context,
+            request_context: request_context.for_plugin::<super::OnGraphqlError>(),
+        };
 
         for plugin in plugins {
             payload = plugin.on_graphql_error(payload);

--- a/lib/executor/src/plugins/plugin_trait.rs
+++ b/lib/executor/src/plugins/plugin_trait.rs
@@ -450,7 +450,10 @@ pub trait RouterPlugin: Send + Sync + 'static {
         start_payload.proceed()
     }
     #[inline]
-    fn on_graphql_error(&self, payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
+    fn on_graphql_error<'req>(
+        &'req self,
+        payload: OnGraphQLErrorHookPayload<'req>,
+    ) -> OnGraphQLErrorHookResult<'req> {
         payload.proceed()
     }
     #[inline]
@@ -495,7 +498,10 @@ pub trait DynRouterPlugin: Send + Sync + 'static {
         &'exec self,
         start_payload: OnSupergraphLoadStartHookPayload,
     ) -> OnSupergraphLoadStartHookResult<'exec>;
-    fn on_graphql_error(&self, payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult;
+    fn on_graphql_error<'req>(
+        &'req self,
+        payload: OnGraphQLErrorHookPayload<'req>,
+    ) -> OnGraphQLErrorHookResult<'req>;
     async fn on_shutdown<'exec>(&'exec self);
 }
 
@@ -568,7 +574,10 @@ where
         RouterPlugin::on_supergraph_reload(self, start_payload)
     }
     #[inline]
-    fn on_graphql_error(&self, payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
+    fn on_graphql_error<'req>(
+        &'req self,
+        payload: OnGraphQLErrorHookPayload<'req>,
+    ) -> OnGraphQLErrorHookResult<'req> {
         RouterPlugin::on_graphql_error(self, payload)
     }
     #[inline]

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -50,7 +50,7 @@ dependencies = [
  "cmac",
  "ctr",
  "dbl",
- "digest",
+ "digest 0.10.7",
  "zeroize",
 ]
 
@@ -467,6 +467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,7 +536,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -682,6 +691,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -767,6 +785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -925,7 +952,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -938,7 +965,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -949,6 +976,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codespan-reporting"
@@ -988,7 +1021,7 @@ checksum = "48629740a3480b865d4083ff45f826a253bd5ce28db618d89359b0e95dc750c3"
 dependencies = [
  "base64",
  "hex",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -1048,6 +1081,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1183,6 +1222,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,6 +1312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto_secretbox"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,7 +1394,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1372,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1405,7 +1481,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1462,10 +1538,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1594,6 +1682,8 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls",
+ "s3s",
+ "s3s-fs",
  "serde",
  "serde_json",
  "sonic-rs",
@@ -1614,7 +1704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1640,7 +1730,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1659,7 +1749,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2086,9 +2176,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2173,7 +2263,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graphql-tools"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "combine",
  "itoa",
@@ -2300,7 +2390,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2348,8 +2438,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "hive-console-sdk"
-version = "0.3.11"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "async-dropper-simple",
@@ -2363,7 +2463,6 @@ dependencies = [
  "lazy_static",
  "md5",
  "moka",
- "ntex",
  "recloser",
  "regex-automata",
  "regress",
@@ -2373,7 +2472,7 @@ dependencies = [
  "retry-policies 0.5.2",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sonic-rs",
  "thiserror 2.0.18",
  "tokio",
@@ -2385,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.0.58"
+version = "0.0.63"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2427,6 +2526,7 @@ dependencies = [
  "ntex-http",
  "ntex-io",
  "ntex-net",
+ "object_store",
  "percent-encoding",
  "prometheus",
  "rand 0.10.1",
@@ -2453,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-config"
-version = "0.0.35"
+version = "0.0.37"
 dependencies = [
  "config",
  "envconfig",
@@ -2478,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-internal"
-version = "0.0.22"
+version = "0.0.25"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2519,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-plan-executor"
-version = "6.13.4"
+version = "6.13.8"
 dependencies = [
  "ahash",
  "async-stream",
@@ -2565,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-query-planner"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "bitflags 2.11.1",
  "graphql-tools",
@@ -2586,7 +2686,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2595,7 +2695,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2687,6 +2796,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -3150,7 +3268,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -3159,7 +3277,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -3315,7 +3433,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -3330,7 +3448,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3443,7 +3561,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e715bb6f273068fc89403d6c4f5eeb83708c62b74c8d43e3e8772ca73a6288"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3575,7 +3703,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -3746,7 +3874,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "uuid",
  "variadics_please",
@@ -4144,6 +4272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numeric_cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,6 +4299,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5 0.10.6",
+ "parking_lot 0.12.5",
+ "percent-encoding",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -4440,7 +4612,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4452,7 +4624,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4524,6 +4696,24 @@ name = "parse-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pathdiff"
@@ -4602,7 +4792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4989,6 +5179,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5361,12 +5571,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -5463,7 +5675,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5548,8 +5760,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5708,6 +5920,88 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "s3s"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf5572ca9bae5fd92d4e5a3e934c73793ab743bcbc761cd5e86a622c2a5e98a"
+dependencies = [
+ "arc-swap",
+ "arrayvec",
+ "async-trait",
+ "atoi",
+ "base64-simd",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "chrono",
+ "crc-fast",
+ "futures",
+ "hex-simd",
+ "hmac 0.13.0-rc.5",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httparse",
+ "hyper",
+ "itoa",
+ "md-5 0.11.0-rc.5",
+ "memchr",
+ "mime",
+ "nom 8.0.0",
+ "numeric_cast",
+ "pin-project-lite",
+ "quick-xml 0.37.5",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1 0.11.0-rc.5",
+ "sha2 0.11.0-rc.5",
+ "smallvec",
+ "std-next",
+ "subtle",
+ "sync_wrapper",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "transform-stream",
+ "url",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
+name = "s3s-fs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63879a5ec0d8d541cdac24f5fd852b57b756c34bd9c225e2ceca2b33acdb34b1"
+dependencies = [
+ "async-trait",
+ "base64-simd",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "hex-simd",
+ "mime",
+ "numeric_cast",
+ "path-absolutize",
+ "s3s",
+ "serde",
+ "serde_json",
+ "std-next",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-error",
+ "transform-stream",
+ "uuid",
+]
 
 [[package]]
 name = "salsa20"
@@ -5956,9 +6250,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -6064,7 +6358,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6075,7 +6369,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6092,7 +6397,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6101,7 +6417,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -6146,7 +6462,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6303,6 +6619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6323,6 +6645,16 @@ name = "static_assertions_next"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
+name = "std-next"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
+dependencies = [
+ "simdutf8",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "string_cache"
@@ -6888,6 +7220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6959,6 +7301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "transform-stream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a814d25437963577f6221d33a2aaa60bfb44acc3330cdc7c334644e9832022"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6976,7 +7327,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -7140,7 +7491,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -7174,6 +7525,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usage-reporting-plugin-example"
@@ -7271,7 +7628,7 @@ dependencies = [
  "crypto_secretbox",
  "csv",
  "ctr",
- "digest",
+ "digest 0.10.7",
  "dns-lookup",
  "domain",
  "dyn-clone",
@@ -7280,7 +7637,7 @@ dependencies = [
  "flate2",
  "grok",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "hostname",
  "iana-time-zone",
  "idna",
@@ -7293,7 +7650,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lz4_flex",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "nom-language",
  "ofb",
@@ -7322,7 +7679,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha-1",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "simdutf8",
  "snafu 0.8.9",
@@ -7476,6 +7833,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/plugin_examples/error_mapping/src/plugin.rs
+++ b/plugin_examples/error_mapping/src/plugin.rs
@@ -1,17 +1,12 @@
 // From https://github.com/apollographql/router/blob/dev/examples/context/rust/src/context_data.rs
 
 use hive_router::{
-    async_trait,
-    http::status,
-    ntex::util::HashMap,
-    plugins::{
+    async_trait, http::status, ntex::util::HashMap, plugins::{
         hooks::{
-            on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult},
-            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+            on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult}, on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult}, on_plugin_init::{OnPluginInitPayload, OnPluginInitResult}
         },
-        plugin_trait::RouterPlugin,
-    },
-    tracing,
+        plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
+    }, tracing
 };
 use serde::Deserialize;
 
@@ -25,6 +20,10 @@ pub struct ErrorMappingPlugin {
     config: HashMap<String, ErrorMappingConfig>,
 }
 
+pub struct ErrorMappingCtx{
+    count: usize,
+}
+
 #[async_trait]
 impl RouterPlugin for ErrorMappingPlugin {
     type Config = HashMap<String, ErrorMappingConfig>;
@@ -35,11 +34,16 @@ impl RouterPlugin for ErrorMappingPlugin {
         let config = payload.config()?;
         payload.initialize_plugin(Self { config })
     }
-    fn on_graphql_error(&self, mut payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
+    fn on_graphql_error<'req>(
+        &self,
+        mut payload: OnGraphQLErrorHookPayload<'req>,
+    ) -> OnGraphQLErrorHookResult<'req> {
+        let mut mapped = false;
         if let Some(code) = &payload.error.extensions.code {
             if let Some(mapping) = self.config.get(code) {
                 if let Some(status_code) = mapping.status_code {
                     if let Ok(status_code) = status::StatusCode::from_u16(status_code) {
+                        mapped = true;
                         payload.status_code = status_code;
                     } else {
                         tracing::error!(
@@ -50,10 +54,39 @@ impl RouterPlugin for ErrorMappingPlugin {
                     }
                 }
                 if let Some(new_code) = &mapping.code {
+                    mapped = true;
                     payload.error.extensions.code = Some(new_code.clone());
                 }
             }
         }
+        if mapped {
+            // Put it in to the context
+            let ctx = payload.context.get_mut::<ErrorMappingCtx>();
+            if let Some(mut ctx) = ctx {
+                ctx.count += 1;
+            } else {
+                payload.context.insert(ErrorMappingCtx { count: 1 });
+            }
+        }
         payload.proceed()
+    }
+    fn on_http_request<'req>(
+        &'req self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
+        payload.on_end(move |payload| {
+            let mapped_errors_count = payload.context.get_ref::<ErrorMappingCtx>().map(|ctx| ctx.count);
+            payload
+                .map_response(move |mut response| {
+                    if let Some(count) = mapped_errors_count {
+                        response.headers_mut().insert(
+                            "x-mapped-errors-count".to_string().parse().unwrap(),
+                            count.to_string().parse().unwrap(),
+                        );
+                    }
+                    response
+                })
+                .proceed()
+        })
     }
 }

--- a/plugin_examples/error_mapping/src/plugin.rs
+++ b/plugin_examples/error_mapping/src/plugin.rs
@@ -1,14 +1,25 @@
 // From https://github.com/apollographql/router/blob/dev/examples/context/rust/src/context_data.rs
 
 use hive_router::{
-    async_trait, http::status, ntex::util::HashMap, plugins::{
+    async_trait,
+    http::status,
+    ntex::{
+        http::header::{HeaderName, HeaderValue},
+        util::HashMap,
+    },
+    plugins::{
         hooks::{
-            on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult}, on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult}, on_plugin_init::{OnPluginInitPayload, OnPluginInitResult}
+            on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult},
+            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         },
         plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
-    }, tracing
+    },
+    tracing,
 };
 use serde::Deserialize;
+
+const MAPPED_ERRORS_COUNT_HEADER: HeaderName = HeaderName::from_static("x-mapped-errors-count");
 
 #[derive(Deserialize)]
 pub struct ErrorMappingConfig {
@@ -20,7 +31,7 @@ pub struct ErrorMappingPlugin {
     config: HashMap<String, ErrorMappingConfig>,
 }
 
-pub struct ErrorMappingCtx{
+pub struct ErrorMappingCtx {
     count: usize,
 }
 
@@ -60,9 +71,7 @@ impl RouterPlugin for ErrorMappingPlugin {
             }
         }
         if mapped {
-            // Put it in to the context
-            let ctx = payload.context.get_mut::<ErrorMappingCtx>();
-            if let Some(mut ctx) = ctx {
+            if let Some(mut ctx) = payload.context.get_mut::<ErrorMappingCtx>() {
                 ctx.count += 1;
             } else {
                 payload.context.insert(ErrorMappingCtx { count: 1 });
@@ -75,14 +84,16 @@ impl RouterPlugin for ErrorMappingPlugin {
         payload: OnHttpRequestHookPayload<'req>,
     ) -> OnHttpRequestHookResult<'req> {
         payload.on_end(move |payload| {
-            let mapped_errors_count = payload.context.get_ref::<ErrorMappingCtx>().map(|ctx| ctx.count);
+            let mapped_errors_count = payload
+                .context
+                .get_ref::<ErrorMappingCtx>()
+                .map(|ctx| ctx.count);
             payload
                 .map_response(move |mut response| {
                     if let Some(count) = mapped_errors_count {
-                        response.headers_mut().insert(
-                            "x-mapped-errors-count".to_string().parse().unwrap(),
-                            count.to_string().parse().unwrap(),
-                        );
+                        response
+                            .headers_mut()
+                            .insert(MAPPED_ERRORS_COUNT_HEADER, HeaderValue::from(count));
                     }
                     response
                 })

--- a/plugin_examples/error_mapping/src/test.rs
+++ b/plugin_examples/error_mapping/src/test.rs
@@ -34,6 +34,12 @@ mod tests {
             "Expected error code to be BadGateway"
         );
 
+        assert_eq!(
+            res.header("x-mapped-errors-count").unwrap(),
+            "1",
+            "Expected x-mapped-errors-count header to be 1"
+        );
+
         mock.assert_async().await;
     }
 
@@ -55,6 +61,12 @@ mod tests {
         assert!(
             res.string_body().await.contains(r#""code":"InvalidInput""#),
             "Expected error code to be InvalidInput"
+        );
+
+        assert_eq!(
+            res.header("x-mapped-errors-count").unwrap(),
+            "1",
+            "Expected x-mapped-errors-count header to be 1"
         );
     }
 }


### PR DESCRIPTION
Ref ROUTER-342

## Expose `context` and `request_context` on `on_graphql_error`

The `on_graphql_error` plugin hook now holds the `PluginContext` and a
`RequestContextPluginApi<OnGraphqlError>` as `context` and `request_context`, matching other request-scoped hooks (`on_http_request`, `on_execute`, etc.).

### Migration

`on_graphql_error` now has a generic over the request lifetime; signatures must be
updated from:

```rust
fn on_graphql_error(&self, mut payload: OnGraphQLErrorHookPayload) -> OnGraphQLErrorHookResult {
    // ...
}
```

to:

```rust
fn on_graphql_error<'req>(
    &'req self,
    mut payload: OnGraphQLErrorHookPayload<'req>,
) -> OnGraphQLErrorHookResult<'req> {
    // ...
}
```