### PR TITLE
Revert "chore(deps): bump memchr from 2.8.0 to 2.8.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,9 +3524,9 @@ checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -64,7 +64,7 @@ rustls = { workspace = true, features = ["aws-lc-rs"] }
 hyper-rustls = { workspace = true, features = ["aws-lc-rs"]}
 dashmap = { workspace = true }
 notify = { workspace = true }
-memchr = "2.8.1"
+memchr = "2.8.0"
 percent-encoding = "2.3.2"
 matchit = "0.9.2"
 


### PR DESCRIPTION
Reverts graphql-hive/router#1079