### PR TITLE
fix(router): serve GraphQL on browser GET when Laboratory is disabled

### DIFF
--- a/.changeset/fix_get_request_detection_when_laboratory_disabled.md
+++ b/.changeset/fix_get_request_detection_when_laboratory_disabled.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+# Fix GET request detection when Laboratory disabled
+
+Hitting the router with a `GET` request from a browser was returning 404 when Laboratory is disabled. 
+
+This change adds a check to only negotiate for Laboratory when Laboratory is enabled, and fallbacks to GET request handling when Laboratory is disabled.

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -223,15 +223,20 @@ impl ResponseMode {
 pub trait RequestAccepts {
     /// Reads the request's `Accept` header and returns the agreed response mode.
     ///
+    /// When `laboratory_enabled` is `true`, a GET request that prefers `text/html`
+    /// (e.g. a browser) negotiates to [`ResponseMode::Laboratory`]. When it is
+    /// `false`, the `text/html` preference is ignored and negotiation falls through
+    /// to the regular GraphQL content types so browsers still get a valid response.
+    ///
     /// Returns an error if no valid content types are found in the Accept header.
-    fn negotiate(&self) -> Result<ResponseMode, PipelineError>;
+    fn negotiate(&self, laboratory_enabled: bool) -> Result<ResponseMode, PipelineError>;
 }
 
 impl RequestAccepts for HttpRequest {
     #[inline]
     /// Reads the `Accept` header contents and returns a tuple of accepted/parsed content types.
     /// It perform negotiation and respects q-weights.
-    fn negotiate(&self) -> Result<ResponseMode, PipelineError> {
+    fn negotiate(&self, laboratory_enabled: bool) -> Result<ResponseMode, PipelineError> {
         let accept_header = self
             .headers()
             .get(ACCEPT)
@@ -249,7 +254,7 @@ impl RequestAccepts for HttpRequest {
             PipelineError::InvalidHeaderValue(ACCEPT)
         })?;
 
-        if self.method() == Method::GET {
+        if laboratory_enabled && self.method() == Method::GET {
             // if the client GETs we negotiate with the all supported media type, including HTML
             // to see if the client wants Laboratory. we negotiate with everything because browsers
             // tend to send very broad accept headers that include text/html with highest q-weight,
@@ -290,10 +295,12 @@ mod tests {
 
     #[test]
     fn negotiate_content_types() {
+        // (method, accept header, laboratory enabled, expected mode)
         let cases = vec![
             (
                 Method::GET,
                 "",
+                true,
                 ResponseMode::Dual(
                     SingleContentType::JSON,
                     StreamContentType::IncrementalDelivery,
@@ -302,6 +309,7 @@ mod tests {
             (
                 Method::GET,
                 "*/*",
+                true,
                 ResponseMode::Dual(
                     SingleContentType::JSON,
                     StreamContentType::IncrementalDelivery,
@@ -310,6 +318,7 @@ mod tests {
             (
                 Method::GET,
                 r#"application/json, text/event-stream, multipart/mixed;subscriptionSpec="1.0""#,
+                true,
                 ResponseMode::Dual(
                     SingleContentType::JSON,
                     StreamContentType::ApolloMultipartHTTP,
@@ -318,6 +327,7 @@ mod tests {
             (
                 Method::GET,
                 r#"application/graphql-response+json, multipart/mixed;q=0.5, text/event-stream;q=1"#,
+                true,
                 ResponseMode::Dual(
                     SingleContentType::GraphQLResponseJSON,
                     StreamContentType::SSE,
@@ -326,46 +336,110 @@ mod tests {
             (
                 Method::GET,
                 r#"application/json;q=0.5, application/graphql-response+json;q=1"#,
+                true,
                 ResponseMode::SingleOnly(SingleContentType::GraphQLResponseJSON),
             ),
             (
                 Method::GET,
                 r#"text/event-stream;q=0.5, multipart/mixed;q=1;subscriptionSpec="1.0""#,
+                true,
                 ResponseMode::StreamOnly(StreamContentType::ApolloMultipartHTTP),
             ),
             (
                 Method::GET,
                 r#"text/event-stream, application/json"#,
+                true,
                 ResponseMode::Dual(SingleContentType::JSON, StreamContentType::SSE),
             ),
             (
                 // actual browser request loading a page
                 Method::GET,
                 r#"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"#,
+                true,
                 ResponseMode::Laboratory,
             ),
             (
                 // browser accept header snippet but for a POST request
                 Method::POST,
                 r#"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"#,
+                true,
                 ResponseMode::Dual(
                     SingleContentType::JSON,
                     StreamContentType::IncrementalDelivery,
                 ),
             ),
+            (
+                // browser GET while Laboratory is disabled: the `text/html` preference is
+                // ignored and the broad `*/*` browsers send is honored, so the client gets a
+                // normal GraphQL response instead of a 404.
+                Method::GET,
+                r#"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"#,
+                false,
+                ResponseMode::Dual(
+                    SingleContentType::JSON,
+                    StreamContentType::IncrementalDelivery,
+                ),
+            ),
+            (
+                // empty Accept on a GET with Laboratory disabled still negotiates normally.
+                Method::GET,
+                "",
+                false,
+                ResponseMode::Dual(
+                    SingleContentType::JSON,
+                    StreamContentType::IncrementalDelivery,
+                ),
+            ),
+            (
+                // explicit GraphQL content type on a GET is unaffected by Laboratory being disabled.
+                Method::GET,
+                r#"application/graphql-response+json"#,
+                false,
+                ResponseMode::SingleOnly(SingleContentType::GraphQLResponseJSON),
+            ),
         ];
 
-        for (method, accept_header, excepted_agreed) in cases {
+        for (method, accept_header, laboratory_enabled, excepted_agreed) in cases {
             let request = TestRequest::default()
                 .method(method.clone())
                 .header(ACCEPT, accept_header)
                 .to_http_request();
-            let agreed = request.negotiate().expect("unable to parse accept header");
+            let agreed = request
+                .negotiate(laboratory_enabled)
+                .expect("unable to parse accept header");
             assert_eq!(
                 agreed, excepted_agreed,
-                "wrong agreed response mode when negotiating method {} with accept: {}",
-                method, accept_header
+                "wrong agreed response mode when negotiating method {} with accept: {} (laboratory_enabled={})",
+                method, accept_header, laboratory_enabled
             );
         }
+    }
+
+    #[test]
+    fn browser_get_with_only_html_and_laboratory_disabled_is_unsupported() {
+        // A client that GETs accepting *only* `text/html` (no `*/*` fallback) while
+        // Laboratory is disabled has no acceptable GraphQL content type, so negotiation
+        // fails with an explicit unsupported-content-type error rather than a misleading 404.
+        let request = TestRequest::default()
+            .method(Method::GET)
+            .header(ACCEPT, "text/html")
+            .to_http_request();
+        let result = request.negotiate(false);
+        assert!(
+            matches!(result, Err(PipelineError::UnsupportedContentType)),
+            "expected UnsupportedContentType, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn html_only_get_renders_laboratory_when_enabled() {
+        // The same `text/html`-only GET renders Laboratory when it is enabled.
+        let request = TestRequest::default()
+            .method(Method::GET)
+            .header(ACCEPT, "text/html")
+            .to_http_request();
+        let agreed = request.negotiate(true).expect("unable to parse accept header");
+        assert_eq!(agreed, ResponseMode::Laboratory);
     }
 }

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -439,7 +439,9 @@ mod tests {
             .method(Method::GET)
             .header(ACCEPT, "text/html")
             .to_http_request();
-        let agreed = request.negotiate(true).expect("unable to parse accept header");
+        let agreed = request
+            .negotiate(true)
+            .expect("unable to parse accept header");
         assert_eq!(agreed, ResponseMode::Laboratory);
     }
 }

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -116,17 +116,16 @@ pub async fn graphql_request_handler(
         return Ok(early_response);
     }
 
-    // agree on the response content type
-    *response_mode = req.negotiate()?;
+    // agree on the response content type. when Laboratory is disabled, negotiation
+    // ignores the `text/html` preference and falls through to regular GraphQL handling,
+    // so browser GETs still get a valid response instead of a 404.
+    *response_mode = req.negotiate(shared_state.router_config.laboratory.enabled)?;
 
+    // `negotiate` only returns `Laboratory` when it is enabled.
     if *response_mode == ResponseMode::Laboratory {
-        if shared_state.router_config.laboratory.enabled {
-            return Ok(web::HttpResponse::Ok()
-                .header(CONTENT_TYPE, TEXT_HTML_MIME)
-                .body(LABORATORY_HTML));
-        } else {
-            return Ok(web::HttpResponse::NotFound().into());
-        }
+        return Ok(web::HttpResponse::Ok()
+            .header(CONTENT_TYPE, TEXT_HTML_MIME)
+            .body(LABORATORY_HTML));
     }
 
     let started_at = Instant::now();


### PR DESCRIPTION
## Problem

Hitting the router with a `GET` from a browser returns **404** when Laboratory is disabled.

A browser sends an `Accept` header that prefers `text/html`:

```
text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
```

`negotiate()` checks `text/html` first on `GET` and short-circuits to `ResponseMode::Laboratory` before ever considering the `*/*;q=0.8` fallback that `application/json` would match. When Laboratory is disabled, `pipeline/mod.rs` then returned `HttpResponse::NotFound()` instead of handling the request as normal GraphQL.

## Fix

`negotiate()` now takes a `laboratory_enabled: bool`. When `false`, it skips the `text/html` GET branch entirely and re-negotiates the regular GraphQL content types, so the broad `*/*` browsers send resolves to `Dual(JSON, IncrementalDelivery)` — a valid GraphQL response.

Because `negotiate()` only returns `Laboratory` when it is enabled, the `else { NotFound }` branch in `pipeline/mod.rs` is now dead and has been removed.

This keeps the full `Accept` header in play (preserving streaming support) rather than hard-coding a single JSON response.

## Tests

In `pipeline::header::tests`:
- `negotiate_content_types` gains a `laboratory_enabled` field and new cases, including the real browser header with Laboratory disabled → `Dual(JSON, IncrementalDelivery)`.
- `browser_get_with_only_html_and_laboratory_disabled_is_unsupported` — a pathological `Accept: text/html`-only GET (no `*/*`) returns an explicit `UnsupportedContentType` error rather than a misleading 404.
- `html_only_get_renders_laboratory_when_enabled` — the same request still serves Laboratory when enabled.