### PR TITLE
fix: do not panic on bad schema unwrap

### DIFF
--- a/.changeset/graceful_handling_of_invalid_supergraph.md
+++ b/.changeset/graceful_handling_of_invalid_supergraph.md
@@ -1,0 +1,11 @@
+---
+hive-router: patch
+---
+
+# Graceful handling of invalid Supergraph while polling
+
+As described in [issue #1089](https://github.com/graphql-hive/router/issues/1089), when the Supergraph fails to parse, the internal mpsc channel should not panic or collapse. 
+
+This fix prevents the Router from crashing when the Supergraph fails to parse, and keeps the channel alive for future updates. 
+
+In case of an invalid Supergraph, the channel is not closed, allowing the Router to continue receiving updates, and the error is being logged. Also, a telemetry (metrics) event is being emitted to track the error.

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -31,7 +31,7 @@ use hive_router_plan_executor::{
 use hive_router_query_planner::planner::plan_nodes::QueryPlan;
 use hive_router_query_planner::{
     planner::{Planner, PlannerError},
-    utils::parsing::parse_schema,
+    utils::parsing::safe_parse_schema,
 };
 use moka::future::Cache;
 use std::sync::Arc;
@@ -135,7 +135,14 @@ impl SchemaState {
                 let process_capture = supergraph_metrics.capture_process();
                 debug!("Received new supergraph SDL, building new supergraph state...");
 
-                let mut new_ast = parse_schema(&new_sdl);
+                let mut new_ast = match safe_parse_schema(&new_sdl) {
+                    Ok(ast) => ast,
+                    Err(e) => {
+                        process_capture.finish_error();
+                        error!("Failed to build new supergraph data: {}", e);
+                        continue;
+                    }
+                };
 
                 let mut on_end_callbacks = vec![];
 

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -139,7 +139,7 @@ impl SchemaState {
                     Ok(ast) => ast,
                     Err(e) => {
                         process_capture.finish_error();
-                        error!("Failed to build new supergraph data: {}", e);
+                        error!(error = %e, "Failed to parse supergraph during update");
                         continue;
                     }
                 };

--- a/e2e/src/supergraph.rs
+++ b/e2e/src/supergraph.rs
@@ -2,9 +2,107 @@
 mod supergraph_e2e_tests {
     use std::time::Duration;
 
-    use sonic_rs::JsonValueTrait;
+    use sonic_rs::{JsonContainerTrait, JsonValueTrait};
 
     use crate::testkit::{wait_until_mock_matched, ClientResponseExt, TestRouter, TestSubgraphs};
+
+    // This test starts the Router with a valid schema.
+    // Then, it triggeres a parser error that could collapse the channel in charge of the updates.
+    // This happens silently as described in https://github.com/graphql-hive/router/pull/1089
+    // Then, it returns a valid ("new") schema.
+    // If the mpsc channel collapsed or paniced, then the Router will still be serving the old schema
+    // and the channel never restores.
+    #[ntex::test]
+    async fn should_not_panic_when_supergraph_update_fail_to_parse() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+        let mock1 = server
+            .mock("GET", "/supergraph")
+            .expect_at_least(1)
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("type Query { old: Old } type Old { v: String }")
+            .create();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                    supergraph:
+                      source: hive
+                      endpoint: http://{host}/supergraph
+                      key: dummy_key
+                      poll_interval: 100ms
+                    "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        wait_until_mock_matched(&mock1)
+            .await
+            .expect("Expected mock1 to be matched");
+
+        mock1.remove();
+
+        let mock2 = server
+            .mock("GET", "/supergraph")
+            .expect_at_least(1)
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("type Query {")
+            .create();
+
+        wait_until_mock_matched(&mock2)
+            .await
+            .expect("Expected mock2 to be matched");
+
+        mock1.remove();
+
+        let mock3 = server
+            .mock("GET", "/supergraph")
+            .expect_at_least(1)
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("type Query { new: New } type New { v: String }")
+            .create();
+
+        wait_until_mock_matched(&mock3)
+            .await
+            .expect("Expected mock3 to be matched");
+
+        mock3.remove();
+
+        ntex::time::sleep(Duration::from_millis(500)).await;
+
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+        let body_json = res.json_body().await;
+
+        assert!(body_json["data"].is_object());
+        assert!(body_json["errors"].is_null());
+
+        assert!(body_json["data"]["__schema"]["types"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|v| v.as_object().unwrap()["name"] == "Query")
+            .is_some());
+        assert!(body_json["data"]["__schema"]["types"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|v| v.as_object().unwrap()["name"] == "Old")
+            .is_none());
+        assert!(body_json["data"]["__schema"]["types"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|v| v.as_object().unwrap()["name"] == "New")
+            .is_some());
+    }
 
     #[ntex::test]
     async fn should_clear_internal_caches_when_supergraph_changes() {


### PR DESCRIPTION
In my company we have custom k8s operator that joins every deployed subgraph to supergraph. In some cases it may generate corrupted schema.

Right now `parse_schema` panics on corrupted schema which leads to destroying `mpsc::rx` so new poll of proper schema will raise an error `Failed to send new supergraph SDL: receiver dropped.`

First approach to handle this was like that:
```rust
#[inline]
pub fn parse_schema(
    sdl: &str,
) -> Result<
    graphql_tools::parser::schema::Document<'static, String>,
    graphql_tools::parser::schema::ParseError,
> {
    graphql_tools::parser::parse_schema(sdl).map(|document| document.into_static())
}
```
With that we can propagate parsing error to `SchemaState` and log it properly. But there are to many tests that relies on `parse_schema` returning `Document` and not `Result` so I decided to show both versions for further discussion.

UPD: never mind, I didn't notice `safe_parse_schema`, thanks gemini.