### PR TITLE
fix(config): improve deserialization of `SingleOrMultiple` and avoid swallowing errors

### DIFF
--- a/.changeset/improve_parsing_of_router_configuration.md
+++ b/.changeset/improve_parsing_of_router_configuration.md
@@ -1,0 +1,12 @@
+---
+hive-router-config: patch
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Improve parsing of Router configuration
+
+Improve error messages when parsing Router configuration, in cases where `SingleOrMultiple<T>` is used and parsing of `T` fails. 
+
+The error is now visible to the user, instead of being swallowed and reported as a generic error.

--- a/e2e/src/tls.rs
+++ b/e2e/src/tls.rs
@@ -18,6 +18,56 @@ mod tls_tests {
         GeneratedKeyPair, TestRouter, TestSubgraphs,
     };
 
+    #[ntex::test]
+    #[should_panic(
+        expected = "failed to parse inline YAML config: ConfigLoadError(Failed to canonicalize path: No such file or directory (os error 2) for key `traffic_shaping.router.tls.key_file`)"
+    )]
+    async fn config_validation_fails_due_to_missing_key_file() {
+        let generated_key_pair = generate_keypair().await;
+        TestRouter::builder()
+            .inline_config(format!(
+                r#"
+            supergraph:
+                source: file
+                path: supergraph.graphql
+            traffic_shaping:
+                router:
+                    tls:
+                        key_file: /doesnt/exists.key
+                        cert_file: {}
+                "#,
+                generated_key_pair.cert_file_path
+            ))
+            .build()
+            .start_without_healthcheck()
+            .await;
+    }
+
+    #[ntex::test]
+    #[should_panic(
+        expected = "failed to parse inline YAML config: ConfigLoadError(expected single value or array, but parsing both failed with error: Failed to canonicalize path: No such file or directory (os error 2) for key `traffic_shaping.router.tls.cert_file"
+    )]
+    async fn config_validation_fails_due_to_missing_cert_file() {
+        let generated_key_pair = generate_keypair().await;
+        TestRouter::builder()
+            .inline_config(format!(
+                r#"
+            supergraph:
+                source: file
+                path: supergraph.graphql
+            traffic_shaping:
+                router:
+                    tls:
+                        key_file: {}
+                        cert_file: /doesnt/exists.crt
+                "#,
+                generated_key_pair.key_file_path
+            ))
+            .build()
+            .start_without_healthcheck()
+            .await;
+    }
+
     // Setup TLS on router
     // And send a request from a client, that has the router's certificate configured as a trusted root, to the router
     // Verify that the request succeeds, indicating that TLS is working correctly on the router

--- a/lib/router-config/src/primitives/single_or_multiple.rs
+++ b/lib/router-config/src/primitives/single_or_multiple.rs
@@ -1,13 +1,44 @@
 use std::borrow::Cow;
 
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
-use serde::{Deserialize, Serialize};
+use serde::de::{DeserializeOwned, Error};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum SingleOrMultiple<T> {
     Single(T),
     Multiple(Vec<T>),
+}
+
+impl<'de, T: DeserializeOwned> Deserialize<'de> for SingleOrMultiple<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        if let Value::Array(_) = &value {
+            match serde_json::from_value::<Vec<T>>(value) {
+                Ok(multiple) => return Ok(SingleOrMultiple::Multiple(multiple)),
+                Err(multiple_err) => {
+                    return Err(D::Error::custom(format!(
+                        "expected array of items: {}",
+                        multiple_err
+                    )));
+                }
+            }
+        }
+
+        match serde_json::from_value::<T>(value) {
+            Ok(single) => Ok(SingleOrMultiple::Single(single)),
+            Err(single_err) => Err(D::Error::custom(format!(
+                "expected single value or array, but parsing both failed with error: {}",
+                single_err
+            ))),
+        }
+    }
 }
 
 impl<T> From<SingleOrMultiple<T>> for Vec<T> {


### PR DESCRIPTION
This tests and fixed the way we parse `SingleOrMultiple`. Instead of using the default parsing method of `serde` for untagged enums, we switch to use a custom deserializator that tries to deserialize a `Vec<T>` first, and only then a `T`. This way we are in control over parsing, and can report the internal errors happening while deserializing the actual `T`. 

An example for that, is when a `SingleOrMultiple<FilePath>` is used with an non-existing file: the error reported is that none of the variants of `SingleOrMultiple` matches, but in reality the internal error is a non-existing file, or a similar error. 