### PR TITLE
fix(query-planner): fix union list FieldMove creation

### DIFF
--- a/.changeset/fix_union_list_fieldmove_creation.md
+++ b/.changeset/fix_union_list_fieldmove_creation.md
@@ -1,0 +1,7 @@
+---
+hive-router-query-planner: patch
+---
+
+# Fix union list FieldMove creation
+
+In some cases union list was treated as single union field in graph. 

--- a/.changeset/fix_union_list_fieldmove_creation.md
+++ b/.changeset/fix_union_list_fieldmove_creation.md
@@ -1,5 +1,8 @@
 ---
 hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
 ---
 
 # Fix union list FieldMove creation

--- a/lib/query-planner/fixture/tests/union-list.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/union-list.supergraph.graphql
@@ -1,0 +1,137 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "")
+  B @join__graph(name: "b", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type PageInfo
+  @join__type(graph: B)
+  @join__type(graph: A)
+{
+  totalPages: Int!
+  totalItems: Int!
+  page: Int!
+  perPage: Int!
+  hasPreviousPage: Boolean!
+  hasNextPage: Boolean!
+}
+
+type Product
+  @join__type(graph: B, key: "id")
+  @join__type(graph: A, key: "id")
+{
+  id: ID!
+  name: String! @join__field(graph: B)
+  slug: String! @join__field(graph: B)
+}
+
+type DigitalBook
+  @join__type(graph: A)
+{
+  product: Product
+}
+
+type PaperBook
+  @join__type(graph: A)
+{
+  product: Product
+}
+
+union OrderItem
+  @join__type(graph: A)
+  @join__unionMember(graph: A, member: "PaperBook")
+  @join__unionMember(graph: A, member: "DigitalBook")
+ = PaperBook | DigitalBook
+
+type Order
+  @join__type(graph: A, key: "id")
+{
+  id: ID!
+  items: [OrderItem!]!
+}
+
+type OrdersPageConnections
+  @join__type(graph: A)
+{
+  items: [Order!]!
+  pageInfo: PageInfo!
+}
+
+type Error
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  message: String!
+}
+
+union OrdersResult
+  @join__type(graph: A)
+  @join__unionMember(graph: A, member: "OrdersPageConnections")
+  @join__unionMember(graph: A, member: "Error")
+ = OrdersPageConnections | Error
+
+type Query
+  @join__type(graph: A)
+{
+  orders: OrdersResult! @join__field(graph: A)
+}

--- a/lib/query-planner/src/graph/mod.rs
+++ b/lib/query-planner/src/graph/mod.rs
@@ -833,7 +833,7 @@ impl Graph {
                                     field_name.clone(),
                                     def_name.clone(),
                                     state.is_scalar_type(target_type),
-                                    false,
+                                    field_definition.field_type.is_list(),
                                     None,
                                     requirements.clone(),
                                     overridden_by.clone(),

--- a/lib/query-planner/src/tests/provides.rs
+++ b/lib/query-planner/src/tests/provides.rs
@@ -245,7 +245,7 @@ fn provides_on_union() -> Result<(), Box<dyn Error>> {
             }
           }
         },
-        Flatten(path: "media|[Movie]") {
+        Flatten(path: "media.@|[Movie]") {
           Fetch(service: "c") {
             {
               ... on Movie {
@@ -281,6 +281,7 @@ fn provides_on_union() -> Result<(), Box<dyn Error>> {
               {
                 "Field": "media"
               },
+              "@",
               {
                 "TypeCondition": [
                   "Movie"

--- a/lib/query-planner/src/tests/union.rs
+++ b/lib/query-planner/src/tests/union.rs
@@ -503,3 +503,93 @@ fn union_overfetching_test() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn union_list_test() -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        {
+          orders {
+            ... on OrdersPageConnections {
+              items {
+                id
+                items {
+                  ... on PaperBook {
+                    product {
+                      id
+                      name
+                      slug
+                    }
+                  }
+                  ... on DigitalBook {
+                    product {
+                      id
+                      name
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan("fixture/tests/union-list.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          {
+            orders {
+              __typename
+              ... on OrdersPageConnections {
+                items {
+                  id
+                  items {
+                    __typename
+                    ... on PaperBook {
+                      product {
+                        ...a
+                      }
+                    }
+                    ... on DigitalBook {
+                      product {
+                        ...a
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          fragment a on Product {
+            __typename
+            id
+          }
+        },
+        Flatten(path: "orders|[OrdersPageConnections].items.@.items.@.product") {
+          Fetch(service: "b") {
+            {
+              ... on Product {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Product {
+                name
+                slug
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
My debug journey started from the end of the chain: I noticed that for my query in which I have two same shaped fragments hive-router resolves data only for one of them.

For query like that:
```graphql
query {
  orders {
    ... on OrdersPageConnections {
      items {
        id
        items {
          ... on PaperBook {
            product {
              id
              name
              slug
            }
          }
          ... on DigitalBook {
            product {
              id
              name
              slug
            }
          }
        }
      }
    }
  }
}
```
my "orders" subgraph resolved IDs for both kinds of items, like this:
```json
[
  {
    "__typename":"PaperBook",
    "product": {
      "__typename": "Product",
      "id": "123"
    }
  },
  {
    "__typename":"DigitalBook",
    "product": {
      "__typename": "Product",
      "id": "456"
    }
  }
]
```
But on the subgraph side I was able to see incoming query only for ID "456".

I quickly found `batch_multi_type` optimization and started thinking that the error is somewhere there because I thought that optimizer cut `@` list definition from `response_path`. But after some time I realized that the issue is somewhere earlier in the planning chain and I found that only in one case we didn't pass `field_definition.field_type.is_list()` to `is_list` parameter of `create_field_move`.