### PR TITLE
fix(router): process initial GraphiQL variables

### DIFF
--- a/bin/router/static/graphiql.html
+++ b/bin/router/static/graphiql.html
@@ -68,7 +68,7 @@
     <script src="https://unpkg.com/@graphql-yoga/graphiql/dist/yoga-graphiql.umd.js"></script>
     <script>
       function parseInitialVariables() {
-        const rawVariables = new URL(location.href).searchParams.get(
+        const rawVariables = new URLSearchParams(location.search).get(
           "variables",
         );
 

--- a/bin/router/static/graphiql.html
+++ b/bin/router/static/graphiql.html
@@ -67,10 +67,37 @@
     </script>
     <script src="https://unpkg.com/@graphql-yoga/graphiql/dist/yoga-graphiql.umd.js"></script>
     <script>
-      prepareWorkers().finally(() => {
-        YogaGraphiQL.renderYogaGraphiQL(root, {
+      function parseInitialVariables() {
+        const rawVariables = new URL(location.href).searchParams.get(
+          "variables",
+        );
+
+        if (rawVariables === null) {
+          return undefined;
+        }
+
+        try {
+          return JSON.stringify(JSON.parse(rawVariables), null, 2);
+        } catch (_error) {
+          return rawVariables;
+        }
+      }
+
+      function createGraphiQLOptions() {
+        const variables = parseInitialVariables();
+        const options = {
           title: "Hive Router GraphiQL",
-        });
+        };
+
+        if (variables !== undefined) {
+          options.variables = variables;
+        }
+
+        return options;
+      }
+
+      prepareWorkers().finally(() => {
+        YogaGraphiQL.renderYogaGraphiQL(root, createGraphiQLOptions());
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary

This fixes the static GraphiQL page so URL-provided `variables` are passed into Yoga GraphiQL as initial variables.

## Root Cause

The Yoga GraphiQL wrapper reads `query` from the current URL, but it does not read the `variables` URL parameter. The static page only passed a title, so links with `?variables=...` opened without the variables editor populated.

## Changes

- Parse the `variables` search parameter from `location.search`.
- Pretty-print valid JSON before handing it to GraphiQL.
- Preserve invalid JSON as raw editor text so GraphiQL can still show/edit it.
- Pass the parsed value through the wrapper's `variables` option only when present.

## Validation

- `git diff --check -- bin/router/static/graphiql.html`
- Node parsing check for valid, invalid, and missing `variables` parameters.
