### PR TITLE
fix(executor): handle case where only `__typename` is used for entity key

### DIFF
--- a/.changeset/fix_projection_when_only_typename_is_used_as_key.md
+++ b/.changeset/fix_projection_when_only_typename_is_used_as_key.md
@@ -1,0 +1,12 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Fix projection when only `__typename` is used as key
+
+As described in [issue #1099](https://github.com/graphql-hive/router/issues/1099), when an entity's `@key` is only `__typename` (e.g. `@key(fields: "__typename")`), the executor built a correct query plan but never issued the `_entities` request to the other subgraph, leaving the cross-subgraph field resolved as `null`.
+
+The representation projection skipped the `__typename` field and only emitted it alongside other fields, so a key using only `__typename` field produced an empty representation and the entity fetch was silently dropped.
+
+The projection now emits a `{ "__typename": ... }` representation in this case, so the entity fetch runs and the field resolves as expected.

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3,6 +3,130 @@ mod issues_e2e_tests {
     use crate::testkit::{ClientResponseExt, Started, TestRouter};
 
     #[ntex::test]
+    /// https://github.com/graphql-hive/federation-gateway-audit `src/test-suites/null-keys`
+    async fn federation_audit_null_keys() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.null-keys.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                      b:
+                        url: "http://{host}/b"
+                      c:
+                        url: "http://{host}/c"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"bookContainers":[
+                    {"book":{"__typename":"Book","upc":"b1"}},
+                    {"book":{"__typename":"Book","upc":"b2"}},
+                    {"book":{"__typename":"Book","upc":"b3"}}
+                ]}}"#,
+            )
+            .create();
+
+        let _b = server
+            .mock("POST", "/b")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"_entities":[
+                    {"__typename":"Book","id":"1"},
+                    {"__typename":"Book","id":"2"},
+                    null
+                ]}}"#,
+            )
+            .create();
+
+        let _c_invalid = server
+            .mock("POST", "/c")
+            .match_request(|r| {
+                let body = String::from_utf8(r.body().unwrap().clone()).unwrap();
+                body.contains(r#"{"__typename":"Book"}"#)
+            })
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"_entities":[
+                    {"__typename":"Book","author":{"__typename":"Author","name":"Alice"}},
+                    {"__typename":"Book","author":{"__typename":"Author","name":"Bob"}},
+                    null
+                ]},"errors":[{"message":"Invalid reference","path":["_entities",2]}]}"#,
+            )
+            .create();
+        let _c_ok = server
+            .mock("POST", "/c")
+            .match_request(|r| {
+                let body = String::from_utf8(r.body().unwrap().clone()).unwrap();
+                !body.contains(r#"{"__typename":"Book"}"#)
+            })
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"_entities":[
+                    {"__typename":"Book","author":{"__typename":"Author","name":"Alice"}},
+                    {"__typename":"Book","author":{"__typename":"Author","name":"Bob"}}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"query { bookContainers { book { upc author { name } } } }"#,
+                None,
+                None,
+            )
+            .await;
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "bookContainers": [
+              {
+                "book": {
+                  "upc": "b1",
+                  "author": {
+                    "name": "Alice"
+                  }
+                }
+              },
+              {
+                "book": {
+                  "upc": "b2",
+                  "author": {
+                    "name": "Bob"
+                  }
+                }
+              },
+              {
+                "book": {
+                  "upc": "b3",
+                  "author": null
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
     /// https://github.com/graphql-hive/router/issues/880
     async fn issue_880_null_in_required_field() {
         let mut server = mockito::Server::new_async().await;

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -815,6 +815,104 @@ mod issues_e2e_tests {
     }
 
     #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1099
+    ///
+    /// When an entity's `@key` is set to only `__typename` (use case is singleton that lives on another subgraph),
+    /// them the executor must still execute the `_entities` fetch call to the subgraph.
+    ///
+    /// Previously the representation projection skipped `__typename`, leading to an empty representation,
+    /// and no fetch call was made.
+    /// This happened because `__typename` has special handling in the representation projection
+    /// that bypassed the standard field projection logic.
+    async fn issue_1099_entities_fetch_with_only_typename_key() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.1099.graphql
+                  query_planner:
+                    allow_expose: true
+                  override_subgraph_urls:
+                    subgraphs:
+                      warehouse:
+                        url: "http://{host}/warehouse"
+                      reviews:
+                        url: "http://{host}/reviews"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // Step 1: warehouse returns catalogEntry { __typename, sku }
+        let warehouse_mock = server
+            .mock("POST", "/warehouse")
+            .match_request(|r| {
+                let body = String::from_utf8(r.body().unwrap().clone()).unwrap();
+                body.contains("catalogEntry")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                  "data": {
+                    "catalogEntry": { "__typename": "CatalogEntry", "sku": "SKU-REPRO-001" }
+                  }
+                }"#,
+            )
+            .create();
+
+        // Step 2: reviews must receive the _entities fetch built from a
+        // representation whose only key field is __typename.
+        let reviews_mock = server
+            .mock("POST", "/reviews")
+            .match_request(|r| {
+                let body = String::from_utf8(r.body().unwrap().clone()).unwrap();
+                body.contains("_entities") && body.contains("$representations")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                  "data": {
+                    "_entities": [
+                      { "__typename": "CatalogEntry", "rating": { "score": 42 } }
+                    ]
+                  }
+                }"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request("{ catalogEntry { sku rating { score } } }", None, None)
+            .await;
+
+        warehouse_mock.assert();
+        reviews_mock.assert();
+
+        // The core thing here is `rating` field - if `__typename` is not written in projections, `rating` is `null`
+        // becuase no fetch is made (and the previous assertion has failed)
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "catalogEntry": {
+              "sku": "SKU-REPRO-001",
+              "rating": {
+                "score": 42
+              }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
     /// Inline string arguments must be re-escaped per the GraphQL spec when
     /// the router emits the operation to a subgraph. A value such as
     /// `"\"quoted\""` is decoded to `"quoted"` while parsing the incoming

--- a/e2e/src/issues/supergraph.1099.graphql
+++ b/e2e/src/issues/supergraph.1099.graphql
@@ -1,0 +1,75 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type CatalogEntry
+  @join__type(graph: REVIEWS, key: "__typename", extension: true)
+  @join__type(graph: WAREHOUSE, key: "__typename")
+{
+  rating: Rating! @join__field(graph: REVIEWS)
+  sku: String! @join__field(graph: WAREHOUSE)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews:9502/graphql")
+  WAREHOUSE @join__graph(name: "warehouse", url: "http://warehouse:9501/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: REVIEWS)
+  @join__type(graph: WAREHOUSE)
+{
+  catalogEntry: CatalogEntry @join__field(graph: WAREHOUSE)
+}
+
+type Rating
+  @join__type(graph: REVIEWS)
+{
+  score: Int!
+}

--- a/e2e/src/issues/supergraph.null-keys.graphql
+++ b/e2e/src/issues/supergraph.null-keys.graphql
@@ -1,0 +1,74 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Author
+  @join__type(graph: C)
+{
+  id: ID!
+  name: String
+}
+
+type Book
+  @join__type(graph: A, key: "upc")
+  @join__type(graph: B, key: "id")
+  @join__type(graph: B, key: "upc")
+  @join__type(graph: C, key: "id")
+{
+  upc: ID! @join__field(graph: A) @join__field(graph: B)
+  id: ID! @join__field(graph: B) @join__field(graph: C)
+  author: Author @join__field(graph: C)
+}
+
+type BookContainer
+  @join__type(graph: A)
+{
+  book: Book
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://a/graphql")
+  B @join__graph(name: "b", url: "http://b/graphql")
+  C @join__graph(name: "c", url: "http://c/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C)
+{
+  bookContainers: [BookContainer] @join__field(graph: A)
+}

--- a/lib/executor/src/projection/request.rs
+++ b/lib/executor/src/projection/request.rs
@@ -24,6 +24,15 @@ fn write_response_key(first: bool, response_key: Option<&str>, buffer: &mut Vec<
     }
 }
 
+#[inline]
+fn write_typename_field(buffer: &mut Vec<u8>, type_name: &str) {
+    buffer.put(QUOTE);
+    buffer.put(TYPENAME);
+    buffer.put(QUOTE);
+    buffer.put(COLON);
+    write_and_escape_string(buffer, type_name);
+}
+
 pub fn project_requires(
     possible_types: &PossibleTypes,
     requires_selections: &Vec<SelectionItem>,
@@ -124,30 +133,47 @@ fn project_requires_map_mut(
     parent_response_key: Option<&str>,
     parent_first: bool,
 ) {
+    // First, check if __typename is present and if it's needs to be added
+    let type_name = entity_obj
+        .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
+        .ok()
+        .and_then(|idx| entity_obj[idx].1.as_str());
+
     for requires_selection in requires_selections {
         match &requires_selection {
             SelectionItem::Field(requires_selection) => {
                 let field_name = &requires_selection.name;
                 let response_key = requires_selection.selection_identifier();
                 if response_key == TYPENAME_FIELD_NAME {
-                    // Skip __typename field, it is handled separately
+                    // __typename is normally written when the object is opened for
+                    // its first non-__typename field (see below).
+                    //
+                    // But, for the very rate case of using only __typename in key (`@key(fields: "__typename")`),
+                    // we need to write it here instead, because the code below never runs (no other fields).
+                    //
+                    // So: if this is the first field, write __typename immediately, and we need to write __typename anyway,
+                    // we write it, and then continue to the next field (marking first=false to avoid re-write)
+                    if *first {
+                        if let Some(type_name) = type_name {
+                            write_response_key(parent_first, parent_response_key, buffer);
+                            buffer.put(OPEN_BRACE);
+                            write_typename_field(buffer, type_name);
+                            *first = false;
+                        }
+                    }
+
                     continue;
                 }
 
                 let original = entity_obj
                     .binary_search_by_key(&field_name.as_str(), |(k, _)| k)
                     .ok()
-                    .map(|idx| &entity_obj[idx].1)
                     .or_else(|| {
-                        if response_key == TYPENAME_FIELD_NAME {
-                            None
-                        } else {
-                            entity_obj
-                                .binary_search_by_key(&response_key, |(k, _)| k)
-                                .ok()
-                                .map(|idx| &entity_obj[idx].1)
-                        }
-                    });
+                        entity_obj
+                            .binary_search_by_key(&response_key, |(k, _)| k)
+                            .ok()
+                    })
+                    .map(|idx| &entity_obj[idx].1);
 
                 let Some(original) = original else {
                     continue;
@@ -161,17 +187,10 @@ fn project_requires_map_mut(
                     object_start_offset = Some(buffer.len());
                     write_response_key(parent_first, parent_response_key, buffer);
                     buffer.put(OPEN_BRACE);
-                    // Write __typename only if the object has other fields
-                    if let Some(type_name) = entity_obj
-                        .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
-                        .ok()
-                        .and_then(|idx| entity_obj[idx].1.as_str())
-                    {
-                        buffer.put(QUOTE);
-                        buffer.put(TYPENAME);
-                        buffer.put(QUOTE);
-                        buffer.put(COLON);
-                        write_and_escape_string(buffer, type_name);
+                    // Write __typename only if the object has other fields,
+                    // and if it wasn't written before (first=true)
+                    if let Some(type_name) = type_name {
+                        write_typename_field(buffer, type_name);
                         *first = false;
                     }
                 }
@@ -391,5 +410,62 @@ mod tests {
 
         let pretty = project_requires_pretty("contactOptions", json!({}));
         assert_eq!(pretty, None);
+    }
+
+    /// Regression testt for https://github.com/graphql-hive/router/issues/1099:
+    /// a key that has only `__typename` must still produce a
+    /// representation, and using `__typename` alongside another field (in
+    /// either order) must not duplicate it, or drop any of the field/__typename
+    #[test]
+    fn project_requires_typename_key() {
+        // Only `__typename` in the key — must still build the representation and return a valid JSON
+        insta::assert_snapshot!(
+          &project_requires_pretty(
+              "__typename", // @key(fields: ["__typename"])
+              json!({
+                  "__typename": "CatalogEntry",
+                  "sku": "SKU-REPRO-001"
+              }),
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "CatalogEntry"
+          }
+        "#);
+
+        // `__typename` is first, then another field
+        insta::assert_snapshot!(
+          &project_requires_pretty(
+              "__typename id", // @key(fields: ["__typename", "id"])
+              json!({
+                  "__typename": "CatalogEntry",
+                  "id": "1"
+              }),
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "CatalogEntry",
+            "id": "1"
+          }
+        "#);
+
+        // Another field listed first, then `__typename` — same result, no duplicates
+        insta::assert_snapshot!(
+          &project_requires_pretty(
+              "id __typename", // @key(fields: ["id", "__typename"])
+              json!({
+                  "__typename": "CatalogEntry",
+                  "id": "1"
+              }),
+          )
+          .expect("projection should produce output"),
+          @r#"
+          {
+            "__typename": "CatalogEntry",
+            "id": "1"
+          }
+        "#);
     }
 }

--- a/lib/executor/src/projection/request.rs
+++ b/lib/executor/src/projection/request.rs
@@ -8,7 +8,7 @@ use crate::{
     response::value::Value,
     utils::consts::{
         CLOSE_BRACE, CLOSE_BRACKET, COLON, COMMA, FALSE, NULL, OPEN_BRACE, OPEN_BRACKET, QUOTE,
-        TRUE, TYPENAME, TYPENAME_FIELD_NAME,
+        TRUE, TYPENAME_FIELD_NAME, TYPENAME_JSON_FIELD,
     },
 };
 
@@ -26,10 +26,7 @@ fn write_response_key(first: bool, response_key: Option<&str>, buffer: &mut Vec<
 
 #[inline]
 fn write_typename_field(buffer: &mut Vec<u8>, type_name: &str) {
-    buffer.put(QUOTE);
-    buffer.put(TYPENAME);
-    buffer.put(QUOTE);
-    buffer.put(COLON);
+    buffer.put(TYPENAME_JSON_FIELD);
     write_and_escape_string(buffer, type_name);
 }
 

--- a/lib/executor/src/projection/request.rs
+++ b/lib/executor/src/projection/request.rs
@@ -133,35 +133,38 @@ fn project_requires_map_mut(
     parent_response_key: Option<&str>,
     parent_first: bool,
 ) {
-    // First, check if __typename is present and if it's needs to be added
+    // First, check if __typename is present in the entity object, we'll use it later
     let type_name = entity_obj
         .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
         .ok()
         .and_then(|idx| entity_obj[idx].1.as_str());
+
+    // An indicator that only `__typename` is used for the key fields.
+    // This is an edge case that we need to identify, in order to detect when
+    // `__typename` alone is a valid key but other fields are also required
+    let only_typename = requires_selections.len() == 1 && requires_selections.iter().all(|selection| {
+        matches!(selection, SelectionItem::Field(field) if field.selection_identifier() == TYPENAME_FIELD_NAME)
+    });
+
+    // If the requires selection is only `__typename`, we can skip the rest of the logic, and just write the `__typename` field
+    if only_typename {
+        if let Some(type_name) = type_name {
+            write_response_key(parent_first, parent_response_key, buffer);
+            buffer.put(OPEN_BRACE);
+            write_typename_field(buffer, type_name);
+            *first = false;
+
+            return;
+        }
+    }
 
     for requires_selection in requires_selections {
         match &requires_selection {
             SelectionItem::Field(requires_selection) => {
                 let field_name = &requires_selection.name;
                 let response_key = requires_selection.selection_identifier();
-                if response_key == TYPENAME_FIELD_NAME {
-                    // __typename is normally written when the object is opened for
-                    // its first non-__typename field (see below).
-                    //
-                    // But, for the very rate case of using only __typename in key (`@key(fields: "__typename")`),
-                    // we need to write it here instead, because the code below never runs (no other fields).
-                    //
-                    // So: if this is the first field, write __typename immediately, and we need to write __typename anyway,
-                    // we write it, and then continue to the next field (marking first=false to avoid re-write)
-                    if *first {
-                        if let Some(type_name) = type_name {
-                            write_response_key(parent_first, parent_response_key, buffer);
-                            buffer.put(OPEN_BRACE);
-                            write_typename_field(buffer, type_name);
-                            *first = false;
-                        }
-                    }
 
+                if response_key == TYPENAME_FIELD_NAME {
                     continue;
                 }
 

--- a/lib/executor/src/utils/consts.rs
+++ b/lib/executor/src/utils/consts.rs
@@ -11,3 +11,4 @@ pub const CLOSE_BRACE: &[u8] = b"}";
 pub const OPEN_BRACKET: &[u8] = b"[";
 pub const CLOSE_BRACKET: &[u8] = b"]";
 pub const EMPTY_OBJECT: &[u8] = b"{}";
+pub const TYPENAME_JSON_FIELD: &[u8] = b"\"__typename\":";


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1099 

## TL;DR:

* `@key(fields: "__typename")` -> should create fetch call (currently, it's skipped)  
* `@key(fields: "__typename id")` + `id = null` ->  should not create fetch call (tested in `null_keys` in fed audit) 
* `@key(fields: "__typename id")` + `id = something` -> should create fetch call ("normal" flow)  

## More stuff 

As described in [issue #1099](https://github.com/graphql-hive/router/issues/1099), when an entity's `@key` is only `__typename` (e.g. `@key(fields: "__typename")`), the executor built a correct query plan but never issued the `_entities` request to the other subgraph, leaving the cross-subgraph field resolved as `null`.

The representation projection skipped the `__typename` field and only emitted it alongside other fields, so a key using only `__typename` field produced an empty representation and the entity fetch was silently dropped.

The projection now emits a `{ "__typename": ... }` representation in this case, so the entity fetch runs and the field resolves as expected.

I've added a few tests to ensure projection is handling different combos of `__typename` (only `__typename`, `__typename`+field, field+`__typename`). Also added a full e2e tests based on the original issue. 
Also, copied the `null_keys` from the Fed audit because I needed to run it here as regression test, because the test there ends up with `{__typename: "..."}` because of a null key for one of the values, and in that edge-case, we do want to drop the fetch step. 
