### PR TITLE
feat(query-planner): fold inline object type fragments to interface type fragment

### DIFF
--- a/.changeset/fold_concrete_to_interface.md
+++ b/.changeset/fold_concrete_to_interface.md
@@ -1,0 +1,17 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Fold repeated object-type selections into a single interface selection
+
+When a `Fetch` node asks for the same fields on different object types, and all
+of those types implement the same interface that matches the field's return type,
+the query planner now merges them into a single inline fragment on the interface
+instead of keeping separate branches.
+
+For example: `query { media { ... on Book { id title } ... on Movie { id title } } }` becomes
+`query { media { id title } }` when the field's return type is `Media` and both
+`Book` and `Movie` implement it in the subgraph.

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -17,6 +17,7 @@ use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_
 use hive_router_query_planner::planner::tree::query_tree::QueryTree;
 use hive_router_query_planner::planner::walker::walk_operation;
 use hive_router_query_planner::planner::walker::ResolvedOperation;
+use hive_router_query_planner::state::supergraph_state::OperationKind;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
 use hive_router_query_planner::utils::cancellation::CancellationToken;
 use hive_router_query_planner::utils::parsing::parse_operation;
@@ -143,7 +144,7 @@ fn process_fetch_graph(
     supergraph_path: &str,
     operation_path: &str,
 ) -> FetchGraph<MultiTypeFetchStep> {
-    let (graph, query_tree, supergraph_state) =
+    let (graph, query_tree, supergraph_state, operation_kind) =
         process_merged_tree(supergraph_path, operation_path);
 
     let override_context = PlannerOverrideContext::default();
@@ -153,6 +154,7 @@ fn process_fetch_graph(
         &supergraph_state,
         &override_context,
         query_tree,
+        operation_kind,
         &cancellation_token,
     )
     .expect("failed to build fetch graph")
@@ -183,6 +185,10 @@ fn process_plan(supergraph_path: &str, operation_path: &str) -> QueryPlan {
         &supergraph,
         &override_context,
         query_tree,
+        operation
+            .operation_kind
+            .clone()
+            .unwrap_or(OperationKind::Query),
         &cancellation_token,
     )
     .expect("failed to build fetch graph");
@@ -194,14 +200,22 @@ fn process_plan(supergraph_path: &str, operation_path: &str) -> QueryPlan {
 fn process_merged_tree(
     supergraph_path: &str,
     operation_path: &str,
-) -> (Graph, QueryTree, SupergraphState) {
-    let (graph, best_paths_per_leaf, _operation, supergraph_state) =
+) -> (Graph, QueryTree, SupergraphState, OperationKind) {
+    let (graph, best_paths_per_leaf, operation, supergraph_state) =
         process_paths(supergraph_path, operation_path);
     let cancellation_token = CancellationToken::new();
     let query_tree =
         find_best_combination(&graph, best_paths_per_leaf, &cancellation_token).unwrap();
 
-    (graph, query_tree, supergraph_state)
+    (
+        graph,
+        query_tree,
+        supergraph_state,
+        operation
+            .operation_kind
+            .clone()
+            .unwrap_or(OperationKind::Query),
+    )
 }
 
 fn get_operation(operation_path: &str, supergraph: &SupergraphState) -> OperationDefinition {

--- a/lib/query-planner/benches/qp_benches.rs
+++ b/lib/query-planner/benches/qp_benches.rs
@@ -9,6 +9,7 @@ use hive_router_query_planner::planner::best::find_best_combination;
 use hive_router_query_planner::planner::fetch::fetch_graph::build_fetch_graph_from_query_tree;
 use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_graph;
 use hive_router_query_planner::planner::walker::walk_operation;
+use hive_router_query_planner::state::supergraph_state::OperationKind;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
 use hive_router_query_planner::utils::cancellation::CancellationToken;
 use hive_router_query_planner::utils::parsing::{parse_operation, parse_schema};
@@ -47,6 +48,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
         b.iter(|| {
             let bb_graph = black_box(&graph);
             let bb_operation = black_box(&operation);
+            let bb_kind = black_box(OperationKind::Query);
             let bb_supergraph_state = black_box(&supergraph_state);
             let bb_override_context = black_box(&override_context);
 
@@ -65,6 +67,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
                 bb_supergraph_state,
                 bb_override_context,
                 query_tree,
+                bb_kind,
                 &cancellation_token,
             )
             .unwrap();
@@ -95,6 +98,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
         b.iter(|| {
             let bb_graph = black_box(&graph);
             let bb_operation = black_box(&operation);
+            let bb_kind = black_box(OperationKind::Query);
             let bb_supergraph_state = black_box(&supergraph_state);
             let bb_override_context = black_box(&override_context);
 
@@ -113,6 +117,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
                 bb_supergraph_state,
                 bb_override_context,
                 query_tree,
+                bb_kind,
                 &cancellation_token,
             )
             .unwrap();

--- a/lib/query-planner/src/ast/merge_path.rs
+++ b/lib/query-planner/src/ast/merge_path.rs
@@ -5,8 +5,48 @@ use std::rc::Rc;
 
 use crate::ast::selection_set::{FieldSelection, InlineFragmentSelection};
 
-// Can be either the alias or the name of the field. This will be used to identify the field in the selection set.
-type SelectionIdentifier = String;
+// This is used to identify the field in the selection set
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FieldPathSegment {
+    pub field_name: String,
+    pub alias: Option<String>,
+}
+
+impl FieldPathSegment {
+    pub fn new(field_name: String, alias: Option<String>) -> Self {
+        Self { field_name, alias }
+    }
+
+    pub fn named(field_name: String) -> Self {
+        Self {
+            field_name,
+            alias: None,
+        }
+    }
+
+    pub fn response_key(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.field_name)
+    }
+
+    pub fn field_name(&self) -> &str {
+        &self.field_name
+    }
+}
+
+impl Display for FieldPathSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.response_key())
+    }
+}
+
+impl From<&FieldSelection> for FieldPathSegment {
+    fn from(field: &FieldSelection) -> Self {
+        Self {
+            field_name: field.name.clone(),
+            alias: field.alias.clone(),
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Condition {
@@ -90,7 +130,7 @@ impl From<&InlineFragmentSelection> for Option<Condition> {
 pub enum Segment {
     // A field with a unique identifier and the arguments hash
     // We used this to uniquely identify the field in the selection set.
-    Field(SelectionIdentifier, u64, Option<Condition>),
+    Field(FieldPathSegment, u64, Option<Condition>),
     List,
     TypeCondition(BTreeSet<String>, Option<Condition>),
 }
@@ -107,11 +147,11 @@ impl Display for Segment {
                     write!(f, "|[{}]", joined)
                 }
             }
-            Self::Field(field_name, _, condition) => {
+            Self::Field(field_seg, _, condition) => {
                 if let Some(condition) = condition {
-                    write!(f, "{} {}", field_name, condition)
+                    write!(f, "{} {}", field_seg.response_key(), condition)
                 } else {
-                    write!(f, "{}", field_name)
+                    write!(f, "{}", field_seg.response_key())
                 }
             }
         }

--- a/lib/query-planner/src/ast/mismatch_finder.rs
+++ b/lib/query-planner/src/ast/mismatch_finder.rs
@@ -96,7 +96,7 @@ fn handle_selection_set<'field, 'schema>(
                     }
 
                     let next_path = path.push(Segment::Field(
-                        field.selection_identifier().to_string(),
+                        field.into(),
                         field.arguments_hash(),
                         field.into(),
                     ));

--- a/lib/query-planner/src/ast/mod.rs
+++ b/lib/query-planner/src/ast/mod.rs
@@ -5,9 +5,9 @@ pub mod hash;
 pub mod minification;
 pub mod normalization;
 pub mod operation;
-pub mod semantic_eq;
 pub mod selection_item;
 pub mod selection_set;
+pub mod semantic_eq;
 
 pub(crate) mod arguments;
 pub(crate) mod merge_path;

--- a/lib/query-planner/src/ast/mod.rs
+++ b/lib/query-planner/src/ast/mod.rs
@@ -5,6 +5,7 @@ pub mod hash;
 pub mod minification;
 pub mod normalization;
 pub mod operation;
+pub mod semantic_eq;
 pub mod selection_item;
 pub mod selection_set;
 

--- a/lib/query-planner/src/ast/safe_merge.rs
+++ b/lib/query-planner/src/ast/safe_merge.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use tracing::trace;
 
 use crate::ast::{
-    merge_path::{MergePath, Segment},
+    merge_path::{FieldPathSegment, MergePath, Segment},
     selection_item::SelectionItem,
     selection_set::SelectionSet,
 };
@@ -108,7 +108,7 @@ impl SafeSelectionSetMerger {
                             decision = ConflictsLookupResult::Merged;
 
                             let next_path = response_path.push(Segment::Field(
-                                source_field.name.clone(),
+                                FieldPathSegment::named(source_field.name.clone()),
                                 source_field.arguments_hash(),
                                 source_field.into(),
                             ));
@@ -217,7 +217,7 @@ impl SafeSelectionSetMerger {
 
                                 let pair = (
                                     response_path.push(Segment::Field(
-                                        new_field.name.clone(),
+                                        FieldPathSegment::named(new_field.name.clone()),
                                         new_field.arguments_hash(),
                                         (&new_field).into(),
                                     )),
@@ -237,7 +237,7 @@ impl SafeSelectionSetMerger {
 
                                 let pair = (
                                     response_path.push(Segment::Field(
-                                        field_selection.name.clone(),
+                                        FieldPathSegment::named(field_selection.name.clone()),
                                         field_selection.arguments_hash(),
                                         field_selection.into(),
                                     )),

--- a/lib/query-planner/src/ast/selection_set.rs
+++ b/lib/query-planner/src/ast/selection_set.rs
@@ -104,6 +104,35 @@ impl SelectionSet {
             None
         })
     }
+
+    pub fn iter_fields_and_fragments_of_same_type<'a>(
+        &'a self,
+        type_name: &'a str,
+    ) -> impl Iterator<Item = &'a FieldSelection> + 'a {
+        let mut stack = vec![self.items.iter()];
+
+        std::iter::from_fn(move || loop {
+            let iter = stack.last_mut()?;
+
+            match iter.next() {
+                Some(SelectionItem::Field(field)) => {
+                    return Some(field);
+                }
+
+                Some(SelectionItem::InlineFragment(fragment))
+                    if fragment.type_condition == type_name =>
+                {
+                    stack.push(fragment.selections.items.iter());
+                }
+
+                Some(_) => {}
+
+                None => {
+                    stack.pop();
+                }
+            }
+        })
+    }
 }
 
 impl Hash for SelectionSet {
@@ -567,14 +596,14 @@ pub fn find_selection_set_by_path_mut<'a>(
                     }
                 }
             }
-            Segment::Field(field_name, args_hash, condition) => {
+            Segment::Field(field_seg, args_hash, condition) => {
                 let next_selection_set_option =
                     current_selection_set
                         .items
                         .iter_mut()
                         .find_map(|item| match item {
                             SelectionItem::Field(field) => {
-                                if field.selection_identifier() == field_name
+                                if field.selection_identifier() == field_seg.response_key()
                                     && field.arguments_hash() == *args_hash
                                     && field_condition_equal(condition, field)
                                 {

--- a/lib/query-planner/src/ast/semantic_eq.rs
+++ b/lib/query-planner/src/ast/semantic_eq.rs
@@ -1,0 +1,68 @@
+use crate::ast::{
+    selection_item::SelectionItem,
+    selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet},
+};
+
+pub trait SemanticEq<Rhs = Self> {
+    fn semantic_eq(&self, other: &Rhs) -> bool;
+}
+
+impl SemanticEq for SelectionSet {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        if self.items.len() != other.items.len() {
+            return false;
+        }
+
+        let mut matched = vec![false; other.items.len()];
+
+        self.items.iter().all(|left| {
+            if let Some(index) = other
+                .items
+                .iter()
+                .enumerate()
+                .position(|(index, right)| !matched[index] && left.semantic_eq(right))
+            {
+                matched[index] = true;
+                true
+            } else {
+                false
+            }
+        })
+    }
+}
+
+impl SemanticEq for FieldSelection {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.alias == other.alias
+            && self.arguments() == other.arguments()
+            && self.skip_if == other.skip_if
+            && self.include_if == other.include_if
+            && self.omit_from_response == other.omit_from_response
+            && self.selections.semantic_eq(&other.selections)
+    }
+}
+
+impl SemanticEq for InlineFragmentSelection {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        self.type_condition == other.type_condition
+            && self.skip_if == other.skip_if
+            && self.include_if == other.include_if
+            && self.selections.semantic_eq(&other.selections)
+    }
+}
+
+impl SemanticEq for SelectionItem {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SelectionItem::Field(left), SelectionItem::Field(right)) => left.semantic_eq(right),
+            (SelectionItem::InlineFragment(left), SelectionItem::InlineFragment(right)) => {
+                left.semantic_eq(right)
+            }
+            (SelectionItem::FragmentSpread(left), SelectionItem::FragmentSpread(right)) => {
+                left == right
+            }
+            _ => false,
+        }
+    }
+}

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1,4 +1,4 @@
-use crate::ast::merge_path::{Condition, MergePath, Segment};
+use crate::ast::merge_path::{Condition, FieldPathSegment, MergePath, Segment};
 use crate::ast::selection_item::SelectionItem;
 use crate::ast::selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet};
 use crate::ast::type_aware_selection::TypeAwareSelection;
@@ -13,7 +13,7 @@ use crate::planner::tree::query_tree::QueryTree;
 use crate::planner::tree::query_tree_node::{MutationFieldPosition, QueryTreeNode};
 use crate::planner::walker::path::OperationPath;
 use crate::planner::walker::pathfinder::can_satisfy_edge;
-use crate::state::supergraph_state::{SubgraphName, SupergraphState};
+use crate::state::supergraph_state::{OperationKind, SubgraphName, SupergraphState};
 use crate::utils::cancellation::CancellationToken;
 use petgraph::algo::has_path_connecting;
 use petgraph::graph::EdgeReference;
@@ -32,12 +32,7 @@ use super::error::FetchGraphError;
 pub struct FetchGraph<State> {
     pub(crate) graph: StableDiGraph<FetchStepData<State>, ()>,
     pub root_index: Option<NodeIndex>,
-}
-
-impl Default for FetchGraph<SingleTypeFetchStep> {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub(crate) operation_kind: OperationKind,
 }
 
 impl FetchGraph<SingleTypeFetchStep> {
@@ -49,13 +44,15 @@ impl FetchGraph<SingleTypeFetchStep> {
         FetchGraph {
             graph: new_graph,
             root_index: self.root_index,
+            operation_kind: self.operation_kind,
         }
     }
 
-    pub fn new() -> Self {
+    pub fn new(kind: OperationKind) -> Self {
         Self {
             graph: StableDiGraph::new(),
             root_index: None,
+            operation_kind: kind,
         }
     }
 }
@@ -1273,23 +1270,26 @@ fn process_plain_field_edge(
         },
     )?;
 
-    let child_segment = query_node.selection_alias().unwrap_or(&field_move.name);
+    let segment_args_hash = query_node
+        .selection_arguments()
+        .map(|a| a.hash_u64())
+        .unwrap_or(0);
+    let segment_field = FieldPathSegment::new(
+        field_move.name.to_string(),
+        query_node.selection_alias().map(|a| a.to_string()),
+    );
     let segment_condition = if should_strip_condition {
         None
     } else {
         condition.cloned()
     };
-    let segment_args_hash = query_node
-        .selection_arguments()
-        .map(|a| a.hash_u64())
-        .unwrap_or(0);
     let mut child_response_path = response_path.push(Segment::Field(
-        child_segment.to_string(),
+        segment_field.clone(),
         segment_args_hash,
         segment_condition.clone(),
     ));
     let mut child_fetch_path = fetch_path.push(Segment::Field(
-        child_segment.to_string(),
+        segment_field,
         segment_args_hash,
         segment_condition,
     ));
@@ -1493,21 +1493,21 @@ fn process_requires_field_edge(
 
     fetch_graph.connect(real_parent_fetch_step_index, step_for_requirements_index);
 
-    let child_segment = query_node.selection_alias().unwrap_or(&field_move.name);
     let segment_args_hash = query_node
         .selection_arguments()
         .map(|a| a.hash_u64())
         .unwrap_or(0);
+    let segment_field = FieldPathSegment::new(
+        field_move.name.to_string(),
+        query_node.selection_alias().map(|a| a.to_string()),
+    );
     let mut child_response_path = response_path.push(Segment::Field(
-        child_segment.to_string(),
+        segment_field.clone(),
         segment_args_hash,
         None,
     ));
-    let mut child_fetch_path = MergePath::default().push(Segment::Field(
-        child_segment.to_string(),
-        segment_args_hash,
-        None,
-    ));
+    let mut child_fetch_path =
+        MergePath::default().push(Segment::Field(segment_field, segment_args_hash, None));
 
     if field_move.is_list {
         child_response_path = child_response_path.push(Segment::List);
@@ -1812,9 +1812,10 @@ pub fn build_fetch_graph_from_query_tree(
     supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_tree: QueryTree,
+    operation_kind: OperationKind,
     cancellation_token: &CancellationToken,
 ) -> Result<FetchGraph<MultiTypeFetchStep>, FetchGraphError> {
-    let mut fetch_graph = FetchGraph::new();
+    let mut fetch_graph = FetchGraph::new(operation_kind);
 
     process_query_node(
         graph,

--- a/lib/query-planner/src/planner/fetch/optimize/apply_internal_aliases_patching.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/apply_internal_aliases_patching.rs
@@ -65,7 +65,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                             let relative_path =
                                 decendent.response_path.slice_from(alias_path.len());
 
-                            if let Some(Segment::Field(field_name, args_hash, condition)) =
+                            if let Some(Segment::Field(field_seg, args_hash, condition)) =
                                 maybe_patched_field
                             {
                                 // TODO: Avoid "except" here of course.
@@ -89,7 +89,7 @@ impl FetchGraph<MultiTypeFetchStep> {
 
                                 trace!(
                               "field '{}' was aliased, relative selection path: '{}', checking if need to patch selection '{}'",
-                              field_name,
+                              field_seg.field_name(),
                               relative_path,
                               selection
                           );
@@ -99,7 +99,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                                     find_selection_set_by_path_mut(selection, &relative_path)
                                 {
                                     trace!("found selection to patch: {}", selection);
-                                    let item_to_patch = selection.items.iter_mut().find(|item| matches!(item, SelectionItem::Field(field) if field.name == *field_name && field.arguments_hash() == *args_hash));
+                                    let item_to_patch = selection.items.iter_mut().find(|item| matches!(item, SelectionItem::Field(field) if field.name == field_seg.field_name() && field.arguments_hash() == *args_hash));
 
                                     if let Some(SelectionItem::Field(field_to_patch)) =
                                         item_to_patch
@@ -128,7 +128,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                               .iter()
                               .enumerate()
                               .find_map(|(idx, part)| {
-                                  if matches!(part, Segment::Field(f, a, c) if f == field_name && a == args_hash && c == condition) {
+                                  if matches!(part, Segment::Field(ref f, a, c) if f.field_name() == field_seg.field_name() && a == args_hash && c == condition) {
                                       Some(idx)
                                   } else {
                                       None
@@ -139,17 +139,17 @@ impl FetchGraph<MultiTypeFetchStep> {
                                     trace!(
                                 "Node [{}] is using aliased field {} in response_path (segment idx: {}, alias: {:?})",
                                 decendent_idx.index(),
-                                field_name,
+                                field_seg.field_name(),
                                 segment_idx_to_patch,
                                 alias_path
                             );
 
                                     let mut new_path = (*decendent.response_path.inner).to_vec();
 
-                                    if let Some(Segment::Field(name, _, _)) =
+                                    if let Some(Segment::Field(ref mut seg, _, _)) =
                                         new_path.get_mut(segment_idx_to_patch)
                                     {
-                                        *name = new_name.clone();
+                                        seg.field_name = new_name.clone();
                                         decendent.response_path = MergePath::new(new_path);
                                     }
                                 }

--- a/lib/query-planner/src/planner/fetch/optimize/batch_multi_type.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/batch_multi_type.rs
@@ -499,7 +499,7 @@ mod tests {
     use std::collections::{BTreeSet, HashMap};
 
     use crate::{
-        ast::merge_path::{MergePath, Segment},
+        ast::merge_path::{FieldPathSegment, MergePath, Segment},
         planner::plan_nodes::FlattenNodePath,
     };
 
@@ -507,12 +507,12 @@ mod tests {
 
     fn path(type_name: &str) -> MergePath {
         MergePath::new(vec![
-            Segment::Field("products".to_string(), 0, None),
+            Segment::Field(FieldPathSegment::named("products".to_string()), 0, None),
             Segment::List,
             Segment::TypeCondition(BTreeSet::from([type_name.to_string()]), None),
-            Segment::Field("reviews".to_string(), 0, None),
+            Segment::Field(FieldPathSegment::named("reviews".to_string()), 0, None),
             Segment::List,
-            Segment::Field("product".to_string(), 0, None),
+            Segment::Field(FieldPathSegment::named("product".to_string()), 0, None),
         ])
     }
 

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -541,13 +541,17 @@ impl MergePath {
                             self
                         ))
                     })?;
-                    let field = definition.fields().get(field_seg.field_name()).ok_or_else(|| {
-                            FetchGraphError::Internal(format!(
-                                "Field {} not found in type {type_name} for given path {}",
-                                field_seg.field_name(),
-                                self
-                            ))
-                        })?;
+                    let field =
+                        definition
+                            .fields()
+                            .get(field_seg.field_name())
+                            .ok_or_else(|| {
+                                FetchGraphError::Internal(format!(
+                                    "Field {} not found in type {type_name} for given path {}",
+                                    field_seg.field_name(),
+                                    self
+                                ))
+                            })?;
 
                     type_name = field.field_type.inner_type();
                 }

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -524,7 +524,7 @@ impl MergePath {
     /// we look up:
     ///   1. `Query.user` -> return type `User`
     ///   2. `User.friends` -> return type `[User]`, inner type `User`
-    /// Returns `User`.
+    ///   3. Returns `User`.
     fn resolve_type_name<'a>(
         &'a self,
         root_type_name: &'a str,

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -1,0 +1,603 @@
+/// If a query asks for the same fields on object types,
+/// and those objects all belong to the same interface (based on the field's return type),
+/// we can replace inline fragments for each object type with a single interface fragment.
+///
+/// During normalization, under a certain condition, the requested interface fields
+/// are replaced with inline fragments for each object type that implements the interface.
+///
+/// In some cases we can fold multiple inline fragments into a single one, for a given interface.
+/// This is what this file does.
+///
+/// Example:
+///
+///   query {
+///     media {
+///       ... on Book { id title }
+///       ... on Movie { id title }
+///     }
+///   }
+///
+/// ->
+///
+///   query {
+///     media { id title }
+///   }
+///
+use std::collections::BTreeSet;
+
+use tracing::instrument;
+
+use crate::{
+    ast::{
+        merge_path::{Condition, MergePath, Segment},
+        selection_item::SelectionItem,
+        selection_set::{merge_selection_set, InlineFragmentSelection, SelectionSet},
+        semantic_eq::SemanticEq,
+    },
+    planner::fetch::{
+        error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
+        state::MultiTypeFetchStep,
+    },
+    state::{
+        subgraph_state::{SubgraphField, SubgraphState},
+        supergraph_state::{OperationKind, SupergraphDefinition, SupergraphState},
+    },
+};
+
+impl FetchGraph<MultiTypeFetchStep> {
+    #[instrument(level = "trace", skip_all)]
+    pub(crate) fn fold_concrete_selections_to_interfaces(
+        &mut self,
+        supergraph: &SupergraphState,
+    ) -> Result<bool, FetchGraphError> {
+        let root_type_name = match self.operation_kind {
+            OperationKind::Query => supergraph.query_type.as_str(),
+            OperationKind::Mutation => supergraph.mutation_type.as_deref().ok_or_else(|| {
+                FetchGraphError::Internal("Expected mutation type to exist".to_string())
+            })?,
+            OperationKind::Subscription => {
+                supergraph.subscription_type.as_deref().ok_or_else(|| {
+                    FetchGraphError::Internal("Expected subscription type to exist".to_string())
+                })?
+            }
+        };
+
+        let mut changed = false;
+        let step_indices = self.step_indices().collect::<Vec<_>>();
+
+        for index in step_indices {
+            let step = self.get_step_data_mut(index)?;
+            let Ok(subgraph) = supergraph.subgraph_state(&step.service_name) else {
+                continue;
+            };
+
+            changed |= StepConverter {
+                root_type_name,
+                supergraph,
+                subgraph: &subgraph,
+            }
+            .rewrite_step(step)?;
+        }
+
+        Ok(changed)
+    }
+}
+
+struct StepConverter<'a> {
+    root_type_name: &'a str,
+    supergraph: &'a SupergraphState,
+    subgraph: &'a SubgraphState,
+}
+
+struct InterfaceInSubgraph<'a> {
+    fields: &'a [SubgraphField],
+    members: BTreeSet<&'a str>,
+}
+
+/// Object-type branch that we might try to fold into an interface
+struct ObjectTypeBranch<'a> {
+    type_name: &'a str,
+    selection_set: &'a SelectionSet,
+    condition: Option<Condition>,
+    remove_index: Option<usize>,
+}
+
+/// The result of folding concrete object type into one interface
+struct FoldedSelection {
+    selection_set: SelectionSet,
+    condition: Option<Condition>,
+    remove_indexes: Vec<usize>,
+}
+
+impl<'a> StepConverter<'a> {
+    fn rewrite_step(
+        &self,
+        step: &mut FetchStepData<MultiTypeFetchStep>,
+    ) -> Result<bool, FetchGraphError> {
+        let mut changed = false;
+        changed |= self.rewrite_root_output(step)?;
+        changed |= self.rewrite_nested_output(step)?;
+        Ok(changed)
+    }
+
+    /// Try to turn top-level object-type selections into an interface selection.
+    ///
+    /// When `Book` and `Movie` both implement `Media`, we turn
+    ///
+    ///   `{ Book: { id } Movie: { id } }`
+    ///
+    /// into
+    ///
+    ///   `{ Media: { id } }`
+    fn rewrite_root_output(
+        &self,
+        step: &mut FetchStepData<MultiTypeFetchStep>,
+    ) -> Result<bool, FetchGraphError> {
+        // Only rewrite if the step is at the root (no response path).
+        if !step.response_path.inner.is_empty() {
+            return Ok(false);
+        }
+
+        let interface_name = step
+            .response_path
+            .resolve_type_name(self.root_type_name, self.supergraph)?;
+
+        let branches = step
+            .output
+            .iter_selections()
+            .map(|(type_name, selection_set)| ObjectTypeBranch {
+                type_name: type_name.as_str(),
+                selection_set,
+                condition: None,
+                remove_index: None,
+            })
+            .collect::<Vec<_>>();
+
+        let Some(folded) = self.try_fold_into_interface(interface_name, branches)? else {
+            return Ok(false);
+        };
+
+        step.output
+            .replace_definitions_with_abstract(interface_name, folded.selection_set);
+
+        Ok(true)
+    }
+
+    /// Before:
+    ///
+    /// `{ media { ... on Book { id } ... on Movie { id } } }`
+    ///
+    /// After:
+    ///
+    /// `{ media { id } }`
+    fn rewrite_nested_output(
+        &self,
+        step: &mut FetchStepData<MultiTypeFetchStep>,
+    ) -> Result<bool, FetchGraphError> {
+        let definition_names = step
+            .output
+            .iter_selections()
+            .map(|(definition_name, _)| definition_name.clone())
+            .collect::<Vec<_>>();
+
+        let mut changed = false;
+
+        for definition_name in definition_names {
+            let Some(selection_set) = step.output.selections_for_definition_mut(&definition_name)
+            else {
+                continue;
+            };
+
+            changed |= self.rewrite_selection_set(&definition_name, selection_set)?;
+        }
+
+        Ok(changed)
+    }
+
+    fn rewrite_selection_set(
+        &self,
+        current_type_name: &str,
+        selection_set: &mut SelectionSet,
+    ) -> Result<bool, FetchGraphError> {
+        let mut changed = false;
+
+        for item in &mut selection_set.items {
+            match item {
+                SelectionItem::Field(field) => {
+                    let child_type_name =
+                        self.field_return_type_name(current_type_name, field.name.as_str())?;
+                    changed |=
+                        self.rewrite_selection_set(child_type_name, &mut field.selections)?;
+                }
+                SelectionItem::InlineFragment(fragment) => {
+                    changed |= self.rewrite_selection_set(
+                        &fragment.type_condition,
+                        &mut fragment.selections,
+                    )?;
+                }
+                SelectionItem::FragmentSpread(_) => {
+                    // Fragment spreads should have been inlined before we get here.
+                    // If we see one, something went wrong earlier.
+                    return Err(FetchGraphError::Internal(
+                        "fragment spreads should have been inlined before abstract type conversion"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+        changed |= self.rewrite_inline_fragments(current_type_name, selection_set)?;
+
+        Ok(changed)
+    }
+
+    fn rewrite_inline_fragments(
+        &self,
+        current_type_name: &str,
+        selection_set: &mut SelectionSet,
+    ) -> Result<bool, FetchGraphError> {
+        let candidate = {
+            let branches = selection_set
+                .items
+                .iter()
+                .enumerate()
+                .filter_map(|(index, item)| match item {
+                    SelectionItem::InlineFragment(fragment) => Some(ObjectTypeBranch {
+                        type_name: fragment.type_condition.as_str(),
+                        selection_set: &fragment.selections,
+                        condition: Option::<Condition>::from(fragment),
+                        remove_index: Some(index),
+                    }),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            self.try_fold_into_interface(current_type_name, branches)?
+        };
+
+        let Some(candidate) = candidate else {
+            return Ok(false);
+        };
+
+        // Remove the branches we folded
+        selection_set.items = selection_set
+            .items
+            .drain(..)
+            .enumerate()
+            .filter_map(|(index, item)| {
+                if candidate.remove_indexes.contains(&index) {
+                    None // drop
+                } else {
+                    Some(item) // keep
+                }
+            })
+            .collect();
+
+        if let Some(condition) = candidate.condition {
+            // If the original branches had @skip/@include
+            selection_set
+                .items
+                .push(SelectionItem::InlineFragment(InlineFragmentSelection {
+                    type_condition: current_type_name.to_string(),
+                    selections: candidate.selection_set,
+                    skip_if: condition.to_skip_if(),
+                    include_if: condition.to_include_if(),
+                }));
+        } else {
+            // Otherwise merge the fields directly into the parent selection set
+            merge_selection_set(selection_set, &candidate.selection_set, false);
+        }
+
+        Ok(true)
+    }
+
+    fn try_fold_into_interface(
+        &self,
+        interface_name: &str,
+        branches: Vec<ObjectTypeBranch<'_>>,
+    ) -> Result<Option<FoldedSelection>, FetchGraphError> {
+        // Folding 1 branch is pointless
+        if branches.len() < 2 {
+            return Ok(None);
+        }
+
+        // The interface exists in this subgraph
+        let Some(interface) = self.local_interface(interface_name) else {
+            return Ok(None);
+        };
+
+        let Some(first_branch) = branches.first() else {
+            return Ok(None);
+        };
+
+        let shared_condition = first_branch.condition.clone();
+        let mut concrete_types = BTreeSet::new();
+
+        for branch in &branches {
+            // Every branch condition (@skip / @include) must be the same
+            if branch.condition != shared_condition {
+                return Ok(None);
+            }
+
+            if !self.object_type_exists_in_subgraph(branch.type_name) {
+                // The object type does not exist in this subgraph
+                return Ok(None);
+            }
+
+            if !self.selected_fields_exist_on_interface(
+                branch.type_name,
+                branch.selection_set,
+                interface.fields,
+            ) {
+                // The selected fields do not exist on the interface
+                return Ok(None);
+            }
+
+            if !self.selection_set_is_valid_for_type(interface_name, branch.selection_set)? {
+                // The selection set (fields and fragments) is not valid for the interface
+                return Ok(None);
+            }
+
+            concrete_types.insert(branch.type_name);
+        }
+
+        // The types must exactly match all interface members in this subgraph
+        if concrete_types != interface.members {
+            return Ok(None);
+        }
+
+        let selection_set = first_branch.selection_set;
+
+        if !branches
+            .iter()
+            .skip(1)
+            // All must branches ask for the same fields
+            .all(|branch| selection_set.semantic_eq(branch.selection_set))
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(FoldedSelection {
+            selection_set: selection_set.clone(),
+            condition: shared_condition,
+            remove_indexes: branches
+                .iter()
+                .filter_map(|branch| branch.remove_index)
+                .collect(),
+        }))
+    }
+
+    /// Check that every field exists on the interface.
+    /// If a field exists on the object type but not on the interface, we cannot fold.
+    fn selected_fields_exist_on_interface(
+        &self,
+        type_name: &str,
+        selection_set: &SelectionSet,
+        interface_fields: &[SubgraphField],
+    ) -> bool {
+        selection_set
+            .iter_fields_and_fragments_of_same_type(type_name)
+            .all(|field| {
+                field.name == "__typename"
+                    || interface_fields
+                        .iter()
+                        .any(|interface_field| interface_field.name == field.name)
+            })
+    }
+
+    /// Check that a selection set is valid for a given type in this subgraph.
+    fn selection_set_is_valid_for_type(
+        &self,
+        type_name: &str,
+        selection_set: &SelectionSet,
+    ) -> Result<bool, FetchGraphError> {
+        if selection_set.items.is_empty() {
+            return Ok(true);
+        }
+
+        let Some(definition) = self.subgraph.definitions.get(type_name) else {
+            return Ok(false);
+        };
+
+        for item in &selection_set.items {
+            match item {
+                SelectionItem::Field(field) => {
+                    if field.name == "__typename" {
+                        continue;
+                    }
+
+                    let Some(field_definition) = definition.field(field.name.as_str()) else {
+                        return Ok(false);
+                    };
+
+                    if !self.selection_set_is_valid_for_type(
+                        field_definition.field_type.inner_type(),
+                        &field.selections,
+                    )? {
+                        return Ok(false);
+                    }
+                }
+                SelectionItem::InlineFragment(fragment) => {
+                    if !self
+                        .fragment_type_is_valid_for_parent_type(type_name, &fragment.type_condition)
+                    {
+                        return Ok(false);
+                    }
+
+                    if !self.selection_set_is_valid_for_type(
+                        &fragment.type_condition,
+                        &fragment.selections,
+                    )? {
+                        return Ok(false);
+                    }
+                }
+                SelectionItem::FragmentSpread(_) => {
+                    return Err(FetchGraphError::Internal(
+                        "fragment spreads should have been inlined before abstract type conversion"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Check that a fragment type is valid for its parent type.
+    ///
+    /// `... on Book` is valid inside `... on Media` only if `Book` implements `Media`.
+    fn fragment_type_is_valid_for_parent_type(
+        &self,
+        parent_type_name: &str,
+        fragment_type_name: &str,
+    ) -> bool {
+        if parent_type_name == fragment_type_name {
+            return true;
+        }
+
+        self.subgraph
+            .definitions
+            .get(parent_type_name)
+            .is_some_and(|definition| definition.is_interface_type())
+            && self.object_is_interface_member_in_subgraph(fragment_type_name, parent_type_name)
+    }
+
+    /// Get information about an interface from the subgraph
+    fn local_interface(&'a self, interface_name: &'a str) -> Option<InterfaceInSubgraph<'a>> {
+        let definition = self.subgraph.definitions.get(interface_name)?;
+
+        if !definition.is_interface_type() {
+            return None;
+        }
+
+        let fields = definition.fields()?;
+        let members = self.interface_object_members_in_subgraph(interface_name)?;
+
+        if members.is_empty() {
+            return None;
+        }
+
+        Some(InterfaceInSubgraph { fields, members })
+    }
+
+    /// Get the set of object types that implement an interface in the subgraph
+    fn interface_object_members_in_subgraph(
+        &'a self,
+        interface_name: &str,
+    ) -> Option<BTreeSet<&'a str>> {
+        Some(
+            self.supergraph
+                .interface_members(interface_name)?
+                .iter()
+                .map(String::as_str)
+                .filter(|name| self.object_is_interface_member_in_subgraph(name, interface_name))
+                .collect(),
+        )
+    }
+
+    /// Check whether an object type actually implements an interface in this subgraph
+    fn object_is_interface_member_in_subgraph(
+        &self,
+        object_type_name: &str,
+        interface_name: &str,
+    ) -> bool {
+        let Some(SupergraphDefinition::Object(object_type)) =
+            self.supergraph.definitions.get(object_type_name)
+        else {
+            return false;
+        };
+
+        self.subgraph.definitions.contains_key(object_type_name)
+            && object_type.join_implements.iter().any(|join_implements| {
+                join_implements.graph_id == self.subgraph.graph_id
+                    && join_implements.interface == interface_name
+            })
+    }
+
+    fn object_type_exists_in_subgraph(&self, type_name: &str) -> bool {
+        self.subgraph
+            .definitions
+            .get(type_name)
+            .is_some_and(|definition| definition.is_object_type())
+    }
+
+    fn field_return_type_name(
+        &self,
+        parent_type_name: &str,
+        field_name: &str,
+    ) -> Result<&str, FetchGraphError> {
+        if field_name == "__typename" {
+            return Ok("String");
+        }
+
+        let definition = self
+            .supergraph
+            .definitions
+            .get(parent_type_name)
+            .ok_or_else(|| {
+                FetchGraphError::Internal(format!(
+                    "No definition found for type: {parent_type_name}"
+                ))
+            })?;
+
+        let field_definition = definition.fields().get(field_name).ok_or_else(|| {
+            FetchGraphError::Internal(format!(
+                "No field found for name '{}' in type '{}'",
+                field_name, parent_type_name
+            ))
+        })?;
+
+        Ok(field_definition.field_type.inner_type())
+    }
+}
+
+impl MergePath {
+    /// Walk through the response path segments and figure out what type we end up at.
+    ///
+    /// If the path is `["user", "friends"]` and the root is `"Query"`,
+    /// we look up:
+    ///   1. `Query.user` -> return type `User`
+    ///   2. `User.friends` -> return type `[User]`, inner type `User`
+    /// Returns `User`.
+    fn resolve_type_name<'a>(
+        &'a self,
+        root_type_name: &'a str,
+        supergraph: &'a SupergraphState,
+    ) -> Result<&'a str, FetchGraphError> {
+        let mut type_name = root_type_name;
+
+        for segment in self.inner.iter() {
+            match segment {
+                Segment::Field(field_seg, _, _) => {
+                    let definition = supergraph.definitions.get(type_name).ok_or_else(|| {
+                        FetchGraphError::Internal(format!(
+                            "Type definition for {type_name} not found"
+                        ))
+                    })?;
+                    let field = definition
+                        .fields()
+                        .get(field_seg.field_name())
+                        .ok_or_else(|| {
+                            FetchGraphError::Internal(format!(
+                                "Field {} not found in type {type_name}",
+                                field_seg.field_name()
+                            ))
+                        })?;
+
+                    type_name = field.field_type.inner_type();
+                }
+                Segment::List => {
+                    // Lists don't change the type, we stay on the same type.
+                }
+                Segment::TypeCondition(type_names, _) => {
+                    type_name = type_names.iter().next().ok_or_else(|| {
+                        FetchGraphError::Internal(
+                            "Expected at least one type in the type condition".to_string(),
+                        )
+                    })?;
+                }
+            }
+        }
+
+        Ok(type_name)
+    }
+}

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -74,7 +74,7 @@ impl FetchGraph<MultiTypeFetchStep> {
             changed |= StepConverter {
                 root_type_name,
                 supergraph,
-                subgraph: &subgraph,
+                subgraph: subgraph,
             }
             .rewrite_step(step)?;
         }
@@ -177,7 +177,7 @@ impl<'a> StepConverter<'a> {
         let mut changed = false;
 
         for (definition_name, selection_set) in step.output.iter_selections_mut() {
-            changed |= self.rewrite_selection_set(&definition_name, selection_set)?;
+            changed |= self.rewrite_selection_set(definition_name, selection_set)?;
         }
 
         Ok(changed)

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -133,11 +133,6 @@ impl<'a> StepConverter<'a> {
         &self,
         step: &mut FetchStepData<MultiTypeFetchStep>,
     ) -> Result<bool, FetchGraphError> {
-        // Only rewrite if the step is at the root (no response path).
-        if !step.response_path.inner.is_empty() {
-            return Ok(false);
-        }
-
         let interface_name = step
             .response_path
             .resolve_type_name(self.root_type_name, self.supergraph)?;

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -74,7 +74,7 @@ impl FetchGraph<MultiTypeFetchStep> {
             changed |= StepConverter {
                 root_type_name,
                 supergraph,
-                subgraph: subgraph,
+                subgraph,
             }
             .rewrite_step(step)?;
         }

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -174,20 +174,9 @@ impl<'a> StepConverter<'a> {
         &self,
         step: &mut FetchStepData<MultiTypeFetchStep>,
     ) -> Result<bool, FetchGraphError> {
-        let definition_names = step
-            .output
-            .iter_selections()
-            .map(|(definition_name, _)| definition_name.clone())
-            .collect::<Vec<_>>();
-
         let mut changed = false;
 
-        for definition_name in definition_names {
-            let Some(selection_set) = step.output.selections_for_definition_mut(&definition_name)
-            else {
-                continue;
-            };
-
+        for (definition_name, selection_set) in step.output.iter_selections_mut() {
             changed |= self.rewrite_selection_set(&definition_name, selection_set)?;
         }
 
@@ -204,8 +193,15 @@ impl<'a> StepConverter<'a> {
         for item in &mut selection_set.items {
             match item {
                 SelectionItem::Field(field) => {
-                    let child_type_name =
-                        self.field_return_type_name(current_type_name, field.name.as_str())?;
+                    let child_type_name = self
+                        .supergraph
+                        .field_return_type_name(current_type_name, field.name.as_str())
+                        .ok_or_else(|| {
+                            FetchGraphError::Internal(format!(
+                                "No field found for name '{}' in type '{}'",
+                                field.name, current_type_name
+                            ))
+                        })?;
                     changed |=
                         self.rewrite_selection_set(child_type_name, &mut field.selections)?;
                 }
@@ -323,20 +319,6 @@ impl<'a> StepConverter<'a> {
                 return Ok(None);
             }
 
-            if !self.selected_fields_exist_on_interface(
-                branch.type_name,
-                branch.selection_set,
-                interface.fields,
-            ) {
-                // The selected fields do not exist on the interface
-                return Ok(None);
-            }
-
-            if !self.selection_set_is_valid_for_type(interface_name, branch.selection_set)? {
-                // The selection set (fields and fragments) is not valid for the interface
-                return Ok(None);
-            }
-
             concrete_types.insert(branch.type_name);
         }
 
@@ -353,6 +335,20 @@ impl<'a> StepConverter<'a> {
             // All must branches ask for the same fields
             .all(|branch| selection_set.semantic_eq(branch.selection_set))
         {
+            return Ok(None);
+        }
+
+        if !self.selected_fields_exist_on_interface(
+            first_branch.type_name,
+            selection_set,
+            interface.fields,
+        ) {
+            // The selected fields do not exist on the interface
+            return Ok(None);
+        }
+
+        if !self.selection_set_is_valid_for_type(interface_name, selection_set)? {
+            // The selection set (fields and fragments) is not valid for the interface
             return Ok(None);
         }
 
@@ -519,35 +515,6 @@ impl<'a> StepConverter<'a> {
             .get(type_name)
             .is_some_and(|definition| definition.is_object_type())
     }
-
-    fn field_return_type_name(
-        &self,
-        parent_type_name: &str,
-        field_name: &str,
-    ) -> Result<&str, FetchGraphError> {
-        if field_name == "__typename" {
-            return Ok("String");
-        }
-
-        let definition = self
-            .supergraph
-            .definitions
-            .get(parent_type_name)
-            .ok_or_else(|| {
-                FetchGraphError::Internal(format!(
-                    "No definition found for type: {parent_type_name}"
-                ))
-            })?;
-
-        let field_definition = definition.fields().get(field_name).ok_or_else(|| {
-            FetchGraphError::Internal(format!(
-                "No field found for name '{}' in type '{}'",
-                field_name, parent_type_name
-            ))
-        })?;
-
-        Ok(field_definition.field_type.inner_type())
-    }
 }
 
 impl MergePath {
@@ -573,15 +540,16 @@ impl MergePath {
                             "Type definition for {type_name} not found"
                         ))
                     })?;
-                    let field = definition
-                        .fields()
-                        .get(field_seg.field_name())
-                        .ok_or_else(|| {
-                            FetchGraphError::Internal(format!(
-                                "Field {} not found in type {type_name}",
-                                field_seg.field_name()
-                            ))
-                        })?;
+                    let field =
+                        definition
+                            .fields()
+                            .get(field_seg.field_name())
+                            .ok_or_else(|| {
+                                FetchGraphError::Internal(format!(
+                                    "Field {} not found in type {type_name}",
+                                    field_seg.field_name()
+                                ))
+                            })?;
 
                     type_name = field.field_type.inner_type();
                 }

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -133,6 +133,11 @@ impl<'a> StepConverter<'a> {
         &self,
         step: &mut FetchStepData<MultiTypeFetchStep>,
     ) -> Result<bool, FetchGraphError> {
+        // Only rewrite if the step is at the root (no response path).
+        if !step.response_path.inner.is_empty() {
+            return Ok(false);
+        }
+
         let interface_name = step
             .response_path
             .resolve_type_name(self.root_type_name, self.supergraph)?;
@@ -532,19 +537,17 @@ impl MergePath {
                 Segment::Field(field_seg, _, _) => {
                     let definition = supergraph.definitions.get(type_name).ok_or_else(|| {
                         FetchGraphError::Internal(format!(
-                            "Type definition for {type_name} not found"
+                            "Type definition for {type_name} not found for given path {}",
+                            self
                         ))
                     })?;
-                    let field =
-                        definition
-                            .fields()
-                            .get(field_seg.field_name())
-                            .ok_or_else(|| {
-                                FetchGraphError::Internal(format!(
-                                    "Field {} not found in type {type_name}",
-                                    field_seg.field_name()
-                                ))
-                            })?;
+                    let field = definition.fields().get(field_seg.field_name()).ok_or_else(|| {
+                            FetchGraphError::Internal(format!(
+                                "Field {} not found in type {type_name} for given path {}",
+                                field_seg.field_name(),
+                                self
+                            ))
+                        })?;
 
                     type_name = field.field_type.inner_type();
                 }

--- a/lib/query-planner/src/planner/fetch/optimize/mod.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/mod.rs
@@ -1,10 +1,12 @@
 mod apply_internal_aliases_patching;
 mod batch_multi_type;
 mod deduplicate_and_prune_fetch_steps;
+mod fold_concrete_selections_to_interfaces;
 mod merge_children_with_parents;
 mod merge_leafs;
 mod merge_passthrough_child;
 mod merge_siblings;
+mod normalize_selection_sets;
 mod turn_mutations_into_sequence;
 mod type_mismatches;
 mod utils;
@@ -37,11 +39,17 @@ impl FetchGraph<MultiTypeFetchStep> {
             self.merge_leafs()?;
             self.deduplicate_and_prune_fetch_steps()?;
             self.batch_multi_type()?;
+            self.normalize_selection_sets(supergraph_state)?;
+            let abstract_type_converted =
+                self.fold_concrete_selections_to_interfaces(supergraph_state)?;
 
             let node_count_after = self.graph.node_count();
             let edge_count_after = self.graph.edge_count();
 
-            if node_count_before == node_count_after && edge_count_before == edge_count_after {
+            if node_count_before == node_count_after
+                && edge_count_before == edge_count_after
+                && !abstract_type_converted
+            {
                 break;
             }
         }

--- a/lib/query-planner/src/planner/fetch/optimize/normalize_selection_sets.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/normalize_selection_sets.rs
@@ -40,7 +40,7 @@ impl SelectionSetNormalizer<'_> {
         step: &mut FetchStepData<MultiTypeFetchStep>,
     ) -> Result<(), FetchGraphError> {
         for (definition_name, selection_set) in step.output.iter_selections_mut() {
-            self.normalize_selection_set(&definition_name, selection_set)?;
+            self.normalize_selection_set(definition_name, selection_set)?;
         }
 
         Ok(())

--- a/lib/query-planner/src/planner/fetch/optimize/normalize_selection_sets.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/normalize_selection_sets.rs
@@ -1,0 +1,131 @@
+use tracing::instrument;
+
+use crate::{
+    ast::{
+        selection_item::SelectionItem,
+        selection_set::{FieldSelection, SelectionSet},
+    },
+    planner::fetch::{
+        error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
+        state::MultiTypeFetchStep,
+    },
+    state::supergraph_state::SupergraphState,
+};
+
+impl FetchGraph<MultiTypeFetchStep> {
+    #[instrument(level = "trace", skip_all)]
+    pub(crate) fn normalize_selection_sets(
+        &mut self,
+        supergraph: &SupergraphState,
+    ) -> Result<(), FetchGraphError> {
+        let step_indices = self.step_indices().collect::<Vec<_>>();
+
+        for index in step_indices {
+            let step = self.get_step_data_mut(index)?;
+            let normalizer = SelectionSetNormalizer { supergraph };
+            normalizer.normalize_step(step)?;
+        }
+
+        Ok(())
+    }
+}
+
+struct SelectionSetNormalizer<'a> {
+    supergraph: &'a SupergraphState,
+}
+
+impl SelectionSetNormalizer<'_> {
+    fn normalize_step(
+        &self,
+        step: &mut FetchStepData<MultiTypeFetchStep>,
+    ) -> Result<(), FetchGraphError> {
+        let definition_names = step
+            .output
+            .iter_selections()
+            .map(|(definition_name, _)| definition_name.clone())
+            .collect::<Vec<_>>();
+
+        for definition_name in definition_names {
+            let Some(selection_set) = step.output.selections_for_definition_mut(&definition_name)
+            else {
+                continue;
+            };
+
+            self.normalize_selection_set(&definition_name, selection_set)?;
+        }
+
+        Ok(())
+    }
+
+    fn normalize_selection_set(
+        &self,
+        current_type_name: &str,
+        selection_set: &mut SelectionSet,
+    ) -> Result<(), FetchGraphError> {
+        let mut normalized_items = Vec::with_capacity(selection_set.items.len());
+
+        for item in std::mem::take(&mut selection_set.items) {
+            match item {
+                SelectionItem::Field(mut field) => {
+                    let child_type_name = self.field_return_type_name(current_type_name, &field)?;
+                    self.normalize_selection_set(child_type_name, &mut field.selections)?;
+                    normalized_items.push(SelectionItem::Field(field));
+                }
+                SelectionItem::InlineFragment(mut fragment) => {
+                    self.normalize_selection_set(
+                        &fragment.type_condition,
+                        &mut fragment.selections,
+                    )?;
+
+                    if fragment.type_condition == current_type_name
+                        && fragment.skip_if.is_none()
+                        && fragment.include_if.is_none()
+                    {
+                        normalized_items.extend(fragment.selections.items);
+                    } else {
+                        normalized_items.push(SelectionItem::InlineFragment(fragment));
+                    }
+                }
+                SelectionItem::FragmentSpread(_) => {
+                    return Err(FetchGraphError::Internal(
+                        "fragment spreads should have been inlined before selection-set normalization"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
+        selection_set.items = normalized_items;
+
+        Ok(())
+    }
+
+    fn field_return_type_name(
+        &self,
+        parent_type_name: &str,
+        field: &FieldSelection,
+    ) -> Result<&str, FetchGraphError> {
+        if field.name == "__typename" {
+            return Ok("String");
+        }
+
+        let definition = self
+            .supergraph
+            .definitions
+            .get(parent_type_name)
+            .ok_or_else(|| {
+                FetchGraphError::Internal(format!(
+                    "No definition found for type: {parent_type_name}"
+                ))
+            })?;
+
+        let field_definition = definition.fields().get(&field.name).ok_or_else(|| {
+            FetchGraphError::Internal(format!(
+                "No field found for name '{}' in type '{}'",
+                field.name, parent_type_name
+            ))
+        })?;
+
+        Ok(field_definition.field_type.inner_type())
+    }
+}

--- a/lib/query-planner/src/planner/fetch/optimize/normalize_selection_sets.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/normalize_selection_sets.rs
@@ -3,7 +3,7 @@ use tracing::instrument;
 use crate::{
     ast::{
         selection_item::SelectionItem,
-        selection_set::{FieldSelection, SelectionSet},
+        selection_set::{merge_selection_set, SelectionSet},
     },
     planner::fetch::{
         error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
@@ -39,18 +39,7 @@ impl SelectionSetNormalizer<'_> {
         &self,
         step: &mut FetchStepData<MultiTypeFetchStep>,
     ) -> Result<(), FetchGraphError> {
-        let definition_names = step
-            .output
-            .iter_selections()
-            .map(|(definition_name, _)| definition_name.clone())
-            .collect::<Vec<_>>();
-
-        for definition_name in definition_names {
-            let Some(selection_set) = step.output.selections_for_definition_mut(&definition_name)
-            else {
-                continue;
-            };
-
+        for (definition_name, selection_set) in step.output.iter_selections_mut() {
             self.normalize_selection_set(&definition_name, selection_set)?;
         }
 
@@ -67,7 +56,15 @@ impl SelectionSetNormalizer<'_> {
         for item in std::mem::take(&mut selection_set.items) {
             match item {
                 SelectionItem::Field(mut field) => {
-                    let child_type_name = self.field_return_type_name(current_type_name, &field)?;
+                    let child_type_name = self
+                        .supergraph
+                        .field_return_type_name(current_type_name, field.name.as_str())
+                        .ok_or_else(|| {
+                            FetchGraphError::Internal(format!(
+                                "No field found for name '{}' in type '{}'",
+                                field.name, current_type_name
+                            ))
+                        })?;
                     self.normalize_selection_set(child_type_name, &mut field.selections)?;
                     normalized_items.push(SelectionItem::Field(field));
                 }
@@ -81,7 +78,12 @@ impl SelectionSetNormalizer<'_> {
                         && fragment.skip_if.is_none()
                         && fragment.include_if.is_none()
                     {
-                        normalized_items.extend(fragment.selections.items);
+                        // normalized_items.extend(fragment.selections.items);
+                        let mut merged = SelectionSet {
+                            items: std::mem::take(&mut normalized_items),
+                        };
+                        merge_selection_set(&mut merged, &fragment.selections, false);
+                        normalized_items = merged.items;
                     } else {
                         normalized_items.push(SelectionItem::InlineFragment(fragment));
                     }
@@ -99,33 +101,45 @@ impl SelectionSetNormalizer<'_> {
 
         Ok(())
     }
+}
 
-    fn field_return_type_name(
-        &self,
-        parent_type_name: &str,
-        field: &FieldSelection,
-    ) -> Result<&str, FetchGraphError> {
-        if field.name == "__typename" {
-            return Ok("String");
-        }
+#[cfg(test)]
+mod tests {
+    use graphql_tools::parser::query::{Definition, OperationDefinition};
 
-        let definition = self
-            .supergraph
-            .definitions
-            .get(parent_type_name)
-            .ok_or_else(|| {
-                FetchGraphError::Internal(format!(
-                    "No definition found for type: {parent_type_name}"
-                ))
-            })?;
+    use crate::{
+        state::supergraph_state::SupergraphState,
+        utils::parsing::{parse_operation, parse_schema},
+    };
 
-        let field_definition = definition.fields().get(&field.name).ok_or_else(|| {
-            FetchGraphError::Internal(format!(
-                "No field found for name '{}' in type '{}'",
-                field.name, parent_type_name
-            ))
-        })?;
+    use super::SelectionSetNormalizer;
 
-        Ok(field_definition.field_type.inner_type())
+    #[test]
+    fn ensure_deduplication() {
+        let schema = parse_schema(
+            r#"
+            directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT
+            scalar join__FieldSet
+            enum join__Graph { A @join__graph(name: "a", url: "") }
+            type Query @join__type(graph: A) { user: User }
+            type User @join__type(graph: A) { id: ID! name: String! }
+          "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+        let normalizer = SelectionSetNormalizer {
+            supergraph: &supergraph,
+        };
+
+        let op = parse_operation("{ id ... on User { id } }");
+        let mut selection_set = match op.definitions.first() {
+            Some(Definition::Operation(OperationDefinition::SelectionSet(s))) => s.clone().into(),
+            _ => panic!("expected top-level selection set"),
+        };
+
+        normalizer
+            .normalize_selection_set("User", &mut selection_set)
+            .unwrap();
+
+        insta::assert_snapshot!(&selection_set.to_string(), @"{id}");
     }
 }

--- a/lib/query-planner/src/planner/fetch/optimize/type_mismatches.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/type_mismatches.rs
@@ -56,7 +56,7 @@ impl FetchGraph<MultiTypeFetchStep> {
             for (root_def_name, mismatch_path) in mismatches_paths {
                 let mut merger = SafeSelectionSetMerger::default();
 
-                if let Some(Segment::Field(field_lookup, args_hash_lookup, condition)) =
+                if let Some(Segment::Field(field_seg, args_hash_lookup, condition)) =
                     mismatch_path.last()
                 {
                     // TODO: We can avoid this cut and slice thing, if we return "SelectionItem" instead of "SelectionSet" inside "find_selection_set_by_path_mut".
@@ -73,7 +73,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                         let item = selection_set
                           .items
                           .iter_mut()
-                          .find(|v| matches!(v, SelectionItem::Field(field) if field.selection_identifier() == *field_lookup && field.arguments_hash() == *args_hash_lookup && field_condition_equal(condition, field)));
+                          .find(|v| matches!(v, SelectionItem::Field(field) if field.selection_identifier() == field_seg.response_key() && field.arguments_hash() == *args_hash_lookup && field_condition_equal(condition, field)));
 
                         if let Some(SelectionItem::Field(field_to_alias)) = item {
                             let original_response_key =

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -308,6 +308,12 @@ impl<State> FetchStepSelections<State> {
         usages
     }
 
+    pub fn iter_selections_mut(&mut self) -> impl Iterator<Item = (&str, &mut SelectionSet)> {
+        self.selections
+            .iter_mut()
+            .map(|(name, selection_set)| (name.as_str(), selection_set))
+    }
+
     pub fn selections_for_definition_mut(
         &mut self,
         definition_name: &str,

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -434,6 +434,16 @@ impl FetchStepSelections<MultiTypeFetchStep> {
         self.selections.entry(def_name.to_string()).or_default();
     }
 
+    pub fn replace_definitions_with_abstract(
+        &mut self,
+        abstract_type: &str,
+        selection_set: SelectionSet,
+    ) {
+        self.selections.clear();
+        self.selections
+            .insert(abstract_type.to_string(), selection_set);
+    }
+
     pub fn migrate_from_another(
         &mut self,
         other: &Self,

--- a/lib/query-planner/src/planner/mod.rs
+++ b/lib/query-planner/src/planner/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         best::find_best_combination,
         fetch::{fetch_graph::FetchGraph, state::MultiTypeFetchStep},
     },
-    state::supergraph_state::SupergraphState,
+    state::supergraph_state::{OperationKind, SupergraphState},
     utils::cancellation::{CancellationError, CancellationToken},
 };
 
@@ -93,6 +93,10 @@ impl Planner {
             &self.supergraph,
             &override_context,
             query_tree,
+            normalized_operation
+                .operation_kind
+                .clone()
+                .unwrap_or(OperationKind::Query),
             cancellation_token,
         )?;
         add_variables_to_fetch_steps(&mut fetch_graph, &normalized_operation.variable_definitions)?;

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -443,9 +443,9 @@ impl From<&MergePath> for Vec<FetchNodePathSegment> {
                 Segment::TypeCondition(type_names, _) => {
                     Some(FetchNodePathSegment::TypenameEquals(type_names.clone()))
                 }
-                Segment::Field(field_seg, _args_hash, _) => {
-                    Some(FetchNodePathSegment::Key(field_seg.response_key().to_string()))
-                }
+                Segment::Field(field_seg, _args_hash, _) => Some(FetchNodePathSegment::Key(
+                    field_seg.response_key().to_string(),
+                )),
                 Segment::List => None,
             })
             .collect()

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -443,8 +443,8 @@ impl From<&MergePath> for Vec<FetchNodePathSegment> {
                 Segment::TypeCondition(type_names, _) => {
                     Some(FetchNodePathSegment::TypenameEquals(type_names.clone()))
                 }
-                Segment::Field(field_name, _args_hash, _) => {
-                    Some(FetchNodePathSegment::Key(field_name.clone()))
+                Segment::Field(field_seg, _args_hash, _) => {
+                    Some(FetchNodePathSegment::Key(field_seg.response_key().to_string()))
                 }
                 Segment::List => None,
             })
@@ -514,8 +514,8 @@ impl From<&MergePath> for FlattenNodePath {
                     Segment::TypeCondition(type_names, _) => {
                         FlattenNodePathSegment::TypeCondition(type_names.clone())
                     }
-                    Segment::Field(field_name, _args_hash, _) => {
-                        FlattenNodePathSegment::Field(field_name.clone())
+                    Segment::Field(field_seg, _args_hash, _) => {
+                        FlattenNodePathSegment::Field(field_seg.response_key().to_string())
                     }
                     Segment::List => FlattenNodePathSegment::List,
                 })

--- a/lib/query-planner/src/planner/query_plan/optimize.rs
+++ b/lib/query-planner/src/planner/query_plan/optimize.rs
@@ -881,7 +881,7 @@ mod tests {
     use crate::{
         ast::{
             document::Document,
-            merge_path::{MergePath, Segment},
+            merge_path::{FieldPathSegment, MergePath, Segment},
             operation::SubgraphFetchOperation,
         },
         planner::plan_nodes::{
@@ -2285,7 +2285,11 @@ mod tests {
         };
 
         let path = FlattenNodePath::from(&MergePath::new(vec![
-            Segment::Field(root_path_field.to_string(), 0, None),
+            Segment::Field(
+                FieldPathSegment::named(root_path_field.to_string()),
+                0,
+                None,
+            ),
             Segment::List,
         ]));
 

--- a/lib/query-planner/src/state/subgraph_state.rs
+++ b/lib/query-planner/src/state/subgraph_state.rs
@@ -224,6 +224,18 @@ impl SubgraphDefinition {
             _ => None,
         }
     }
+
+    pub fn is_object_type(&self) -> bool {
+        matches!(self, SubgraphDefinition::Object(_))
+    }
+
+    pub fn is_interface_type(&self) -> bool {
+        matches!(self, SubgraphDefinition::Interface(_))
+    }
+
+    pub fn field(&self, field_name: &str) -> Option<&SubgraphField> {
+        self.fields()?.iter().find(|field| field.name == field_name)
+    }
 }
 
 #[derive(Debug)]

--- a/lib/query-planner/src/state/supergraph_state.rs
+++ b/lib/query-planner/src/state/supergraph_state.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt::{Debug, Display},
 };
 
@@ -53,6 +53,7 @@ pub struct ProgressiveOverrides {
 }
 
 type InterfaceObjectToSubgraphsMap = HashMap<String, HashSet<String>>;
+type InterfaceToObjectTypesMap = HashMap<String, BTreeSet<String>>;
 type DefinitionMap = HashMap<String, SupergraphDefinition>;
 
 /// Information about linked specifications used in the supergraph
@@ -159,6 +160,8 @@ pub struct SupergraphState {
     /// Holds a map of interface names to a set of subgraph ids
     /// that hold the @interfaceObject
     pub interface_object_types_in_subgraphs: InterfaceObjectToSubgraphsMap,
+    /// Holds a map of interface names to all object types implementing them.
+    pub interface_to_object_types: InterfaceToObjectTypesMap,
     /// A pre-computed set of all progressive override labels in the supergraph
     pub progressive_overrides: ProgressiveOverrides,
 }
@@ -172,11 +175,13 @@ impl SupergraphState {
         let definitions = Self::build_map(schema, linked_specs);
         let interface_object_types_in_subgraphs =
             Self::create_interface_object_in_subgraph(&definitions);
+        let interface_to_object_types = Self::create_interface_to_object_types(&definitions);
         let progressive_overrides = Self::extract_progressive_overrides(&definitions);
 
         let mut instance = Self {
             definitions,
             interface_object_types_in_subgraphs,
+            interface_to_object_types,
             progressive_overrides,
             known_subgraphs,
             subgraph_endpoint_map,
@@ -234,6 +239,10 @@ impl SupergraphState {
             .is_some_and(|subgraph_ids| subgraph_ids.contains(graph_id))
     }
 
+    pub fn interface_members(&self, interface_name: &str) -> Option<&BTreeSet<String>> {
+        self.interface_to_object_types.get(interface_name)
+    }
+
     fn create_interface_object_in_subgraph(
         definitions: &DefinitionMap,
     ) -> InterfaceObjectToSubgraphsMap {
@@ -258,6 +267,25 @@ impl SupergraphState {
         }
 
         interface_object_types_in_subgraphs
+    }
+
+    fn create_interface_to_object_types(definitions: &DefinitionMap) -> InterfaceToObjectTypesMap {
+        let mut interface_to_object_types = InterfaceToObjectTypesMap::new();
+
+        for definition in definitions.values() {
+            let SupergraphDefinition::Object(object_type) = definition else {
+                continue;
+            };
+
+            for join_implements in &object_type.join_implements {
+                interface_to_object_types
+                    .entry(join_implements.interface.clone())
+                    .or_default()
+                    .insert(object_type.name.clone());
+            }
+        }
+
+        interface_to_object_types
     }
 
     fn extract_progressive_overrides(definitions: &DefinitionMap) -> ProgressiveOverrides {

--- a/lib/query-planner/src/state/supergraph_state.rs
+++ b/lib/query-planner/src/state/supergraph_state.rs
@@ -243,6 +243,16 @@ impl SupergraphState {
         self.interface_to_object_types.get(interface_name)
     }
 
+    pub fn field_return_type_name(&self, type_name: &str, field_name: &str) -> Option<&str> {
+        if field_name == "__typename" {
+            return Some("String");
+        }
+
+        let definition = self.definitions.get(type_name)?;
+        let field_definition = definition.fields().get(field_name)?;
+        Some(field_definition.field_type.inner_type())
+    }
+
     fn create_interface_object_in_subgraph(
         definitions: &DefinitionMap,
     ) -> InterfaceObjectToSubgraphsMap {

--- a/lib/query-planner/src/tests/include_skip.rs
+++ b/lib/query-planner/src/tests/include_skip.rs
@@ -1465,7 +1465,10 @@ fn qp_abstract_interface_mixed_conditions_stay_scoped() -> Result<(), Box<dyn Er
                   }
                 } =>
                 {
-                  ... on Product {
+                  ... on Book {
+                    reviewsCount
+                  }
+                  ... on Magazine {
                     reviewsCount
                   }
                 }
@@ -1558,7 +1561,11 @@ fn qp_abstract_interface_shared_condition_can_skip_remote_fetch() -> Result<(), 
                 }
               } =>
               {
-                ... on Product {
+                ... on Book {
+                  reviewsCount
+                  reviewsScore
+                }
+                ... on Magazine {
                   reviewsCount
                   reviewsScore
                 }

--- a/lib/query-planner/src/tests/include_skip.rs
+++ b/lib/query-planner/src/tests/include_skip.rs
@@ -1446,16 +1446,7 @@ fn qp_abstract_interface_mixed_conditions_stay_scoped() -> Result<(), Box<dyn Er
             products {
               id
               __typename
-              ... on Book {
-                __typename
-                sku @skip(if: $hideSku)
-                id
-              }
-              ... on Magazine {
-                __typename
-                sku @skip(if: $hideSku)
-                id
-              }
+              sku @skip(if: $hideSku)
             }
           }
         },
@@ -1475,14 +1466,10 @@ fn qp_abstract_interface_mixed_conditions_stay_scoped() -> Result<(), Box<dyn Er
                 } =>
                 {
                   ... on Book {
-                    ... on Book {
-                      reviewsCount
-                    }
+                    reviewsCount
                   }
                   ... on Magazine {
-                    ... on Magazine {
-                      reviewsCount
-                    }
+                    reviewsCount
                   }
                 }
               },
@@ -1557,14 +1544,6 @@ fn qp_abstract_interface_shared_condition_can_skip_remote_fetch() -> Result<(), 
             products {
               id
               __typename
-              ... on Book {
-                __typename
-                id
-              }
-              ... on Magazine {
-                __typename
-                id
-              }
             }
           }
         },
@@ -1583,16 +1562,12 @@ fn qp_abstract_interface_shared_condition_can_skip_remote_fetch() -> Result<(), 
               } =>
               {
                 ... on Book {
-                  ... on Book {
-                    reviewsCount
-                    reviewsScore
-                  }
+                  reviewsCount
+                  reviewsScore
                 }
                 ... on Magazine {
-                  ... on Magazine {
-                    reviewsCount
-                    reviewsScore
-                  }
+                  reviewsCount
+                  reviewsScore
                 }
               }
             },

--- a/lib/query-planner/src/tests/include_skip.rs
+++ b/lib/query-planner/src/tests/include_skip.rs
@@ -1465,10 +1465,7 @@ fn qp_abstract_interface_mixed_conditions_stay_scoped() -> Result<(), Box<dyn Er
                   }
                 } =>
                 {
-                  ... on Book {
-                    reviewsCount
-                  }
-                  ... on Magazine {
+                  ... on Product {
                     reviewsCount
                   }
                 }
@@ -1561,11 +1558,7 @@ fn qp_abstract_interface_shared_condition_can_skip_remote_fetch() -> Result<(), 
                 }
               } =>
               {
-                ... on Book {
-                  reviewsCount
-                  reviewsScore
-                }
-                ... on Magazine {
+                ... on Product {
                   reviewsCount
                   reviewsScore
                 }

--- a/lib/query-planner/src/tests/interface.rs
+++ b/lib/query-planner/src/tests/interface.rs
@@ -539,11 +539,19 @@ fn type_expand_interface_field() -> Result<(), Box<dyn Error>> {
               }
             } =>
             {
-              ... on Product {
+              ... on Book {
                 reviews {
-                  id
+                  ...a
                 }
               }
+              ... on Magazine {
+                reviews {
+                  ...a
+                }
+              }
+            }
+            fragment a on Review {
+              id
             }
           },
         },
@@ -633,12 +641,22 @@ fn requires_on_field_with_args_test() -> Result<(), Box<dyn Error>> {
           }
           {
             _e0: _entities(representations: $__batch_reps_0) {
-              ... on Product {
+              ... on Book {
                 delivery(zip: "1234") {
-                  fastestDelivery
-                  estimatedDelivery
+                  ...a
                 }
               }
+              ... on Magazine {
+                delivery(zip: "1234") {
+                  ...a
+                }
+              }
+            }
+          }
+          fragment a on DeliveryEstimates {
+            ... on DeliveryEstimates {
+              fastestDelivery
+              estimatedDelivery
             }
           }
         },
@@ -699,13 +717,21 @@ fn nested_interface_field_with_inline_fragments() -> Result<(), Box<dyn Error>> 
               }
             } =>
             {
-              ... on Product {
+              ... on Book {
                 reviews {
-                  product {
-                    id
-                    __typename
-                  }
+                  ...a
                 }
+              }
+              ... on Magazine {
+                reviews {
+                  ...a
+                }
+              }
+            }
+            fragment a on Review {
+              product {
+                id
+                __typename
               }
             }
           },
@@ -804,13 +830,21 @@ fn nested_interface_field_with_redundant_inline_fragments() -> Result<(), Box<dy
               }
             } =>
             {
-              ... on Product {
+              ... on Book {
                 reviews {
-                  product {
-                    id
-                    __typename
-                  }
+                  ...a
                 }
+              }
+              ... on Magazine {
+                reviews {
+                  ...a
+                }
+              }
+            }
+            fragment a on Review {
+              product {
+                id
+                __typename
               }
             }
           },

--- a/lib/query-planner/src/tests/interface.rs
+++ b/lib/query-planner/src/tests/interface.rs
@@ -539,19 +539,11 @@ fn type_expand_interface_field() -> Result<(), Box<dyn Error>> {
               }
             } =>
             {
-              ... on Book {
+              ... on Product {
                 reviews {
-                  ...a
+                  id
                 }
               }
-              ... on Magazine {
-                reviews {
-                  ...a
-                }
-              }
-            }
-            fragment a on Review {
-              id
             }
           },
         },
@@ -641,22 +633,12 @@ fn requires_on_field_with_args_test() -> Result<(), Box<dyn Error>> {
           }
           {
             _e0: _entities(representations: $__batch_reps_0) {
-              ... on Book {
+              ... on Product {
                 delivery(zip: "1234") {
-                  ...a
+                  fastestDelivery
+                  estimatedDelivery
                 }
               }
-              ... on Magazine {
-                delivery(zip: "1234") {
-                  ...a
-                }
-              }
-            }
-          }
-          fragment a on DeliveryEstimates {
-            ... on DeliveryEstimates {
-              fastestDelivery
-              estimatedDelivery
             }
           }
         },
@@ -717,21 +699,13 @@ fn nested_interface_field_with_inline_fragments() -> Result<(), Box<dyn Error>> 
               }
             } =>
             {
-              ... on Book {
+              ... on Product {
                 reviews {
-                  ...a
+                  product {
+                    id
+                    __typename
+                  }
                 }
-              }
-              ... on Magazine {
-                reviews {
-                  ...a
-                }
-              }
-            }
-            fragment a on Review {
-              product {
-                id
-                __typename
               }
             }
           },
@@ -830,21 +804,13 @@ fn nested_interface_field_with_redundant_inline_fragments() -> Result<(), Box<dy
               }
             } =>
             {
-              ... on Book {
+              ... on Product {
                 reviews {
-                  ...a
+                  product {
+                    id
+                    __typename
+                  }
                 }
-              }
-              ... on Magazine {
-                reviews {
-                  ...a
-                }
-              }
-            }
-            fragment a on Review {
-              product {
-                id
-                __typename
               }
             }
           },

--- a/lib/query-planner/src/tests/interface.rs
+++ b/lib/query-planner/src/tests/interface.rs
@@ -523,14 +523,6 @@ fn type_expand_interface_field() -> Result<(), Box<dyn Error>> {
             products {
               id
               __typename
-              ... on Book {
-                __typename
-                id
-              }
-              ... on Magazine {
-                __typename
-                id
-              }
             }
           }
         },
@@ -613,26 +605,11 @@ fn requires_on_field_with_args_test() -> Result<(), Box<dyn Error>> {
           fragment a on Product {
             id
             __typename
-            ... on Book {
-              __typename
-              sku
-              id
-              dimensions {
-                ...b
-              }
+            sku
+            dimensions {
+              weight
+              size
             }
-            ... on Magazine {
-              __typename
-              sku
-              id
-              dimensions {
-                ...b
-              }
-            }
-          }
-          fragment b on ProductDimension {
-            weight
-            size
           }
         },
         BatchFetch(service: "inventory") {
@@ -724,14 +701,6 @@ fn nested_interface_field_with_inline_fragments() -> Result<(), Box<dyn Error>> 
             products {
               id
               __typename
-              ... on Book {
-                __typename
-                id
-              }
-              ... on Magazine {
-                __typename
-                id
-              }
             }
           }
         },
@@ -763,14 +732,6 @@ fn nested_interface_field_with_inline_fragments() -> Result<(), Box<dyn Error>> 
               product {
                 id
                 __typename
-                ... on Book {
-                  __typename
-                  id
-                }
-                ... on Magazine {
-                  __typename
-                  id
-                }
               }
             }
           },
@@ -853,14 +814,6 @@ fn nested_interface_field_with_redundant_inline_fragments() -> Result<(), Box<dy
             products {
               id
               __typename
-              ... on Book {
-                __typename
-                id
-              }
-              ... on Magazine {
-                __typename
-                id
-              }
             }
           }
         },
@@ -892,14 +845,6 @@ fn nested_interface_field_with_redundant_inline_fragments() -> Result<(), Box<dy
               product {
                 id
                 __typename
-                ... on Book {
-                  __typename
-                  id
-                }
-                ... on Magazine {
-                  __typename
-                  id
-                }
               }
             }
           },

--- a/lib/query-planner/src/tests/provides.rs
+++ b/lib/query-planner/src/tests/provides.rs
@@ -348,14 +348,8 @@ fn provides_on_interface_1_test() -> Result<(), Box<dyn Error>> {
             ... on Book {
               animals {
                 __typename
-                ... on Cat {
-                  id
-                  name
-                }
-                ... on Dog {
-                  id
-                  name
-                }
+                id
+                name
               }
             }
             id

--- a/lib/query-planner/src/tests/testkit.rs
+++ b/lib/query-planner/src/tests/testkit.rs
@@ -17,7 +17,7 @@ use crate::planner::fetch::fetch_graph::build_fetch_graph_from_query_tree;
 use crate::planner::plan_nodes::QueryPlan;
 use crate::planner::query_plan::build_query_plan_from_fetch_graph;
 use crate::planner::walker::walk_operation;
-use crate::state::supergraph_state::SupergraphState;
+use crate::state::supergraph_state::{OperationKind, SupergraphState};
 use crate::utils::cancellation::CancellationToken;
 use crate::utils::parsing::parse_schema;
 
@@ -78,6 +78,10 @@ pub fn build_query_plan_with_context(
         &supergraph_state,
         &override_context,
         query_tree,
+        operation
+            .operation_kind
+            .clone()
+            .unwrap_or(OperationKind::Query),
         &cancellation_token,
     )?;
     add_variables_to_fetch_steps(&mut fetch_graph, &operation.variable_definitions)?;


### PR DESCRIPTION
Closes https://github.com/graphql-hive/router/pull/970 
Ref [ROUTER-327](https://linear.app/the-guild/issue/ROUTER-327)

When a `Fetch` node asks for the same fields on different object types, and all
of those types implement the same interface that matches the field's return type,
the query planner now merges them into a single inline fragment on the interface
instead of keeping separate branches.

For example: `query { media { ... on Book { id title } ... on Movie { id title } } }` becomes
`query { media { id title } }` when the field's return type is `Media` and both
`Book` and `Movie` implement it in the subgraph.

---

I introduced `FieldPathSegment` in `merge_path.rs` that holds both the field name and the optional alias. The field name information in the `MergePath` is needed to resolve a field's return type in the queries (fetch steps output).

New method on `MergePath::resolve_type_name()` - walks the segments to resolve the return type of a field at a given path.

New `SemanticEq` trait - it's for structural comparison. Compares everything but in order-independent way, so the order of fields and fragments does not matter for equality. Used by new fold optimization to verify branches are equivalent before merging.

The `normalize_selection_sets` optimization is basically to drop nesting like `... on Book { ... on Book { id } }` -> `{ id }` or `... on Book { id }`.

The `fold_concrete_selections_to_interfaces` optimization is the core of this PR.