### PR TITLE
fix(query-planner): `partial-union` test suite 

### DIFF
--- a/.changeset/partial_unions.md
+++ b/.changeset/partial_unions.md
@@ -7,6 +7,6 @@ node-addon: patch
 
 # Improve handling of unions
 
-The query planner improves handling of union types whose members vary between subgraphs. Previously, the planner always computed an intersection of union members, ignoreing subgraph-specific members.
+The query planner improves handling of union types whose members vary between subgraphs. Previously, the planner always computed an intersection of union members, ignoring subgraph-specific members.
 
 Fixes [#1098](https://github.com/graphql-hive/router/issues/1098)

--- a/.changeset/partial_unions.md
+++ b/.changeset/partial_unions.md
@@ -1,0 +1,12 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Improve handling of unions
+
+The query planner improves handling of union types whose members vary between subgraphs. Previously, the planner always computed an intersection of union members, ignoreing subgraph-specific members.
+
+Fixes [#1098](https://github.com/graphql-hive/router/issues/1098)

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -16,7 +16,6 @@ use hive_router_query_planner::planner::plan_nodes::QueryPlan;
 use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_graph;
 use hive_router_query_planner::planner::tree::query_tree::QueryTree;
 use hive_router_query_planner::planner::walker::walk_operation;
-use hive_router_query_planner::planner::walker::ResolvedOperation;
 use hive_router_query_planner::planner::QueryPlannerOptions;
 use hive_router_query_planner::state::supergraph_state::OperationKind;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
@@ -61,8 +60,17 @@ fn main() {
             println!("{}", graph);
         }
         "paths" => {
-            let (graph, best_paths_per_leaf, _operation, _supergraph_state) =
-                process_paths(&args[2], &args[3]);
+            let (graph, operation, supergraph_state) = load_graph_operation(&args[2], &args[3]);
+            let override_context = PlannerOverrideContext::default();
+            let cancellation_token = CancellationToken::new();
+            let best_paths_per_leaf = walk_operation(
+                &graph,
+                &supergraph_state,
+                &override_context,
+                &operation,
+                &cancellation_token,
+            )
+            .unwrap();
 
             for (index, best_path) in best_paths_per_leaf
                 .root_field_groups
@@ -163,12 +171,7 @@ fn process_fetch_graph(
 }
 
 fn process_plan(supergraph_path: &str, operation_path: &str) -> QueryPlan {
-    let supergraph_sdl =
-        std::fs::read_to_string(supergraph_path).expect("Unable to read input file");
-    let parsed_schema = parse_schema(&supergraph_sdl);
-    let supergraph = SupergraphState::new(&parsed_schema);
-    let graph = Graph::graph_from_supergraph_state(&supergraph).expect("failed to create graph");
-    let operation = get_operation(operation_path, &supergraph);
+    let (graph, operation, supergraph) = load_graph_operation(supergraph_path, operation_path);
     let override_context = PlannerOverrideContext::default();
     let cancellation_token = CancellationToken::new();
 
@@ -204,9 +207,17 @@ fn process_merged_tree(
     supergraph_path: &str,
     operation_path: &str,
 ) -> (Graph, QueryTree, SupergraphState, OperationKind) {
-    let (graph, best_paths_per_leaf, operation, supergraph_state) =
-        process_paths(supergraph_path, operation_path);
+    let (graph, operation, supergraph_state) = load_graph_operation(supergraph_path, operation_path);
+    let override_context = PlannerOverrideContext::default();
     let cancellation_token = CancellationToken::new();
+    let best_paths_per_leaf = walk_operation(
+        &graph,
+        &supergraph_state,
+        &override_context,
+        &operation,
+        &cancellation_token,
+    )
+    .unwrap();
     let query_tree =
         find_best_combination(&graph, best_paths_per_leaf, &cancellation_token).unwrap();
 
@@ -230,31 +241,16 @@ fn get_operation(operation_path: &str, supergraph: &SupergraphState) -> Operatio
     operation.clone()
 }
 
-fn process_paths(
+fn load_graph_operation(
     supergraph_path: &str,
     operation_path: &str,
-) -> (
-    Graph,
-    ResolvedOperation,
-    OperationDefinition,
-    SupergraphState,
-) {
+) -> (Graph, OperationDefinition, SupergraphState) {
     let supergraph_sdl =
         std::fs::read_to_string(supergraph_path).expect("Unable to read input file");
     let parsed_schema = parse_schema(&supergraph_sdl);
     let supergraph = SupergraphState::new(&parsed_schema);
     let graph = Graph::graph_from_supergraph_state(&supergraph).expect("failed to create graph");
     let operation = get_operation(operation_path, &supergraph);
-    let override_context = PlannerOverrideContext::default();
-    let cancellation_token = CancellationToken::new();
-    let best_paths_per_leaf = walk_operation(
-        &graph,
-        &supergraph,
-        &override_context,
-        &operation,
-        &cancellation_token,
-    )
-    .unwrap();
 
-    (graph, best_paths_per_leaf, operation, supergraph)
+    (graph, operation, supergraph)
 }

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -207,7 +207,8 @@ fn process_merged_tree(
     supergraph_path: &str,
     operation_path: &str,
 ) -> (Graph, QueryTree, SupergraphState, OperationKind) {
-    let (graph, operation, supergraph_state) = load_graph_operation(supergraph_path, operation_path);
+    let (graph, operation, supergraph_state) =
+        load_graph_operation(supergraph_path, operation_path);
     let override_context = PlannerOverrideContext::default();
     let cancellation_token = CancellationToken::new();
     let best_paths_per_leaf = walk_operation(

--- a/lib/query-planner/fixture/tests/partial-union-complex.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/partial-union-complex.supergraph.graphql
@@ -1,0 +1,94 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+union Action
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__unionMember(graph: A, member: "Common")
+  @join__unionMember(graph: B, member: "Common")
+  @join__unionMember(graph: A, member: "OnlyA")
+  @join__unionMember(graph: B, member: "OnlyB")
+ = Common | OnlyA | OnlyB
+
+type Common
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  label: String
+}
+
+type Container
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id")
+{
+  id: ID!
+  wrapper: Wrapper
+  bWrapper: Wrapper @join__field(graph: B)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://localhost:4200/partial-union-complex/a")
+  B @join__graph(name: "b", url: "http://localhost:4200/partial-union-complex/b")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type OnlyA
+  @join__type(graph: A)
+{
+  a: String
+}
+
+type OnlyB
+  @join__type(graph: B)
+{
+  b: String
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  rootA: Container @join__field(graph: A)
+  rootB: Container @join__field(graph: B)
+  shared: Container
+}
+
+type Wrapper
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  actions: Action
+}

--- a/lib/query-planner/fixture/tests/partial-union.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/partial-union.supergraph.graphql
@@ -1,0 +1,88 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+union Action
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__unionMember(graph: A, member: "Alpha")
+  @join__unionMember(graph: B, member: "Alpha")
+  @join__unionMember(graph: A, member: "Beta")
+  @join__unionMember(graph: A, member: "Gamma")
+ = Alpha | Beta | Gamma
+
+type Alpha
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  id: ID!
+  value: String
+}
+
+type Beta
+  @join__type(graph: A)
+{
+  id: ID!
+  name: String
+  details: String
+}
+
+type Gamma
+  @join__type(graph: A)
+{
+  id: ID!
+  label: String
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://localhost:4200/partial-union/a")
+  B @join__graph(name: "b", url: "http://localhost:4200/partial-union/b")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  getResponse: Response @join__field(graph: A)
+}
+
+type Response
+  @join__type(graph: A)
+  @join__type(graph: B)
+{
+  actions: [Action!]!
+  message: String
+}

--- a/lib/query-planner/src/graph/mod.rs
+++ b/lib/query-planner/src/graph/mod.rs
@@ -10,14 +10,13 @@ mod tests;
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Display},
-    hash::Hash,
 };
 
 use super::ast::normalization::utils::extract_type_condition;
 use crate::{
     ast::type_aware_selection::TypeAwareSelection,
     federation_spec::FederationRules,
-    graph::node::{SubgraphTypeSpecialization, UnionSubsetData},
+    graph::node::{SubgraphTypeSpecialization, UnionMembersData},
     state::supergraph_state::{
         OperationKind, SupergraphDefinition, SupergraphField, SupergraphState,
     },
@@ -36,7 +35,11 @@ use super::graph::{edge::Edge, node::Node};
 
 type InnerGraph = Petgraph<Node, Edge, Directed>;
 
-type UnionRegistyHashMap<'a> = HashMap<&'a str, HashMap<&'a str, HashSet<&'a str>>>;
+type UnionTypeName<'a> = &'a str;
+type SubgraphName<'a> = &'a str;
+type UnionMemberTypes<'a> = HashSet<&'a str>;
+type UnionRegistyHashMap<'a> =
+    HashMap<UnionTypeName<'a>, HashMap<SubgraphName<'a>, UnionMemberTypes<'a>>>;
 
 #[derive(Debug, Default)]
 struct UnionDefinitions<'a> {
@@ -52,7 +55,7 @@ impl<'a> UnionDefinitions<'a> {
             .iter()
             .filter(|(_, d)| matches!(d, SupergraphDefinition::Union(_)))
         {
-            let mut in_subgraphs: HashMap<&'a str, HashSet<&'a str>> = HashMap::new();
+            let mut in_subgraphs: HashMap<SubgraphName<'a>, UnionMemberTypes<'a>> = HashMap::new();
 
             for join_member in definition.join_union_members() {
                 in_subgraphs
@@ -61,7 +64,7 @@ impl<'a> UnionDefinitions<'a> {
                         e.insert(&join_member.member);
                     })
                     .or_insert_with(|| {
-                        let mut set: HashSet<&'a str> = HashSet::new();
+                        let mut set: UnionMemberTypes<'a> = HashSet::new();
                         set.insert(&join_member.member);
                         set
                     });
@@ -79,63 +82,37 @@ impl<'a> UnionDefinitions<'a> {
         self.registry.contains_key(type_name)
     }
 
-    fn members_in_subgraph(&self, type_name: &str, graph: &'a str) -> Option<&HashSet<&'a str>> {
+    fn members_in_subgraph(&self, type_name: &str, graph: &str) -> Option<&UnionMemberTypes<'a>> {
         self.registry.get(type_name).and_then(|r| r.get(graph))
     }
 
-    /// Produces a list of names of the object types.
-    pub fn intersections(
+    /// Produces the union members visible from a field resolved in a subgraph
+    pub fn members_for_field_in_graph(
         &self,
-        type_def: &'a SupergraphDefinition,
         field_def: &'a SupergraphField,
         field_type: &str,
-    ) -> HashSet<String> {
+        graph_id: &str,
+    ) -> UnionMemberTypes<'a> {
         // Collect subgraphs the field was defined in.
         // First, look for join__field(graph:),
         // If not defined, look at type's join__type(graph:).
-
-        let mut members_per_subgraph: HashMap<&str, HashSet<String>> = HashMap::new();
-
-        if field_def.join_field.is_empty() {
-            for join_type in type_def.join_types() {
-                let mut members_in_subgraph: HashSet<String> = HashSet::new();
-                for union_member in self
-                    .members_in_subgraph(field_type, &join_type.graph_id)
-                    .unwrap()
-                {
-                    members_in_subgraph.insert(union_member.to_string());
+        if let Some(join_field) = field_def.join_field.iter().find(|join_field| {
+            join_field
+                .graph_id
+                .as_ref()
+                .is_some_and(|field_graph_id| field_graph_id == graph_id)
+        }) {
+            if let Some(type_in_graph) = join_field.type_in_graph.as_ref().map(|t| t.inner_type()) {
+                // join__field(type:) can narrow a union-returning field to one concrete member.
+                if type_in_graph != field_type {
+                    return UnionMemberTypes::from([type_in_graph]);
                 }
-
-                members_per_subgraph.insert(&join_type.graph_id, members_in_subgraph);
             }
         }
 
-        for join_field in field_def.join_field.iter() {
-            if let Some(graph_id) = join_field.graph_id.as_ref() {
-                let mut members_in_subgraph: HashSet<String> = HashSet::new();
-
-                if let Some(type_in_graph) =
-                    join_field.type_in_graph.as_ref().map(|t| t.inner_type())
-                {
-                    // look for join__field(type:) - it could point to `Object` or `Union`
-                    if type_in_graph != field_type {
-                        // the field_type is a union, as we previously checked,
-                        // so if the type_in_graph is different,
-                        // it means it's an object type (one of the members).
-                        members_in_subgraph.insert(type_in_graph.to_string());
-                        members_per_subgraph.insert(graph_id, members_in_subgraph);
-                        continue;
-                    }
-                }
-
-                for union_member in self.members_in_subgraph(field_type, graph_id).unwrap() {
-                    members_in_subgraph.insert(union_member.to_string());
-                }
-                members_per_subgraph.insert(graph_id, members_in_subgraph);
-            }
-        }
-
-        intersections(members_per_subgraph.values().collect())
+        self.members_in_subgraph(field_type, graph_id)
+            .cloned()
+            .unwrap_or_default()
     }
 }
 
@@ -766,8 +743,18 @@ impl Graph {
                             state.is_interface_object_in_subgraph(def_name, graph_id),
                         ));
 
-                        let member_types =
-                            unions.intersections(definition, field_definition, target_type);
+                        // Build union-member edges for the current subgraph only. Doing a global
+                        // intersection here strips valid members from pinned paths such as
+                        // Query.getResponse -> Response/A -> actions, where A knows the full union.
+                        let mut member_types = unions
+                            .members_for_field_in_graph(field_definition, target_type, graph_id)
+                            .into_iter()
+                            .collect::<Vec<_>>();
+                        member_types.sort_unstable();
+                        let possible_members: Vec<String> = member_types
+                            .iter()
+                            .map(|member| member.to_string())
+                            .collect::<Vec<_>>();
 
                         trace!(
                             "Handling a field {}.{}/{} resolving a union type {}",
@@ -782,17 +769,18 @@ impl Graph {
                                 target_type,
                                 state.resolve_graph_id(graph_id)?,
                                 state.is_interface_object_in_subgraph(target_type, graph_id),
-                                SubgraphTypeSpecialization::UnionSubset(UnionSubsetData {
+                                SubgraphTypeSpecialization::UnionMembers(UnionMembersData {
                                     type_name: def_name.clone(),
                                     field_name: field_name.clone(),
-                                    object_type_name: member.clone(),
+                                    object_type_name: member.to_string(),
+                                    possible_members: possible_members.clone(),
                                     provides: None,
                                 }),
                             ));
                             let abstract_tail = self.upsert_node(Node::new_node(
-                                &member,
+                                member,
                                 state.resolve_graph_id(graph_id)?,
-                                state.is_interface_object_in_subgraph(&member, graph_id),
+                                state.is_interface_object_in_subgraph(member, graph_id),
                             ));
                             // because we duplicate tails, we need to add __typename to all of them
                             let typename_tail = self.upsert_node(Node::new_node(
@@ -847,7 +835,7 @@ impl Graph {
                             self.upsert_edge(
                                 tail,
                                 abstract_tail,
-                                Edge::AbstractMove(member.clone()),
+                                Edge::AbstractMove(member.to_string()),
                             );
                         }
 
@@ -1229,27 +1217,4 @@ impl Display for Graph {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", Dot::with_config(&self.graph, &[]))
     }
-}
-
-fn intersections<T>(sets: Vec<&HashSet<T>>) -> HashSet<T>
-where
-    T: Clone + Eq + Hash,
-{
-    sets.iter()
-        .enumerate()
-        .min_by_key(|&(_, s)| s.len())
-        .map(|(smallest_set_index, _)| {
-            let (other_sets_left, [smallest_set, other_sets_right @ ..]) =
-                sets.split_at(smallest_set_index)
-            else {
-                unreachable!()
-            };
-            let other_sets = || other_sets_left.iter().chain(other_sets_right);
-            smallest_set
-                .iter()
-                .filter(|item| other_sets().all(|o| o.contains(item)))
-                .cloned()
-                .collect()
-        })
-        .unwrap_or_default()
 }

--- a/lib/query-planner/src/graph/node.rs
+++ b/lib/query-planner/src/graph/node.rs
@@ -3,13 +3,15 @@ use std::fmt::{Debug, Display};
 use crate::state::supergraph_state::SubgraphName;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct UnionSubsetData {
+pub struct UnionMembersData {
     /// Represents the type owning the field
     pub type_name: String,
     /// Represents the field resolving a union type
     pub field_name: String,
     /// Represents a union member
     pub object_type_name: String,
+    /// Represents all union members reachable for the same field in this subgraph.
+    pub possible_members: Vec<String>,
     pub provides: Option<u64>,
 }
 
@@ -17,14 +19,22 @@ pub struct UnionSubsetData {
 pub enum SubgraphTypeSpecialization {
     /// Node was created due to @provides path.
     Provides(u64),
-    /// Node is part of the union intersection.
-    /// When dealing with unions,
-    /// we need to point field-move edge's tails (union)
-    /// to a subset of object types.
-    /// We do it by creating a new Node for each edge's tail (union),
-    /// and from that tail we create an abstract-move edges to the object types.
-    /// (type_name, field_name, union_member_name)
-    UnionSubset(UnionSubsetData),
+    /// Node represents a union member tail for a specific subgraph.
+    ///
+    /// For union-returning field moves, we may need a tail that only exposes the
+    /// members reachable in the current subgraph. We model that by creating
+    /// per-member specialized nodes and then abstract-move edges from those tails
+    /// to the concrete member types.
+    UnionMembers(UnionMembersData),
+}
+
+impl SubgraphTypeSpecialization {
+    pub fn union_members_data(&self) -> Option<&UnionMembersData> {
+        match self {
+            SubgraphTypeSpecialization::UnionMembers(data) => Some(data),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -55,7 +65,7 @@ impl Node {
                     SubgraphTypeSpecialization::Provides(provides_id) => {
                         format!("{}/{}/{}", st.name, st.subgraph.0, provides_id)
                     }
-                    SubgraphTypeSpecialization::UnionSubset(u) => {
+                    SubgraphTypeSpecialization::UnionMembers(u) => {
                         // we rely on display_name when it comes to deduplicating nodes (upsert_node),
                         // that's why the string produced here should "mimic" hashing
                         format!(
@@ -120,6 +130,19 @@ impl Node {
             Node::SubscriptionRoot(_) => None,
             Node::SubgraphType(st) => Some(&st.subgraph.0),
         }
+    }
+
+    pub fn subgraph_type(&self) -> Option<&SubgraphType> {
+        match self {
+            Node::SubgraphType(st) => Some(st),
+            _ => None,
+        }
+    }
+
+    pub fn union_members_data(&self) -> Option<&UnionMembersData> {
+        self.subgraph_type()
+            .and_then(|st| st.specialization.as_ref())
+            .and_then(|s| s.union_members_data())
     }
 }
 

--- a/lib/query-planner/src/planner/best.rs
+++ b/lib/query-planner/src/planner/best.rs
@@ -62,9 +62,9 @@ use crate::{
     utils::cancellation::CancellationToken,
 };
 
-type PathAndPosition = (OperationPath, MutationFieldPosition);
+type PathAndPosition<'graph> = (OperationPath<'graph>, MutationFieldPosition);
 type QueryTreeResult = Result<QueryTree, GraphError>;
-type LazyQueryTree = LazyTransform<PathAndPosition, QueryTreeResult>;
+type LazyQueryTree<'graph> = LazyTransform<PathAndPosition<'graph>, QueryTreeResult>;
 
 /// The high-penalty cost for crossing a subgraph boundary or satisfying a requirement.
 /// This is the primary driver of the optimization, encouraging plans with fewer subgraphs.
@@ -74,19 +74,19 @@ const FIELD_COST: u64 = 1;
 /// A lazily-evaluated, potential piece of the final query plan.
 /// It represents one of many possible ways to resolve a part of the query.
 #[derive(Clone)]
-struct Candidate {
+struct Candidate<'graph> {
     /// The actual `QueryTree` for this candiate, computed only when first needed.
-    tree: LazyQueryTree,
+    tree: LazyQueryTree<'graph>,
     /// The cached cost of this tree, computed only once.
     cost: OnceCell<u64>,
 }
 
 /// Represents a set of alternative Candidates to satisfy a single leaf in the query.
 /// The final plan must choose exactly one fragment from each ChoiceGroup.
-type Alternatives = Vec<Candidate>;
+type Alternatives<'graph> = Vec<Candidate<'graph>>;
 
-impl Candidate {
-    fn new(path: OperationPath, mutation_pos: MutationFieldPosition) -> Self {
+impl<'graph> Candidate<'graph> {
+    fn new(path: OperationPath<'graph>, mutation_pos: MutationFieldPosition) -> Self {
         Self {
             tree: LazyTransform::new((path, mutation_pos)),
             cost: OnceCell::new(),
@@ -114,14 +114,14 @@ impl Candidate {
 }
 
 /// Each `Alternatives` group represents a set of possible ways to satisfy one leaf of the query.
-fn prepare_alternatives(operation: ResolvedOperation) -> Vec<Alternatives> {
+fn prepare_alternatives<'graph>(operation: ResolvedOperation<'graph>) -> Vec<Alternatives<'graph>> {
     let is_mutation = matches!(operation.operation_kind, OperationKind::Mutation);
-    let mut per_leaf_alternatives_asc: Vec<Alternatives> = Vec::new();
+    let mut per_leaf_alternatives_asc: Vec<Alternatives<'graph>> = Vec::new();
 
     for (index, root_field_options) in operation.root_field_groups.into_iter().enumerate() {
         let mutation_field_position: MutationFieldPosition = is_mutation.then_some(index);
 
-        let leaf_alternatives: Vec<Alternatives> = root_field_options
+        let leaf_alternatives: Vec<Alternatives<'graph>> = root_field_options
             .into_iter()
             .map(|paths_to_leaf| {
                 paths_to_leaf

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1626,6 +1626,7 @@ fn find_satisfiable_key<'a>(
                 last_segment: None,
                 visited_edge_indices: Default::default(),
                 cost: 0,
+                union_context: None,
             },
             &Default::default(),
             true,

--- a/lib/query-planner/src/planner/walker/best_path.rs
+++ b/lib/query-planner/src/planner/walker/best_path.rs
@@ -8,10 +8,10 @@ pub struct BestPathTracker<'graph> {
     graph: &'graph Graph,
     /// A map from subgraph name to the best path and its cost.
     /// BTreeMap instead of HashMap to keep the order of inserted keys deterministic.
-    subgraph_to_best_paths: BTreeMap<String, (Vec<OperationPath>, u64)>,
+    subgraph_to_best_paths: BTreeMap<&'graph str, (Vec<OperationPath<'graph>>, u64)>,
 }
 
-pub fn find_best_paths(paths: Vec<OperationPath>) -> Vec<OperationPath> {
+pub fn find_best_paths<'graph>(paths: Vec<OperationPath<'graph>>) -> Vec<OperationPath<'graph>> {
     let mut best_paths = Vec::new();
     let mut best_cost = 0;
 
@@ -38,14 +38,14 @@ impl<'graph> BestPathTracker<'graph> {
         }
     }
 
-    pub fn add(&mut self, path: &OperationPath) -> Result<(), WalkOperationError> {
+    pub fn add(&mut self, path: &OperationPath<'graph>) -> Result<(), WalkOperationError> {
         let tail_graph_id = self
             .graph
             .node(path.tail())?
             .graph_id()
             .expect("Graph ID not found in node");
 
-        match self.subgraph_to_best_paths.entry(tail_graph_id.to_string()) {
+        match self.subgraph_to_best_paths.entry(tail_graph_id) {
             Entry::Occupied(mut entry) => {
                 let (existing_paths, existing_cost) = entry.get_mut();
 
@@ -71,10 +71,10 @@ impl<'graph> BestPathTracker<'graph> {
         Ok(())
     }
 
-    pub fn get_best_paths(self) -> Vec<OperationPath> {
+    pub fn get_best_paths(self) -> Vec<OperationPath<'graph>> {
         self.subgraph_to_best_paths
             .into_values()
             .flat_map(|(paths, _)| paths)
-            .collect::<Vec<OperationPath>>()
+            .collect::<Vec<OperationPath<'graph>>>()
     }
 }

--- a/lib/query-planner/src/planner/walker/excluded.rs
+++ b/lib/query-planner/src/planner/walker/excluded.rs
@@ -4,13 +4,13 @@ use crate::ast::type_aware_selection::TypeAwareSelection;
 
 // TODO: Consider interior mutability with Rc<RefCell<ExcludedFromLookup>> to avoid full clone while traversing
 #[derive(Default)]
-pub struct ExcludedFromLookup {
-    pub graph_ids: HashSet<String>,
+pub struct ExcludedFromLookup<'graph> {
+    pub graph_ids: HashSet<&'graph str>,
     pub requirement: HashSet<TypeAwareSelection>,
 }
 
-impl ExcludedFromLookup {
-    pub fn new() -> ExcludedFromLookup {
+impl<'graph> ExcludedFromLookup<'graph> {
+    pub fn new() -> ExcludedFromLookup<'graph> {
         Default::default()
     }
 }

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -31,28 +31,28 @@ use pathfinder::{find_direct_paths, find_indirect_paths};
 use tracing::{instrument, span, trace, Level};
 use utils::get_entrypoints;
 
-pub struct ResolvedOperation {
+pub struct ResolvedOperation<'graph> {
     pub operation_kind: OperationKind,
-    pub root_field_groups: Vec<BestPathsPerLeaf>,
+    pub root_field_groups: Vec<BestPathsPerLeaf<'graph>>,
 }
 
 // TODO: Make a better struct
-pub type BestPathsPerLeaf = Vec<Vec<OperationPath>>;
+pub type BestPathsPerLeaf<'graph> = Vec<Vec<OperationPath<'graph>>>;
 
 // TODO: Consider to use VecDeque(fixed_size) if we can predict it?
 // TODO: Consider to drop this IR layer and just go with QTP directly.
 
-type WorkItem<'a> = (&'a SelectionItem, Vec<OperationPath>);
-type ResolutionStack<'a> = Vec<WorkItem<'a>>;
+type WorkItem<'graph, 'op> = (&'op SelectionItem, Vec<OperationPath<'graph>>);
+type ResolutionStack<'graph, 'op> = Vec<WorkItem<'graph, 'op>>;
 
 #[instrument(level = "trace", skip_all)]
-pub fn walk_operation(
-    graph: &Graph,
-    supergraph: &SupergraphState,
-    override_context: &PlannerOverrideContext,
-    operation: &OperationDefinition,
-    cancellation_token: &CancellationToken,
-) -> Result<ResolvedOperation, WalkOperationError> {
+pub fn walk_operation<'graph, 'op: 'graph>(
+    graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
+    override_context: &'graph PlannerOverrideContext,
+    operation: &'op OperationDefinition,
+    cancellation_token: &'graph CancellationToken,
+) -> Result<ResolvedOperation<'graph>, WalkOperationError> {
     let operation_kind = operation
         .operation_kind
         .clone()
@@ -61,7 +61,7 @@ pub fn walk_operation(
     trace!("operation is of type {:?}", op_type);
 
     let root_entrypoints = get_entrypoints(graph, op_type)?;
-    let initial_paths: Vec<OperationPath> = root_entrypoints
+    let initial_paths: Vec<OperationPath<'graph>> = root_entrypoints
         .iter()
         .map(|edge| OperationPath::new_entrypoint(edge))
         .collect();
@@ -75,7 +75,7 @@ pub fn walk_operation(
 
         stack_to_resolve.push_back((selection_item, initial_paths.to_vec()));
 
-        let mut paths_per_leaf: Vec<Vec<OperationPath>> = vec![];
+        let mut paths_per_leaf: Vec<Vec<OperationPath<'graph>>> = vec![];
 
         while let Some((selection_item, paths)) = stack_to_resolve.pop_front() {
             cancellation_token.bail_if_cancelled()?;
@@ -85,7 +85,7 @@ pub fn walk_operation(
                 override_context,
                 selection_item,
                 &paths,
-                &vec![],
+                &[],
                 cancellation_token,
             )?;
 
@@ -104,17 +104,23 @@ pub fn walk_operation(
     })
 }
 
-fn process_selection<'a>(
-    graph: &'a Graph,
-    supergraph: &'a SupergraphState,
-    override_context: &'a PlannerOverrideContext,
-    selection_item: &'a SelectionItem,
-    paths: &Vec<OperationPath>,
-    fields_to_resolve_locally: &Vec<String>,
-    cancellation_token: &CancellationToken,
-) -> Result<(ResolutionStack<'a>, Vec<Vec<OperationPath>>), WalkOperationError> {
+fn process_selection<'graph, 'op: 'graph>(
+    graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
+    override_context: &'graph PlannerOverrideContext,
+    selection_item: &'op SelectionItem,
+    paths: &[OperationPath<'graph>],
+    fields_to_resolve_locally: &[String],
+    cancellation_token: &'graph CancellationToken,
+) -> Result<
+    (
+        ResolutionStack<'graph, 'op>,
+        Vec<Vec<OperationPath<'graph>>>,
+    ),
+    WalkOperationError,
+> {
     let mut stack_to_resolve: ResolutionStack = vec![];
-    let mut paths_per_leaf: Vec<Vec<OperationPath>> = vec![];
+    let mut paths_per_leaf: Vec<Vec<OperationPath<'graph>>> = vec![];
 
     match selection_item {
         SelectionItem::InlineFragment(fragment) => {
@@ -152,17 +158,23 @@ fn process_selection<'a>(
 }
 
 #[instrument(level = "trace", skip_all)]
-fn process_selection_set<'a>(
-    graph: &'a Graph,
-    supergraph: &'a SupergraphState,
-    override_context: &'a PlannerOverrideContext,
-    selection_set: &'a SelectionSet,
-    paths: &Vec<OperationPath>,
-    fields_to_resolve_locally: &Vec<String>,
-    cancellation_token: &CancellationToken,
-) -> Result<(ResolutionStack<'a>, Vec<Vec<OperationPath>>), WalkOperationError> {
+fn process_selection_set<'graph, 'op: 'graph>(
+    graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
+    override_context: &'graph PlannerOverrideContext,
+    selection_set: &'op SelectionSet,
+    paths: &[OperationPath<'graph>],
+    fields_to_resolve_locally: &[String],
+    cancellation_token: &'graph CancellationToken,
+) -> Result<
+    (
+        ResolutionStack<'graph, 'op>,
+        Vec<Vec<OperationPath<'graph>>>,
+    ),
+    WalkOperationError,
+> {
     let mut stack_to_resolve: ResolutionStack = vec![];
-    let mut paths_per_leaf: Vec<Vec<OperationPath>> = vec![];
+    let mut paths_per_leaf: Vec<Vec<OperationPath<'graph>>> = vec![];
 
     for item in selection_set.items.iter() {
         let (next_stack_to_resolve, new_paths_per_leaf) = process_selection(
@@ -184,15 +196,21 @@ fn process_selection_set<'a>(
 #[instrument(level = "trace", skip_all, fields(
   type_condition = fragment.type_condition,
 ))]
-fn process_inline_fragment<'a>(
-    graph: &'a Graph,
-    supergraph: &'a SupergraphState,
-    override_context: &'a PlannerOverrideContext,
-    fragment: &'a InlineFragmentSelection,
-    paths: &Vec<OperationPath>,
-    fields_to_resolve_locally: &Vec<String>,
-    cancellation_token: &CancellationToken,
-) -> Result<(ResolutionStack<'a>, Vec<Vec<OperationPath>>), WalkOperationError> {
+fn process_inline_fragment<'graph, 'op: 'graph>(
+    graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
+    override_context: &'graph PlannerOverrideContext,
+    fragment: &'op InlineFragmentSelection,
+    paths: &[OperationPath<'graph>],
+    fields_to_resolve_locally: &[String],
+    cancellation_token: &'graph CancellationToken,
+) -> Result<
+    (
+        ResolutionStack<'graph, 'op>,
+        Vec<Vec<OperationPath<'graph>>>,
+    ),
+    WalkOperationError,
+> {
     trace!(
         "Processing inline fragment '{}' on type '{}' (skip: {:?}, include: {:?}) through {} possible paths",
         fragment.selections,
@@ -249,7 +267,7 @@ fn process_inline_fragment<'a>(
         // and jumping straight to its selections.
         let condition: Option<Condition> = fragment.into();
 
-        let mut next_paths: Vec<OperationPath> = Vec::with_capacity(paths.len());
+        let mut next_paths: Vec<OperationPath<'graph>> = Vec::with_capacity(paths.len());
         for path in paths {
             let path_span = span!(
                 Level::TRACE,
@@ -291,7 +309,7 @@ fn process_inline_fragment<'a>(
         paths.len()
     );
 
-    let mut next_paths: Vec<OperationPath> = Vec::with_capacity(paths.len());
+    let mut next_paths: Vec<OperationPath<'graph>> = Vec::with_capacity(paths.len());
     for path in paths {
         let path_span = span!(
             Level::TRACE,
@@ -392,21 +410,124 @@ fn process_inline_fragment<'a>(
     )
 }
 
+/// The same union may have different members in different subgraphs.
+/// For example:
+///
+/// - graph A: Action = Common | OnlyA
+/// - graph B: Action = Common | OnlyB
+///
+/// If the planner still has valid candidate paths through both A and B,
+/// the response shape must not depend on which path wins later.
+/// In that case we keep only members that are available in every candidate graph.
+///
+/// In the example above, only `Common` is safe to keep.
+fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
+    if paths.len() <= 1 {
+        return;
+    }
+
+    let Some(union_context) = paths.first().and_then(|path| path.union_context.as_ref()) else {
+        return;
+    };
+
+    let all_same_field = paths.iter().all(|path| {
+        path.union_context
+            .as_ref()
+            .is_some_and(|ctx| ctx.eq_field(union_context))
+    });
+
+    if !all_same_field {
+        return;
+    }
+
+    // Collect the union members that each subgraph can return.
+    //
+    // All paths through the same graph share the same `possible_members` because they originate
+    // from the same `UnionMembersData` (one per graph). We only need to record each graph's member
+    // set once — no accumulation is required.
+    type GraphId<'graph> = &'graph str;
+    type MembersPerGraph<'graph> = Vec<(GraphId<'graph>, Vec<&'graph str>)>;
+    let mut members_per_graph: MembersPerGraph<'graph> = Vec::new();
+
+    for path in paths.iter() {
+        let context = path
+            .union_context
+            .as_ref()
+            // It's safe to unwrap as `all_same_field` checked that all paths have the same context
+            .expect("union member context should exist at this point");
+
+        if !members_per_graph
+            .iter()
+            .any(|(graph_id, _)| graph_id == &context.graph_id)
+        {
+            members_per_graph.push((context.graph_id, context.possible_members.clone()));
+        }
+    }
+
+    if members_per_graph.len() <= 1 {
+        return;
+    }
+
+    let (_, least_members_set) = members_per_graph
+        .iter()
+        .min_by_key(|(_, members)| members.len())
+        // It's safe as we checked that `members_per_graph` has at least two entries above
+        .expect("members_per_graph has at least two entries");
+
+    // Start from the smallest member list.
+    // Then shrink it with each graph until only shared members remain.
+    let mut shared_members: Vec<&'graph str> = least_members_set.clone();
+
+    for (_, members) in &members_per_graph {
+        shared_members.retain(|member| members.contains(member));
+
+        if shared_members.is_empty() {
+            // No union member exists in every candidate subgraph.
+            // None of these paths is safe to keep.
+            paths.clear();
+            return;
+        }
+    }
+
+    paths.retain_mut(|path| {
+        // It's safe to unwrap as we checked that `union_context` exists already
+        let scope = path
+            .union_context
+            .as_mut()
+            .expect("union context should exist at this point");
+
+        // Keep only paths whose current member is shared
+        if !shared_members.contains(&scope.member_name) {
+            return false;
+        }
+
+        // Update the possible members to the shared members set.
+        scope.possible_members = shared_members.clone();
+        true
+    });
+}
+
 #[instrument(level = "trace", skip_all, fields(
   field_name = &field.name,
   leaf = field.is_leaf()
 ))]
-fn process_field<'a>(
-    graph: &'a Graph,
-    supergraph: &'a SupergraphState,
-    override_context: &'a PlannerOverrideContext,
-    field: &'a FieldSelection,
-    paths: &[OperationPath],
+fn process_field<'graph, 'op: 'graph>(
+    graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
+    override_context: &'graph PlannerOverrideContext,
+    field: &'op FieldSelection,
+    paths: &[OperationPath<'graph>],
     fields_to_resolve_locally: &[String],
-    cancellation_token: &CancellationToken,
-) -> Result<(ResolutionStack<'a>, Vec<Vec<OperationPath>>), WalkOperationError> {
+    cancellation_token: &'graph CancellationToken,
+) -> Result<
+    (
+        ResolutionStack<'graph, 'op>,
+        Vec<Vec<OperationPath<'graph>>>,
+    ),
+    WalkOperationError,
+> {
     let mut next_stack_to_resolve: ResolutionStack = vec![];
-    let mut paths_per_leaf: Vec<Vec<OperationPath>> = vec![];
+    let mut paths_per_leaf: Vec<Vec<OperationPath<'graph>>> = vec![];
     let mut tracker = BestPathTracker::new(graph);
 
     trace!(
@@ -477,6 +598,7 @@ fn process_field<'a>(
     }
 
     let mut next_paths = tracker.get_best_paths();
+    narrow_partial_union_paths(&mut next_paths);
     if next_paths.is_empty() {
         return Err(WalkOperationError::NoPathsFound(field.name.to_string()));
     }
@@ -549,7 +671,8 @@ fn process_field<'a>(
             "Shareable interface detected. Validating that sub-selections can be resolved from a single path."
         );
         let _enter = path_span.enter();
-        let mut valid_paths_for_children: Vec<OperationPath> = Vec::with_capacity(next_paths.len());
+        let mut valid_paths_for_children: Vec<OperationPath<'graph>> =
+            Vec::with_capacity(next_paths.len());
         for candidate_path in &next_paths {
             let mut all_children_resolvable = true;
             // We don't need the results of the sub-walk here, only whether it was successful
@@ -559,7 +682,7 @@ fn process_field<'a>(
                     supergraph,
                     override_context,
                     child_selection,
-                    &vec![candidate_path.clone()],
+                    std::slice::from_ref(candidate_path),
                     &fields_to_resolve_locally,
                     cancellation_token,
                 );

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -450,11 +450,9 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
     let mut members_per_graph: MembersPerGraph<'graph> = Vec::new();
 
     for path in paths.iter() {
-        let context = path
-            .union_context
-            .as_ref()
-            // It's safe to unwrap as `all_same_field` checked that all paths have the same context
-            .expect("union member context should exist at this point");
+        let Some(context) = path.union_context.as_ref() else {
+            return;
+        };
 
         if !members_per_graph
             .iter()
@@ -490,19 +488,17 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
     }
 
     paths.retain_mut(|path| {
-        // It's safe to unwrap as we checked that `union_context` exists already
-        let scope = path
-            .union_context
-            .as_mut()
-            .expect("union context should exist at this point");
+        let Some(context) = path.union_context.as_mut() else {
+            return false;
+        };
 
         // Keep only paths whose current member is shared
-        if !shared_members.contains(&scope.member_name) {
+        if !shared_members.contains(&context.member_name) {
             return false;
         }
 
         // Update the possible members to the shared members set.
-        scope.possible_members = shared_members.clone();
+        context.possible_members = shared_members.clone();
         true
     });
 }

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -450,9 +450,11 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
     let mut members_per_graph: MembersPerGraph<'graph> = Vec::new();
 
     for path in paths.iter() {
-        let Some(context) = path.union_context.as_ref() else {
-            return;
-        };
+        let context = path
+            .union_context
+            .as_ref()
+            // It's safe to unwrap as `all_same_field` checked that all paths have the same context
+            .expect("union member context should exist at this point");
 
         if !members_per_graph
             .iter()
@@ -488,9 +490,11 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
     }
 
     paths.retain_mut(|path| {
-        let Some(context) = path.union_context.as_mut() else {
-            return false;
-        };
+        // It's safe to unwrap as we checked that `union_context` exists already
+        let context = path
+            .union_context
+            .as_mut()
+            .expect("union context should exist at this point");
 
         // Keep only paths whose current member is shared
         if !shared_members.contains(&context.member_name) {

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -51,9 +51,7 @@ pub struct UnionContext<'graph> {
 
 impl<'graph> UnionContext<'graph> {
     fn can_resolve_member(&self, member_type_name: &str) -> bool {
-        self.possible_members
-            .iter()
-            .any(|possible_member| *possible_member == member_type_name)
+        self.possible_members.contains(&member_type_name)
     }
 
     pub fn eq_field(&self, other: &Self) -> bool {

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -11,7 +11,7 @@ use crate::ast::merge_path::Condition;
 use crate::planner::walker::pathfinder::NavigationTarget;
 use crate::{
     ast::arguments::ArgumentsMap,
-    graph::{edge::EdgeReference, Graph},
+    graph::{edge::Edge, edge::EdgeReference, Graph},
     planner::tree::query_tree_node::QueryTreeNode,
 };
 
@@ -40,6 +40,37 @@ pub struct PathSegment {
     pub condition: Option<Condition>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnionContext<'graph> {
+    pub parent_type_name: &'graph str,
+    pub field_name: &'graph str,
+    pub graph_id: &'graph str,
+    pub member_name: &'graph str,
+    pub possible_members: Vec<&'graph str>,
+}
+
+impl<'graph> UnionContext<'graph> {
+    fn can_resolve_member(&self, member_type_name: &str) -> bool {
+        self.possible_members
+            .iter()
+            .any(|possible_member| *possible_member == member_type_name)
+    }
+
+    pub fn eq_field(&self, other: &Self) -> bool {
+        self.parent_type_name == other.parent_type_name && self.field_name == other.field_name
+    }
+
+    fn narrow_to_member(&self, member_type_name: &'graph str) -> Self {
+        Self {
+            parent_type_name: self.parent_type_name,
+            field_name: self.field_name,
+            graph_id: self.graph_id,
+            member_name: member_type_name,
+            possible_members: vec![member_type_name],
+        }
+    }
+}
+
 impl PathSegment {
     pub fn new_root(edge: &EdgeReference) -> Self {
         Self {
@@ -55,14 +86,15 @@ impl PathSegment {
 }
 
 #[derive(Clone)]
-pub struct OperationPath {
+pub struct OperationPath<'graph> {
     pub root_node: NodeIndex,
     pub last_segment: Option<Rc<PathSegment>>,
     pub visited_edge_indices: Rc<HashSet<EdgeIndex>>,
     pub cost: u64,
+    pub union_context: Option<UnionContext<'graph>>,
 }
 
-impl Debug for OperationPath {
+impl Debug for OperationPath<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut out = f.debug_struct("");
         let mut out = out.field("cost", &self.cost);
@@ -84,7 +116,7 @@ impl Debug for OperationPath {
     }
 }
 
-impl OperationPath {
+impl<'graph> OperationPath<'graph> {
     pub fn new(
         root_node_index: NodeIndex,
         last_segment: Option<Rc<PathSegment>>,
@@ -97,6 +129,7 @@ impl OperationPath {
                 .map_or(0, |segment| segment.cumulative_cost),
             last_segment,
             visited_edge_indices,
+            union_context: None,
         }
     }
 
@@ -111,10 +144,11 @@ impl OperationPath {
 
     pub fn advance(
         &self,
-        edge_ref: &EdgeReference<'_>,
+        graph: &'graph Graph,
+        edge_ref: &EdgeReference<'graph>,
         requirement: Option<Rc<QueryTreeNode>>,
         target: &NavigationTarget,
-    ) -> OperationPath {
+    ) -> OperationPath<'graph> {
         let prev_cost = self.cost;
         let edge_cost = edge_ref.weight().cost();
         let new_cost = prev_cost + edge_cost;
@@ -141,7 +175,48 @@ impl OperationPath {
         };
         let new_segment = Rc::new(new_segment_data);
 
-        OperationPath::new(self.root_node, Some(new_segment), new_visited)
+        let union_context = match edge_ref.weight() {
+            Edge::FieldMove(_) => {
+                let tail = graph.node(edge_ref.target()).ok();
+                let union_data = tail.and_then(|tail| tail.union_members_data());
+                let graph_id = tail.and_then(|tail| tail.graph_id());
+
+                match (union_data, graph_id) {
+                    (Some(union_data), Some(graph_id)) => Some(UnionContext {
+                        parent_type_name: &union_data.type_name,
+                        field_name: &union_data.field_name,
+                        graph_id,
+                        member_name: &union_data.object_type_name,
+                        possible_members: union_data
+                            .possible_members
+                            .iter()
+                            .map(|member| member.as_str())
+                            .collect(),
+                    }),
+                    _ => None,
+                }
+            }
+            Edge::AbstractMove(member_type_name) => self
+                .union_context
+                .as_ref()
+                .map(|scope| scope.narrow_to_member(member_type_name)),
+            Edge::EntityMove(_) | Edge::InterfaceObjectTypeMove(_) => None,
+            _ => self.union_context.clone(),
+        };
+
+        OperationPath {
+            root_node: self.root_node,
+            cost: new_cost,
+            last_segment: Some(new_segment),
+            visited_edge_indices: new_visited,
+            union_context,
+        }
+    }
+
+    pub fn can_resolve_union_member(&self, member_type_name: &str) -> bool {
+        self.union_context
+            .as_ref()
+            .is_none_or(|scope| scope.can_resolve_member(member_type_name))
     }
 
     pub fn tail(&self) -> NodeIndex {
@@ -215,7 +290,7 @@ impl OperationPath {
      * self: The original path from which the requirement check started.
      * other: The path found that satisfies (part of) the requirement.
      */
-    pub fn build_requirement_continuation_path(&self, other: &Self) -> Self {
+    pub fn build_requirement_continuation_path(&self, other: &OperationPath<'graph>) -> Self {
         let source_segments: Vec<Rc<PathSegment>> = self.get_segments();
         let target_segments: Vec<Rc<PathSegment>> = other.get_segments();
 
@@ -278,5 +353,12 @@ impl OperationPath {
             previous_new_segment,
             self.visited_edge_indices.clone(),
         )
+        // The requirement continuation reuses other's tail, so it also must reuse its union context
+        .with_union_context(other.union_context.clone())
+    }
+
+    fn with_union_context(mut self, scope: Option<UnionContext<'graph>>) -> Self {
+        self.union_context = scope;
+        self
     }
 }

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -89,6 +89,9 @@ pub struct OperationPath<'graph> {
     pub last_segment: Option<Rc<PathSegment>>,
     pub visited_edge_indices: Rc<HashSet<EdgeIndex>>,
     pub cost: u64,
+    // The union context for the current path, if any.
+    // If we hit a field returning a union, this will be set to the union context.
+    // If we hit a field returning a non-union type, this will be cleared.
     pub union_context: Option<UnionContext<'graph>>,
 }
 

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -217,6 +217,9 @@ impl<'graph> OperationPath<'graph> {
     pub fn can_resolve_union_member(&self, member_type_name: &str) -> bool {
         self.union_context
             .as_ref()
+            // If the union context is not present, it means we're not resolving things
+            // for the field returning a union type,
+            // therefore we don't limit members.
             .is_none_or(|scope| scope.can_resolve_member(member_type_name))
     }
 

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -26,15 +26,22 @@ use crate::{
 
 use super::{error::WalkOperationError, excluded::ExcludedFromLookup, path::OperationPath};
 
-pub type VisitedGraphs = HashSet<String>;
+pub type VisitedGraphs<'graph> = HashSet<&'graph str>;
 type ActiveEdgeChecks = HashSet<(NodeIndex, EdgeIndex)>;
 
-struct IndirectPathsLookupQueue {
-    queue: Vec<(VisitedGraphs, HashSet<TypeAwareSelection>, OperationPath)>,
+struct IndirectPathsLookupQueue<'graph> {
+    queue: Vec<(
+        VisitedGraphs<'graph>,
+        HashSet<TypeAwareSelection>,
+        OperationPath<'graph>,
+    )>,
 }
 
-impl IndirectPathsLookupQueue {
-    pub fn new_from_excluded(excluded: &ExcludedFromLookup, path: &OperationPath) -> Self {
+impl<'graph> IndirectPathsLookupQueue<'graph> {
+    pub fn new_from_excluded(
+        excluded: &ExcludedFromLookup<'graph>,
+        path: &OperationPath<'graph>,
+    ) -> Self {
         IndirectPathsLookupQueue {
             queue: vec![(
                 excluded.graph_ids.clone(),
@@ -50,32 +57,38 @@ impl IndirectPathsLookupQueue {
 
     pub fn add(
         &mut self,
-        visited_graphs: VisitedGraphs,
+        visited_graphs: VisitedGraphs<'graph>,
         selections: HashSet<TypeAwareSelection>,
-        path: OperationPath,
+        path: OperationPath<'graph>,
     ) {
         self.queue.push((visited_graphs, selections, path));
     }
 
-    pub fn pop(&mut self) -> Option<(VisitedGraphs, HashSet<TypeAwareSelection>, OperationPath)> {
+    pub fn pop(
+        &mut self,
+    ) -> Option<(
+        VisitedGraphs<'graph>,
+        HashSet<TypeAwareSelection>,
+        OperationPath<'graph>,
+    )> {
         self.queue.pop()
     }
 }
 
 #[derive(Debug)]
-pub enum NavigationTarget<'a> {
-    Field(&'a FieldSelection),
-    ConcreteType(&'a str, Option<Condition>),
+pub enum NavigationTarget<'op> {
+    Field(&'op FieldSelection),
+    ConcreteType(&'op str, Option<Condition>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum NavigationTargetKey<'a> {
-    Field(&'a str),
-    ConcreteType(&'a str),
+enum NavigationTargetKey<'op> {
+    Field(&'op str),
+    ConcreteType(&'op str),
 }
 
-impl<'a> From<&'a NavigationTarget<'a>> for NavigationTargetKey<'a> {
-    fn from(target: &'a NavigationTarget<'a>) -> Self {
+impl<'op> From<&'op NavigationTarget<'op>> for NavigationTargetKey<'op> {
+    fn from(target: &'op NavigationTarget<'op>) -> Self {
         match target {
             NavigationTarget::Field(field) => NavigationTargetKey::Field(&field.name),
             NavigationTarget::ConcreteType(type_name, _) => {
@@ -85,20 +98,20 @@ impl<'a> From<&'a NavigationTarget<'a>> for NavigationTargetKey<'a> {
     }
 }
 
-struct PathSearch<'a> {
-    graph: &'a Graph,
-    override_context: &'a PlannerOverrideContext,
-    cancellation_token: &'a CancellationToken,
+struct PathSearch<'graph> {
+    graph: &'graph Graph,
+    override_context: &'graph PlannerOverrideContext,
+    cancellation_token: &'graph CancellationToken,
     /// Edges currently being checked in this path search.
     /// Used to stop recursive loops when an edge depends on itself.
     active_edge_checks: ActiveEdgeChecks,
 }
 
-impl<'a> PathSearch<'a> {
+impl<'graph> PathSearch<'graph> {
     fn new(
-        graph: &'a Graph,
-        override_context: &'a PlannerOverrideContext,
-        cancellation_token: &'a CancellationToken,
+        graph: &'graph Graph,
+        override_context: &'graph PlannerOverrideContext,
+        cancellation_token: &'graph CancellationToken,
     ) -> Self {
         Self {
             graph,
@@ -113,25 +126,25 @@ impl<'a> PathSearch<'a> {
   path = path.pretty_print(graph),
   current_cost = path.cost
 ))]
-pub fn find_indirect_paths(
-    graph: &Graph,
-    override_context: &PlannerOverrideContext,
-    path: &OperationPath,
-    target: &NavigationTarget,
-    excluded: &ExcludedFromLookup,
-    cancellation_token: &CancellationToken,
-) -> Result<Vec<OperationPath>, WalkOperationError> {
+pub fn find_indirect_paths<'graph>(
+    graph: &'graph Graph,
+    override_context: &'graph PlannerOverrideContext,
+    path: &OperationPath<'graph>,
+    target: &NavigationTarget<'_>,
+    excluded: &ExcludedFromLookup<'graph>,
+    cancellation_token: &'graph CancellationToken,
+) -> Result<Vec<OperationPath<'graph>>, WalkOperationError> {
     PathSearch::new(graph, override_context, cancellation_token)
         .find_indirect_paths(path, target, excluded)
 }
 
-impl PathSearch<'_> {
+impl<'graph> PathSearch<'graph> {
     fn find_indirect_paths(
         &mut self,
-        path: &OperationPath,
-        target: &NavigationTarget,
-        excluded: &ExcludedFromLookup,
-    ) -> Result<Vec<OperationPath>, WalkOperationError> {
+        path: &OperationPath<'graph>,
+        target: &NavigationTarget<'_>,
+        excluded: &ExcludedFromLookup<'graph>,
+    ) -> Result<Vec<OperationPath<'graph>>, WalkOperationError> {
         let graph = self.graph;
         let cancellation_token = self.cancellation_token;
         let mut tracker = BestPathTracker::new(graph);
@@ -142,6 +155,13 @@ impl PathSearch<'_> {
         let source_graph_id = tail_node
             .graph_id()
             .ok_or(WalkOperationError::TailMissingInfo(tail_node_index))?;
+
+        // Respect the path's current union scope when targeting a concrete type.
+        if let NavigationTarget::ConcreteType(type_name, _) = target {
+            if !path.can_resolve_union_member(type_name) {
+                return Ok(Vec::new());
+            }
+        }
 
         let mut queue = IndirectPathsLookupQueue::new_from_excluded(excluded, path);
 
@@ -217,7 +237,7 @@ impl PathSearch<'_> {
                 }
 
                 let mut new_excluded_graph_ids = visited_graphs.clone();
-                new_excluded_graph_ids.insert(edge_tail_graph_id.to_string());
+                new_excluded_graph_ids.insert(edge_tail_graph_id);
                 let new_excluded = ExcludedFromLookup {
                     graph_ids: new_excluded_graph_ids,
                     requirement: visited_key_fields.clone(),
@@ -238,6 +258,7 @@ impl PathSearch<'_> {
                         );
 
                         let next_resolution_path = path.advance(
+                            graph,
                             &edge_ref,
                             QueryTreeNode::from_paths(graph, &paths, None)?,
                             target,
@@ -261,7 +282,7 @@ impl PathSearch<'_> {
                             trace!("No direct paths found");
 
                             let mut new_visited_graphs = visited_graphs.clone();
-                            new_visited_graphs.insert(edge_tail_graph_id.to_string());
+                            new_visited_graphs.insert(edge_tail_graph_id);
 
                             let next_requirements = match edge.requirements() {
                                 Some(requirements) => {
@@ -295,13 +316,13 @@ impl PathSearch<'_> {
     }
 }
 
-impl PathSearch<'_> {
+impl<'graph> PathSearch<'graph> {
     fn try_advance_direct_path(
         &mut self,
-        path: &OperationPath,
-        edge_ref: &EdgeReference,
-        target: &NavigationTarget,
-    ) -> Result<Option<OperationPath>, WalkOperationError> {
+        path: &OperationPath<'graph>,
+        edge_ref: &EdgeReference<'graph>,
+        target: &NavigationTarget<'_>,
+    ) -> Result<Option<OperationPath<'graph>>, WalkOperationError> {
         let graph = self.graph;
         trace!(
             "Checking edge {}",
@@ -320,6 +341,7 @@ impl PathSearch<'_> {
                 );
 
                 let next_resolution_path = path.advance(
+                    graph,
                     edge_ref,
                     QueryTreeNode::from_paths(graph, &paths, None)?,
                     target,
@@ -335,14 +357,14 @@ impl PathSearch<'_> {
     }
 }
 
-pub fn find_self_referencing_direct_path(
-    graph: &Graph,
-    override_context: &PlannerOverrideContext,
-    path: &OperationPath,
-    type_name: &str,
+pub fn find_self_referencing_direct_path<'graph>(
+    graph: &'graph Graph,
+    override_context: &'graph PlannerOverrideContext,
+    path: &OperationPath<'graph>,
+    type_name: &'graph str,
     condition: &Condition,
-    cancellation_token: &CancellationToken,
-) -> Result<OperationPath, WalkOperationError> {
+    cancellation_token: &'graph CancellationToken,
+) -> Result<OperationPath<'graph>, WalkOperationError> {
     let path_tail_index = path.tail();
     let mut path_search = PathSearch::new(graph, override_context, cancellation_token);
 
@@ -372,25 +394,32 @@ pub fn find_self_referencing_direct_path(
     path = path.pretty_print(graph),
     current_cost = path.cost,
 ))]
-pub fn find_direct_paths(
-    graph: &Graph,
-    override_context: &PlannerOverrideContext,
-    path: &OperationPath,
-    target: &NavigationTarget,
-    cancellation_token: &CancellationToken,
-) -> Result<Vec<OperationPath>, WalkOperationError> {
+pub fn find_direct_paths<'graph>(
+    graph: &'graph Graph,
+    override_context: &'graph PlannerOverrideContext,
+    path: &OperationPath<'graph>,
+    target: &NavigationTarget<'_>,
+    cancellation_token: &'graph CancellationToken,
+) -> Result<Vec<OperationPath<'graph>>, WalkOperationError> {
     PathSearch::new(graph, override_context, cancellation_token).find_direct_paths(path, target)
 }
 
-impl PathSearch<'_> {
+impl<'graph> PathSearch<'graph> {
     fn find_direct_paths(
         &mut self,
-        path: &OperationPath,
-        target: &NavigationTarget,
-    ) -> Result<Vec<OperationPath>, WalkOperationError> {
+        path: &OperationPath<'graph>,
+        target: &NavigationTarget<'_>,
+    ) -> Result<Vec<OperationPath<'graph>>, WalkOperationError> {
         let graph = self.graph;
-        let mut result: Vec<OperationPath> = vec![];
+        let mut result: Vec<OperationPath<'graph>> = vec![];
         let path_tail_index = path.tail();
+
+        // Respect the path's current union scope when targeting a concrete type.
+        if let NavigationTarget::ConcreteType(type_name, _) = target {
+            if !path.can_resolve_union_member(type_name) {
+                return Ok(result);
+            }
+        }
 
         let edges_iter: Box<dyn Iterator<Item = _>> = match target {
             NavigationTarget::Field(field) => {
@@ -428,15 +457,15 @@ impl PathSearch<'_> {
   path = path.pretty_print(graph),
   edge = edge_ref.weight().display_name(),
 ))]
-pub fn can_satisfy_edge(
-    graph: &Graph,
-    override_context: &PlannerOverrideContext,
-    edge_ref: &EdgeReference,
-    path: &OperationPath,
-    excluded: &ExcludedFromLookup,
+pub fn can_satisfy_edge<'graph>(
+    graph: &'graph Graph,
+    override_context: &'graph PlannerOverrideContext,
+    edge_ref: &EdgeReference<'graph>,
+    path: &OperationPath<'graph>,
+    excluded: &ExcludedFromLookup<'graph>,
     use_only_direct_edges: bool,
-    cancellation_token: &CancellationToken,
-) -> Result<Option<Vec<OperationPath>>, WalkOperationError> {
+    cancellation_token: &'graph CancellationToken,
+) -> Result<Option<Vec<OperationPath<'graph>>>, WalkOperationError> {
     PathSearch::new(graph, override_context, cancellation_token).can_satisfy_edge(
         edge_ref,
         path,
@@ -445,14 +474,14 @@ pub fn can_satisfy_edge(
     )
 }
 
-impl PathSearch<'_> {
+impl<'graph> PathSearch<'graph> {
     fn can_satisfy_edge(
         &mut self,
-        edge_ref: &EdgeReference,
-        path: &OperationPath,
-        excluded: &ExcludedFromLookup,
+        edge_ref: &EdgeReference<'graph>,
+        path: &OperationPath<'graph>,
+        excluded: &ExcludedFromLookup<'graph>,
         use_only_direct_edges: bool,
-    ) -> Result<Option<Vec<OperationPath>>, WalkOperationError> {
+    ) -> Result<Option<Vec<OperationPath<'graph>>>, WalkOperationError> {
         let graph = self.graph;
         let active_key = (path.tail(), edge_ref.id());
         if !self.active_edge_checks.insert(active_key) {
@@ -473,11 +502,11 @@ impl PathSearch<'_> {
 
     fn check_edge_requirements(
         &mut self,
-        edge_ref: &EdgeReference,
-        path: &OperationPath,
-        excluded: &ExcludedFromLookup,
+        edge_ref: &EdgeReference<'graph>,
+        path: &OperationPath<'graph>,
+        excluded: &ExcludedFromLookup<'graph>,
         use_only_direct_edges: bool,
-    ) -> Result<Option<Vec<OperationPath>>, WalkOperationError> {
+    ) -> Result<Option<Vec<OperationPath<'graph>>>, WalkOperationError> {
         let graph = self.graph;
         let override_context = self.override_context;
         let cancellation_token = self.cancellation_token;
@@ -501,7 +530,7 @@ impl PathSearch<'_> {
                 );
 
                 let mut requirements: VecDeque<MoveRequirement> = VecDeque::new();
-                let mut paths_to_requirements: Vec<OperationPath> = vec![];
+                let mut paths_to_requirements: Vec<OperationPath<'graph>> = vec![];
 
                 for selection in selections.selection_set.items.iter() {
                     requirements.push_front(MoveRequirement {
@@ -596,26 +625,28 @@ impl PathSearch<'_> {
 }
 
 #[derive(Debug)]
-pub struct MoveRequirement {
-    pub paths: Rc<Vec<OperationPath>>,
+pub struct MoveRequirement<'graph> {
+    pub paths: Rc<Vec<OperationPath<'graph>>>,
     pub selection: SelectionItem,
 }
 
-type FieldRequirementsResult = Option<(Vec<OperationPath>, Vec<MoveRequirement>)>;
-type FragmentRequirementsResult = Option<(Vec<OperationPath>, Vec<MoveRequirement>)>;
+type FieldRequirementsResult<'graph> =
+    Option<(Vec<OperationPath<'graph>>, Vec<MoveRequirement<'graph>>)>;
+type FragmentRequirementsResult<'graph> =
+    Option<(Vec<OperationPath<'graph>>, Vec<MoveRequirement<'graph>>)>;
 
-impl PathSearch<'_> {
+impl<'graph> PathSearch<'graph> {
     #[instrument(level = "trace", skip_all, fields(field = field.name))]
     fn validate_field_requirement(
         &mut self,
-        move_requirement: &MoveRequirement, // Contains Rc<Vec<OperationPath>>
+        move_requirement: &MoveRequirement<'graph>,
         field: &FieldSelection,
-        excluded: &ExcludedFromLookup,
+        excluded: &ExcludedFromLookup<'graph>,
         use_only_direct_edges: bool,
-    ) -> Result<FieldRequirementsResult, WalkOperationError> {
-        let mut direct_path_results: Vec<Vec<OperationPath>> =
+    ) -> Result<FieldRequirementsResult<'graph>, WalkOperationError> {
+        let mut direct_path_results: Vec<Vec<OperationPath<'graph>>> =
             Vec::with_capacity(move_requirement.paths.len());
-        let mut indirect_path_results: Vec<Vec<OperationPath>> =
+        let mut indirect_path_results: Vec<Vec<OperationPath<'graph>>> =
             Vec::with_capacity(move_requirement.paths.len());
 
         for path in move_requirement.paths.iter() {
@@ -638,7 +669,7 @@ impl PathSearch<'_> {
         let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
             + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
 
-        let mut next_paths: Vec<OperationPath> = Vec::with_capacity(total_capacity);
+        let mut next_paths: Vec<OperationPath<'graph>> = Vec::with_capacity(total_capacity);
 
         // These extend calls should not reallocate `next_paths`.
         for paths_vec in direct_path_results {
@@ -664,7 +695,7 @@ impl PathSearch<'_> {
         }
 
         let shared_next_paths_for_subs = Rc::new(next_paths.clone());
-        let next_requirements: Vec<MoveRequirement> = move_requirement
+        let next_requirements: Vec<MoveRequirement<'graph>> = move_requirement
             .selection
             .selections()
             .unwrap() // Safe due to the check above
@@ -679,17 +710,17 @@ impl PathSearch<'_> {
     }
 }
 
-impl PathSearch<'_> {
+impl<'graph> PathSearch<'graph> {
     #[instrument(level = "trace", skip_all, fields(type_condition = fragment_selection.type_condition))]
     fn validate_fragment_requirement(
         &mut self,
-        requirement: &MoveRequirement,
+        requirement: &MoveRequirement<'graph>,
         fragment_selection: &InlineFragmentSelection,
-        excluded: &ExcludedFromLookup,
-    ) -> Result<FragmentRequirementsResult, WalkOperationError> {
+        excluded: &ExcludedFromLookup<'graph>,
+    ) -> Result<FragmentRequirementsResult<'graph>, WalkOperationError> {
         let type_name = &fragment_selection.type_condition;
-        // Collect all Vec<OperationPath> results from find_direct_paths
-        let mut direct_path_results: Vec<Vec<OperationPath>> =
+        // Collect all Vec<OperationPath<'graph>> results from find_direct_paths
+        let mut direct_path_results: Vec<Vec<OperationPath<'graph>>> =
             Vec::with_capacity(requirement.paths.len());
         for path in requirement.paths.iter() {
             direct_path_results.push(self.find_direct_paths(
@@ -700,8 +731,8 @@ impl PathSearch<'_> {
             )?);
         }
 
-        // Collect all Vec<OperationPath> results from find_indirect_paths
-        let mut indirect_path_results: Vec<Vec<OperationPath>> =
+        // Collect all Vec<OperationPath<'graph>> results from find_indirect_paths
+        let mut indirect_path_results: Vec<Vec<OperationPath<'graph>>> =
             Vec::with_capacity(requirement.paths.len());
         for path_from_rc in requirement.paths.iter() {
             indirect_path_results.push(self.find_indirect_paths(
@@ -717,7 +748,7 @@ impl PathSearch<'_> {
         let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
             + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
 
-        let mut next_paths: Vec<OperationPath> = Vec::with_capacity(total_capacity);
+        let mut next_paths: Vec<OperationPath<'graph>> = Vec::with_capacity(total_capacity);
 
         // These extend calls should not reallocate `next_paths`.
         for paths_vec in direct_path_results {
@@ -742,7 +773,7 @@ impl PathSearch<'_> {
         }
 
         let shared_next_paths_for_subs = Rc::new(next_paths.clone());
-        let next_requirements: Vec<MoveRequirement> = requirement
+        let next_requirements: Vec<MoveRequirement<'graph>> = requirement
             .selection
             .selections()
             .unwrap() // Safe due to the check above

--- a/lib/query-planner/src/tests/union.rs
+++ b/lib/query-planner/src/tests/union.rs
@@ -398,6 +398,70 @@ fn union_member_entity_call_many() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// Related: https://github.com/graphql-hive/router/issues/1098
+// Related: https://github.com/graphql-hive/federation-gateway-audit/pull/347
+#[test]
+fn partial_union_member_only_in_one_subgraph() -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          getResponse {
+            message
+            actions {
+              __typename
+              ... on Alpha {
+                id
+                value
+              }
+              ... on Beta {
+                id
+                name
+                details
+              }
+              ... on Gamma {
+                id
+                label
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan("fixture/tests/partial-union.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          getResponse {
+            message
+            actions {
+              __typename
+              ... on Alpha {
+                id
+                value
+              }
+              ... on Beta {
+                id
+                name
+                details
+              }
+              ... on Gamma {
+                id
+                label
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
 #[test]
 fn union_overfetching_test() -> Result<(), Box<dyn Error>> {
     init_logger();

--- a/lib/query-planner/src/tests/union.rs
+++ b/lib/query-planner/src/tests/union.rs
@@ -429,7 +429,8 @@ fn partial_union_member_only_in_one_subgraph() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan("fixture/tests/partial-union.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/partial-union.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -455,6 +456,342 @@ fn partial_union_member_only_in_one_subgraph() -> Result<(), Box<dyn Error>> {
             }
           }
         }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+// Related: https://github.com/graphql-hive/federation-gateway-audit/pull/347
+#[test]
+fn partial_union_members_missing_from_other_subgraph_only() -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          getResponse {
+            actions {
+              __typename
+              ... on Beta {
+                name
+              }
+              ... on Gamma {
+                label
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/partial-union.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          getResponse {
+            actions {
+              __typename
+              ... on Beta {
+                name
+              }
+              ... on Gamma {
+                label
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn nested_partial_union_entity_representable_a_path_keeps_only_common_members(
+) -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          rootA {
+            wrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+                ... on OnlyA {
+                  a
+                }
+                ... on OnlyB {
+                  b
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/partial-union-complex.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          rootA {
+            wrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn nested_partial_union_entity_representable_b_path_keeps_only_common_members(
+) -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          rootB {
+            wrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+                ... on OnlyA {
+                  a
+                }
+                ... on OnlyB {
+                  b
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/partial-union-complex.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "b") {
+        {
+          rootB {
+            wrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn nested_partial_union_missing_member_from_pinned_path_falls_back_to_typename(
+) -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          rootA {
+            wrapper {
+              actions {
+                __typename
+                ... on OnlyB {
+                  b
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/partial-union-complex.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          rootA {
+            wrapper {
+              actions {
+                __typename
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn nested_partial_union_ambiguous_shareable_path_keeps_only_common_members(
+) -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          shared {
+            wrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+                ... on OnlyA {
+                  a
+                }
+                ... on OnlyB {
+                  b
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/partial-union-complex.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          shared {
+            wrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn nested_partial_union_uses_members_from_subgraph_reached_by_entity_move(
+) -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query {
+          rootA {
+            bWrapper {
+              actions {
+                __typename
+                ... on Common {
+                  label
+                }
+                ... on OnlyA {
+                  a
+                }
+                ... on OnlyB {
+                  b
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/partial-union-complex.supergraph.graphql",
+        document,
+    )?;
+    let query_plan = format!("{}", query_plan);
+
+    // bWrapper forces an entity move from Container/a to Container/b before resolving actions,
+    // so Action must be narrowed to B's local members and keep OnlyB while dropping OnlyA.
+    assert!(query_plan.contains("... on OnlyB"));
+    assert!(!query_plan.contains("... on OnlyA"));
+
+    insta::assert_snapshot!(query_plan, @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          {
+            rootA {
+              __typename
+              id
+            }
+          }
+        },
+        Flatten(path: "rootA") {
+          Fetch(service: "b") {
+            {
+              ... on Container {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Container {
+                bWrapper {
+                  actions {
+                    __typename
+                    ... on Common {
+                      label
+                    }
+                    ... on OnlyB {
+                      b
+                    }
+                  }
+                }
+              }
+            }
+          },
+        },
       },
     },
     "#);


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1098 and adds lifetimes in code (agreed with Dotan to include it in the PR - we can now allocate much much less).

Let me explain the changes in a few points.

## Per-subgraph union member edges in the graph

Previously, `UnionDefinitions::intersections` computed the intersection of all union members across all subgraphs, and only some members were turned into `AbstractMove` edges. This meant subgraph-specific members were eliminated from the graph.

Now we no longer do the intersection of union members when building the graph. A subgraph that knows `Action = Common | OnlyA` gets edges only to `Common` and `OnlyA`, and a subgraph that knows `Action = Common | OnlyB` gets edges only to `Common` and `OnlyB`.

The intersection decision lives now in the walker.

## `UnionContext` in `OperationPath`

Each `OperationPath` contains an optional `UnionContext`, that has:
- `parent_type_name` and `field_name` - union field that was traversed
- `graph_id` - which subgraph we're in
- `member_name` - union member the path resolved to
- `possible_members` - the list of union members available in this subgraph

The context is set when a `FieldMove` edge represents a field returning a union type.

## Per-path union members

In `find_direct_paths` and `find_indirect_paths`, when the navigation target is a `ConcreteType` (like `... on OnlyB`), the path finder checks if the type can be resolved, before even exploring edges. If there's `UnionContext` of course.

## Intersection

The intersection of members is done in the walker module now, and it's part of `narrow_partial_union_paths` function. This function performs the intersection of `possible_members` from paths, from all subgraphs.

- drops paths where current member is not in the intersection
- replaces the `possible_members` with the intersection
- if the intersection is empty, drops all paths as no member is allowed