### PR TITLE
at-least-once sampling

### DIFF
--- a/.changeset/at_least_once_sampling.md
+++ b/.changeset/at_least_once_sampling.md
@@ -1,0 +1,34 @@
+---
+hive-router: minor
+hive-router-config: minor
+hive-console-sdk: minor
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-apollo-router-plugin: patch
+---
+
+# Add at-least-once sampling for Usage Reporting
+
+Hive Router now supports at-least-once sampling for Usage Reporting.
+
+This feature is useful when you want to keep a low sampling rate, but still make sure all operations are visible in Hive at least once.
+
+The first request for each unique key is always reported. Later requests for the same key follow the configured sampling `rate`.
+
+Example configuration:
+
+```yaml
+telemetry:
+  hive:
+    usage_reporting:
+      enabled: true
+      sampling:
+        rate: "10%" # 10% of operations will be reported
+        at_least_once:
+          key: # the combination of operation's name and body makes the request unique
+            - operation_name
+            - operation_body
+          max_distinct_keys: 12000 # how many keys to track and hold in memory
+```
+
+Keys are tracked in memory, up to `max_distinct_keys` (default: `100_000`). Every key takes approximately 16 bytes of memory.

--- a/.changeset/excluding_before_sampling.md
+++ b/.changeset/excluding_before_sampling.md
@@ -1,0 +1,11 @@
+---
+hive-router: minor
+hive-console-sdk: minor
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-apollo-router-plugin: patch
+---
+
+# Apply usage-reporting excludes before sampling
+
+Exclusion of Usage Reports is now evaluated before sampling. Excluded operations are dropped immediately and sampling is not affected.

--- a/.changeset/sample_rate_sampling.md
+++ b/.changeset/sample_rate_sampling.md
@@ -1,0 +1,22 @@
+---
+hive-router-config: minor
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Move `sample_rate` into `sampling.rate`
+
+**Breaking change** The sampling configuration of Usage Reporting has been reorganized.
+
+```diff
+telemetry:
+  hive:
+    usage_reporting:
+-      sample_rate: "10%"
++      sampling:
++        rate: "10%"
+```
+
+
+The old top-level `sample_rate` field has been replaced by `sampling.rate`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,7 @@ dependencies = [
 name = "hive-console-sdk"
 version = "0.3.15"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-dropper-simple",
  "async-trait",
@@ -2570,6 +2571,7 @@ dependencies = [
  "md5",
  "mockito",
  "moka",
+ "rand 0.10.1",
  "recloser",
  "regex-automata",
  "regress",
@@ -2587,6 +2589,7 @@ dependencies = [
  "tracing",
  "typify",
  "vrl",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -155,7 +155,11 @@ pub async fn graphql_request_handler(
         let mut request_headers = req.headers().clone();
         let request_context = req.read_request_context()?;
 
-        let client = identify_client(&request_headers, &request_context, &shared_state.router_config.telemetry.client_identification)?;
+        let client = identify_client(
+            &request_headers,
+            &request_context,
+            &shared_state.router_config.telemetry.client_identification,
+        )?;
         let client_name = client.name.as_deref();
         let client_version = client.version.as_deref();
 
@@ -214,7 +218,7 @@ pub async fn graphql_request_handler(
 
         let Some(ref supergraph) = **schema_state.current_supergraph() else {
             return Err(PipelineError::NoSupergraphAvailable {
-              response_headers: vec![(RETRY_AFTER, HeaderValue::from_static("10"))],
+                response_headers: vec![(RETRY_AFTER, HeaderValue::from_static("10"))],
             });
         };
 
@@ -231,23 +235,24 @@ pub async fn graphql_request_handler(
         }
 
         request_context.update(|ctx| {
-          ctx.operation.update(parser_payload.operation_name.clone(), Some(parser_payload.operation_type.clone()));
+            ctx.operation.update(
+                parser_payload.operation_name.clone(),
+                Some(parser_payload.operation_type.clone()),
+            );
 
-          // Set initial state for progressive overrides in request context
-          let progressive_overrides = &supergraph.planner.supergraph.progressive_overrides;
-          if !progressive_overrides.flags.is_empty() {
-            ctx.progressive_override.unresolved_labels = Some(progressive_overrides.flags.clone());
-          }
+            // Set initial state for progressive overrides in request context
+            let progressive_overrides = &supergraph.planner.supergraph.progressive_overrides;
+            if !progressive_overrides.flags.is_empty() {
+                ctx.progressive_override.unresolved_labels =
+                    Some(progressive_overrides.flags.clone());
+            }
         })?;
 
         if let Some(coprocessor_runtime) = shared_state.coprocessor.as_ref() {
             let performed_mutations = match coprocessor_runtime
-                .on_graphql_request(
-                    req,
-                    &mut request_headers,
-                    &mut graphql_params,
-                    || supergraph.public_schema.sdl.clone()
-                )
+                .on_graphql_request(req, &mut request_headers, &mut graphql_params, || {
+                    supergraph.public_schema.sdl.clone()
+                })
                 .await?
             {
                 ControlFlow::Break(response) => return Ok(response),
@@ -289,16 +294,17 @@ pub async fn graphql_request_handler(
             Some(normalize_payload.operation_identity.operation_type.as_str()),
         );
 
-                // Update the request context if the operation name or type has changed
-                if parser_payload.operation_name.as_ref() != normalize_payload.operation_identity.name.as_ref()
-                        || parser_payload.operation_type != normalize_payload.operation_identity.operation_type
-                {
-                        request_context.update(|ctx| {
-                                ctx.operation.update(
-                                        normalize_payload.operation_identity.name.clone(),
-                                        Some(normalize_payload.operation_identity.operation_type.clone()),
-                                );
-                        })?;
+        // Update the request context if the operation name or type has changed
+        if parser_payload.operation_name.as_ref()
+            != normalize_payload.operation_identity.name.as_ref()
+            || parser_payload.operation_type != normalize_payload.operation_identity.operation_type
+        {
+            request_context.update(|ctx| {
+                ctx.operation.update(
+                    normalize_payload.operation_identity.name.clone(),
+                    Some(normalize_payload.operation_identity.operation_type.clone()),
+                );
+            })?;
         }
 
         if req.method() == Method::GET {
@@ -322,8 +328,12 @@ pub async fn graphql_request_handler(
             return Err(PipelineError::SubscriptionsNotSupported);
         }
 
-        let request_dedupe_enabled =
-            shared_state.router_config.traffic_shaping.router.dedupe.enabled;
+        let request_dedupe_enabled = shared_state
+            .router_config
+            .traffic_shaping
+            .router
+            .dedupe
+            .enabled;
 
         let fingerprint = if request_dedupe_enabled
             && matches!(
@@ -355,22 +365,24 @@ pub async fn graphql_request_handler(
         let request_context = req.read_request_context()?;
         let path_params = req.match_info().into();
 
-        let exec = |guard| execute_planned_request(
-            req.method(),
-            req.uri(),
-            request_headers,
-            path_params,
-            graphql_params,
-            &normalize_payload,
-            supergraph,
-            shared_state,
-            schema_state,
-            operation_span,
-            plugin_req_state,
-            &request_context,
-            response_mode,
-            guard,
-        );
+        let exec = |guard| {
+            execute_planned_request(
+                req.method(),
+                req.uri(),
+                request_headers,
+                path_params,
+                graphql_params,
+                &normalize_payload,
+                supergraph,
+                shared_state,
+                schema_state,
+                operation_span,
+                plugin_req_state,
+                &request_context,
+                response_mode,
+                guard,
+            )
+        };
 
         let shared_response = if let Some(fp) = fingerprint {
             let (shared_response, _role) = if is_subscription {
@@ -401,18 +413,6 @@ pub async fn graphql_request_handler(
                 normalize_payload.operation_for_plan.operation_kind.as_ref(),
                 &parser_payload.minified_document,
                 hive_usage_agent,
-                shared_state
-                    .router_config
-                    .telemetry
-                    .hive
-                    .as_ref()
-                    .map(|c| &c.usage_reporting)
-                    .expect(
-                        // SAFETY: According to `configure_app_from_config` in `bin/router/src/lib.rs`,
-                        // the UsageAgent is only created when usage reporting is enabled.
-                        // Thus, this expect should never panic.
-                        "Expected Usage Reporting options to be present when Hive Usage Agent is initialized",
-                    ),
                 shared_response.error_count(),
                 Some(usage_reporting::request_details_from_ntex_request(req)),
             )

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -6,16 +6,17 @@ use std::{
 use async_trait::async_trait;
 use graphql_tools::parser::schema::Document;
 use hive_console_sdk::agent::usage_agent::{
-    AgentError, ExecutionReport, OperationType, RequestDetails, UsageAgent, UsageAgentExt,
+    AgentError, ExecutionReport, OperationType, RequestDetails, SamplingKey, UsageAgent,
+    UsageAgentExt,
 };
 use hive_router_config::{
+    headers::OneOrMany,
     telemetry::hive::{is_slug_target_ref, is_uuid_target_ref, HiveTelemetryConfig},
-    usage_reporting::{UsageReportingConfig, UsageReportingExclude},
+    usage_reporting::{UsageReportingExclude, UsageReportingSamplingKeyKind},
 };
 use hive_router_internal::background_tasks::{BackgroundTask, BackgroundTasksManager};
 use hive_router_internal::telemetry::utils::resolve_value_or_expression;
 use hive_router_query_planner::state::supergraph_state::OperationKind;
-use rand::prelude::*;
 use tokio_util::sync::CancellationToken;
 
 use crate::consts::ROUTER_VERSION;
@@ -65,6 +66,7 @@ pub fn init_hive_usage_agent(
         .user_agent(user_agent)
         .endpoint(usage_config.endpoint.clone())
         .token(access_token)
+        .sample_rate(usage_config.sampling.rate.as_f64())
         .buffer_size(usage_config.buffer_size)
         .connect_timeout(usage_config.connect_timeout)
         .request_timeout(usage_config.request_timeout)
@@ -77,6 +79,20 @@ pub fn init_hive_usage_agent(
 
     if let Some(UsageReportingExclude::Expression { expression }) = &usage_config.exclude {
         agent_builder = agent_builder.exclude_expression(expression.clone());
+    }
+
+    if let Some(UsageReportingExclude::OperationNames(operation_names)) = &usage_config.exclude {
+        agent_builder = agent_builder.exclude_operation_names(operation_names.clone());
+    }
+
+    if let Some(at_least_once) = &usage_config.sampling.at_least_once {
+        agent_builder = agent_builder.at_least_once_sampling(
+            match &at_least_once.key {
+                OneOrMany::One(kind) => vec![map_sampling_key_to_sdk(kind)],
+                OneOrMany::Many(kinds) => kinds.iter().map(map_sampling_key_to_sdk).collect(),
+            },
+            at_least_once.max_distinct_keys,
+        );
     }
 
     let agent = agent_builder.build()?;
@@ -97,21 +113,9 @@ pub async fn collect_usage_report<'a>(
     operation_kind: Option<&'a OperationKind>,
     operation_body: &'a str,
     hive_usage_agent: &UsageAgent,
-    usage_config: &UsageReportingConfig,
     error_count: usize,
     request_details: Option<RequestDetails>,
 ) {
-    let sample_rate = usage_config.sample_rate.as_f64();
-    if sample_rate < 1.0 && !rand::rng().random_bool(sample_rate) {
-        return;
-    }
-    if let Some(operation_name) = operation_name {
-        if let Some(UsageReportingExclude::OperationNames(excluded_names)) = &usage_config.exclude {
-            if excluded_names.iter().any(|name| name == operation_name) {
-                return;
-            }
-        }
-    }
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -139,6 +143,14 @@ pub async fn collect_usage_report<'a>(
         .await
     {
         tracing::error!("Failed to send usage report: {}", err);
+    }
+}
+
+fn map_sampling_key_to_sdk(kind: &UsageReportingSamplingKeyKind) -> SamplingKey {
+    match kind {
+        UsageReportingSamplingKeyKind::OperationName => SamplingKey::OperationName,
+        UsageReportingSamplingKeyKind::OperationType => SamplingKey::OperationType,
+        UsageReportingSamplingKeyKind::OperationBody => SamplingKey::OperationBody,
     }
 }
 

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -541,13 +541,6 @@ async fn handle_text_frame(
                         normalize_payload.operation_for_plan.operation_kind.as_ref(),
                         &parser_payload.minified_document,
                         hive_usage_agent,
-                        shared_state
-                            .router_config
-                            .telemetry
-                            .hive
-                            .as_ref()
-                            .map(|c| &c.usage_reporting)
-                            .expect("Expected Usage Reporting options to be present when Hive Usage Agent is initialized"),
                         shared_response.error_count(),
                         Some(request_details),
                     )

--- a/docs/README.md
+++ b/docs/README.md
@@ -2895,7 +2895,7 @@ version_header: graphql-client-version
 |**target**||A target ID, this can either be a slug following the format “$organizationSlug/$projectSlug/$targetSlug” (e.g “the-guild/graphql-hive/staging”) or an UUID (e.g. “a0f4c605-6541-4350-8cfe-b31f21a4bf80”). To be used when the token is configured with an organization access token.<br/>||
 |**token**||Your [Registry Access Token](https://the-guild.dev/graphql/hive/docs/management/targets#registry-access-tokens) with write permission.<br/>||
 |[**tracing**](#telemetryhivetracing)|`object`|Default: `{"batch_processor":{"max_concurrent_exports":1,"max_export_batch_size":500,"max_export_timeout":"5s","max_queue_size":20000,"max_spans_per_trace":1000,"max_traces_in_memory":30000,"scheduled_delay":"5s"},"enabled":false,"endpoint":"https://api.graphql-hive.com/otel/v1/traces"}`<br/>||
-|[**usage\_reporting**](#telemetryhiveusage_reporting)|`object`|Default: `{"accept_invalid_certs":false,"buffer_size":1000,"connect_timeout":"5s","enabled":false,"endpoint":"https://app.graphql-hive.com/usage","exclude":null,"flush_interval":"5s","request_timeout":"15s","sample_rate":"100%"}`<br/>||
+|[**usage\_reporting**](#telemetryhiveusage_reporting)|`object`|Default: `{"accept_invalid_certs":false,"buffer_size":1000,"connect_timeout":"5s","enabled":false,"endpoint":"https://app.graphql-hive.com/usage","exclude":null,"flush_interval":"5s","request_timeout":"15s","sampling":{"at_least_once":null,"rate":"100%"}}`<br/>||
 
 **Additional Properties:** not allowed  
 **Example**
@@ -2977,7 +2977,7 @@ scheduled_delay: 5s
 |**exclude**||An expression in VRL to exclude certain operations from being sent to Hive Console.<br/>Returning `true` from this expression will exclude the operation, while `false` will include it.<br/>This expression is a VRL expression that has access to the request and operation details;<br/><br/>```vrl<br/> if (.request.operation.name == "ExcludeMe") {<br/>   true<br/> } else {<br/>   false<br/> }<br/>```<br/>Backward compatible with both:<br/>- an expression object: `{ expression: "..." }`<br/>- a list of operation names<br/>||
 |**flush\_interval**|`string`|Frequency of flushing the buffer to the server<br/>Default: 5 seconds<br/>Default: `"5s"`<br/>||
 |**request\_timeout**|`string`|A timeout for the entire request to Hive Console<br/>Default: 15 seconds<br/>Default: `"15s"`<br/>||
-|**sample\_rate**|`string`|Sample rate to determine sampling.<br/>0% = never being sent<br/>50% = half of the requests being sent<br/>100% = always being sent<br/>Default: 100%<br/>Default: `"100%"`<br/>||
+|[**sampling**](#telemetryhiveusage_reportingsampling)|`object`|Sample rate to determine sampling.<br/>Default: `{"at_least_once":null,"rate":"100%"}`<br/>||
 
 **Additional Properties:** not allowed  
 **Example**
@@ -2991,7 +2991,64 @@ endpoint: https://app.graphql-hive.com/usage
 exclude: null
 flush_interval: 5s
 request_timeout: 15s
-sample_rate: 100%
+sampling:
+  at_least_once: null
+  rate: 100%
+
+```
+
+<a name="telemetryhiveusage_reportingsampling"></a>
+##### telemetry\.hive\.usage\_reporting\.sampling: object
+
+Sample rate to determine sampling.
+0% = never being sent
+50% = half of the requests being sent
+100% = always being sent
+Default: 100%
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|[**at\_least\_once**](#telemetryhiveusage_reportingsamplingat_least_once)|`object`, `null`|At-least-once sampling configuration.<br/>|yes|
+|**rate**|`string`|Default: `"100%"`<br/>||
+
+**Additional Properties:** not allowed  
+**Example**
+
+```yaml
+at_least_once: null
+rate: 100%
+
+```
+
+<a name="telemetryhiveusage_reportingsamplingat_least_once"></a>
+###### telemetry\.hive\.usage\_reporting\.sampling\.at\_least\_once: object,null
+
+At-least-once sampling configuration.
+
+Used together with `rate`.
+The first request for each unique key is always sampled.
+Later requests for the same key are sampled using the configured rate.
+
+The distinct key is built from the `key` field.
+
+Disabled by default.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**key**||The key used for at-least-once sampling, to determine unique operations.<br/><br/>Possible values:<br/> - `operation_name`: the name of the GraphQL operation<br/> - `operation_type`: the type<br/> - `operation_body`: the body<br/><br/><br/>You can also provide multiple values. In that case, the router combines them<br/>into one key.<br/><br/>No default value.<br/>|yes|
+|**max\_distinct\_keys**|`integer`|Maximum number of unique keys kept in memory for at-least-once sampling.<br/>When the limit is reached, older keys may be removed.<br/><br/>Every key consumes 16 bytes of memory.<br/><br/>Defaults to 100k.<br/>Default: `100000`<br/>Format: `"uint64"`<br/>Minimum: `0`<br/>|no|
+
+**Additional Properties:** not allowed  
+**Example**
+
+```yaml
+{}
 
 ```
 

--- a/e2e/src/telemetry/usage_reporting.rs
+++ b/e2e/src/telemetry/usage_reporting.rs
@@ -145,8 +145,6 @@ async fn usage_reporting_sends_reports_without_exclude() {
         first_report.get("operations").is_some(),
         "Report should contain operations"
     );
-
-    drop(router);
 }
 
 /// Test that an exclude expression matching the operation name prevents the report from being sent.
@@ -193,8 +191,6 @@ async fn usage_reporting_excludes_by_operation_name() {
 
     // Wait a reasonable time to ensure no reports arrive
     mock.assert_no_reports(Duration::from_secs(2)).await;
-
-    drop(router);
 }
 
 /// Test that an exclude expression does NOT exclude non-matching operations.
@@ -246,8 +242,6 @@ async fn usage_reporting_does_not_exclude_non_matching_operations() {
         !reports.is_empty(),
         "Expected report for non-excluded operation"
     );
-
-    drop(router);
 }
 
 /// Test that an exclude expression can filter by request header.
@@ -301,8 +295,6 @@ async fn usage_reporting_excludes_by_header() {
     assert!(res.status().is_success());
 
     mock.assert_no_reports(Duration::from_secs(2)).await;
-
-    drop(router);
 }
 
 /// Test that requests without the excluded header still get reported.
@@ -354,8 +346,6 @@ async fn usage_reporting_sends_when_header_not_matching() {
         !reports.is_empty(),
         "Expected report when header does not match"
     );
-
-    drop(router);
 }
 
 /// Test a complex exclude expression using if/else to exclude introspection AND mutations.
@@ -435,8 +425,6 @@ async fn usage_reporting_complex_exclude_expression() {
         total_ops >= 1,
         "Expected at least one operation in reports for non-excluded query"
     );
-
-    drop(router);
 }
 
 /// Test backward compatibility with legacy operation-name list in usage_reporting.exclude.
@@ -481,8 +469,6 @@ async fn usage_reporting_legacy_exclude_list_still_excludes() {
     assert!(res.status().is_success());
 
     mock.assert_no_reports(Duration::from_secs(2)).await;
-
-    drop(router);
 }
 
 /// Test backward compatibility with legacy list while allowing non-matching operations.
@@ -527,8 +513,6 @@ async fn usage_reporting_legacy_exclude_list_allows_non_matching_operation() {
     assert!(res.status().is_success());
 
     mock.wait_for_reports(1).await;
-
-    drop(router);
 }
 
 /// Test explicit expression object format for usage_reporting.exclude.
@@ -575,4 +559,336 @@ async fn usage_reporting_exclude_expression_object_excludes() {
     mock.assert_no_reports(Duration::from_secs(2)).await;
 
     drop(router);
+}
+
+#[ntex::test]
+async fn usage_reporting_at_least_once_keeps_first_occurrence_at_zero_rate() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let mock = MockUsageEndpoint::start();
+    let usage_endpoint = &mock.address;
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+            supergraph:
+              source: file
+              path: {supergraph_path}
+
+            telemetry:
+              hive:
+                token: test-token
+                usage_reporting:
+                  enabled: true
+                  endpoint: {usage_endpoint}
+                  sampling:
+                    rate: "0%"
+                    at_least_once:
+                      key: operation_name
+                  buffer_size: 1
+                  flush_interval: 100ms
+            "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    let res = router
+        .send_graphql_request("query GetUsers { users { id } }", None, None)
+        .await;
+    assert!(res.status().is_success());
+
+    let res = router
+        .send_graphql_request("query GetUsers { users { id } }", None, None)
+        .await;
+    assert!(res.status().is_success());
+
+    mock.wait_for_reports(1).await;
+    let total_ops = mock.total_operations_count().await;
+    assert_eq!(
+        total_ops, 1,
+        "expected only the first occurrence to be reported"
+    );
+}
+
+#[ntex::test]
+async fn at_least_once_operation_name_different_body() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let mock = MockUsageEndpoint::start();
+    let usage_endpoint = &mock.address;
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+            supergraph:
+              source: file
+              path: {supergraph_path}
+
+            telemetry:
+              hive:
+                token: test-token
+                usage_reporting:
+                  enabled: true
+                  endpoint: {usage_endpoint}
+                  sampling:
+                    rate: "0%"
+                    at_least_once:
+                      key: operation_name
+                  buffer_size: 1
+                  flush_interval: 100ms
+            "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    assert!(router
+        .send_graphql_request("query foo { users { id } }", None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request("query foo { users { username } }", None, None)
+        .await
+        .status()
+        .is_success());
+
+    mock.wait_for_reports(1).await;
+    let total_ops = mock.total_operations_count().await;
+    // We expect only one operation, as we group by operation name,
+    // even though the body is different..
+    assert_eq!(total_ops, 1);
+}
+
+#[ntex::test]
+async fn at_least_once_operation_body() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let mock = MockUsageEndpoint::start();
+    let usage_endpoint = &mock.address;
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+            supergraph:
+              source: file
+              path: {supergraph_path}
+
+            telemetry:
+              hive:
+                token: test-token
+                usage_reporting:
+                  enabled: true
+                  endpoint: {usage_endpoint}
+                  sampling:
+                    rate: "0%"
+                    at_least_once:
+                      key: operation_body
+                  buffer_size: 1
+                  flush_interval: 100ms
+            "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    let op1 = "{ users { id } }";
+    let op2 = "{ users { username } }";
+
+    assert!(router
+        .send_graphql_request(op1, None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request(op2, None, None)
+        .await
+        .status()
+        .is_success());
+
+    mock.wait_for_reports(1).await;
+    let total_ops = mock.total_operations_count().await;
+    assert_eq!(total_ops, 2);
+
+    // Repeat the requests and send one more
+    assert!(router
+        .send_graphql_request(op1, None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request(op2, None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request("{ users { id username } }", None, None)
+        .await
+        .status()
+        .is_success());
+
+    mock.wait_for_reports(2).await;
+    let total_ops = mock.total_operations_count().await;
+    // We expect to get only the new operation
+    assert_eq!(total_ops, 3);
+}
+
+#[ntex::test]
+async fn at_least_once_many_key_type_and_name() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let mock = MockUsageEndpoint::start();
+    let usage_endpoint = &mock.address;
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+            supergraph:
+              source: file
+              path: {supergraph_path}
+
+            telemetry:
+              hive:
+                token: test-token
+                usage_reporting:
+                  enabled: true
+                  endpoint: {usage_endpoint}
+                  sampling:
+                    rate: "0%"
+                    at_least_once:
+                      key:
+                        - operation_name
+                        - operation_type
+                  buffer_size: 1
+                  flush_interval: 100ms
+            "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    assert!(router
+        .send_graphql_request("query SharedName { users { id } }", None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request("query SharedName { users { name } }", None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request("mutation SharedName { upload }", None, None)
+        .await
+        .status()
+        .is_success());
+
+    mock.wait_for_reports(1).await;
+    let total_ops = mock.total_operations_count().await;
+    // We expect query+SharedName (deduplicated) and mutation+SharedName only.
+    assert_eq!(total_ops, 2);
+}
+
+#[ntex::test]
+async fn usage_reporting_exclude_runs_before_at_least_once() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let mock = MockUsageEndpoint::start();
+    let usage_endpoint = &mock.address;
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+            supergraph:
+              source: file
+              path: {supergraph_path}
+
+            telemetry:
+              hive:
+                token: test-token
+                usage_reporting:
+                  enabled: true
+                  endpoint: {usage_endpoint}
+                  exclude:
+                    expression: '.request.headers."x-skip" == "true"'
+                  sampling:
+                    rate: "0%"
+                    at_least_once:
+                      key:
+                        - operation_name
+                  buffer_size: 1
+                  flush_interval: 100ms
+            "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    let op = "query GetUsers { users { id } }";
+
+    // Excluded
+    assert!(router
+        .send_graphql_request(
+            op,
+            None,
+            Some({
+                let mut headers = http::HeaderMap::new();
+                headers.insert("x-skip", "true".parse().unwrap());
+                headers
+            }),
+        )
+        .await
+        .status()
+        .is_success());
+    // Included
+    assert!(router
+        .send_graphql_request("query FetchUsers { users { id name } }", None, None,)
+        .await
+        .status()
+        .is_success());
+
+    mock.wait_for_reports(1).await;
+    let total_ops = mock.total_operations_count().await;
+    assert_eq!(total_ops, 1);
+
+    assert!(router
+        .send_graphql_request(op, None, None)
+        .await
+        .status()
+        .is_success());
+    assert!(router
+        .send_graphql_request(op, None, None)
+        .await
+        .status()
+        .is_success());
+
+    mock.wait_for_reports(2).await;
+    let total_ops = mock.total_operations_count().await;
+    assert_eq!(total_ops, 2);
 }

--- a/lib/hive-console-sdk/Cargo.toml
+++ b/lib/hive-console-sdk/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["full"] }
 md5 = "0.8.0"
 serde_json = { workspace = true }
 moka = { workspace = true }
+rand = { workspace = true }
 sha2 = { version = "0.10.8", features = ["std"] }
 tokio-util = { workspace = true }
 regex-automata = { workspace = true }
@@ -40,6 +41,8 @@ bytes ={ workspace = true }
 sonic-rs = { workspace = true }
 humantime = { workspace = true }
 http-serde = "2.1.1"
+xxhash-rust = { workspace = true }
+ahash = { workspace = true }
 
 [dev-dependencies]
 mockito = { workspace = true }

--- a/lib/hive-console-sdk/src/agent/builder.rs
+++ b/lib/hive-console-sdk/src/agent/builder.rs
@@ -8,10 +8,14 @@ use reqwest_retry::RetryTransientMiddleware;
 use std::sync::LazyLock;
 
 use crate::agent::buffer::Buffer;
-use crate::agent::usage_agent::{non_empty_string, AgentError, UsageAgent, UsageAgentInner};
+use crate::agent::usage_agent::{
+    non_empty_string, AgentError, AtLeastOnceSampling, Exclude, SamplingKey, UsageAgent,
+    UsageAgentInner,
+};
 use crate::agent::utils::OperationProcessor;
 use crate::circuit_breaker;
 use crate::expressions::CompileExpression;
+use crate::helpers::SharedFifoSet;
 use retry_policies::policies::ExponentialBackoff;
 
 pub struct UsageAgentBuilder {
@@ -26,8 +30,24 @@ pub struct UsageAgentBuilder {
     retry_policy: ExponentialBackoff,
     user_agent: Option<String>,
     circuit_breaker: Option<AsyncRecloser>,
-    exclude_expression: Option<String>,
+    exclude: Option<BuilderExclude>,
+    sample_rate: f64,
+    at_least_once: Option<AtLeastOnceSamplingConfig>,
 }
+
+#[derive(Clone)]
+enum BuilderExclude {
+    OperationNames(Vec<String>),
+    Expression(String),
+}
+
+#[derive(Clone)]
+pub struct AtLeastOnceSamplingConfig {
+    key: AtLeastOnceSamplingKey,
+    max_distinct_keys: u64,
+}
+
+pub type AtLeastOnceSamplingKey = Vec<SamplingKey>;
 
 pub static DEFAULT_HIVE_USAGE_ENDPOINT: &str = "https://app.graphql-hive.com/usage";
 
@@ -45,7 +65,9 @@ impl Default for UsageAgentBuilder {
             retry_policy: ExponentialBackoff::builder().build_with_max_retries(3),
             user_agent: None,
             circuit_breaker: None,
-            exclude_expression: None,
+            exclude: None,
+            sample_rate: 1.0,
+            at_least_once: None,
         }
     }
 }
@@ -125,6 +147,27 @@ impl UsageAgentBuilder {
         self.retry_policy = ExponentialBackoff::builder().build_with_max_retries(max_retries);
         self
     }
+    pub fn sample_rate(mut self, sample_rate: f64) -> Self {
+        self.sample_rate = sample_rate.clamp(0.0, 1.0);
+        self
+    }
+    pub fn exclude_operation_names(mut self, operation_names: Vec<String>) -> Self {
+        if !operation_names.is_empty() {
+            self.exclude = Some(BuilderExclude::OperationNames(operation_names));
+        }
+        self
+    }
+    pub fn at_least_once_sampling(
+        mut self,
+        key: AtLeastOnceSamplingKey,
+        max_distinct_keys: u64,
+    ) -> Self {
+        self.at_least_once = Some(AtLeastOnceSamplingConfig {
+            key,
+            max_distinct_keys,
+        });
+        self
+    }
     pub(crate) fn build_agent(self) -> Result<UsageAgentInner, AgentError> {
         let mut default_headers = HeaderMap::new();
 
@@ -186,8 +229,21 @@ impl UsageAgentBuilder {
 
         let buffer = Buffer::new(self.buffer_size);
 
-        let exclude = if let Some(expr) = self.exclude_expression {
-            expr.compile_expression(None)?.into()
+        let exclude = match self.exclude {
+            None => None,
+            Some(BuilderExclude::OperationNames(operation_names)) => {
+                Some(Exclude::OperationNames(operation_names))
+            }
+            Some(BuilderExclude::Expression(expression)) => Some(Exclude::Expression(Box::new(
+                expression.compile_expression(None)?,
+            ))),
+        };
+
+        let at_least_once = if let Some(config) = self.at_least_once {
+            Some(AtLeastOnceSampling {
+                key: config.key,
+                seen_hashes: SharedFifoSet::new(config.max_distinct_keys.max(1) as usize),
+            })
         } else {
             None
         };
@@ -199,12 +255,14 @@ impl UsageAgentBuilder {
             client,
             flush_interval: self.flush_interval,
             circuit_breaker,
-            exclude_expression: exclude,
+            exclude,
+            sample_rate: self.sample_rate,
+            at_least_once,
         })
     }
     pub fn exclude_expression(mut self, expression: String) -> Self {
         if let Some(expression) = non_empty_string(Some(expression)) {
-            self.exclude_expression = Some(expression);
+            self.exclude = Some(BuilderExclude::Expression(expression));
         }
         self
     }

--- a/lib/hive-console-sdk/src/agent/usage_agent.rs
+++ b/lib/hive-console-sdk/src/agent/usage_agent.rs
@@ -1,9 +1,11 @@
 use async_dropper_simple::{AsyncDrop, AsyncDropper};
 use graphql_tools::parser::schema::Document;
+use rand::prelude::*;
 use recloser::AsyncRecloser;
 use reqwest_middleware::ClientWithMiddleware;
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap},
+    hash::{Hash, Hasher},
     sync::Arc,
     time::Duration,
 };
@@ -14,12 +16,14 @@ use crate::expressions::lib::FromVrlValue;
 use crate::{
     agent::{buffer::AddStatus, utils::OperationProcessor},
     expressions::ExecutableProgram,
+    helpers::SharedFifoSet,
 };
 use crate::{
     agent::{buffer::Buffer, builder::UsageAgentBuilder},
     expressions::values::boolean::BooleanConversionError,
 };
 use vrl::{compiler::Program as VrlProgram, core::Value as VrlValue, value::KeyString};
+use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, Clone, Default)]
 pub enum OperationType {
@@ -53,7 +57,27 @@ pub struct UsageAgentInner {
     pub(crate) client: ClientWithMiddleware,
     pub(crate) flush_interval: Duration,
     pub(crate) circuit_breaker: AsyncRecloser,
-    pub(crate) exclude_expression: Option<VrlProgram>,
+    pub(crate) exclude: Option<Exclude>,
+    pub(crate) sample_rate: f64,
+    pub(crate) at_least_once: Option<AtLeastOnceSampling>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Exclude {
+    OperationNames(Vec<String>),
+    Expression(Box<VrlProgram>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SamplingKey {
+    OperationName,
+    OperationType,
+    OperationBody,
+}
+
+pub struct AtLeastOnceSampling {
+    pub(crate) key: Vec<SamplingKey>,
+    pub(crate) seen_hashes: SharedFifoSet,
 }
 
 pub fn non_empty_string(value: Option<String>) -> Option<String> {
@@ -120,6 +144,36 @@ pub trait UsageAgentExt {
 }
 
 impl UsageAgentInner {
+    fn should_exclude(
+        &self,
+        execution_report: &ExecutionReport,
+        request: Option<&RequestDetails>,
+    ) -> Result<bool, AgentError> {
+        self.exclude.as_ref().map_or(Ok(false), |exclude| {
+            exclude.should_exclude(execution_report, request)
+        })
+    }
+
+    fn should_sample(&self, execution_report: &ExecutionReport) -> bool {
+        if let Some(at_least_once) = &self.at_least_once {
+            let key_hash = at_least_once.resolve_key_hash(execution_report);
+            // Every first distinct report should be sampled
+            if at_least_once.mark_seen(key_hash) {
+                return true;
+            }
+        }
+
+        let sample_rate = self.sample_rate;
+        if sample_rate >= 1.0 {
+            return true;
+        }
+        if sample_rate <= 0.0 {
+            return false;
+        }
+
+        rand::rng().random_bool(sample_rate)
+    }
+
     fn produce_report(&self, reports: Vec<ExecutionReport>) -> Result<Report, AgentError> {
         let mut report = Report {
             size: 0,
@@ -252,6 +306,30 @@ impl UsageAgentInner {
     }
 }
 
+impl Exclude {
+    fn should_exclude(
+        &self,
+        execution_report: &ExecutionReport,
+        request: Option<&RequestDetails>,
+    ) -> Result<bool, AgentError> {
+        match self {
+            Exclude::OperationNames(operation_names) => Ok(execution_report
+                .operation_name
+                .as_deref()
+                .is_some_and(|operation_name| {
+                    operation_names.iter().any(|name| name == operation_name)
+                })),
+            Exclude::Expression(program) => {
+                let result = program.execute(get_vrl_value_from_execution_report_and_request(
+                    execution_report,
+                    request.cloned(),
+                ))?;
+                bool::from_vrl_value(result).map_err(AgentError::from)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RequestDetails {
     pub method: http::Method,
@@ -285,22 +363,26 @@ impl UsageAgentExt for UsageAgent {
     ) -> Result<(), AgentError> {
         let inner = self.inner();
 
-        if let Some(exclude_program) = &inner.exclude_expression {
-            let result = exclude_program.execute(
-                get_vrl_value_from_execution_report_and_request(&execution_report, request),
-            )?;
-            let result_bool = bool::from_vrl_value(result)?;
-            if result_bool {
-                tracing::debug!(
-                    "Excluding report for operation \"{}\" based on exclude expression evaluation",
-                    execution_report
-                        .operation_name
-                        .clone()
-                        .or_else(|| Some("anonymous".to_string()))
-                        .unwrap()
-                );
-                return Ok(());
-            }
+        if inner.should_exclude(&execution_report, request.as_ref())? {
+            tracing::debug!(
+                "Excluding report for operation \"{}\" based on exclude expression evaluation",
+                execution_report
+                    .operation_name
+                    .as_deref()
+                    .unwrap_or("anonymous")
+            );
+            return Ok(());
+        }
+
+        if !inner.should_sample(&execution_report) {
+            tracing::debug!(
+                "Sampling dropped report for operation \"{}\"",
+                execution_report
+                    .operation_name
+                    .as_deref()
+                    .unwrap_or("anonymous")
+            );
+            return Ok(());
         }
 
         if let AddStatus::Full { drained } = inner.buffer.add(execution_report).await {
@@ -369,6 +451,35 @@ impl From<RequestDetails> for VrlValue {
             ("headers".into(), headers_value),
             ("url".into(), url_value),
         ]))
+    }
+}
+
+impl AtLeastOnceSampling {
+    fn resolve_key_hash(&self, report: &ExecutionReport) -> u64 {
+        let mut hasher = Xxh3::new();
+
+        for key in &self.key {
+            let value = match key {
+                SamplingKey::OperationName => {
+                    report.operation_name.as_deref().unwrap_or("anonymous")
+                }
+                SamplingKey::OperationType => match report.operation_type.as_ref() {
+                    None | Some(OperationType::Query) => "query",
+                    Some(OperationType::Mutation) => "mutation",
+                    Some(OperationType::Subscription) => "subscription",
+                },
+                SamplingKey::OperationBody => report.operation_body.as_str(),
+            };
+            value.hash(&mut hasher);
+            0u8.hash(&mut hasher);
+        }
+
+        hasher.finish()
+    }
+
+    /// Marks the given key hash as seen, returning true if it was not already seen.
+    fn mark_seen(&self, key_hash: u64) -> bool {
+        self.seen_hashes.insert(key_hash)
     }
 }
 

--- a/lib/hive-console-sdk/src/helpers.rs
+++ b/lib/hive-console-sdk/src/helpers.rs
@@ -1,0 +1,114 @@
+use ahash::HashSet;
+use std::sync::Mutex;
+
+/// A shared, thread-safe version of [`FifoSet`].
+pub struct SharedFifoSet {
+    inner: Mutex<FifoSet>,
+}
+
+impl SharedFifoSet {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(FifoSet::new(capacity)),
+        }
+    }
+
+    /// See [`FifoSet::insert`].
+    pub fn insert(&self, value: u64) -> bool {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("Failed to acquire lock on SharedFifoSet");
+        inner.insert(value)
+    }
+}
+
+/// FIFO set that evicts the oldest entry when full.
+///
+/// The idea here is to keep the least amount of memory footprint possible,
+/// while still providing fast lookup and eviction of the oldest entry when full.
+///
+/// Why this struct and not let's say Moka?
+///
+/// Moka's Cache eats 256 bytes per entry,
+/// This implementation takes 16 bytes per entry.
+/// For 100k entries, this implementation uses ~1.6MB, compared to ~24MB for Moka.
+pub struct FifoSet {
+    /// Vector stores the values in the order they were inserted.
+    eviction_order: Vec<u64>,
+    /// Set stores the values for fast lookup.
+    seen: HashSet<u64>, // Yeah, we duplicate the memory footprint, but it's still much less than LRU or Moka
+    /// The next slot to evict when the set is full.
+    next_evict: u32,
+    /// The capacity of the set.
+    capacity: u32,
+}
+
+impl FifoSet {
+    pub fn new(capacity: usize) -> Self {
+        assert!(
+            capacity > 0 && capacity < 10_000_000_usize,
+            "capacity must be between 1 and 10M"
+        );
+        Self {
+            eviction_order: Vec::new(),
+            seen: HashSet::default(),
+            next_evict: 0,
+            capacity: capacity as u32,
+        }
+    }
+
+    /// Insert if absent. Returns true if inserted.
+    /// When full, evicts the oldest entry to make room.
+    #[inline]
+    pub fn insert(&mut self, value: u64) -> bool {
+        if self.seen.contains(&value) {
+            return false;
+        }
+
+        if self.seen.len() == self.capacity as usize {
+            self.seen
+                .remove(&self.eviction_order[self.next_evict as usize]);
+            // Replace the oldest element
+            self.eviction_order[self.next_evict as usize] = value;
+        } else {
+            // Not full, so add
+            self.eviction_order.push(value);
+        }
+
+        self.seen.insert(value);
+        self.next_evict = (self.next_evict + 1) % self.capacity;
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fifo_set_overflow() {
+        let capacity = 3;
+        let mut set = FifoSet::new(capacity);
+
+        assert!(set.insert(1));
+        assert!(set.insert(2));
+        assert!(set.insert(3));
+
+        // Should not insert
+        assert!(!set.insert(3));
+
+        // Should be full
+        assert_eq!(set.seen.len(), 3);
+
+        // This should trigger eviction of the oldest (1)
+        assert!(set.insert(4));
+        assert!(!set.seen.contains(&1));
+        assert!(set.seen.contains(&4));
+
+        assert!(set.insert(5));
+        assert!(!set.seen.contains(&2));
+        assert!(set.seen.contains(&5));
+    }
+}

--- a/lib/hive-console-sdk/src/lib.rs
+++ b/lib/hive-console-sdk/src/lib.rs
@@ -5,3 +5,4 @@ pub mod supergraph_fetcher;
 pub use async_dropper_simple::AsyncDropper;
 pub use graphql_tools;
 pub mod expressions;
+mod helpers;

--- a/lib/router-config/src/usage_reporting.rs
+++ b/lib/router-config/src/usage_reporting.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::headers::OneOrMany;
 use crate::primitives::percentage::Percentage;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -10,6 +11,73 @@ use crate::primitives::percentage::Percentage;
 pub enum UsageReportingExclude {
     Expression { expression: String },
     OperationNames(Vec<String>),
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageReportingSamplingKeyKind {
+    #[default]
+    OperationName,
+    OperationType,
+    OperationBody,
+}
+
+pub type UsageReportingSamplingKey = OneOrMany<UsageReportingSamplingKeyKind>;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AtLeastOnceSamplingConfig {
+    /// The key used for at-least-once sampling, to determine unique operations.
+    ///
+    /// Possible values:
+    ///  - `operation_name`: the name of the GraphQL operation
+    ///  - `operation_type`: the type
+    ///  - `operation_body`: the body
+    ///
+    ///
+    /// You can also provide multiple values. In that case, the router combines them
+    /// into one key.
+    ///
+    /// No default value.
+    pub key: UsageReportingSamplingKey,
+
+    #[serde(default = "default_max_distinct_keys")]
+    /// Maximum number of unique keys kept in memory for at-least-once sampling.
+    /// When the limit is reached, older keys may be removed.
+    ///
+    /// Every key consumes 16 bytes of memory.
+    ///
+    /// Defaults to 100k.
+    pub max_distinct_keys: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct UsageReportingSamplingConfig {
+    #[serde(default = "default_sample_rate")]
+    #[schemars(with = "String")]
+    pub rate: Percentage,
+
+    #[serde(default)]
+    /// At-least-once sampling configuration.
+    ///
+    /// Used together with `rate`.
+    /// The first request for each unique key is always sampled.
+    /// Later requests for the same key are sampled using the configured rate.
+    ///
+    /// The distinct key is built from the `key` field.
+    ///
+    /// Disabled by default.
+    pub at_least_once: Option<AtLeastOnceSamplingConfig>,
+}
+
+impl Default for UsageReportingSamplingConfig {
+    fn default() -> Self {
+        Self {
+            rate: default_sample_rate(),
+            at_least_once: None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -27,9 +95,8 @@ pub struct UsageReportingConfig {
     /// 50% = half of the requests being sent
     /// 100% = always being sent
     /// Default: 100%
-    #[serde(default = "default_sample_rate")]
-    #[schemars(with = "String")]
-    pub sample_rate: Percentage,
+    #[serde(default)]
+    pub sampling: UsageReportingSamplingConfig,
 
     /// An expression in VRL to exclude certain operations from being sent to Hive Console.
     /// Returning `true` from this expression will exclude the operation, while `false` will include it.
@@ -92,13 +159,14 @@ pub struct UsageReportingConfig {
 #[cfg(test)]
 mod tests {
     use super::UsageReportingConfig;
+    use crate::usage_reporting::UsageReportingExclude;
 
     #[test]
     fn exclude_supports_expression_object() {
         let config: UsageReportingConfig = serde_json::from_str(
             r#"{
                 "enabled": true,
-                "sample_rate": "100%",
+                "sampling": { "rate": "100%" },
                 "exclude": { "expression": ".request.operation.name == \"Health\"" }
             }"#,
         )
@@ -106,11 +174,8 @@ mod tests {
 
         let exclude = config.exclude.expect("exclude should be present");
 
-        assert!(matches!(
-            exclude,
-            super::UsageReportingExclude::Expression { .. }
-        ));
-        if let super::UsageReportingExclude::Expression { expression } = exclude {
+        assert!(matches!(exclude, UsageReportingExclude::Expression { .. }));
+        if let UsageReportingExclude::Expression { expression } = exclude {
             assert_eq!(
                 expression, ".request.operation.name == \"Health\"",
                 "expression should match the input"
@@ -123,24 +188,39 @@ mod tests {
         let config: UsageReportingConfig = serde_json::from_str(
             r#"{
                 "enabled": true,
-                "sample_rate": "100%",
+                "sampling": { "rate": "100%" },
                 "exclude": ["IntrospectionQuery", "HealthCheck"]
             }"#,
         )
         .expect("config with legacy operation list should deserialize");
 
         let exclude = config.exclude.expect("exclude should be present");
-        assert!(matches!(
-            exclude,
-            super::UsageReportingExclude::OperationNames(_)
-        ));
-        if let super::UsageReportingExclude::OperationNames(names) = exclude {
+        assert!(matches!(exclude, UsageReportingExclude::OperationNames(_)));
+        if let UsageReportingExclude::OperationNames(names) = exclude {
             assert_eq!(
                 names,
                 vec!["IntrospectionQuery".to_string(), "HealthCheck".to_string()],
                 "operation names should match the input"
             );
         }
+    }
+
+    #[test]
+    fn at_least_once_no_default() {
+        let config = serde_json::from_str::<UsageReportingConfig>(
+            r#"{
+                "enabled": true,
+                "sampling": {
+                    "rate": "10%",
+                    "at_least_once": {}
+                }
+            }"#,
+        );
+
+        assert!(
+            config.is_err(),
+            "config with no key should fail to deserialize"
+        );
     }
 }
 
@@ -149,7 +229,7 @@ impl Default for UsageReportingConfig {
         Self {
             enabled: default_enabled(),
             endpoint: default_endpoint(),
-            sample_rate: default_sample_rate(),
+            sampling: Default::default(),
             exclude: None,
             buffer_size: default_buffer_size(),
             accept_invalid_certs: default_accept_invalid_certs(),
@@ -170,6 +250,10 @@ fn default_endpoint() -> String {
 
 fn default_sample_rate() -> Percentage {
     Percentage::from_f64(1.0).unwrap()
+}
+
+fn default_max_distinct_keys() -> u64 {
+    100_000
 }
 
 fn default_buffer_size() -> usize {


### PR DESCRIPTION
The goal is to allow users to keep a low reporting sample rate while still making sure every distinct operation is visible in Hive Console at least once.

Before this change, Usage Reporting had a single top-level `sample_rate` option. That works well for reducing amount of usage reports, but it means some operations can be completely missed.

```yaml
telemetry:
  hive:
    usage_reporting:
      enabled: true
      sampling:
        rate: "10%"
        at_least_once:
          key:
            - operation_name
            - operation_body
          max_distinct_keys: 12000
```

## Breaking Change in configuration

```diff
telemetry:
  hive:
    usage_reporting:
-      sample_rate: "10%"
+      sampling:
+        rate: "10%"
```
---

## Behavior changes

Usage Reporting now runs exclusion before sampling. That means excluded operations are dropped immediately and do not affect sampling and its seen keys. Crucial to not affect at-least-once sampling.

---

## Changes in SDK

The sampling decision now lives in SDK. The same applies to exclusion over operation names.

## Seen-key storage

At-least-once sampling tracks hashes of distinct keys, not the full operation body strings, names or types. This way we store u64 (8 bytes) instead of random size of bytes (operation body or name could end up eating lots of memory).

I intentionally did not use a cache like Moka here. We do not need its features, as the only behavior we need is to:

- check whether a `u64` was seen
- insert if absent
- evict the oldest key when the storage is full

The FIFO Set I did holds 16 bytes per key so it's super cheap and efficient.

## Apollo Router Plugin 

The feature request was for Hive Router to support at-least-once sampling, that's why I did not touch our plugin for Apollo's Router. I also tried to keep the diff low (it could be lower but formatting changed a bit) and amount of changes as low as possible. Nothing here prevents us from adopting the same functionality in the plugin at some point.

---

Closes #990

The main difference between this PR and #990 is the scope of the changes.

#990 makes a larger refactor, moves configuration types into the SDK, introduces a tagged sampler, updates the Apollo Router plugin configuration etc. This PR takes a more focused approach.

The goal here is to add support for at-least-once sampling in Hive Router's Usage Reporting. I modified only the parts needed for that feaure: updating the sampling configuration in Hive Router, moving the sampling into the SDK, exclusions before sampling.

The seen-key storage is also implemented differently. The previous implementation had a flaw. Instead of storing full strings such as operation names, operation bodies, or VRL-generated values, this PR hashes the key into `u64` and stores that in a FIFO set. 

It does that to keep memory usage tiny, especially in cases where users choose keys such as `operation_body`, which can be quite huge.
I also chose not to use Moka in this implementation, because it has 10x bigger memory footprint per key and we want to store a lot of keys at small cost.

I left Apollo Router plugin untouched, since the feature request was about Hive Router.
