### PR TITLE
fix(router): skip null entities in batched fetches

### DIFF
--- a/.changeset/null_entity_fix.md
+++ b/.changeset/null_entity_fix.md
@@ -1,0 +1,6 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+Fixes batched entity fetching when the entity list contains null items

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -967,7 +967,7 @@ mod issues_e2e_tests {
             .mock("POST", "/products")
             .match_request(|r| {
                 let body = r.body().unwrap();
-                let body_str = String::from_utf8(body.clone()).unwrap();
+                let body_str = std::str::from_utf8(&body).unwrap();
 
                 body_str.contains("products") && body_str.contains("topProducts")
             })
@@ -996,7 +996,7 @@ mod issues_e2e_tests {
             .mock("POST", "/inventory")
             .match_request(|r| {
                 let body = r.body().unwrap();
-                let body_str = String::from_utf8(body.clone()).unwrap();
+                let body_str = std::str::from_utf8(&body).unwrap();
 
                 body_str.contains("_entities")
                     && body_str.contains("_e0")

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -939,6 +939,132 @@ mod issues_e2e_tests {
     }
 
     #[ntex::test]
+    // Reproduces a bug where batched entity fetches were built from nullable list
+    // items without filtering out `null` values.
+    async fn batch_fetch_skips_null_source_entities() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.batch-null-entity.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      inventory:
+                        url: "http://{host}/inventory"
+                      products:
+                        url: "http://{host}/products"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let products_mock = server
+            .mock("POST", "/products")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("products") && body_str.contains("topProducts")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "products": [
+                      { "__typename": "Product", "upc": "1", "price": 100, "weight": 1 },
+                      { "__typename": "Product", "upc": "2", "price": 200, "weight": 2 },
+                      null
+                    ],
+                    "topProducts": [
+                      { "__typename": "Product", "upc": "3" }
+                    ]
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let inventory_mock = server
+            .mock("POST", "/inventory")
+            .match_request(|r| {
+                let body = r.body().unwrap();
+                let body_str = String::from_utf8(body.clone()).unwrap();
+
+                body_str.contains("_entities")
+                    && body_str.contains("_e0")
+                    && body_str.contains("_e1")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "_e0": [
+                      { "shippingEstimate": 10 },
+                      { "shippingEstimate": 20 }
+                    ],
+                    "_e1": [
+                      { "inStock": true }
+                    ]
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                {
+                  products {
+                    shippingEstimate
+                  }
+                  topProducts {
+                    inStock
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        products_mock.assert();
+        inventory_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "shippingEstimate": 10
+              },
+              {
+                "shippingEstimate": 20
+              },
+              null
+            ],
+            "topProducts": [
+              {
+                "inStock": true
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
     /// https://github.com/graphql-hive/router/issues/1099
     ///
     /// When an entity's `@key` is set to only `__typename` (use case is singleton that lives on another subgraph),

--- a/e2e/src/issues/supergraph.batch-null-entity.graphql
+++ b/e2e/src/issues/supergraph.batch-null-entity.graphql
@@ -1,0 +1,80 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc") {
+  upc: String!
+  weight: Int @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+}
+
+type Query @join__type(graph: INVENTORY) @join__type(graph: PRODUCTS) {
+  products: [Product] @join__field(graph: PRODUCTS)
+  topProducts: [Product] @join__field(graph: PRODUCTS)
+}

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -1,4 +1,3 @@
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::vec;
@@ -617,7 +616,7 @@ pub enum ExecutionJob<'exec> {
         operation: &'exec SubgraphFetchOperation,
         response: SubgraphResponse<'exec>,
         flatten_node_path: &'exec FlattenNodePath,
-        representation_hashes: Vec<u64>,
+        representation_hashes: Vec<Option<u64>>,
         representation_hash_to_index: AHashMap<u64, usize>,
         output_rewrites: Option<&'exec [FetchRewrite]>,
     },
@@ -637,7 +636,7 @@ pub struct AliasBatchState<'exec> {
 
 struct AliasPathState<'exec> {
     merge_path: &'exec FlattenNodePath,
-    representation_hashes: Arc<Vec<u64>>,
+    representation_hashes: Arc<Vec<Option<u64>>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -839,7 +838,7 @@ impl<'exec> Executor<'exec> {
                 let mut filtered_representations = Vec::new();
                 filtered_representations.put(OPEN_BRACKET);
                 let possible_types = &self.schema_metadata.possible_types;
-                let mut representation_hashes: Vec<u64> = Vec::new();
+                let mut representation_hashes: Vec<Option<u64>> = Vec::new();
                 let mut representation_hash_to_index: AHashMap<u64, usize> = AHashMap::new();
                 let arena = bumpalo::Bump::new();
 
@@ -848,17 +847,19 @@ impl<'exec> Executor<'exec> {
                     normalized_path,
                     &self.schema_metadata.possible_types,
                     &mut |entity| {
-                        let hash = entity.to_hash(&requires_nodes.items, possible_types);
+                        if entity.is_null() {
+                            representation_hashes.push(None);
+                            return;
+                        }
 
-                        if !entity.is_null() {
-                            representation_hashes.push(hash);
+                        let hash = entity.to_hash(&requires_nodes.items, possible_types);
+                        representation_hashes.push(Some(hash));
+
+                        if representation_hash_to_index.contains_key(&hash) {
+                            return;
                         }
 
                         let is_first_representation = representation_hash_to_index.is_empty();
-                        let vacant_entry = match representation_hash_to_index.entry(hash) {
-                            Entry::Occupied(_) => return,
-                            Entry::Vacant(vacant_entry) => vacant_entry,
-                        };
 
                         let entity = if let Some(input_rewrites) = &fetch_node.input_rewrites {
                             let new_entity = arena.alloc(entity.clone());
@@ -881,7 +882,7 @@ impl<'exec> Executor<'exec> {
                         );
 
                         if is_projected {
-                            vacant_entry.insert(index);
+                            representation_hash_to_index.insert(hash, index);
                         }
 
                         index += 1;
@@ -1034,7 +1035,13 @@ impl<'exec> Executor<'exec> {
                                 self.schema_metadata,
                                 initial_error_path,
                                 &mut |target, error_path| {
-                                    let hash = representation_hashes[index];
+                                    let hash = representation_hashes.get(index).copied();
+                                    index += 1;
+
+                                    let Some(Some(hash)) = hash else {
+                                        return;
+                                    };
+
                                     if let Some(entity_index) =
                                         representation_hash_to_index.get(&hash)
                                     {
@@ -1055,7 +1062,6 @@ impl<'exec> Executor<'exec> {
                                             deep_merge(target, new_val);
                                         }
                                     }
-                                    index += 1;
                                 },
                             );
 
@@ -1267,7 +1273,13 @@ impl<'exec> Executor<'exec> {
                 self.schema_metadata,
                 initial_error_path,
                 &mut |target_data, error_path| {
-                    let hash = path_state.representation_hashes[index];
+                    let hash = path_state.representation_hashes.get(index).copied();
+                    index += 1;
+
+                    let Some(Some(hash)) = hash else {
+                        return;
+                    };
+
                     // Find matching entity index from hash->index map
                     if let Some(entity_index) = alias_state.representation_hash_to_index.get(&hash)
                     {
@@ -1288,8 +1300,6 @@ impl<'exec> Executor<'exec> {
                             deep_merge(target_data, new_val);
                         }
                     }
-
-                    index += 1;
                 },
             );
         }
@@ -1319,7 +1329,7 @@ impl<'exec> Executor<'exec> {
             filtered_representations.put(OPEN_BRACKET);
             let mut representation_hash_to_index: AHashMap<u64, usize> = AHashMap::new();
             let arena = bumpalo::Bump::new();
-            let mut path_hashes_by_index: Vec<Option<Arc<Vec<u64>>>> =
+            let mut path_hashes_by_index: Vec<Option<Arc<Vec<Option<u64>>>>> =
                 vec![None; alias_spec.merge_paths.len()];
 
             let mut path_groups: Vec<(&FlattenNodePath, Vec<usize>)> =
@@ -1335,20 +1345,22 @@ impl<'exec> Executor<'exec> {
             }
 
             for (merge_path, grouped_target_indices) in path_groups {
-                let mut representation_hashes: Vec<u64> = Vec::new();
+                let mut representation_hashes: Vec<Option<u64>> = Vec::new();
 
                 traverse_and_callback(data, merge_path.as_slice(), possible_types, &mut |entity| {
-                    let hash = entity.to_hash(&alias_spec.requires.items, possible_types);
+                    if entity.is_null() {
+                        representation_hashes.push(None);
+                        return;
+                    }
 
-                    if !entity.is_null() {
-                        representation_hashes.push(hash);
+                    let hash = entity.to_hash(&alias_spec.requires.items, possible_types);
+                    representation_hashes.push(Some(hash));
+
+                    if representation_hash_to_index.contains_key(&hash) {
+                        return;
                     }
 
                     let is_first_representation = representation_hash_to_index.is_empty();
-                    let vacant_entry = match representation_hash_to_index.entry(hash) {
-                        Entry::Occupied(_) => return,
-                        Entry::Vacant(vacant_entry) => vacant_entry,
-                    };
 
                     let entity = if let Some(input_rewrites) = &alias_spec.input_rewrites {
                         let new_entity = arena.alloc(entity.clone());
@@ -1370,7 +1382,7 @@ impl<'exec> Executor<'exec> {
                     );
 
                     if is_projected {
-                        vacant_entry.insert(index);
+                        representation_hash_to_index.insert(hash, index);
                     }
 
                     index += 1;

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::vec;
@@ -854,12 +855,11 @@ impl<'exec> Executor<'exec> {
 
                         let hash = entity.to_hash(&requires_nodes.items, possible_types);
                         representation_hashes.push(Some(hash));
-
-                        if representation_hash_to_index.contains_key(&hash) {
-                            return;
-                        }
-
                         let is_first_representation = representation_hash_to_index.is_empty();
+                        let vacant_entry = match representation_hash_to_index.entry(hash) {
+                            Entry::Occupied(_) => return,
+                            Entry::Vacant(vacant_entry) => vacant_entry,
+                        };
 
                         let entity = if let Some(input_rewrites) = &fetch_node.input_rewrites {
                             let new_entity = arena.alloc(entity.clone());
@@ -882,10 +882,9 @@ impl<'exec> Executor<'exec> {
                         );
 
                         if is_projected {
-                            representation_hash_to_index.insert(hash, index);
+                            vacant_entry.insert(index);
+                            index += 1;
                         }
-
-                        index += 1;
                     },
                 );
 
@@ -1355,12 +1354,11 @@ impl<'exec> Executor<'exec> {
 
                     let hash = entity.to_hash(&alias_spec.requires.items, possible_types);
                     representation_hashes.push(Some(hash));
-
-                    if representation_hash_to_index.contains_key(&hash) {
-                        return;
-                    }
-
                     let is_first_representation = representation_hash_to_index.is_empty();
+                    let vacant_entry = match representation_hash_to_index.entry(hash) {
+                        Entry::Occupied(_) => return,
+                        Entry::Vacant(vacant_entry) => vacant_entry,
+                    };
 
                     let entity = if let Some(input_rewrites) = &alias_spec.input_rewrites {
                         let new_entity = arena.alloc(entity.clone());
@@ -1382,10 +1380,9 @@ impl<'exec> Executor<'exec> {
                     );
 
                     if is_projected {
-                        representation_hash_to_index.insert(hash, index);
+                        vacant_entry.insert(index);
+                        index += 1;
                     }
-
-                    index += 1;
                 });
 
                 let representation_hashes = Arc::new(representation_hashes);


### PR DESCRIPTION
Fixes batched entity fetching when the entity list contains `null` items.

The executor skipped `null` entities when building the batch of representations, but when the subgraph response was processed the logic still assumed every original list item had a matching result. We ended up using incorrect indexes (out of bounds).

Now `null` entities are preserved as empty slots, they are not sent to the subgraph, and the subgraph response processing logic skips those same slots when applying the results.
