### PR TITLE
Fix __typename with interfaceObject

### DIFF
--- a/lib/query-planner/fixture/issues/infinite-typename-interfaceobject.graphql
+++ b/lib/query-planner/fixture/issues/infinite-typename-interfaceobject.graphql
@@ -1,0 +1,93 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) {
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+enum join__Graph {
+  S0 @join__graph(name: "s0", url: "http://localhost:4001/s0")
+  S1 @join__graph(name: "s1", url: "http://localhost:4001/s1")
+  S2 @join__graph(name: "s2", url: "http://localhost:4001/s2")
+  S3 @join__graph(name: "s3", url: "http://localhost:4001/s3")
+}
+
+type Query
+  @join__type(graph: S0)
+  @join__type(graph: S1)
+  @join__type(graph: S2)
+  @join__type(graph: S3) {
+  me: Account @join__field(graph: S3)
+}
+
+type AccountA implements Account
+  @join__type(graph: S2, key: "notUsed")
+  @join__type(graph: S3, key: "notUsed")
+  @join__implements(graph: S3, interface: "Account") {
+  notUsed: Boolean!
+    @join__field(graph: S2, external: true)
+    @join__field(graph: S3)
+}
+
+type AccountB implements Account
+  @join__type(graph: S3, key: "notUsed")
+  @join__implements(graph: S3, interface: "Account") {
+  notUsed: Boolean! @join__field(graph: S3)
+}
+
+interface Account
+  @join__type(graph: S0, key: "notUsed", isInterfaceObject: true)
+  @join__type(graph: S1, key: "notUsed", isInterfaceObject: true)
+  @join__type(graph: S3) {
+  notUsed: Boolean!
+}

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -436,15 +436,16 @@ fn process_field<'a>(
             cancellation_token,
         )?;
         trace!("Direct paths found: {}", direct_paths.len());
+        let found_direct_paths_to_leaf = !direct_paths.is_empty() && field.is_leaf();
 
         if !direct_paths.is_empty() {
             advanced = true;
-            for direct_path in direct_paths {
-                tracker.add(&direct_path)?;
+            for direct_path in &direct_paths {
+                tracker.add(direct_path)?;
             }
         }
 
-        if !fields_to_resolve_locally.contains(&field.name) {
+        if !fields_to_resolve_locally.contains(&field.name) && !found_direct_paths_to_leaf {
             let indirect_paths = find_indirect_paths(
                 graph,
                 override_context,

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -260,6 +260,39 @@ fn issue_190_test() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn issue_interface_object_typename_prefers_direct_leaf_path() -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        {
+          me {
+            __typename
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/issues/infinite-typename-interfaceobject.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "s3") {
+        {
+          me {
+            __typename
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn issue_939_test() -> Result<(), Box<dyn Error>> {
     init_logger();
 


### PR DESCRIPTION
This change updates the query planner to stop exploring indirect paths for leaf fields when a direct path already exists.