### PR TITLE
Header propagation on failure paths

### DIFF
--- a/.changeset/header_propagation_non_happy.md
+++ b/.changeset/header_propagation_non_happy.md
@@ -1,0 +1,8 @@
+---
+hive-router: patch
+hive-router-plan-executor: patch
+---
+
+# Fix response header propagation on error paths
+
+Response header rules now run consistently for successful responses, partial GraphQL error responses, deduped requests, and execution failures.

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -14,6 +14,7 @@ mod utils;
 
 use std::ops::ControlFlow;
 use std::sync::Arc;
+use tracing::error;
 
 use crate::{
     consts::ROUTER_VERSION,
@@ -70,6 +71,7 @@ use hive_router_internal::{
 };
 pub use hive_router_plan_executor::execution::plan::PlanExecutionOutput;
 pub use hive_router_plan_executor::executors::http::SubgraphHttpResponse;
+use hive_router_plan_executor::headers::response::ResponseHeaderSink;
 pub use hive_router_plan_executor::response::graphql_error::GraphQLError;
 pub use hive_router_query_planner as query_planner;
 pub use http;
@@ -168,6 +170,8 @@ async fn graphql_endpoint_dispatch(
     );
     let _ = root_http_request_span.set_parent(parent_ctx);
 
+    let response_header_sink = ResponseHeaderSink::default();
+
     async {
         // Set it to the default value in case of the negotiation failing,
         // so that we can still generate an error response in the correct format.
@@ -182,6 +186,7 @@ async fn graphql_endpoint_dispatch(
             schema_state.get_ref(),
             &root_http_request_span,
             &mut response_mode,
+            response_header_sink.clone(),
         );
 
         // Handle the request with a timeout. If the timeout is reached, a timeout error response will be generated.
@@ -194,6 +199,13 @@ async fn graphql_endpoint_dispatch(
                 handle_pipeline_error(err, request, &app_state, &response_mode)
             }
         };
+
+        if let Err(err) = response_header_sink
+            .take()
+            .modify_client_response_headers(response.headers_mut())
+        {
+            error!(error = %err, "Failed to apply response header rules to the outgoing client response");
+        }
 
         // Apply CORS headers to the final response if CORS is configured.
         if let Some(cors) = app_state.cors_runtime.as_ref() {

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -13,6 +13,7 @@ use hive_router_plan_executor::execution::plan::{
     execute_query_plan, CoerceVariablesPayload, ExecutionResultExtensions, PlanExecutionOutput,
     QueryPlanExecutionOpts, QueryPlanExecutionResult,
 };
+use hive_router_plan_executor::headers::response::ResponseHeaderSink;
 use hive_router_plan_executor::hooks::on_supergraph_load::SupergraphData;
 use hive_router_plan_executor::introspection::resolve::IntrospectionContext;
 use hive_router_plan_executor::plugin_context::PluginRequestState;
@@ -47,6 +48,7 @@ pub async fn execute_plan<'exec>(
     app_state: &RouterSharedState,
     planned_request: PlannedRequest<'exec>,
     span: GraphQLOperationSpan,
+    response_header_sink: ResponseHeaderSink,
 ) -> Result<QueryPlanExecutionResult, PipelineError> {
     let execute_span = GraphQLExecuteSpan::new();
     let introspection_context = IntrospectionContext {
@@ -145,6 +147,7 @@ pub async fn execute_plan<'exec>(
                 supergraph.operation_name_forward_config.clone(),
                 operation_name,
             ),
+            response_header_sink,
         })
         .await?;
 

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -13,7 +13,7 @@ use hive_router_plan_executor::{
         },
         plan::{CoerceVariablesPayload, PlanExecutionOutput, QueryPlanExecutionResult},
     },
-    headers::response::ResponseHeaderAggregator,
+    headers::response::{ResponseHeaderAggregator, ResponseHeaderSink},
     hooks::{on_graphql_params::GraphQLParams, on_supergraph_load::SupergraphData},
     plugin_context::{PluginContext, PluginRequestState},
     request_context::{RequestContextExt, SharedRequestContext},
@@ -110,6 +110,7 @@ pub async fn graphql_request_handler(
     schema_state: &Arc<SchemaState>,
     http_server_request_span: &HttpServerRequestSpan,
     response_mode: &mut ResponseMode,
+    response_header_sink: ResponseHeaderSink,
 ) -> Result<web::HttpResponse, PipelineError> {
     // If an early CORS response is needed, return it immediately.
     if let Some(early_response) = shared_state
@@ -381,6 +382,7 @@ pub async fn graphql_request_handler(
                 &request_context,
                 response_mode,
                 guard,
+                response_header_sink.clone(),
             )
         };
 
@@ -453,6 +455,7 @@ pub async fn execute_planned_request<'exec>(
     request_context: &SharedRequestContext,
     response_mode: &'exec ResponseMode,
     guard: Option<SharedRouterResponseGuard>,
+    response_header_sink: ResponseHeaderSink,
 ) -> Result<SharedRouterResponse, PipelineError> {
     let jwt_request_details = match &shared_state.jwt_auth_runtime {
         Some(jwt_auth_runtime) => match jwt_auth_runtime
@@ -503,6 +506,7 @@ pub async fn execute_planned_request<'exec>(
         operation_span,
         plugin_req_state,
         request_context,
+        response_header_sink,
     )
     .await?
     {
@@ -534,9 +538,6 @@ pub async fn execute_planned_request<'exec>(
             });
 
             let mut builder = web::HttpResponse::Ok();
-            if let Some(aggregator) = result.response_headers_aggregator {
-                aggregator.modify_client_response_headers(&mut builder)?;
-            };
             builder.content_type(stream_content_type.as_ref());
             let headers = Arc::new(builder.finish().headers().clone());
 
@@ -557,9 +558,6 @@ pub async fn execute_planned_request<'exec>(
             // drop the `guard` as soon as the response is ready
 
             let mut builder = web::HttpResponse::Ok();
-            if let Some(aggregator) = result.response_headers_aggregator {
-                aggregator.modify_client_response_headers(&mut builder)?;
-            };
             builder.content_type(single_content_type.as_ref());
             let headers = Arc::new(builder.finish().headers().clone());
 
@@ -586,6 +584,7 @@ pub async fn execute_pipeline<'exec>(
     operation_span: GraphQLOperationSpan,
     plugin_req_state: Option<PluginRequestState<'exec>>,
     request_context: &SharedRequestContext,
+    response_header_sink: ResponseHeaderSink,
 ) -> Result<QueryPlanExecutionResult, PipelineError> {
     if normalize_payload.operation_for_introspection.is_some() {
         handle_introspection_policy(&shared_state.introspection_policy, &client_request_details)?;
@@ -634,14 +633,17 @@ pub async fn execute_pipeline<'exec>(
                     _ => Vec::new(),
                 };
 
-                return Ok(QueryPlanExecutionResult::Single(PlanExecutionOutput {
-                    body,
+                if !response.headers().is_empty() {
                     // It's an early return, so the headers from the coprocessor response
                     // should all be applied to the final response.
                     // No header propagation rules should be applied.
-                    response_headers_aggregator: Some(
-                        ResponseHeaderAggregator::from_early_response(response.headers()),
-                    ),
+                    response_header_sink.store(ResponseHeaderAggregator::from_early_response(
+                        response.headers(),
+                    ));
+                }
+
+                return Ok(QueryPlanExecutionResult::Single(PlanExecutionOutput {
+                    body,
                     error_count: 0,
                     status_code: response.status(),
                 }));
@@ -698,7 +700,14 @@ pub async fn execute_pipeline<'exec>(
         plugin_req_state,
     };
 
-    execute_plan(supergraph, shared_state, planned_request, operation_span).await
+    execute_plan(
+        supergraph,
+        shared_state,
+        planned_request,
+        operation_span,
+        response_header_sink,
+    )
+    .await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -506,7 +506,7 @@ pub async fn execute_planned_request<'exec>(
         operation_span,
         plugin_req_state,
         request_context,
-        response_header_sink,
+        response_header_sink.clone(),
     )
     .await?
     {
@@ -537,9 +537,10 @@ pub async fn execute_planned_request<'exec>(
                 // dropping producer_handle closes the broadcast channel
             });
 
-            let mut builder = web::HttpResponse::Ok();
-            builder.content_type(stream_content_type.as_ref());
-            let headers = Arc::new(builder.finish().headers().clone());
+            let headers = materialize_shared_response_headers(
+                stream_content_type.as_ref(),
+                &response_header_sink,
+            );
 
             Ok(SharedRouterResponse::Stream(SharedRouterStreamResponse {
                 body: sender,
@@ -557,9 +558,10 @@ pub async fn execute_planned_request<'exec>(
 
             // drop the `guard` as soon as the response is ready
 
-            let mut builder = web::HttpResponse::Ok();
-            builder.content_type(single_content_type.as_ref());
-            let headers = Arc::new(builder.finish().headers().clone());
+            let headers = materialize_shared_response_headers(
+                single_content_type.as_ref(),
+                &response_header_sink,
+            );
 
             Ok(SharedRouterResponse::Single(SharedRouterSingleResponse {
                 body: ntex::util::Bytes::from(result.body),
@@ -569,6 +571,26 @@ pub async fn execute_planned_request<'exec>(
             }))
         }
     }
+}
+
+fn materialize_shared_response_headers(
+    content_type: &str,
+    response_header_sink: &ResponseHeaderSink,
+) -> Arc<HeaderMap> {
+    let mut builder = web::HttpResponse::Ok();
+    builder.content_type(content_type);
+    let mut response = builder.finish();
+
+    // Deduped requests reuse this shared response, but header sinks are per-request,
+    // so propagated headers must be finalized here instead of relying on each sink.
+    if let Err(err) = response_header_sink
+        .take()
+        .modify_client_response_headers(response.headers_mut())
+    {
+        error!(error = %err, "Failed to apply response header rules to client response");
+    }
+
+    Arc::new(response.headers().clone())
 }
 
 #[inline]

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -1,4 +1,5 @@
 use hive_console_sdk::agent::usage_agent::RequestDetails;
+use hive_router_plan_executor::headers::response::ResponseHeaderSink;
 use http::Method;
 use ntex::channel::oneshot;
 use ntex::http::{header::HeaderName, header::HeaderValue, HeaderMap};
@@ -208,6 +209,8 @@ async fn handle_text_frame(
     ws_uri: &http::Uri,
     ws_path: &Path<http::Uri>,
 ) -> Option<ws::Message> {
+    // TODO: cover response header aggregation for WS
+    let response_header_sink = ResponseHeaderSink::default();
     let client_msg: ClientMessage = match sonic_rs::from_str(&text) {
         Ok(msg) => msg,
         Err(e) => {
@@ -479,6 +482,7 @@ async fn handle_text_frame(
                     request_context,
                     &response_mode,
                     guard,
+                    response_header_sink.clone()
                 );
 
                 let shared_response = if let Some(fp) = fingerprint {

--- a/e2e/src/demand_control/extensions.rs
+++ b/e2e/src/demand_control/extensions.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod extensions_tests {
     use super::super::common::*;
+    use crate::testkit::some_header_map;
 
     #[ntex::test]
     async fn exposes_cost_headers_when_enabled() {
@@ -221,5 +222,321 @@ mod extensions_tests {
         assert_eq!(res.cost_header("x-cost-estimated"), Some(1));
         assert_eq!(res.cost_header("x-cost-actual"), None);
         assert_eq!(res.cost_header("x-cost-max"), None);
+    }
+
+    #[ntex::test]
+    async fn exposes_cost_headers_for_deduped_follower_requests() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        traffic_shaping:
+            all:
+                dedupe_enabled: false
+            router:
+                dedupe:
+                    enabled: true
+        demand_control:
+            enabled: true
+            operation_cost:
+              max: 100
+              mode: enforce
+              expose_headers:
+                estimated: true
+                actual: true
+                max: true
+            subgraphs_budget:
+              mode: enforce
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let query = r#"query { me { name } }"#;
+        let (response_a, response_b) = futures::join!(
+            router.send_graphql_request(query, None, None),
+            router.send_graphql_request(query, None, None)
+        );
+
+        for response in [&response_a, &response_b] {
+            assert!(response.status().is_success(), "Expected 200 OK");
+            assert_eq!(response.cost_header("x-cost-estimated"), Some(1));
+            assert_eq!(response.cost_header("x-cost-actual"), Some(1));
+            assert_eq!(response.cost_header("x-cost-max"), Some(100));
+        }
+
+        let accounts_requests = subgraphs
+            .get_requests_log("accounts")
+            .unwrap_or_default()
+            .len();
+        assert_eq!(
+            accounts_requests, 1,
+            "expected exactly one accounts subgraph request when router dedupe is enabled"
+        );
+    }
+
+    #[ntex::test]
+    async fn custom_cost_header_names_survive_deduped_follower_requests() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        traffic_shaping:
+            all:
+                dedupe_enabled: false
+            router:
+                dedupe:
+                    enabled: true
+        demand_control:
+            enabled: true
+            operation_cost:
+              max: 100
+              mode: enforce
+              expose_headers:
+                estimated: "X-My-Estimated"
+                actual: "X-My-Actual"
+                max: "X-My-Max"
+            subgraphs_budget:
+              mode: enforce
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let query = r#"query { me { name } }"#;
+        let (response_a, response_b) = futures::join!(
+            router.send_graphql_request(query, None, None),
+            router.send_graphql_request(query, None, None)
+        );
+
+        for response in [&response_a, &response_b] {
+            assert!(response.status().is_success(), "Expected 200 OK");
+            assert_eq!(response.cost_header("x-my-estimated"), Some(1));
+            assert_eq!(response.cost_header("x-my-actual"), Some(1));
+            assert_eq!(response.cost_header("x-my-max"), Some(100));
+            assert_eq!(response.cost_header("x-cost-estimated"), None);
+            assert_eq!(response.cost_header("x-cost-actual"), None);
+            assert_eq!(response.cost_header("x-cost-max"), None);
+        }
+    }
+
+    #[ntex::test]
+    async fn selective_cost_headers_survive_deduped_follower_requests() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        traffic_shaping:
+            all:
+                dedupe_enabled: false
+            router:
+                dedupe:
+                    enabled: true
+        demand_control:
+            enabled: true
+            operation_cost:
+              max: 100
+              mode: enforce
+              expose_headers:
+                estimated: true
+            subgraphs_budget:
+              mode: enforce
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let query = r#"query { me { name } }"#;
+        let (response_a, response_b) = futures::join!(
+            router.send_graphql_request(query, None, None),
+            router.send_graphql_request(query, None, None)
+        );
+
+        for response in [&response_a, &response_b] {
+            assert!(response.status().is_success(), "Expected 200 OK");
+            assert_eq!(response.cost_header("x-cost-estimated"), Some(1));
+            assert_eq!(response.cost_header("x-cost-actual"), None);
+            assert_eq!(response.cost_header("x-cost-max"), None);
+        }
+    }
+
+    #[ntex::test]
+    async fn does_not_expose_cost_headers_when_estimated_cost_rejects_request() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        demand_control:
+            enabled: true
+            operation_cost:
+              max: 0
+              mode: enforce
+              expose_headers:
+                estimated: true
+                actual: true
+                max: true
+            subgraphs_budget:
+              mode: enforce
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"query { me { name } }"#, None, None)
+            .await;
+        let json = res.json_body().await;
+
+        assert_eq!(
+            json["errors"][0]["extensions"]["code"].as_str(),
+            Some("COST_ESTIMATED_TOO_EXPENSIVE")
+        );
+        assert_eq!(res.cost_header("x-cost-estimated"), Some(1));
+        assert_eq!(res.cost_header("x-cost-actual"), None);
+        assert_eq!(res.cost_header("x-cost-max"), Some(0));
+    }
+
+    #[ntex::test]
+    async fn exposes_cost_headers_on_partial_graphql_error_responses() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let mut accounts_server = mockito::Server::new_async().await;
+        let host = accounts_server.host_with_port();
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        override_subgraph_urls:
+            subgraphs:
+                accounts:
+                    url: "http://{host}/accounts"
+        demand_control:
+            enabled: true
+            operation_cost:
+              max: 100
+              mode: enforce
+              expose_headers:
+                estimated: true
+                actual: true
+                max: true
+            subgraphs_budget:
+              mode: enforce
+        "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let accounts_response_mock = accounts_server
+            .mock("POST", "/accounts")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"users":[{"id":"1"}]},"errors":[{"message":"upstream is unhappy","extensions":{"code":"UPSTREAM_FAILURE"}}]}"#,
+            )
+            .expect(1)
+            .create();
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+        let json = res.json_body().await;
+
+        accounts_response_mock.assert();
+        assert!(res.status().is_success(), "Expected 200 OK");
+        assert!(json["errors"].is_array(), "expected GraphQL errors: {json}");
+        assert_eq!(json["data"]["users"][0]["id"].as_str(), Some("1"));
+        assert_eq!(res.cost_header("x-cost-estimated"), Some(0));
+        assert_eq!(res.cost_header("x-cost-actual"), Some(1));
+        assert_eq!(res.cost_header("x-cost-max"), Some(100));
+    }
+
+    #[ntex::test]
+    async fn does_not_leak_cost_headers_between_distinct_requests() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        traffic_shaping:
+            all:
+                dedupe_enabled: false
+            router:
+                dedupe:
+                    enabled: true
+        demand_control:
+            enabled: true
+            operation_cost:
+              max: 100
+              mode: enforce
+              expose_headers:
+                estimated: true
+            subgraphs_budget:
+              mode: enforce
+        "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let deduped_query = r#"query { me { name } }"#;
+        let (response_a, response_b, response_plain) = futures::join!(
+            router.send_graphql_request(deduped_query, None, None),
+            router.send_graphql_request(deduped_query, None, None),
+            router.send_graphql_request(
+                r#"query { topProducts { name price } }"#,
+                None,
+                some_header_map! { "x-user" => "separate-request" },
+            )
+        );
+
+        for response in [&response_a, &response_b] {
+            assert_eq!(response.cost_header("x-cost-estimated"), Some(1));
+        }
+
+        assert!(response_plain.status().is_success(), "Expected 200 OK");
+        assert_eq!(response_plain.cost_header("x-cost-estimated"), Some(0));
     }
 }

--- a/e2e/src/header_propagation.rs
+++ b/e2e/src/header_propagation.rs
@@ -96,4 +96,58 @@ mod header_propagation_e2e_tests {
             );
         }
     }
+
+    #[ntex::test]
+    async fn should_propagate_response_headers_on_failures() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let mut accounts_server = mockito::Server::new_async().await;
+        let host = accounts_server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  headers:
+                    all:
+                      response:
+                        - propagate:
+                            named: x-subgraph
+                            algorithm: last
+                  override_subgraph_urls:
+                      subgraphs:
+                          accounts:
+                              url: "http://{host}/accounts"
+                  "#
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        let accounts_response_mock = accounts_server
+            .mock("POST", "/accounts")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("x-subgraph", "accounts")
+            .expect(1)
+            .create();
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        accounts_response_mock.assert();
+
+        assert_eq!(
+            res.headers()
+                .get("x-subgraph")
+                .and_then(|v| v.to_str().ok()),
+            Some("accounts"),
+            "expected x-subgraph header to be propagated"
+        );
+    }
 }

--- a/e2e/src/header_propagation.rs
+++ b/e2e/src/header_propagation.rs
@@ -2,6 +2,7 @@
 
 mod header_propagation_e2e_tests {
     use crate::testkit::{some_header_map, TestRouter, TestSubgraphs};
+    use futures::join;
 
     #[ntex::test]
     async fn should_propagate_headers_to_subgraphs() {
@@ -148,6 +149,207 @@ mod header_propagation_e2e_tests {
                 .and_then(|v| v.to_str().ok()),
             Some("accounts"),
             "expected x-subgraph header to be propagated"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_propagate_response_headers_for_deduped_follower_requests() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(std::time::Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let mut accounts_server = mockito::Server::new_async().await;
+        let host = accounts_server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  traffic_shaping:
+                    all:
+                      dedupe_enabled: false
+                    router:
+                      dedupe:
+                        enabled: true
+                  headers:
+                    all:
+                      response:
+                        - propagate:
+                            named: x-subgraph
+                            algorithm: last
+                  override_subgraph_urls:
+                      subgraphs:
+                          accounts:
+                              url: "http://{host}/accounts"
+                  "#
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        let accounts_response_mock = accounts_server
+            .mock("POST", "/accounts")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("x-subgraph", "accounts")
+            .expect(1)
+            .create();
+
+        let (response_a, response_b) = join!(
+            router.send_graphql_request("{ users { id } }", None, None),
+            router.send_graphql_request("{ users { id } }", None, None)
+        );
+
+        accounts_response_mock.assert();
+
+        for response in [&response_a, &response_b] {
+            assert!(response.status().is_success(), "Expected 200 OK");
+            assert_eq!(
+                response
+                    .headers()
+                    .get("x-subgraph")
+                    .and_then(|v| v.to_str().ok()),
+                Some("accounts"),
+                "expected x-subgraph header to be propagated"
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn should_not_leak_propagated_response_headers_between_distinct_requests() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let mut accounts_server = mockito::Server::new_async().await;
+        let host = accounts_server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  traffic_shaping:
+                    all:
+                      dedupe_enabled: false
+                    router:
+                      dedupe:
+                        enabled: true
+                  headers:
+                    all:
+                      response:
+                        - propagate:
+                            named: x-subgraph
+                            algorithm: last
+                  override_subgraph_urls:
+                      subgraphs:
+                          accounts:
+                              url: "http://{host}/accounts"
+                  "#
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        let accounts_response_mock = accounts_server
+            .mock("POST", "/accounts")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("x-subgraph", "accounts")
+            .expect(1)
+            .create();
+
+        let deduped_res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+        accounts_response_mock.assert();
+        assert_eq!(
+            deduped_res
+                .headers()
+                .get("x-subgraph")
+                .and_then(|v| v.to_str().ok()),
+            Some("accounts")
+        );
+
+        let plain_res = router
+            .send_graphql_request("{ topProducts { name } }", None, None)
+            .await;
+
+        assert!(plain_res.status().is_success(), "Expected 200 OK");
+        assert_eq!(
+            plain_res
+                .headers()
+                .get("x-subgraph")
+                .and_then(|v| v.to_str().ok()),
+            Some("products"),
+            "expected the distinct request to carry its own propagated subgraph header"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_not_override_router_selected_content_type() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let mut accounts_server = mockito::Server::new_async().await;
+        let host = accounts_server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  traffic_shaping:
+                    all:
+                      dedupe_enabled: false
+                    router:
+                      dedupe:
+                        enabled: true
+                  headers:
+                    all:
+                      response:
+                        - propagate:
+                            named: content-type
+                            algorithm: last
+                  override_subgraph_urls:
+                      subgraphs:
+                          accounts:
+                              url: "http://{host}/accounts"
+                  "#
+            ))
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        let accounts_response_mock = accounts_server
+            .mock("POST", "/accounts")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .expect(1)
+            .create();
+
+        let headers = some_header_map! {
+          http::header::ACCEPT => "application/graphql-response+json"
+        }
+        .expect("failed to compile headers");
+
+        let response = router
+            .send_graphql_request("{ users { id } }", None, Some(headers.clone()))
+            .await;
+
+        accounts_response_mock.assert();
+
+        assert!(response.status().is_success(), "Expected 200 OK");
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/graphql-response+json"),
+            "expected content-type to win over propagated content-type"
         );
     }
 }

--- a/lib/executor/src/execution/error.rs
+++ b/lib/executor/src/execution/error.rs
@@ -76,6 +76,15 @@ impl PlanExecutionError {
     pub fn affected_path(&self) -> &Option<String> {
         &self.context.affected_path
     }
+
+    pub fn subgraph_response_headers(&self) -> Option<&http::HeaderMap> {
+        match &self.kind {
+            PlanExecutionErrorKind::SubgraphExecutor(subgraph_error) => {
+                subgraph_error.response_headers()
+            }
+            _ => None,
+        }
+    }
 }
 
 // This is needed for individual fetch node error handling

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -47,12 +47,12 @@ use crate::{
     headers::{
         plan::HeaderRulesPlan,
         request::modify_subgraph_request_headers,
-        response::{apply_subgraph_response_headers, ResponseHeaderAggregator},
+        response::{apply_subgraph_response_headers, ResponseHeaderAggregator, ResponseHeaderSink},
     },
     hooks::{
         on_execute::{
             DemandControlCost, DemandControlEstimatedCost, OnExecuteEndHookPayload,
-            OnExecuteStartHookPayload,
+            OnExecuteResponse, OnExecuteStartHookPayload,
         },
         on_graphql_error::handle_graphql_errors_with_plugins,
     },
@@ -61,7 +61,7 @@ use crate::{
         schema::SchemaMetadata,
     },
     plugin_context::PluginRequestState,
-    plugin_trait::{EndControlFlow, StartControlFlow},
+    plugin_trait::{EarlyHTTPResponse, EndControlFlow, StartControlFlow},
     plugins::hooks,
     projection::{
         plan::FieldProjectionPlan, request::project_requires, response::project_by_operation,
@@ -129,11 +129,11 @@ pub struct QueryPlanExecutionOpts<'exec> {
     pub span: GraphQLOperationSpan,
     pub plugin_req_state: Option<PluginRequestState<'exec>>,
     pub operation_name_factory: OperationNameFactory,
+    pub response_header_sink: ResponseHeaderSink,
 }
 
 pub struct PlanSubscriptionOutput {
     pub body: BoxStream<'static, Vec<u8>>,
-    pub response_headers_aggregator: Option<ResponseHeaderAggregator>,
     pub error_count: usize,
 }
 
@@ -145,7 +145,6 @@ pub enum QueryPlanExecutionResult {
 #[derive(Default)]
 pub struct PlanExecutionOutput {
     pub body: Vec<u8>,
-    pub response_headers_aggregator: Option<ResponseHeaderAggregator>,
     pub error_count: usize,
     pub status_code: StatusCode,
 }
@@ -168,6 +167,23 @@ impl FailedExecutionResult {
             })
             .unwrap()
         })
+    }
+}
+
+fn early_http_response_into_execution_output(
+    response: EarlyHTTPResponse,
+    response_header_sink: &ResponseHeaderSink,
+) -> PlanExecutionOutput {
+    if !response.headers.is_empty() {
+        response_header_sink.store(ResponseHeaderAggregator::from_http_headers(
+            &response.headers,
+        ));
+    }
+
+    PlanExecutionOutput {
+        body: response.body,
+        error_count: 0,
+        status_code: response.status_code,
     }
 }
 
@@ -293,6 +309,7 @@ pub async fn execute_query_plan<'exec>(
         let client_operation_kind = opts.client_request.operation.kind;
         let client_jwt = opts.client_request.jwt.clone();
         let client_path_params = opts.client_request.path_params.into_owned();
+        let response_header_sink = opts.response_header_sink.clone();
 
         let operation_name_factory = opts.operation_name_factory.clone();
 
@@ -356,6 +373,7 @@ pub async fn execute_query_plan<'exec>(
                     graphql_error_recorder: None,
                     operation_name_factory: operation_name_factory.clone(),
                     demand_control_context: opts.demand_control_context.clone(),
+                    response_header_sink: response_header_sink.clone(),
                 };
                 match execute_query_plan_with_data(response.data, opts).await {
                     Ok(result) => yield result.body,
@@ -372,7 +390,6 @@ pub async fn execute_query_plan<'exec>(
 
         return Ok(QueryPlanExecutionResult::Stream(PlanSubscriptionOutput {
             body: body_stream,
-            response_headers_aggregator: None,
             error_count: 0, // NOTE: errors can only happen before streaming started
         }));
     }
@@ -431,9 +448,15 @@ async fn execute_query_plan_with_data<'exec>(
             start_payload = result.payload;
             match result.control_flow {
                 StartControlFlow::Proceed => { /* continue to next plugin */ }
-                StartControlFlow::EndWithResponse(response) => {
-                    return Ok(response);
-                }
+                StartControlFlow::EndWithResponse(response) => match response {
+                    OnExecuteResponse::Output(response) => return Ok(response),
+                    OnExecuteResponse::EarlyResponse(response) => {
+                        return Ok(early_http_response_into_execution_output(
+                            response,
+                            &opts.response_header_sink,
+                        ));
+                    }
+                },
                 StartControlFlow::OnEnd(callback) => {
                     on_end_callbacks.push(callback);
                 }
@@ -464,6 +487,9 @@ async fn execute_query_plan_with_data<'exec>(
 
     if let Some(node) = &opts.query_plan.node {
         executor.execute_plan_node(&mut exec_ctx, node).await;
+
+        opts.response_header_sink
+            .store(std::mem::take(&mut exec_ctx.response_headers_aggregator));
     }
 
     let error_count = exec_ctx.errors.len(); // Added for usage reporting
@@ -539,9 +565,15 @@ async fn execute_query_plan_with_data<'exec>(
             end_payload = result.payload;
             match result.control_flow {
                 EndControlFlow::Proceed => { /* continue to next callback */ }
-                EndControlFlow::EndWithResponse(response) => {
-                    return Ok(response);
-                }
+                EndControlFlow::EndWithResponse(response) => match response {
+                    OnExecuteResponse::Output(response) => return Ok(response),
+                    OnExecuteResponse::EarlyResponse(response) => {
+                        return Ok(early_http_response_into_execution_output(
+                            response,
+                            &opts.response_header_sink,
+                        ));
+                    }
+                },
             }
         }
 
@@ -586,7 +618,6 @@ async fn execute_query_plan_with_data<'exec>(
 
     Ok(PlanExecutionOutput {
         body,
-        response_headers_aggregator: exec_ctx.response_headers_aggregator.none_if_empty(),
         error_count,
         status_code,
     })
@@ -944,6 +975,26 @@ impl<'exec> Executor<'exec> {
     ) {
         match job {
             Err(ref err) => {
+                if let (Some(subgraph_name), Some(subgraph_headers)) = (
+                    err.subgraph_name().as_deref(),
+                    err.subgraph_response_headers(),
+                ) {
+                    if let Err(ref propagation_err) = apply_subgraph_response_headers(
+                        self.headers_plan,
+                        subgraph_name,
+                        subgraph_headers,
+                        self.client_request,
+                        &mut ctx.response_headers_aggregator,
+                    )
+                    .with_plan_context(LazyPlanContext {
+                        subgraph_name: || Some(subgraph_name.to_string()),
+                        affected_path: || err.affected_path().clone(),
+                    }) {
+                        self.log_error(propagation_err);
+                        ctx.errors.push(propagation_err.into());
+                    }
+                }
+
                 self.log_error(err);
                 ctx.errors.push(err.into());
             }

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -487,9 +487,6 @@ async fn execute_query_plan_with_data<'exec>(
 
     if let Some(node) = &opts.query_plan.node {
         executor.execute_plan_node(&mut exec_ctx, node).await;
-
-        opts.response_header_sink
-            .store(std::mem::take(&mut exec_ctx.response_headers_aggregator));
     }
 
     let error_count = exec_ctx.errors.len(); // Added for usage reporting
@@ -544,6 +541,9 @@ async fn execute_query_plan_with_data<'exec>(
         );
         demand_control.apply_expose_headers(&mut exec_ctx.response_headers_aggregator, actual);
     }
+
+    opts.response_header_sink
+        .store(std::mem::take(&mut exec_ctx.response_headers_aggregator));
 
     // TODO: coprocessor.on_execution_response
     if !on_end_callbacks.is_empty() {

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use hive_console_sdk::circuit_breaker::CircuitBreakerError;
-use http::{uri::InvalidUri, StatusCode};
+use http::{uri::InvalidUri, HeaderMap, StatusCode};
 use rustls::server::VerifierBuilderError;
 use strum::IntoStaticStr;
 
@@ -50,13 +52,13 @@ pub enum SubgraphExecutorError {
     RequestTimeout(#[from] tokio::time::error::Elapsed),
     #[error("Failed to read response body from subgraph \"{0}\": {1}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_READ_FAILURE")]
-    ResponseBodyReadFailure(String, String),
+    ResponseBodyReadFailure(String, String, Arc<HeaderMap>),
     #[error("Received empty response body from subgraph \"{0}\"")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_EMPTY")]
-    EmptyResponseBody(String),
+    EmptyResponseBody(String, Arc<HeaderMap>),
     #[error("Failed to deserialize subgraph response: {0}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_DESERIALIZATION_FAILURE")]
-    ResponseDeserializationFailure(sonic_rs::Error),
+    ResponseDeserializationFailure(sonic_rs::Error, Option<Arc<HeaderMap>>),
     #[error(transparent)]
     #[strum(serialize = "SUBGRAPH_HTTPS_CERTS_FAILURE")]
     TlsCertificatesError(#[from] TlsCertificatesError),
@@ -121,6 +123,16 @@ pub enum SubgraphExecutorError {
 impl SubgraphExecutorError {
     pub fn error_code(&self) -> &'static str {
         self.into()
+    }
+
+    pub fn response_headers(&self) -> Option<&http::HeaderMap> {
+        match self {
+            Self::InternalServerError(response) => response.headers.as_deref(),
+            Self::EmptyResponseBody(_, headers) => Some(headers.as_ref()),
+            Self::ResponseBodyReadFailure(_, _, headers) => Some(headers.as_ref()),
+            Self::ResponseDeserializationFailure(_, headers) => headers.as_deref(),
+            _ => None,
+        }
     }
 }
 

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -257,20 +257,22 @@ async fn send_request<'a>(
         );
 
         let (parts, body) = res.into_parts();
-        let body = body
-            .collect()
-            .await
-            .map_err(|err| {
-                SubgraphExecutorError::ResponseBodyReadFailure(
+
+        let body = match body.collect().await {
+            Ok(body) => body.to_bytes(),
+            Err(err) => {
+                return Err(SubgraphExecutorError::ResponseBodyReadFailure(
                     endpoint.to_string(),
                     err.to_string(),
-                )
-            })?
-            .to_bytes();
+                    parts.headers.into(),
+                ));
+            }
+        };
 
         if body.is_empty() {
             return Err(SubgraphExecutorError::EmptyResponseBody(
                 subgraph_name.to_string(),
+                parts.headers.into(),
             ));
         }
 
@@ -674,13 +676,18 @@ impl SubgraphHttpResponse {
         self,
         custom_scalar_paths: Option<&CustomScalarPaths>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
-        SubgraphResponse::deserialize_from_bytes(self.body, custom_scalar_paths).map(
-            |mut resp: SubgraphResponse| {
-                resp.headers = Some(self.headers);
+        SubgraphResponse::deserialize_from_bytes(self.body, custom_scalar_paths)
+            .map(|mut resp: SubgraphResponse| {
+                resp.headers = Some(self.headers.clone());
                 resp.status = Some(self.status);
                 resp
-            },
-        )
+            })
+            .map_err(|e| match e {
+                SubgraphExecutorError::ResponseDeserializationFailure(err, _) => {
+                    SubgraphExecutorError::ResponseDeserializationFailure(err, Some(self.headers))
+                }
+                other => other,
+            })
     }
 }
 

--- a/lib/executor/src/executors/multipart_subscribe.rs
+++ b/lib/executor/src/executors/multipart_subscribe.rs
@@ -258,7 +258,7 @@ fn extract_payload(
             .map(Some)
         }
         Err(e) => Err(ParseError::InvalidSubgraphResponse(
-            SubgraphExecutorError::ResponseDeserializationFailure(e),
+            SubgraphExecutorError::ResponseDeserializationFailure(e, None),
         )),
     }
 }

--- a/lib/executor/src/headers/mod.rs
+++ b/lib/executor/src/headers/mod.rs
@@ -375,11 +375,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut response_builder = ntex::http::Response::Ok();
+        let mut response = ntex::http::Response::Ok().finish();
         accumulator
-            .modify_client_response_headers(&mut response_builder)
+            .modify_client_response_headers(response.headers_mut())
             .unwrap();
-        let response = response_builder.finish();
         let final_headers = response.headers();
 
         insta::assert_snapshot!(final_headers.to_string(), @r#"
@@ -444,11 +443,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut response_builder = ntex::http::Response::Ok();
+        let mut response = ntex::http::Response::Ok().finish();
         accumulator
-            .modify_client_response_headers(&mut response_builder)
+            .modify_client_response_headers(response.headers_mut())
             .unwrap();
-        let response = response_builder.finish();
         let final_headers = response.headers();
 
         insta::assert_snapshot!(final_headers.to_string(), @r#"
@@ -506,11 +504,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut response_builder = ntex::http::Response::Ok();
+        let mut response = ntex::http::Response::Ok().finish();
         accumulator
-            .modify_client_response_headers(&mut response_builder)
+            .modify_client_response_headers(response.headers_mut())
             .unwrap();
-        let response = response_builder.finish();
         let final_headers = response.headers();
 
         insta::assert_snapshot!(final_headers.to_string(), @r#"
@@ -568,11 +565,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut response_builder = ntex::http::Response::Ok();
+        let mut response = ntex::http::Response::Ok().finish();
         accumulator
-            .modify_client_response_headers(&mut response_builder)
+            .modify_client_response_headers(response.headers_mut())
             .unwrap();
-        let response = response_builder.finish();
         let final_headers = response.headers();
 
         insta::assert_snapshot!(final_headers.to_string(), @r#"
@@ -625,11 +621,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut response_builder = ntex::http::Response::Ok();
+        let mut response = ntex::http::Response::Ok().finish();
         accumulator
-            .modify_client_response_headers(&mut response_builder)
+            .modify_client_response_headers(response.headers_mut())
             .unwrap();
-        let response = response_builder.finish();
         let final_headers = response.headers();
 
         insta::assert_snapshot!(final_headers.to_string(), @r#"

--- a/lib/executor/src/headers/plan.rs
+++ b/lib/executor/src/headers/plan.rs
@@ -117,7 +117,7 @@ pub struct ResponsePropagateRegex {
     pub strategy: HeaderAggregationStrategy,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum HeaderAggregationStrategy {
     First,
     Last,

--- a/lib/executor/src/headers/response.rs
+++ b/lib/executor/src/headers/response.rs
@@ -8,7 +8,6 @@ use crate::{
             ResponseInsertExpression, ResponseInsertStatic, ResponsePropagateNamed,
             ResponsePropagateRegex, ResponseRemoveNamed, ResponseRemoveRegex,
         },
-        sanitizer::is_denied_header,
     },
 };
 use ahash::HashMap;
@@ -17,7 +16,7 @@ use ntex::http::HeaderMap as NtexHeaderMap;
 use std::iter::once;
 use std::sync::{Arc, Mutex};
 
-use super::sanitizer::is_never_join_header;
+use super::sanitizer::{is_denied_response_header, is_never_join_header};
 use http::{header::InvalidHeaderValue, HeaderMap, HeaderName, HeaderValue};
 
 pub fn apply_subgraph_response_headers(
@@ -92,7 +91,7 @@ impl ApplyResponseHeader for ResponsePropagateNamed {
         let mut matched = false;
 
         for header_name in &self.names {
-            if is_denied_header(header_name) {
+            if is_denied_response_header(header_name) {
                 continue;
             }
 
@@ -110,7 +109,7 @@ impl ApplyResponseHeader for ResponsePropagateNamed {
             if let (Some(default_value), Some(first_name)) = (&self.default, self.names.first()) {
                 let destination_name = self.rename.as_ref().unwrap_or(first_name);
 
-                if is_denied_header(destination_name) {
+                if is_denied_response_header(destination_name) {
                     return Ok(());
                 }
 
@@ -129,7 +128,7 @@ impl ApplyResponseHeader for ResponsePropagateRegex {
         accumulator: &mut ResponseHeaderAggregator,
     ) -> Result<(), HeaderRuleRuntimeError> {
         for (header_name, header_value) in ctx.subgraph_headers {
-            if is_denied_header(header_name) {
+            if is_denied_response_header(header_name) {
                 continue;
             }
 
@@ -164,7 +163,7 @@ impl ApplyResponseHeader for ResponseInsertStatic {
         _ctx: &ResponseExpressionContext,
         accumulator: &mut ResponseHeaderAggregator,
     ) -> Result<(), HeaderRuleRuntimeError> {
-        if is_denied_header(&self.name) {
+        if is_denied_response_header(&self.name) {
             return Ok(());
         }
 
@@ -186,7 +185,7 @@ impl ApplyResponseHeader for ResponseInsertExpression {
         ctx: &ResponseExpressionContext,
         accumulator: &mut ResponseHeaderAggregator,
     ) -> Result<(), HeaderRuleRuntimeError> {
-        if is_denied_header(&self.name) {
+        if is_denied_response_header(&self.name) {
             return Ok(());
         }
         let value = self.expression.execute(ctx.into()).map_err(|err| {
@@ -213,7 +212,7 @@ impl ApplyResponseHeader for ResponseRemoveNamed {
         accumulator: &mut ResponseHeaderAggregator,
     ) -> Result<(), HeaderRuleRuntimeError> {
         for header_name in &self.names {
-            if is_denied_header(header_name) {
+            if is_denied_response_header(header_name) {
                 continue;
             }
             accumulator.entries.remove(header_name);
@@ -230,7 +229,7 @@ impl ApplyResponseHeader for ResponseRemoveRegex {
         accumulator: &mut ResponseHeaderAggregator,
     ) -> Result<(), HeaderRuleRuntimeError> {
         accumulator.entries.retain(|name, _| {
-            if is_denied_header(name) {
+            if is_denied_response_header(name) {
                 // Denied headers (hop-by–hop) are never inserted in the first place
                 // and should not be removed here.
                 return true;

--- a/lib/executor/src/headers/response.rs
+++ b/lib/executor/src/headers/response.rs
@@ -15,6 +15,7 @@ use ahash::HashMap;
 use hive_router_internal::expressions::ExecutableProgram;
 use ntex::http::HeaderMap as NtexHeaderMap;
 use std::iter::once;
+use std::sync::{Arc, Mutex};
 
 use super::sanitizer::is_never_join_header;
 use http::{header::InvalidHeaderValue, HeaderMap, HeaderName, HeaderValue};
@@ -247,7 +248,7 @@ impl ResponseHeaderAggregator {
     #[inline]
     pub fn modify_client_response_headers(
         self,
-        out: &mut ntex::http::ResponseBuilder,
+        headers: &mut ntex::http::HeaderMap,
     ) -> Result<(), HeaderRuleRuntimeError> {
         for (name, (agg_strategy, mut values)) in self.entries {
             if values.is_empty() {
@@ -257,20 +258,20 @@ impl ResponseHeaderAggregator {
             if is_never_join_header(&name) {
                 // never-join headers must be emitted as multiple header fields
                 for value in values {
-                    out.header(&name, value);
+                    headers.append(name.clone(), value.into());
                 }
                 continue;
             }
 
             if values.len() == 1 {
-                out.set_header(name, values.pop().unwrap());
+                headers.insert(name, values.pop().unwrap().into());
                 continue;
             }
 
             if matches!(agg_strategy, HeaderAggregationStrategy::Append) {
                 let joined = join_with_comma(&values)
                     .map_err(|_| HeaderRuleRuntimeError::BadHeaderValue(name.to_string()))?;
-                out.set_header(name, joined);
+                headers.insert(name, joined.into());
             }
         }
 
@@ -303,18 +304,36 @@ fn join_with_comma(values: &[HeaderValue]) -> Result<HeaderValue, InvalidHeaderV
 
 type AggregatedHeader = (HeaderAggregationStrategy, Vec<HeaderValue>);
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ResponseHeaderAggregator {
     pub entries: HashMap<HeaderName, AggregatedHeader>,
 }
 
-impl ResponseHeaderAggregator {
-    pub fn none_if_empty(self) -> Option<Self> {
-        if self.entries.is_empty() {
-            None
-        } else {
-            Some(self)
+#[derive(Clone, Default, Debug)]
+pub struct ResponseHeaderSink(Arc<Mutex<ResponseHeaderAggregator>>);
+
+impl ResponseHeaderSink {
+    pub fn store(&self, aggregator: ResponseHeaderAggregator) {
+        match self.0.lock() {
+            Ok(mut sink) => sink.replace_with(aggregator),
+            Err(poisoned) => poisoned.into_inner().replace_with(aggregator),
         }
+    }
+
+    pub fn take(&self) -> ResponseHeaderAggregator {
+        match self.0.lock() {
+            Ok(mut sink) => std::mem::take(&mut *sink),
+            Err(poisoned) => {
+                let mut sink = poisoned.into_inner();
+                std::mem::take(&mut *sink)
+            }
+        }
+    }
+}
+
+impl ResponseHeaderAggregator {
+    pub fn replace_with(&mut self, other: Self) {
+        self.entries = other.entries
     }
 
     /// Write a header to the aggregator according to the specified strategy.
@@ -372,6 +391,16 @@ impl ResponseHeaderAggregator {
                 // it's handled already by ntex's HeaderMap.
                 HeaderAggregationStrategy::Last,
             );
+        }
+        aggregator
+    }
+
+    pub fn from_http_headers(headers: &HeaderMap) -> Self {
+        let mut aggregator = Self::default();
+        for (name, value) in headers {
+            // Why Last and not First or Append?
+            // Check the comment in from_early_response fn
+            aggregator.write(name, value, HeaderAggregationStrategy::Append);
         }
         aggregator
     }

--- a/lib/executor/src/headers/sanitizer.rs
+++ b/lib/executor/src/headers/sanitizer.rs
@@ -1,9 +1,16 @@
 use hive_router_config::headers::{HOP_BY_HOP_HEADERS, NEVER_JOIN_HEADERS};
 use http::HeaderName;
 
+const ROUTER_OWNED_RESPONSE_HEADERS: &[&str] = &["content-type"];
+
 #[inline]
 pub fn is_denied_header(name: &http::HeaderName) -> bool {
     HOP_BY_HOP_HEADERS.contains(&name.as_str())
+}
+
+#[inline]
+pub fn is_denied_response_header(name: &http::HeaderName) -> bool {
+    is_denied_header(name) || ROUTER_OWNED_RESPONSE_HEADERS.contains(&name.as_str())
 }
 
 pub fn is_never_join_header(name: &HeaderName) -> bool {

--- a/lib/executor/src/plugins/hooks/on_execute.rs
+++ b/lib/executor/src/plugins/hooks/on_execute.rs
@@ -8,8 +8,8 @@ use sonic_rs::json;
 use crate::execution::plan::PlanExecutionOutput;
 use crate::plugin_context::{PluginContext, RouterHttpRequest};
 use crate::plugin_trait::{
-    from_graphql_errors_to_bytes, EndHookPayload, EndHookResult, FromGraphQLErrorToResponse,
-    FromGraphQLErrorsToResponse, StartHookPayload, StartHookResult,
+    from_graphql_errors_to_bytes, EarlyHTTPResponse, EndHookPayload, EndHookResult,
+    FromGraphQLErrorToResponse, FromGraphQLErrorsToResponse, StartHookPayload, StartHookResult,
 };
 use crate::request_context::RequestContextPluginApi;
 use crate::response::graphql_error::GraphQLError;
@@ -40,6 +40,23 @@ pub struct DemandControlCost {
     pub max: u64,
     /// The post-execution actual cost, computed from the real response.
     pub actual: u64,
+}
+
+pub enum OnExecuteResponse {
+    Output(PlanExecutionOutput),
+    EarlyResponse(EarlyHTTPResponse),
+}
+
+impl From<PlanExecutionOutput> for OnExecuteResponse {
+    fn from(response: PlanExecutionOutput) -> Self {
+        Self::Output(response)
+    }
+}
+
+impl From<EarlyHTTPResponse> for OnExecuteResponse {
+    fn from(response: EarlyHTTPResponse) -> Self {
+        Self::EarlyResponse(response)
+    }
 }
 
 pub struct OnExecuteStartHookPayload<'exec> {
@@ -148,7 +165,7 @@ impl<'exec> OnExecuteStartHookPayload<'exec> {
     }
 }
 
-impl<'exec> StartHookPayload<OnExecuteEndHookPayload<'exec>, PlanExecutionOutput>
+impl<'exec> StartHookPayload<OnExecuteEndHookPayload<'exec>, OnExecuteResponse>
     for OnExecuteStartHookPayload<'exec>
 {
 }
@@ -157,7 +174,7 @@ pub type OnExecuteStartHookResult<'exec> = StartHookResult<
     'exec,
     OnExecuteStartHookPayload<'exec>,
     OnExecuteEndHookPayload<'exec>,
-    PlanExecutionOutput,
+    OnExecuteResponse,
 >;
 
 pub struct OnExecuteEndHookPayload<'exec> {
@@ -204,10 +221,31 @@ impl<'exec> OnExecuteEndHookPayload<'exec> {
     }
 }
 
-impl<'exec> EndHookPayload<PlanExecutionOutput> for OnExecuteEndHookPayload<'exec> {}
+impl<'exec> EndHookPayload<OnExecuteResponse> for OnExecuteEndHookPayload<'exec> {}
 
 pub type OnExecuteEndHookResult<'exec> =
-    EndHookResult<OnExecuteEndHookPayload<'exec>, PlanExecutionOutput>;
+    EndHookResult<OnExecuteEndHookPayload<'exec>, OnExecuteResponse>;
+
+impl FromGraphQLErrorToResponse for OnExecuteResponse {
+    fn from_graphql_error_to_response(error: GraphQLError, status_code: http::StatusCode) -> Self {
+        Self::Output(PlanExecutionOutput::from_graphql_error_to_response(
+            error,
+            status_code,
+        ))
+    }
+}
+
+impl FromGraphQLErrorsToResponse for OnExecuteResponse {
+    fn from_graphql_errors_to_response(
+        errors: Vec<GraphQLError>,
+        status_code: http::StatusCode,
+    ) -> Self {
+        Self::Output(PlanExecutionOutput::from_graphql_errors_to_response(
+            errors,
+            status_code,
+        ))
+    }
+}
 
 impl FromGraphQLErrorToResponse for PlanExecutionOutput {
     fn from_graphql_error_to_response(error: GraphQLError, status_code: http::StatusCode) -> Self {
@@ -224,7 +262,6 @@ impl FromGraphQLErrorsToResponse for PlanExecutionOutput {
         PlanExecutionOutput {
             body: from_graphql_errors_to_bytes(errors),
             error_count,
-            response_headers_aggregator: None,
             status_code,
         }
     }

--- a/lib/executor/src/plugins/plugin_trait.rs
+++ b/lib/executor/src/plugins/plugin_trait.rs
@@ -1,7 +1,4 @@
 use crate::{
-    execution::plan::PlanExecutionOutput,
-    headers::plan::HeaderAggregationStrategy,
-    headers::response::ResponseHeaderAggregator,
     hooks::{
         on_execute::{OnExecuteStartHookPayload, OnExecuteStartHookResult},
         on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult},
@@ -23,8 +20,6 @@ use crate::{
     },
     response::graphql_error::GraphQLError,
 };
-use ahash::HashMap;
-use http::{HeaderName, HeaderValue};
 use serde::de::DeserializeOwned;
 use sonic_rs::json;
 
@@ -598,35 +593,4 @@ pub struct EarlyHTTPResponse {
     pub body: Vec<u8>,
     pub headers: http::HeaderMap,
     pub status_code: http::StatusCode,
-}
-
-impl From<EarlyHTTPResponse> for PlanExecutionOutput {
-    fn from(val: EarlyHTTPResponse) -> Self {
-        let response_headers_aggregator = if val.headers.is_empty() {
-            None
-        } else {
-            let mut entries: HashMap<HeaderName, (HeaderAggregationStrategy, Vec<HeaderValue>)> =
-                Default::default();
-            let mut last_name = None;
-            for (name, value) in val.headers.into_iter() {
-                if let Some(name) = name {
-                    last_name = Some(name);
-                }
-                if let Some(name) = &last_name {
-                    let aggregated_header = entries
-                        .entry(name.clone())
-                        .or_insert_with(|| (HeaderAggregationStrategy::Append, Vec::new()));
-                    aggregated_header.1.push(value);
-                }
-            }
-
-            Some(ResponseHeaderAggregator { entries })
-        };
-        PlanExecutionOutput {
-            body: val.body,
-            response_headers_aggregator,
-            error_count: 0,
-            status_code: val.status_code,
-        }
-    }
 }

--- a/lib/executor/src/response/subgraph_response.rs
+++ b/lib/executor/src/response/subgraph_response.rs
@@ -266,11 +266,11 @@ impl<'a> SubgraphResponse<'a> {
             custom_scalar_paths: custom_scalar_paths.unwrap_or(&EMPTY_CUSTOM_SCALAR_PATHS),
         }
         .deserialize(&mut deserializer)
-        .map_err(SubgraphExecutorError::ResponseDeserializationFailure)
+        .map_err(|e| SubgraphExecutorError::ResponseDeserializationFailure(e, None))
         .and_then(|mut resp: SubgraphResponse<'static>| {
             deserializer
                 .end()
-                .map_err(SubgraphExecutorError::ResponseDeserializationFailure)?;
+                .map_err(|e| SubgraphExecutorError::ResponseDeserializationFailure(e, None))?;
             resp.bytes = Some(bytes);
             Ok(resp)
         })


### PR DESCRIPTION
Closes #1088

This PR makes response header propagation run consistently across successful responses, partial GraphQL error responses, and execution failures. Previously, response header propagation was executed only on the successful executions.

Keeps `content-type` header excluded from response header propagation, as it's decided by Router based on `Accept`.

Preserves subgraph response headers on executor errors:
- empty response body
- response body read failure
- response deserialization failure
- subgraph's internal server errors

> [!WARNING]  
> WebSocket response header propagation is not covered and is left as a TODO

---

Introduces a per-request `ResponseHeaderSink` used to collect response headers. Applies collected response headers at the final router -> client response, including deduped request responses.