### PR TITLE
bug: introspection leaks fields hidden by on_graphql_validation + with_schema override

### DIFF
--- a/plugin_examples/feature_flags/src/test.rs
+++ b/plugin_examples/feature_flags/src/test.rs
@@ -3,6 +3,57 @@ mod tests {
     use e2e::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
     use hive_router::ntex;
 
+    /// `on_graphql_validation` + `with_schema` swaps the schema used for
+    /// validation, but `__type`/`__schema` introspection still resolves against
+    /// the full supergraph today, so feature-gated fields remain visible through
+    /// introspection even when they are blocked for queries.
+    ///
+    /// This test FAILS on stock hive-router main — see the assertion message for
+    /// the actual leaked output.  The desired behaviour is for introspection to
+    /// follow the same schema override, so that `with_schema` is the single knob
+    /// that controls both validation and introspection consistently.
+    #[ntex::test]
+    async fn introspection_should_hide_fields_removed_by_validation_schema_override() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("../plugin_examples/feature_flags/router.config.yaml")
+            .register_plugin::<crate::plugin::FeatureFlagsPlugin>()
+            .build()
+            .start()
+            .await;
+
+        // No x-feature-flags header: the plugin's `with_schema` override removes
+        // both `inStock` and `shippingEstimate` from the validation schema.
+        // Introspection must reflect the same filtered view.
+        let res = router
+            .send_graphql_request(
+                r#"{ __type(name: "Product") { fields { name } } }"#,
+                None,
+                e2e::some_header_map! {},
+            )
+            .await;
+
+        assert_eq!(res.status(), 200);
+        let body = res.json_body_string_pretty().await;
+
+        // Non-gated fields must still be visible.
+        assert!(body.contains("\"name\": \"name\""), "non-gated field `name` missing: {body}");
+
+        // Gated fields must not appear — if they do, introspection is leaking past
+        // the validation-schema override applied by `with_schema`.
+        assert!(
+            !body.contains("shippingEstimate"),
+            "`shippingEstimate` leaked through introspection even though the feature is \
+             disabled.\nActual response:\n{body}"
+        );
+        assert!(
+            !body.contains("inStock"),
+            "`inStock` leaked through introspection even though the feature is disabled.\
+             \nActual response:\n{body}"
+        );
+    }
+
     #[ntex::test]
     async fn do_not_allow_disabled_feature_flags() {
         let subgraphs = TestSubgraphs::builder().build().start().await;


### PR DESCRIPTION
## What this demonstrates

When a plugin overrides the validation schema via `on_graphql_validation` / `with_schema`, the router correctly rejects queries that use removed fields. However, `__type` and `__schema` introspection still resolve against the **full supergraph**, so the hidden fields remain fully visible through introspection.

This PR adds a **failing test** to the `feature_flags` example that reproduces the leak. It is intentionally not a fix — the goal is to agree on the right approach before sending a full diff.

## How to reproduce

```
cargo test --manifest-path plugin_examples/feature_flags/Cargo.toml \
  introspection_should_hide_fields_removed_by_validation_schema_override
```

**Failure output:**

```
thread 'test::tests::introspection_should_hide_fields_removed_by_validation_schema_override'
  panicked at '`shippingEstimate` leaked through introspection even though the feature is disabled.
Actual response:
{
  "data": {
    "__type": {
      "fields": [
        { "name": "upc" },
        { "name": "weight" },
        { "name": "price" },
        { "name": "inStock" },        <-- should be hidden
        { "name": "shippingEstimate" }, <-- should be hidden
        { "name": "name" },
        { "name": "reviews" },
        ...
      ]
    }
  }
}'
```

## Context

We are migrating the commercetools GraphQL federation gateway to Hive Router. One customization presents each tenant a **filtered view of the supergraph** — elements gated behind inactive `@feature` directives are removed. For this to work correctly, validation **and** introspection must present the same filtered surface; otherwise the hidden elements are still discoverable via `__type`.

The `feature_flags` example is the exact pattern we use (minus the external tags service). The current behaviour — `with_schema` silently not covering introspection — is the blocker.
