### PR TITLE
feat(query-planner): avoid indirect lookup for directly resolved leaf fields + infinite loop detection

### DIFF
--- a/.changeset/leaf_no_indirect.md
+++ b/.changeset/leaf_no_indirect.md
@@ -1,0 +1,10 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Avoid indirect lookup for directly resolved leaf fields
+
+The planner now skips indirect path lookup when a leaf field already has a valid direct path.

--- a/lib/query-planner/fixture/issues/infinite-typename-interfaceobject.graphql
+++ b/lib/query-planner/fixture/issues/infinite-typename-interfaceobject.graphql
@@ -1,0 +1,93 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) {
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+enum join__Graph {
+  S0 @join__graph(name: "s0", url: "http://localhost:4001/s0")
+  S1 @join__graph(name: "s1", url: "http://localhost:4001/s1")
+  S2 @join__graph(name: "s2", url: "http://localhost:4001/s2")
+  S3 @join__graph(name: "s3", url: "http://localhost:4001/s3")
+}
+
+type Query
+  @join__type(graph: S0)
+  @join__type(graph: S1)
+  @join__type(graph: S2)
+  @join__type(graph: S3) {
+  me: Account @join__field(graph: S3)
+}
+
+type AccountA implements Account
+  @join__type(graph: S2, key: "notUsed")
+  @join__type(graph: S3, key: "notUsed")
+  @join__implements(graph: S3, interface: "Account") {
+  notUsed: Boolean!
+    @join__field(graph: S2, external: true)
+    @join__field(graph: S3)
+}
+
+type AccountB implements Account
+  @join__type(graph: S3, key: "notUsed")
+  @join__implements(graph: S3, interface: "Account") {
+  notUsed: Boolean! @join__field(graph: S3)
+}
+
+interface Account
+  @join__type(graph: S0, key: "notUsed", isInterfaceObject: true)
+  @join__type(graph: S1, key: "notUsed", isInterfaceObject: true)
+  @join__type(graph: S3) {
+  notUsed: Boolean!
+}

--- a/lib/query-planner/src/planner/walker/excluded.rs
+++ b/lib/query-planner/src/planner/walker/excluded.rs
@@ -13,18 +13,4 @@ impl ExcludedFromLookup {
     pub fn new() -> ExcludedFromLookup {
         Default::default()
     }
-
-    pub fn next(
-        &self,
-        graph_id: &str,
-        requirements: &HashSet<TypeAwareSelection>,
-    ) -> ExcludedFromLookup {
-        let mut graph_ids = self.graph_ids.clone();
-        graph_ids.insert(graph_id.to_string());
-
-        ExcludedFromLookup {
-            graph_ids,
-            requirement: requirements.clone(),
-        }
-    }
 }

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -437,14 +437,16 @@ fn process_field<'a>(
         )?;
         trace!("Direct paths found: {}", direct_paths.len());
 
+        let found_direct_paths_to_leaf = !direct_paths.is_empty() && field.is_leaf();
+
         if !direct_paths.is_empty() {
             advanced = true;
-            for direct_path in direct_paths {
-                tracker.add(&direct_path)?;
+            for direct_path in &direct_paths {
+                tracker.add(direct_path)?;
             }
         }
 
-        if !fields_to_resolve_locally.contains(&field.name) {
+        if !fields_to_resolve_locally.contains(&field.name) && !found_direct_paths_to_leaf {
             let indirect_paths = find_indirect_paths(
                 graph,
                 override_context,

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::rc::Rc;
 
+use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::{EdgeRef, NodeRef};
 use tracing::{instrument, trace};
 
@@ -26,6 +27,7 @@ use crate::{
 use super::{error::WalkOperationError, excluded::ExcludedFromLookup, path::OperationPath};
 
 pub type VisitedGraphs = HashSet<String>;
+type ActiveEdgeChecks = HashSet<(NodeIndex, EdgeIndex)>;
 
 struct IndirectPathsLookupQueue {
     queue: Vec<(VisitedGraphs, HashSet<TypeAwareSelection>, OperationPath)>,
@@ -66,6 +68,47 @@ pub enum NavigationTarget<'a> {
     ConcreteType(&'a str, Option<Condition>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum NavigationTargetKey<'a> {
+    Field(&'a str),
+    ConcreteType(&'a str),
+}
+
+impl<'a> From<&'a NavigationTarget<'a>> for NavigationTargetKey<'a> {
+    fn from(target: &'a NavigationTarget<'a>) -> Self {
+        match target {
+            NavigationTarget::Field(field) => NavigationTargetKey::Field(&field.name),
+            NavigationTarget::ConcreteType(type_name, _) => {
+                NavigationTargetKey::ConcreteType(type_name)
+            }
+        }
+    }
+}
+
+struct PathSearch<'a> {
+    graph: &'a Graph,
+    override_context: &'a PlannerOverrideContext,
+    cancellation_token: &'a CancellationToken,
+    /// Edges currently being checked in this path search.
+    /// Used to stop recursive loops when an edge depends on itself.
+    active_edge_checks: ActiveEdgeChecks,
+}
+
+impl<'a> PathSearch<'a> {
+    fn new(
+        graph: &'a Graph,
+        override_context: &'a PlannerOverrideContext,
+        cancellation_token: &'a CancellationToken,
+    ) -> Self {
+        Self {
+            graph,
+            override_context,
+            cancellation_token,
+            active_edge_checks: ActiveEdgeChecks::new(),
+        }
+    }
+}
+
 #[instrument(level = "trace", skip_all, fields(
   path = path.pretty_print(graph),
   current_cost = path.cost
@@ -78,204 +121,216 @@ pub fn find_indirect_paths(
     excluded: &ExcludedFromLookup,
     cancellation_token: &CancellationToken,
 ) -> Result<Vec<OperationPath>, WalkOperationError> {
-    let mut tracker = BestPathTracker::new(graph);
-    let tail_node_index = path.tail();
-    let tail_node = graph.node(tail_node_index)?;
-    let source_graph_id = tail_node
-        .graph_id()
-        .ok_or(WalkOperationError::TailMissingInfo(tail_node_index))?;
+    PathSearch::new(graph, override_context, cancellation_token)
+        .find_indirect_paths(path, target, excluded)
+}
 
-    let mut queue = IndirectPathsLookupQueue::new_from_excluded(excluded, path);
+impl PathSearch<'_> {
+    fn find_indirect_paths(
+        &mut self,
+        path: &OperationPath,
+        target: &NavigationTarget,
+        excluded: &ExcludedFromLookup,
+    ) -> Result<Vec<OperationPath>, WalkOperationError> {
+        let graph = self.graph;
+        let cancellation_token = self.cancellation_token;
+        let mut tracker = BestPathTracker::new(graph);
+        let mut seen = HashSet::new();
+        let target_key = NavigationTargetKey::from(target);
+        let tail_node_index = path.tail();
+        let tail_node = graph.node(tail_node_index)?;
+        let source_graph_id = tail_node
+            .graph_id()
+            .ok_or(WalkOperationError::TailMissingInfo(tail_node_index))?;
 
-    while let Some(item) = queue.pop() {
-        cancellation_token.bail_if_cancelled()?;
-        let (visited_graphs, visited_key_fields, path) = item;
+        let mut queue = IndirectPathsLookupQueue::new_from_excluded(excluded, path);
 
-        let relevant_edges = graph.edges_from(path.tail()).filter(|e| {
-            matches!(
-                e.weight(),
-                Edge::EntityMove { .. } | Edge::InterfaceObjectTypeMove { .. }
-            )
-        });
+        while let Some(item) = queue.pop() {
+            cancellation_token.bail_if_cancelled()?;
+            let (visited_graphs, visited_key_fields, path) = item;
 
-        for edge_ref in relevant_edges {
-            trace!(
-                "Exploring edge {}",
-                graph.pretty_print_edge(edge_ref.id(), false)
-            );
-
-            let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
-
-            if visited_graphs.contains(edge_tail_graph_id) {
+            if !seen.insert((path.tail(), target_key)) {
                 trace!(
-                    "Ignoring, graph is excluded and already visited (current: {}, visited: {:?})",
-                    edge_tail_graph_id,
-                    visited_graphs
+                    "Ignoring. Already searched this path tail for this target: {}",
+                    path.pretty_print(graph)
                 );
                 continue;
             }
 
-            let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
-            let edge = edge_ref.weight();
+            let relevant_edges = graph.edges_from(path.tail()).filter(|e| {
+                matches!(
+                    e.weight(),
+                    Edge::EntityMove { .. } | Edge::InterfaceObjectTypeMove { .. }
+                )
+            });
 
-            if edge_tail_graph_id == source_graph_id
-                && !matches!(edge, Edge::InterfaceObjectTypeMove(..))
-            {
-                // Prevent a situation where we are going back to the same graph
-                // The only exception is when we are moving to an abstract type
-                trace!("Ignoring. We would go back to the same graph");
-                continue;
-            }
+            for edge_ref in relevant_edges {
+                trace!(
+                    "Exploring edge {}",
+                    graph.pretty_print_edge(edge_ref.id(), false)
+                );
 
-            // A huge win for performance, is when you do less work :D
-            // We can ignore an edge that has already been visited with the same key fields / requirements.
-            // The way entity-move edges are created, where every graph points to every other graph:
-            //  Graph A: User @key(id) @key(name)
-            //  Graph B: User @key(id)
-            //  Edges in a merged graph:
-            //    - User/A @key(id) -> User/B
-            //    - User/B @key(id) -> User/A
-            //    - User/B @key(name) -> User/A
-            // Allows us to ignore an edge with the same key fields.
-            // That's because in some other path, we will or already have checked the other edge.
-            let requirements_already_checked = match edge.requirements() {
-                Some(selection_requirements) => visited_key_fields.contains(selection_requirements),
-                None => false,
-            };
+                let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
 
-            if requirements_already_checked {
-                trace!("Ignoring. Already visited similar edge");
-                continue;
-            }
-
-            let new_excluded = excluded.next(edge_tail_graph_id, &visited_key_fields);
-
-            let can_be_satisfied = can_satisfy_edge(
-                graph,
-                override_context,
-                &edge_ref,
-                &path,
-                &new_excluded,
-                false,
-                cancellation_token,
-            )?;
-
-            match can_be_satisfied {
-                None => {
-                    trace!("Requirements not satisfied, continue look up...");
+                if visited_graphs.contains(edge_tail_graph_id) {
+                    trace!(
+                    "Ignoring, graph is excluded and already visited (current: {}, visited: {:?})",
+                    edge_tail_graph_id,
+                    visited_graphs
+                );
                     continue;
                 }
-                Some(paths) => {
-                    trace!(
-                        "Advancing path to {}",
-                        graph.pretty_print_edge(edge_ref.id(), false)
-                    );
 
-                    let next_resolution_path = path.advance(
-                        &edge_ref,
-                        QueryTreeNode::from_paths(graph, &paths, None)?,
-                        target,
-                    );
+                let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
+                let edge = edge_ref.weight();
 
-                    let direct_paths = find_direct_paths(
-                        graph,
-                        override_context,
-                        &next_resolution_path,
-                        target,
-                        cancellation_token,
-                    )?;
+                if edge_tail_graph_id == source_graph_id
+                    && !matches!(edge, Edge::InterfaceObjectTypeMove(..))
+                {
+                    // Prevent a situation where we are going back to the same graph
+                    // The only exception is when we are moving to an abstract type
+                    trace!("Ignoring. We would go back to the same graph");
+                    continue;
+                }
 
-                    if !direct_paths.is_empty() {
+                // A huge win for performance, is when you do less work :D
+                // We can ignore an edge that has already been visited with the same key fields / requirements.
+                // The way entity-move edges are created, where every graph points to every other graph:
+                //  Graph A: User @key(id) @key(name)
+                //  Graph B: User @key(id)
+                //  Edges in a merged graph:
+                //    - User/A @key(id) -> User/B
+                //    - User/B @key(id) -> User/A
+                //    - User/B @key(name) -> User/A
+                // Allows us to ignore an edge with the same key fields.
+                // That's because in some other path, we will or already have checked the other edge.
+                let requirements_already_checked = match edge.requirements() {
+                    Some(selection_requirements) => {
+                        visited_key_fields.contains(selection_requirements)
+                    }
+                    None => false,
+                };
+
+                if requirements_already_checked {
+                    trace!("Ignoring. Already visited similar edge");
+                    continue;
+                }
+
+                let mut new_excluded_graph_ids = visited_graphs.clone();
+                new_excluded_graph_ids.insert(edge_tail_graph_id.to_string());
+                let new_excluded = ExcludedFromLookup {
+                    graph_ids: new_excluded_graph_ids,
+                    requirement: visited_key_fields.clone(),
+                };
+
+                let can_be_satisfied =
+                    self.can_satisfy_edge(&edge_ref, &path, &new_excluded, false)?;
+
+                match can_be_satisfied {
+                    None => {
+                        trace!("Requirements not satisfied, continue look up...");
+                        continue;
+                    }
+                    Some(paths) => {
                         trace!(
-                            "Found {} direct paths to {}",
-                            direct_paths.len(),
+                            "Advancing path to {}",
                             graph.pretty_print_edge(edge_ref.id(), false)
                         );
 
-                        for direct_path in direct_paths {
-                            tracker.add(&direct_path)?;
-                        }
+                        let next_resolution_path = path.advance(
+                            &edge_ref,
+                            QueryTreeNode::from_paths(graph, &paths, None)?,
+                            target,
+                        );
 
-                        continue;
-                    } else {
-                        trace!("No direct paths found");
+                        let direct_paths = self.find_direct_paths(&next_resolution_path, target)?;
 
-                        let mut new_visited_graphs = visited_graphs.clone();
-                        new_visited_graphs.insert(edge_tail_graph_id.to_string());
+                        if !direct_paths.is_empty() {
+                            trace!(
+                                "Found {} direct paths to {}",
+                                direct_paths.len(),
+                                graph.pretty_print_edge(edge_ref.id(), false)
+                            );
 
-                        let next_requirements = match edge.requirements() {
-                            Some(requirements) => {
-                                let mut new_visited_key_fields = visited_key_fields.clone();
-                                new_visited_key_fields.insert(requirements.clone());
-                                new_visited_key_fields
+                            for direct_path in direct_paths {
+                                tracker.add(&direct_path)?;
                             }
-                            None => visited_key_fields.clone(),
-                        };
 
-                        queue.add(new_visited_graphs, next_requirements, next_resolution_path);
+                            continue;
+                        } else {
+                            trace!("No direct paths found");
 
-                        trace!("going deeper");
+                            let mut new_visited_graphs = visited_graphs.clone();
+                            new_visited_graphs.insert(edge_tail_graph_id.to_string());
+
+                            let next_requirements = match edge.requirements() {
+                                Some(requirements) => {
+                                    let mut new_visited_key_fields = visited_key_fields.clone();
+                                    new_visited_key_fields.insert(requirements.clone());
+                                    new_visited_key_fields
+                                }
+                                None => visited_key_fields.clone(),
+                            };
+
+                            queue.add(new_visited_graphs, next_requirements, next_resolution_path);
+
+                            trace!("going deeper");
+                        }
                     }
                 }
             }
         }
+
+        let best_paths = tracker.get_best_paths();
+
+        trace!(
+            "Finished finding indirect paths, found total of {}",
+            best_paths.len()
+        );
+
+        // TODO: this should be done in a more efficient way, like I do in the satisfiability checker
+        // I set shortest path right after each path is generated
+
+        Ok(best_paths)
     }
-
-    let best_paths = tracker.get_best_paths();
-
-    trace!(
-        "Finished finding indirect paths, found total of {}",
-        best_paths.len()
-    );
-
-    // TODO: this should be done in a more efficient way, like I do in the satisfiability checker
-    // I set shortest path right after each path is generated
-
-    Ok(best_paths)
 }
 
-fn try_advance_direct_path<'a>(
-    graph: &'a Graph,
-    path: &OperationPath,
-    override_context: &PlannerOverrideContext,
-    edge_ref: &EdgeReference,
-    target: &NavigationTarget<'a>,
-    cancellation_token: &CancellationToken,
-) -> Result<Option<OperationPath>, WalkOperationError> {
-    trace!(
-        "Checking edge {}",
-        graph.pretty_print_edge(edge_ref.id(), false)
-    );
+impl PathSearch<'_> {
+    fn try_advance_direct_path(
+        &mut self,
+        path: &OperationPath,
+        edge_ref: &EdgeReference,
+        target: &NavigationTarget,
+    ) -> Result<Option<OperationPath>, WalkOperationError> {
+        let graph = self.graph;
+        trace!(
+            "Checking edge {}",
+            graph.pretty_print_edge(edge_ref.id(), false)
+        );
 
-    let can_be_satisfied = can_satisfy_edge(
-        graph,
-        override_context,
-        edge_ref,
-        path,
-        &ExcludedFromLookup::new(),
-        false,
-        cancellation_token,
-    )?;
+        let can_be_satisfied =
+            self.can_satisfy_edge(edge_ref, path, &ExcludedFromLookup::new(), false)?;
 
-    match can_be_satisfied {
-        Some(paths) => {
-            trace!(
-                "Advancing path {} with edge {}",
-                path.pretty_print(graph),
-                graph.pretty_print_edge(edge_ref.id(), false)
-            );
+        match can_be_satisfied {
+            Some(paths) => {
+                trace!(
+                    "Advancing path {} with edge {}",
+                    path.pretty_print(graph),
+                    graph.pretty_print_edge(edge_ref.id(), false)
+                );
 
-            let next_resolution_path = path.advance(
-                edge_ref,
-                QueryTreeNode::from_paths(graph, &paths, None)?,
-                target,
-            );
+                let next_resolution_path = path.advance(
+                    edge_ref,
+                    QueryTreeNode::from_paths(graph, &paths, None)?,
+                    target,
+                );
 
-            Ok(Some(next_resolution_path))
-        }
-        None => {
-            trace!("Edge not satisfied, continue look up...");
-            Ok(None)
+                Ok(Some(next_resolution_path))
+            }
+            None => {
+                trace!("Edge not satisfied, continue look up...");
+                Ok(None)
+            }
         }
     }
 }
@@ -289,6 +344,7 @@ pub fn find_self_referencing_direct_path(
     cancellation_token: &CancellationToken,
 ) -> Result<OperationPath, WalkOperationError> {
     let path_tail_index = path.tail();
+    let mut path_search = PathSearch::new(graph, override_context, cancellation_token);
 
     for edge_ref in graph
         .edges_from(path_tail_index)
@@ -297,13 +353,10 @@ pub fn find_self_referencing_direct_path(
             _ => false,
         })
     {
-        if let Some(new_path) = try_advance_direct_path(
-            graph,
+        if let Some(new_path) = path_search.try_advance_direct_path(
             path,
-            override_context,
             &edge_ref,
             &NavigationTarget::ConcreteType(type_name, Some(condition.clone())),
-            cancellation_token,
         )? {
             trace!("Finished finding direct path, found one",);
             return Ok(new_path);
@@ -326,45 +379,49 @@ pub fn find_direct_paths(
     target: &NavigationTarget,
     cancellation_token: &CancellationToken,
 ) -> Result<Vec<OperationPath>, WalkOperationError> {
-    let mut result: Vec<OperationPath> = vec![];
-    let path_tail_index = path.tail();
+    PathSearch::new(graph, override_context, cancellation_token).find_direct_paths(path, target)
+}
 
-    let edges_iter: Box<dyn Iterator<Item = _>> = match target {
-        NavigationTarget::Field(field) => Box::new(
-            graph
-                .edges_from(path_tail_index)
-                .filter(move |e| matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name)),
-        ),
-        NavigationTarget::ConcreteType(type_name, _condition) => Box::new(
-            graph
-                .edges_from(path_tail_index)
-                .filter(move |e| match e.weight() {
-                    Edge::AbstractMove(t) => t == type_name,
-                    Edge::InterfaceObjectTypeMove(t) => &t.object_type_name == type_name,
-                    _ => false,
-                }),
-        ),
-    };
+impl PathSearch<'_> {
+    fn find_direct_paths(
+        &mut self,
+        path: &OperationPath,
+        target: &NavigationTarget,
+    ) -> Result<Vec<OperationPath>, WalkOperationError> {
+        let graph = self.graph;
+        let mut result: Vec<OperationPath> = vec![];
+        let path_tail_index = path.tail();
 
-    for edge_ref in edges_iter {
-        if let Some(new_path) = try_advance_direct_path(
-            graph,
-            path,
-            override_context,
-            &edge_ref,
-            target,
-            cancellation_token,
-        )? {
-            result.push(new_path);
+        let edges_iter: Box<dyn Iterator<Item = _>> = match target {
+            NavigationTarget::Field(field) => {
+                Box::new(graph.edges_from(path_tail_index).filter(
+                    move |e| matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name),
+                ))
+            }
+            NavigationTarget::ConcreteType(type_name, _condition) => Box::new(
+                graph
+                    .edges_from(path_tail_index)
+                    .filter(move |e| match e.weight() {
+                        Edge::AbstractMove(t) => t == type_name,
+                        Edge::InterfaceObjectTypeMove(t) => &t.object_type_name == type_name,
+                        _ => false,
+                    }),
+            ),
+        };
+
+        for edge_ref in edges_iter {
+            if let Some(new_path) = self.try_advance_direct_path(path, &edge_ref, target)? {
+                result.push(new_path);
+            }
         }
+
+        trace!(
+            "Finished finding direct paths, found total of {}",
+            result.len()
+        );
+
+        Ok(result)
     }
-
-    trace!(
-        "Finished finding direct paths, found total of {}",
-        result.len()
-    );
-
-    Ok(result)
 }
 
 #[instrument(level = "trace", skip_all, fields(
@@ -380,119 +437,160 @@ pub fn can_satisfy_edge(
     use_only_direct_edges: bool,
     cancellation_token: &CancellationToken,
 ) -> Result<Option<Vec<OperationPath>>, WalkOperationError> {
-    let edge = edge_ref.weight();
+    PathSearch::new(graph, override_context, cancellation_token).can_satisfy_edge(
+        edge_ref,
+        path,
+        excluded,
+        use_only_direct_edges,
+    )
+}
 
-    if let Edge::FieldMove(field_move) = edge {
-        // TODO: This should be passed from the executor,
-        //       I will work on it next.
-        if !field_move.satisfies_override_rules(override_context) {
+impl PathSearch<'_> {
+    fn can_satisfy_edge(
+        &mut self,
+        edge_ref: &EdgeReference,
+        path: &OperationPath,
+        excluded: &ExcludedFromLookup,
+        use_only_direct_edges: bool,
+    ) -> Result<Option<Vec<OperationPath>>, WalkOperationError> {
+        let graph = self.graph;
+        let active_key = (path.tail(), edge_ref.id());
+        if !self.active_edge_checks.insert(active_key) {
+            trace!(
+                "Ignoring. Already trying to satisfy edge '{}' from this path tail: {}",
+                graph.pretty_print_edge(edge_ref.id(), false),
+                path.pretty_print(graph)
+            );
             return Ok(None);
         }
+
+        let result = self.check_edge_requirements(edge_ref, path, excluded, use_only_direct_edges);
+
+        self.active_edge_checks.remove(&active_key);
+
+        result
     }
 
-    match edge.requirements() {
-        None => Ok(Some(vec![])),
-        Some(selections) => {
-            trace!(
-                "checking requirements {} for edge '{}'",
-                selections,
-                graph.pretty_print_edge(edge_ref.id(), false)
-            );
+    fn check_edge_requirements(
+        &mut self,
+        edge_ref: &EdgeReference,
+        path: &OperationPath,
+        excluded: &ExcludedFromLookup,
+        use_only_direct_edges: bool,
+    ) -> Result<Option<Vec<OperationPath>>, WalkOperationError> {
+        let graph = self.graph;
+        let override_context = self.override_context;
+        let cancellation_token = self.cancellation_token;
+        let edge = edge_ref.weight();
 
-            let mut requirements: VecDeque<MoveRequirement> = VecDeque::new();
-            let mut paths_to_requirements: Vec<OperationPath> = vec![];
-
-            for selection in selections.selection_set.items.iter() {
-                requirements.push_front(MoveRequirement {
-                    paths: Rc::new(vec![path.clone()]),
-                    selection: selection.clone(),
-                });
+        if let Edge::FieldMove(field_move) = edge {
+            // TODO: This should be passed from the executor,
+            //       I will work on it next.
+            if !field_move.satisfies_override_rules(override_context) {
+                return Ok(None);
             }
+        }
 
-            // it's important to pop from the end as we want to process the last added requirement first
-            while let Some(requirement) = requirements.pop_back() {
-                cancellation_token.bail_if_cancelled()?;
-                match &requirement.selection {
-                    SelectionItem::Field(selection_field_requirement) => {
-                        let result = validate_field_requirement(
-                            graph,
-                            override_context,
-                            &requirement,
-                            selection_field_requirement,
-                            excluded,
-                            use_only_direct_edges,
-                            cancellation_token,
-                        )?;
+        match edge.requirements() {
+            None => Ok(Some(vec![])),
+            Some(selections) => {
+                trace!(
+                    "checking requirements {} for edge '{}'",
+                    selections,
+                    graph.pretty_print_edge(edge_ref.id(), false)
+                );
 
-                        match result {
-                            Some((next_paths, next_requirements)) => {
-                                trace!("Paths for {}", selection_field_requirement);
+                let mut requirements: VecDeque<MoveRequirement> = VecDeque::new();
+                let mut paths_to_requirements: Vec<OperationPath> = vec![];
 
-                                for next_path in next_paths.iter() {
-                                    trace!("  Path {} is valid", next_path.pretty_print(graph));
-                                }
+                for selection in selections.selection_set.items.iter() {
+                    requirements.push_front(MoveRequirement {
+                        paths: Rc::new(vec![path.clone()]),
+                        selection: selection.clone(),
+                    });
+                }
 
-                                if selection_field_requirement.is_leaf() {
-                                    let best_paths = find_best_paths(next_paths);
-                                    trace!(
-                                        "Found {} best paths for this leaf requirement",
-                                        best_paths.len()
-                                    );
+                // it's important to pop from the end as we want to process the last added requirement first
+                while let Some(requirement) = requirements.pop_back() {
+                    cancellation_token.bail_if_cancelled()?;
+                    match &requirement.selection {
+                        SelectionItem::Field(selection_field_requirement) => {
+                            let result = self.validate_field_requirement(
+                                &requirement,
+                                selection_field_requirement,
+                                excluded,
+                                use_only_direct_edges,
+                            )?;
 
-                                    for best_path in best_paths {
-                                        paths_to_requirements.push(
-                                            path.build_requirement_continuation_path(&best_path),
+                            match result {
+                                Some((next_paths, next_requirements)) => {
+                                    trace!("Paths for {}", selection_field_requirement);
+
+                                    for next_path in next_paths.iter() {
+                                        trace!("  Path {} is valid", next_path.pretty_print(graph));
+                                    }
+
+                                    if selection_field_requirement.is_leaf() {
+                                        let best_paths = find_best_paths(next_paths);
+                                        trace!(
+                                            "Found {} best paths for this leaf requirement",
+                                            best_paths.len()
                                         );
+
+                                        for best_path in best_paths {
+                                            paths_to_requirements.push(
+                                                path.build_requirement_continuation_path(
+                                                    &best_path,
+                                                ),
+                                            );
+                                        }
+                                    }
+
+                                    for req in next_requirements.into_iter().rev() {
+                                        requirements.push_front(req);
                                     }
                                 }
-
-                                for req in next_requirements.into_iter().rev() {
-                                    requirements.push_front(req);
+                                None => {
+                                    return Ok(None);
                                 }
-                            }
-                            None => {
-                                return Ok(None);
-                            }
-                        };
-                    }
-                    SelectionItem::InlineFragment(fragment_selection) => {
-                        let fragment_requirements = validate_fragment_requirement(
-                            graph,
-                            override_context,
-                            &requirement,
-                            fragment_selection,
-                            excluded,
-                            cancellation_token,
-                        )?;
+                            };
+                        }
+                        SelectionItem::InlineFragment(fragment_selection) => {
+                            let fragment_requirements = self.validate_fragment_requirement(
+                                &requirement,
+                                fragment_selection,
+                                excluded,
+                            )?;
 
-                        match fragment_requirements {
-                            Some((next_paths, next_requirements)) => {
-                                trace!("Paths for {}", fragment_selection);
+                            match fragment_requirements {
+                                Some((next_paths, next_requirements)) => {
+                                    trace!("Paths for {}", fragment_selection);
 
-                                for next_path in next_paths.iter() {
-                                    trace!("  Path {} is valid", next_path.pretty_print(graph));
+                                    for next_path in next_paths.iter() {
+                                        trace!("  Path {} is valid", next_path.pretty_print(graph));
+                                    }
+
+                                    for req in next_requirements.into_iter().rev() {
+                                        requirements.push_front(req);
+                                    }
                                 }
-
-                                for req in next_requirements.into_iter().rev() {
-                                    requirements.push_front(req);
+                                None => {
+                                    return Ok(None);
                                 }
-                            }
-                            None => {
-                                return Ok(None);
-                            }
-                        };
-                    }
-                    SelectionItem::FragmentSpread(_) => {
-                        // No processing needed for FragmentSpread
+                            };
+                        }
+                        SelectionItem::FragmentSpread(_) => {
+                            // No processing needed for FragmentSpread
+                        }
                     }
                 }
-            }
 
-            for path in paths_to_requirements.iter() {
-                trace!("path {} is valid", path.pretty_print(graph));
-            }
+                for path in paths_to_requirements.iter() {
+                    trace!("path {} is valid", path.pretty_print(graph));
+                }
 
-            Ok(Some(paths_to_requirements))
+                Ok(Some(paths_to_requirements))
+            }
         }
     }
 }
@@ -506,174 +604,155 @@ pub struct MoveRequirement {
 type FieldRequirementsResult = Option<(Vec<OperationPath>, Vec<MoveRequirement>)>;
 type FragmentRequirementsResult = Option<(Vec<OperationPath>, Vec<MoveRequirement>)>;
 
-#[instrument(level = "trace", skip_all, fields(field = field.name))]
-fn validate_field_requirement(
-    graph: &Graph,
-    override_context: &PlannerOverrideContext,
-    move_requirement: &MoveRequirement, // Contains Rc<Vec<OperationPath>>
-    field: &FieldSelection,
-    excluded: &ExcludedFromLookup,
-    use_only_direct_edges: bool,
-    cancellation_token: &CancellationToken,
-) -> Result<FieldRequirementsResult, WalkOperationError> {
-    let mut direct_path_results: Vec<Vec<OperationPath>> =
-        Vec::with_capacity(move_requirement.paths.len());
-    let mut indirect_path_results: Vec<Vec<OperationPath>> =
-        Vec::with_capacity(move_requirement.paths.len());
+impl PathSearch<'_> {
+    #[instrument(level = "trace", skip_all, fields(field = field.name))]
+    fn validate_field_requirement(
+        &mut self,
+        move_requirement: &MoveRequirement, // Contains Rc<Vec<OperationPath>>
+        field: &FieldSelection,
+        excluded: &ExcludedFromLookup,
+        use_only_direct_edges: bool,
+    ) -> Result<FieldRequirementsResult, WalkOperationError> {
+        let mut direct_path_results: Vec<Vec<OperationPath>> =
+            Vec::with_capacity(move_requirement.paths.len());
+        let mut indirect_path_results: Vec<Vec<OperationPath>> =
+            Vec::with_capacity(move_requirement.paths.len());
 
-    for path in move_requirement.paths.iter() {
-        let direct_paths = find_direct_paths(
-            graph,
-            override_context,
-            path,
-            &NavigationTarget::Field(field),
-            cancellation_token,
-        )?;
-        // Skip looking for indirect paths if we already found direct paths to a leaf
-        let found_direct_paths_to_leaf = !direct_paths.is_empty() && field.is_leaf();
-        direct_path_results.push(direct_paths);
+        for path in move_requirement.paths.iter() {
+            let direct_paths = self.find_direct_paths(path, &NavigationTarget::Field(field))?;
+            // Skip looking for indirect paths if we already found direct paths to a leaf
+            let found_direct_paths_to_leaf = !direct_paths.is_empty() && field.is_leaf();
+            direct_path_results.push(direct_paths);
 
-        let needs_indirect = !use_only_direct_edges && !found_direct_paths_to_leaf;
-        let indirect_paths = if needs_indirect {
-            find_indirect_paths(
-                graph,
-                override_context,
-                path,
-                &NavigationTarget::Field(field),
-                excluded,
-                cancellation_token,
-            )?
-        } else {
-            Vec::new()
-        };
+            let needs_indirect = !use_only_direct_edges && !found_direct_paths_to_leaf;
+            let indirect_paths = if needs_indirect {
+                self.find_indirect_paths(path, &NavigationTarget::Field(field), excluded)?
+            } else {
+                Vec::new()
+            };
 
-        indirect_path_results.push(indirect_paths);
-    }
+            indirect_path_results.push(indirect_paths);
+        }
 
-    // sum of direct and indirect
-    let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
-        + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
+        // sum of direct and indirect
+        let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
+            + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
 
-    let mut next_paths: Vec<OperationPath> = Vec::with_capacity(total_capacity);
+        let mut next_paths: Vec<OperationPath> = Vec::with_capacity(total_capacity);
 
-    // These extend calls should not reallocate `next_paths`.
-    for paths_vec in direct_path_results {
-        next_paths.extend(paths_vec);
-    }
-    // No need to check use_only_direct_edges again, indirect_path_results_vecs will be empty if not used.
-    for paths_vec in indirect_path_results {
-        next_paths.extend(paths_vec);
-    }
+        // These extend calls should not reallocate `next_paths`.
+        for paths_vec in direct_path_results {
+            next_paths.extend(paths_vec);
+        }
+        // No need to check use_only_direct_edges again, indirect_path_results_vecs will be empty if not used.
+        for paths_vec in indirect_path_results {
+            next_paths.extend(paths_vec);
+        }
 
-    if next_paths.is_empty() {
-        return Ok(None);
-    }
+        if next_paths.is_empty() {
+            return Ok(None);
+        }
 
-    if move_requirement.selection.selections().is_none()
-        || move_requirement
+        if move_requirement.selection.selections().is_none()
+            || move_requirement
+                .selection
+                .selections()
+                .is_some_and(|s| s.is_empty())
+        {
+            // No sub-selections, next_paths is returned directly.
+            return Ok(Some((next_paths, vec![])));
+        }
+
+        let shared_next_paths_for_subs = Rc::new(next_paths.clone());
+        let next_requirements: Vec<MoveRequirement> = move_requirement
             .selection
             .selections()
-            .is_some_and(|s| s.is_empty())
-    {
-        // No sub-selections, next_paths is returned directly.
-        return Ok(Some((next_paths, vec![])));
+            .unwrap() // Safe due to the check above
+            .iter()
+            .map(|selection_item| MoveRequirement {
+                selection: selection_item.clone(),
+                paths: Rc::clone(&shared_next_paths_for_subs),
+            })
+            .collect();
+
+        Ok(Some((next_paths, next_requirements)))
     }
-
-    let shared_next_paths_for_subs = Rc::new(next_paths.clone());
-    let next_requirements: Vec<MoveRequirement> = move_requirement
-        .selection
-        .selections()
-        .unwrap() // Safe due to the check above
-        .iter()
-        .map(|selection_item| MoveRequirement {
-            selection: selection_item.clone(),
-            paths: Rc::clone(&shared_next_paths_for_subs),
-        })
-        .collect();
-
-    Ok(Some((next_paths, next_requirements)))
 }
 
-#[instrument(level = "trace", skip_all, fields(type_condition = fragment_selection.type_condition))]
-fn validate_fragment_requirement(
-    graph: &Graph,
-    override_context: &PlannerOverrideContext,
-    requirement: &MoveRequirement,
-    fragment_selection: &InlineFragmentSelection,
-    excluded: &ExcludedFromLookup,
-    cancellation_token: &CancellationToken,
-) -> Result<FragmentRequirementsResult, WalkOperationError> {
-    let type_name = &fragment_selection.type_condition;
-    // Collect all Vec<OperationPath> results from find_direct_paths
-    let mut direct_path_results: Vec<Vec<OperationPath>> =
-        Vec::with_capacity(requirement.paths.len());
-    for path in requirement.paths.iter() {
-        direct_path_results.push(find_direct_paths(
-            graph,
-            override_context,
-            path,
-            // @skip/@include can't be used in @requires and @provides,
-            // that's why we pass no condition
-            &NavigationTarget::ConcreteType(type_name, None),
-            cancellation_token,
-        )?);
-    }
+impl PathSearch<'_> {
+    #[instrument(level = "trace", skip_all, fields(type_condition = fragment_selection.type_condition))]
+    fn validate_fragment_requirement(
+        &mut self,
+        requirement: &MoveRequirement,
+        fragment_selection: &InlineFragmentSelection,
+        excluded: &ExcludedFromLookup,
+    ) -> Result<FragmentRequirementsResult, WalkOperationError> {
+        let type_name = &fragment_selection.type_condition;
+        // Collect all Vec<OperationPath> results from find_direct_paths
+        let mut direct_path_results: Vec<Vec<OperationPath>> =
+            Vec::with_capacity(requirement.paths.len());
+        for path in requirement.paths.iter() {
+            direct_path_results.push(self.find_direct_paths(
+                path,
+                // @skip/@include can't be used in @requires and @provides,
+                // that's why we pass no condition
+                &NavigationTarget::ConcreteType(type_name, None),
+            )?);
+        }
 
-    // Collect all Vec<OperationPath> results from find_indirect_paths
-    let mut indirect_path_results: Vec<Vec<OperationPath>> =
-        Vec::with_capacity(requirement.paths.len());
-    for path_from_rc in requirement.paths.iter() {
-        indirect_path_results.push(find_indirect_paths(
-            graph,
-            override_context,
-            path_from_rc,
-            // @skip/@include can't be used in @requires and @provides,
-            // that's why we pass no condition
-            &NavigationTarget::ConcreteType(type_name, None),
-            excluded,
-            cancellation_token,
-        )?);
-    }
+        // Collect all Vec<OperationPath> results from find_indirect_paths
+        let mut indirect_path_results: Vec<Vec<OperationPath>> =
+            Vec::with_capacity(requirement.paths.len());
+        for path_from_rc in requirement.paths.iter() {
+            indirect_path_results.push(self.find_indirect_paths(
+                path_from_rc,
+                // @skip/@include can't be used in @requires and @provides,
+                // that's why we pass no condition
+                &NavigationTarget::ConcreteType(type_name, None),
+                excluded,
+            )?);
+        }
 
-    // sum of direct and indirect
-    let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
-        + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
+        // sum of direct and indirect
+        let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
+            + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
 
-    let mut next_paths: Vec<OperationPath> = Vec::with_capacity(total_capacity);
+        let mut next_paths: Vec<OperationPath> = Vec::with_capacity(total_capacity);
 
-    // These extend calls should not reallocate `next_paths`.
-    for paths_vec in direct_path_results {
-        next_paths.extend(paths_vec);
-    }
-    for paths_vec in indirect_path_results {
-        next_paths.extend(paths_vec);
-    }
+        // These extend calls should not reallocate `next_paths`.
+        for paths_vec in direct_path_results {
+            next_paths.extend(paths_vec);
+        }
+        for paths_vec in indirect_path_results {
+            next_paths.extend(paths_vec);
+        }
 
-    if next_paths.is_empty() {
-        return Ok(None);
-    }
+        if next_paths.is_empty() {
+            return Ok(None);
+        }
 
-    if requirement.selection.selections().is_none()
-        || requirement
+        if requirement.selection.selections().is_none()
+            || requirement
+                .selection
+                .selections()
+                .is_some_and(|s| s.is_empty())
+        {
+            // No sub-selections, next_paths is returned directly.
+            return Ok(Some((next_paths, vec![])));
+        }
+
+        let shared_next_paths_for_subs = Rc::new(next_paths.clone());
+        let next_requirements: Vec<MoveRequirement> = requirement
             .selection
             .selections()
-            .is_some_and(|s| s.is_empty())
-    {
-        // No sub-selections, next_paths is returned directly.
-        return Ok(Some((next_paths, vec![])));
+            .unwrap() // Safe due to the check above
+            .iter()
+            .map(|selection_item| MoveRequirement {
+                selection: selection_item.clone(),
+                paths: Rc::clone(&shared_next_paths_for_subs),
+            })
+            .collect();
+
+        Ok(Some((next_paths, next_requirements)))
     }
-
-    let shared_next_paths_for_subs = Rc::new(next_paths.clone());
-    let next_requirements: Vec<MoveRequirement> = requirement
-        .selection
-        .selections()
-        .unwrap() // Safe due to the check above
-        .iter()
-        .map(|selection_item| MoveRequirement {
-            selection: selection_item.clone(),
-            paths: Rc::clone(&shared_next_paths_for_subs),
-        })
-        .collect();
-
-    Ok(Some((next_paths, next_requirements)))
 }

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -546,3 +546,36 @@ fn issue_965_mixed_nested_fragments_with_directives_test() -> Result<(), Box<dyn
 
     Ok(())
 }
+
+#[test]
+fn issue_interface_object_typename() -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        {
+          me {
+            __typename
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/issues/infinite-typename-interfaceobject.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "s3") {
+        {
+          me {
+            __typename
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes query planning for leaf fields that can already be resolved through a direct path.

Previously, after finding a direct path for a field, the planner could still continue looking for indirect paths. For leaf fields this is unnecessary as the field is already resolved.

Closes #1124