### PR TITLE
feat(executor): log subgraph WebSocket connect and handshake failures…

### DIFF
--- a/.changeset/log_subscription_errors.md
+++ b/.changeset/log_subscription_errors.md
@@ -1,0 +1,8 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Log subgraph subscription failures at error level
+
+Subgraph subscription failures (WebSocket handshake, HTTP-callback connect, SSE stream, etc.) are now logged at `error` level via the central `plan.rs` handler, matching how non-subscription subgraph errors are already logged. Previously these failures only reached the client; the router itself logged nothing above `debug`.

--- a/.changeset/log_subscription_errors.md
+++ b/.changeset/log_subscription_errors.md
@@ -1,6 +1,5 @@
 ---
 hive-router-plan-executor: patch
-hive-router: patch
 ---
 
 # Log subgraph subscription failures at error level

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -187,6 +187,18 @@ fn early_http_response_into_execution_output(
     }
 }
 
+fn log_plan_execution_error(error: &PlanExecutionError) {
+    if let Some(subgraph_name) = error.subgraph_name() {
+        tracing::error!(
+            "Error executing plan with subgraph '{}': {}",
+            subgraph_name,
+            error
+        );
+    } else {
+        tracing::error!("Error executing plan: {}", error);
+    }
+}
+
 pub async fn execute_query_plan<'exec>(
     opts: QueryPlanExecutionOpts<'exec>,
 ) -> Result<QueryPlanExecutionResult, PlanExecutionError> {
@@ -333,6 +345,7 @@ pub async fn execute_query_plan<'exec>(
                         // just to be on the safe side and avoid infinite error streaming because
                         // we cannot guarantee that the subgraph will recover and clients might
                         // simply ignore errors wasting the router's resources
+                        log_plan_execution_error(err);
                         yield FailedExecutionResult {
                             errors: vec![err.into()],
                         }.serialize();
@@ -379,6 +392,7 @@ pub async fn execute_query_plan<'exec>(
                     Ok(result) => yield result.body,
                     Err(ref err) => {
                         // fatal error, stream it and stop
+                        log_plan_execution_error(err);
                         yield FailedExecutionResult {
                             errors: vec![err.into()],
                         }.serialize();
@@ -1184,15 +1198,7 @@ impl<'exec> Executor<'exec> {
     }
 
     fn log_error(&self, error: &PlanExecutionError) {
-        if let Some(subgraph_name) = error.subgraph_name() {
-            tracing::error!(
-                "Error executing plan with subgraph '{}': {}",
-                subgraph_name,
-                error
-            );
-        } else {
-            tracing::error!("Error executing plan: {}", error);
-        }
+        log_plan_execution_error(error);
     }
 
     fn partition_batch_errors_by_alias(

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -7,7 +7,7 @@ use futures::stream::BoxStream;
 use futures_util::StreamExt;
 use ntex::rt;
 use tokio::sync::mpsc;
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
@@ -72,12 +72,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 let connection = match connect(&endpoint, tls_config).await {
                     Ok(conn) => conn,
                     Err(e) => {
-                        error!(
-                            subgraph = %subgraph_name,
-                            endpoint = %endpoint,
-                            error = %e,
-                            "Failed to connect WebSocket to subgraph",
-                        );
                         return Err(SubgraphExecutorError::WebSocketConnectFailure(
                             endpoint.to_string(),
                             e.to_string(),
@@ -88,12 +82,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 let mut client = match WsClient::init(connection, init_payload).await {
                     Ok(client) => client,
                     Err(e) => {
-                        error!(
-                            subgraph = %subgraph_name,
-                            endpoint = %endpoint,
-                            error = %e,
-                            "WebSocket protocol handshake with subgraph failed",
-                        );
                         return Err(SubgraphExecutorError::WebSocketHandshakeFailure(
                             endpoint.to_string(),
                             e.to_string(),
@@ -162,12 +150,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             let connection = match connect(&endpoint, tls_config).await {
                 Ok(conn) => conn,
                 Err(e) => {
-                    error!(
-                        subgraph = %subgraph_name,
-                        endpoint = %endpoint,
-                        error = %e,
-                        "Failed to connect WebSocket to subgraph",
-                    );
                     let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketConnectFailure(
                         endpoint.to_string(),
                         e.to_string(),
@@ -179,12 +161,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             let mut client = match WsClient::init(connection, init_payload).await {
                 Ok(client) => client,
                 Err(e) => {
-                    error!(
-                        subgraph = %subgraph_name,
-                        endpoint = %endpoint,
-                        error = %e,
-                        "WebSocket protocol handshake with subgraph failed",
-                    );
                     let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
                         endpoint.to_string(),
                         e.to_string(),

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -7,7 +7,7 @@ use futures::stream::BoxStream;
 use futures_util::StreamExt;
 use ntex::rt;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
@@ -72,6 +72,12 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 let connection = match connect(&endpoint, tls_config).await {
                     Ok(conn) => conn,
                     Err(e) => {
+                        error!(
+                            subgraph = %subgraph_name,
+                            endpoint = %endpoint,
+                            error = %e,
+                            "Failed to connect WebSocket to subgraph",
+                        );
                         return Err(SubgraphExecutorError::WebSocketConnectFailure(
                             endpoint.to_string(),
                             e.to_string(),
@@ -82,6 +88,12 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 let mut client = match WsClient::init(connection, init_payload).await {
                     Ok(client) => client,
                     Err(e) => {
+                        error!(
+                            subgraph = %subgraph_name,
+                            endpoint = %endpoint,
+                            error = %e,
+                            "WebSocket protocol handshake with subgraph failed",
+                        );
                         return Err(SubgraphExecutorError::WebSocketHandshakeFailure(
                             endpoint.to_string(),
                             e.to_string(),
@@ -150,6 +162,12 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             let connection = match connect(&endpoint, tls_config).await {
                 Ok(conn) => conn,
                 Err(e) => {
+                    error!(
+                        subgraph = %subgraph_name,
+                        endpoint = %endpoint,
+                        error = %e,
+                        "Failed to connect WebSocket to subgraph",
+                    );
                     let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketConnectFailure(
                         endpoint.to_string(),
                         e.to_string(),
@@ -161,6 +179,12 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             let mut client = match WsClient::init(connection, init_payload).await {
                 Ok(client) => client,
                 Err(e) => {
+                    error!(
+                        subgraph = %subgraph_name,
+                        endpoint = %endpoint,
+                        error = %e,
+                        "WebSocket protocol handshake with subgraph failed",
+                    );
                     let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
                         endpoint.to_string(),
                         e.to_string(),


### PR DESCRIPTION
## Summary

Surface subgraph subscription failures (WebSocket handshake, HTTP connect, SSE stream, etc.) in the router logs at `error` level. Previously these were silent on the router side — the only signal was the `SubgraphExecutorError` returned to the client, while the router itself logged nothing above `debug`.

In practice this meant a client seeing

```
WebSocket protocol handshake with 'ws://<subgraph>:.../subscriptions' failed: Connection closed before acknowledgement
```

while operators looking at router logs at the default `info` level saw nothing.

## Why subscriptions specifically

Non-subscription executor errors already log through `QueryPlanExecution::log_error` at `plan.rs:1135`. The subscription path skips that handler — it yields `FailedExecutionResult` directly to the client stream at `plan.rs:312-323` and `plan.rs:362-368` without ever invoking it. That gap is what makes failed WebSocket subscriptions invisible to operators.

## Changes

`lib/executor/src/execution/plan.rs`:

- Extract the body of `log_error()` into a free `log_plan_execution_error(error: &PlanExecutionError)` helper, sharing the same format string as before (`"Error executing plan with subgraph '{}': {}"` when the subgraph name is known, otherwise `"Error executing plan: {}"`).
- Call it at the two subscription-stream error yield sites in `execute_query_plan` before yielding the `FailedExecutionResult`.
- `QueryPlanExecution::log_error()` now delegates to the same helper, so non-subscription paths log identically to before.

`lib/executor/src/executors/websocket.rs`:

- An earlier iteration of this PR added `error!` logs at the four `WsClient` connect / handshake failure sites; those have been removed in favour of the central handler above. No behavior change vs. `main` in this file.

## Why this approach over per-executor logging

- Matches the existing pattern: `log_error` is already the central handler for non-subscription executor errors. Subscriptions were the one path that bypassed it.
- Covers HTTP-callback and SSE subscription failures with the same fix, not just WebSocket.
- Keeps `lib/executor/src/executors/websocket.rs` purely transport-level, no logging-policy concerns.

## Test plan

- [ ] Point a subgraph at a refused WebSocket endpoint and confirm one `error` line with `subgraph` and the connect error appears (instead of the previous silence).
- [ ] Point at a subgraph that closes the socket after the upgrade without sending `connection_ack` and confirm the handshake-failure `error` line appears.
- [ ] Same check with HTTP-callback and SSE subscription failures — confirm they now also produce an error log.
- [ ] Confirm non-subscription subgraph errors continue to log exactly as on `main` (format string unchanged).
- [ ] Confirm a healthy subscription path produces no new error logs at steady state.