### PR TITLE
fix(executor): mark failed subgraph HTTP requests as errors on trace

### DIFF
--- a/.changeset/subgraph_http_error_span.md
+++ b/.changeset/subgraph_http_error_span.md
@@ -1,0 +1,8 @@
+---
+hive-router-internal: patch
+hive-router-plan-executor: patch
+---
+
+# Mark failed subgraph HTTP requests as errors on their trace span
+
+When an outgoing subgraph HTTP request failed at the transport level (connection error, timeout, body read failure, etc.), the `http.client` span was left with an unset `otel.status_code`, so the failure was not surfaced as an error in traces (e.g. Datadog). The error was only recorded in metrics. The span is now marked with `otel.status_code = "Error"` and the corresponding `error.type` on the failure path, matching the existing metrics behaviour.

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -292,6 +292,7 @@ async fn send_request<'a>(
             transport_duration,
         }),
         Err(err) => {
+            http_request_span.record_error(err.error_code());
             http_request_capture.finish_error(err.error_code(), transport_duration);
             Err(err)
         }

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -283,6 +283,18 @@ impl HttpClientRequestSpan {
             "error.type" = 500,
         );
     }
+
+    pub fn record_error(&self, error_type: &'static str) {
+        if self.span.is_disabled() {
+            return;
+        }
+
+        record_all!(
+            self.span,
+            "otel.status_code" = "Error",
+            "error.type" = error_type,
+        );
+    }
 }
 
 pub struct HttpInflightRequestSpan {

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -284,7 +284,7 @@ impl HttpClientRequestSpan {
         );
     }
 
-    pub fn record_error(&self, error_type: &'static str) {
+    pub fn record_error(&self, error_type: &str) {
         if self.span.is_disabled() {
             return;
         }


### PR DESCRIPTION
## Problem

When an outgoing subgraph HTTP request fails at the **transport level** (connection error, timeout, body read failure, empty body, etc.), the `http.client` span is left with an unset `otel.status_code`. As a result the failure is **not surfaced as an error in traces** (e.g. Datadog) — it only shows up in metrics.

Root cause: in `send_request` (`lib/executor/src/executors/http.rs`), `HttpClientRequestSpan::record_response` — the only place that sets `otel.status_code` — is called solely on the success path. The error branch only calls `http_request_capture.finish_error` (metrics), leaving the span status `Empty`.

## Fix

- Add `HttpClientRequestSpan::record_error(error_type)` (mirrors the existing `record_internal_server_error`), setting `otel.status_code = "Error"` and `error.type`.
- Call it on the `Err` branch of `send_request`, alongside the existing `finish_error` metrics call.

This makes the span (trace) and metric failure handling symmetric:

|        | success           | failure                |
| ------ | ----------------- | ---------------------- |
| Metrics | `finish`          | `finish_error`         |
| Span    | `record_response` | `record_error` (new)   |

## Notes

`record_response` still only marks the span as `Error` for `5xx` responses; non-2xx-but-non-5xx responses continue to rely on GraphQL-level error recording. This PR is scoped to the transport-failure path only.