### PR TITLE
feat(query-planner): experimental fold any matching interface (opt-in)

### DIFF
--- a/.changeset/experimental_fold_abstract_any.md
+++ b/.changeset/experimental_fold_abstract_any.md
@@ -1,0 +1,32 @@
+---
+hive-router-plan-executor: minor
+hive-router-query-planner: minor
+hive-router: minor
+hive-router-config: minor
+node-addon: patch
+hive-router-internal: patch
+---
+
+## Add an experimental query planner option, `experimental_abstract_type_folding`
+
+```yaml
+query_planner:
+    experimental_abstract_type_folding: true # false by default
+```
+
+Folds matching concrete object-type fragments in subgraph calls, into a shared interface fragment even when that interface is not the field's declared return type.
+
+It's an opt-in addition to [`011be5b`](https://github.com/graphql-hive/router/commit/011be5bdbfb00bf1e415eb7a50e6be91f565ef05).
+
+```diff
+# queries `product-service` subgraph
+query {
+  products {
+-    ... on Book  { id title }
+-    ... on Movie { id title }
++    ... on Media { id title }
+  }
+}
+```
+
+The `products` field returns `Product` interface, but one object-type member of this interface called `Album` is not present in the query, therefore `... on Product {...}` is not possible to use (default behavior). With the feature flag enabled, both fragments are folded into `... on Media { ... }`, because `Book` and `Movie` are the only members of the `Media` interface in the `product-service` subgraph.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -302,6 +302,8 @@ jobs:
   federation-audit:
     name: test / federation-audit
     runs-on: ubuntu-latest
+    env:
+      GATEWAY_TIMEOUT: 1800000 # 30 minutes, to prevent CI timeout for long-running tests
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: setup rust
@@ -312,8 +314,6 @@ jobs:
           node-version-file: .node-version
       - name: Run Audits
         run: npm run test:federation-all
-        env:
-          GATEWAY_TIMEOUT: 1800000 # 30 minutes, to prevent CI timeout for long-running tests
         working-directory: audits
         continue-on-error: true # continue even if the test fails
       - name: Upload logs
@@ -332,3 +332,9 @@ jobs:
           comment_mode: off
           files: |
             audits/reports/*.xml
+      - name: Run Audits (experimental_abstract_type_folding)
+        run: npm run test:federation-all
+        env:
+          QUERY_PLANNER_EXPERIMENTAL_ABSTRACT_TYPE_FOLDING: true
+        working-directory: audits
+        continue-on-error: true # continue even if the test fails

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -17,6 +17,7 @@ use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_
 use hive_router_query_planner::planner::tree::query_tree::QueryTree;
 use hive_router_query_planner::planner::walker::walk_operation;
 use hive_router_query_planner::planner::walker::ResolvedOperation;
+use hive_router_query_planner::planner::QueryPlannerOptions;
 use hive_router_query_planner::state::supergraph_state::OperationKind;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
 use hive_router_query_planner::utils::cancellation::CancellationToken;
@@ -155,6 +156,7 @@ fn process_fetch_graph(
         &override_context,
         query_tree,
         operation_kind,
+        &QueryPlannerOptions::default(),
         &cancellation_token,
     )
     .expect("failed to build fetch graph")
@@ -189,6 +191,7 @@ fn process_plan(supergraph_path: &str, operation_path: &str) -> QueryPlan {
             .operation_kind
             .clone()
             .unwrap_or(OperationKind::Query),
+        &QueryPlannerOptions::default(),
         &cancellation_token,
     )
     .expect("failed to build fetch graph");

--- a/bin/router/benches/router_benches.rs
+++ b/bin/router/benches/router_benches.rs
@@ -35,7 +35,7 @@ fn authorization_benchmark(c: &mut Criterion) {
     let supergraph_sdl = get_supergraph_sdl();
     let parsed_supergraph_sdl = parse_schema(supergraph_sdl);
     let supergraph_state = SupergraphState::new(&parsed_supergraph_sdl);
-    let planner = Planner::new_from_supergraph(&parsed_supergraph_sdl).unwrap();
+    let planner = Planner::new_from_supergraph(&parsed_supergraph_sdl, Default::default()).unwrap();
     let metadata = planner.consumer_schema.schema_metadata();
     let authorization = AuthorizationMetadata::build(&planner.supergraph, &metadata).unwrap();
 

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -28,9 +28,8 @@ use hive_router_plan_executor::{
     response::graphql_error::GraphQLError,
     SubgraphExecutorMap,
 };
-use hive_router_query_planner::planner::plan_nodes::QueryPlan;
 use hive_router_query_planner::{
-    planner::{Planner, PlannerError},
+    planner::{plan_nodes::QueryPlan, Planner, PlannerError, QueryPlannerOptions},
     utils::parsing::safe_parse_schema,
 };
 use moka::future::Cache;
@@ -280,7 +279,15 @@ impl SchemaState {
         parsed_supergraph_sdl: Document,
         callback_subscriptions: CallbackSubscriptionsMap,
     ) -> Result<SupergraphData, SupergraphManagerError> {
-        let planner = Planner::new_from_supergraph(&parsed_supergraph_sdl)?;
+        let planner = Planner::new_from_supergraph(
+            &parsed_supergraph_sdl,
+            QueryPlannerOptions {
+                experimental_abstract_type_folding: router_config
+                    .query_planner
+                    .experimental_abstract_type_folding,
+                ..QueryPlannerOptions::default()
+            },
+        )?;
         let metadata = Arc::new(planner.consumer_schema.schema_metadata());
         let authorization = AuthorizationMetadata::build(&planner.supergraph, &metadata)?;
         let operation_name_forward_config = Arc::new(OperationNameForwardConfig::new(

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -285,7 +285,6 @@ impl SchemaState {
                 experimental_abstract_type_folding: router_config
                     .query_planner
                     .experimental_abstract_type_folding,
-                ..QueryPlannerOptions::default()
             },
         )?;
         let metadata = Arc::new(planner.consumer_schema.schema_metadata());

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@
 |[**override\_subgraph\_urls**](#override_subgraph_urls)|`object`|Configuration for overriding subgraph URLs.<br/>Default: `{}`<br/>||
 |[**persisted\_documents**](#persisted_documents)|`object`|Configuration for persisted documents extraction and resolution.<br/>Default: `{"enabled":false,"log_missing_id":false,"require_id":false,"selectors":null,"storage":null}`<br/>||
 |[**plugins**](#plugins)|`object`|Configuration for custom plugins<br/>||
-|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"timeout":"10s"}`<br/>||
+|[**query\_planner**](#query_planner)|`object`|Query planning configuration.<br/>Default: `{"allow_expose":false,"experimental_abstract_type_folding":false,"timeout":"10s"}`<br/>||
 |[**storages**](#storages)|`object`|Configuration for storage sources.<br/>||
 |[**subscriptions**](#subscriptions)|`object`|Configuration for subscriptions.<br/>Default: `{"broadcast_capacity":0,"enabled":false}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>||
@@ -133,6 +133,7 @@ persisted_documents:
 plugins: {}
 query_planner:
   allow_expose: false
+  experimental_abstract_type_folding: false
   timeout: 10s
 storages: {}
 subscriptions:
@@ -2526,6 +2527,7 @@ Query planning configuration.
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**allow\_expose**|`boolean`|A flag to allow exposing the query plan in the response.<br/>When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.<br/>Default: `false`<br/>||
+|**experimental\_abstract\_type\_folding**|`boolean`|Enables an experimental feature that folds matching object-type inline fragments<br/>into an interface fragment, even when that interface is not the field's declared return type.<br/><br/>The fold is only applied when the concrete object branches select the same fields and<br/>exactly match the interface members in the target subgraph.<br/><br/>Can also be set via the `QUERY_PLANNER_EXPERIMENTAL_ABSTRACT_TYPE_FOLDING` environment variable.<br/><br/>Default: false.<br/>Default: `false`<br/>||
 |**timeout**|`string`|The maximum time for the query planner to create an execution plan.<br/>This acts as a safeguard against overly complex or malicious queries that could degrade server performance.<br/>When the timeout is reached, the planning process is cancelled.<br/><br/>Default: 10s.<br/>Default: `"10s"`<br/>||
 
 **Additional Properties:** not allowed  
@@ -2533,6 +2535,7 @@ Query planning configuration.
 
 ```yaml
 allow_expose: false
+experimental_abstract_type_folding: false
 timeout: 10s
 
 ```

--- a/lib/executor/benches/executor_benches.rs
+++ b/lib/executor/benches/executor_benches.rs
@@ -15,8 +15,11 @@ fn project_data_by_operation_test(c: &mut Criterion) {
         .expect("Unable to read input file");
     let parsed_schema = parse_schema(&supergraph_sdl);
     let planner = Box::leak(Box::new(
-        hive_router_query_planner::planner::Planner::new_from_supergraph(&parsed_schema)
-            .expect("Failed to create planner from supergraph"),
+        hive_router_query_planner::planner::Planner::new_from_supergraph(
+            &parsed_schema,
+            Default::default(),
+        )
+        .expect("Failed to create planner from supergraph"),
     ));
     let parsed_document = parse_operation(
         &std::fs::read_to_string(operation_path).expect("Unable to read input file"),

--- a/lib/executor/src/response/subgraph_response.rs
+++ b/lib/executor/src/response/subgraph_response.rs
@@ -496,7 +496,7 @@ mod tests {
             }
             "#,
         );
-        let planner = Planner::new_from_supergraph(&schema).expect("planner");
+        let planner = Planner::new_from_supergraph(&schema, Default::default()).expect("planner");
         let operation = parse_operation(
             r#"
             {

--- a/lib/node-addon/src/lib.rs
+++ b/lib/node-addon/src/lib.rs
@@ -30,9 +30,10 @@ impl QueryPlanner {
         let parsed_supergraph =
             safe_parse_schema(&supergraph_sdl).map_err(QueryPlanError::SchemaParse)?;
 
-        let planner = Planner::new_from_supergraph(&parsed_supergraph).map_err(|err| {
-            napi::Error::from_reason(format!("Failed to create query planner: {}", err))
-        })?;
+        let planner = Planner::new_from_supergraph(&parsed_supergraph, Default::default())
+            .map_err(|err| {
+                napi::Error::from_reason(format!("Failed to create query planner: {}", err))
+            })?;
 
         let consumer_schema = planner.consumer_schema.document.to_string();
         let override_labels = planner

--- a/lib/query-planner/benches/qp_benches.rs
+++ b/lib/query-planner/benches/qp_benches.rs
@@ -9,6 +9,7 @@ use hive_router_query_planner::planner::best::find_best_combination;
 use hive_router_query_planner::planner::fetch::fetch_graph::build_fetch_graph_from_query_tree;
 use hive_router_query_planner::planner::query_plan::build_query_plan_from_fetch_graph;
 use hive_router_query_planner::planner::walker::walk_operation;
+use hive_router_query_planner::planner::QueryPlannerOptions;
 use hive_router_query_planner::state::supergraph_state::OperationKind;
 use hive_router_query_planner::state::supergraph_state::SupergraphState;
 use hive_router_query_planner::utils::cancellation::CancellationToken;
@@ -68,6 +69,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
                 bb_override_context,
                 query_tree,
                 bb_kind,
+                &QueryPlannerOptions::default(),
                 &cancellation_token,
             )
             .unwrap();
@@ -118,6 +120,7 @@ fn query_plan_pipeline(c: &mut Criterion) {
                 bb_override_context,
                 query_tree,
                 bb_kind,
+                &QueryPlannerOptions::default(),
                 &cancellation_token,
             )
             .unwrap();

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -13,6 +13,7 @@ use crate::planner::tree::query_tree::QueryTree;
 use crate::planner::tree::query_tree_node::{MutationFieldPosition, QueryTreeNode};
 use crate::planner::walker::path::OperationPath;
 use crate::planner::walker::pathfinder::can_satisfy_edge;
+use crate::planner::QueryPlannerOptions;
 use crate::state::supergraph_state::{OperationKind, SubgraphName, SupergraphState};
 use crate::utils::cancellation::CancellationToken;
 use petgraph::algo::has_path_connecting;
@@ -1813,6 +1814,7 @@ pub fn build_fetch_graph_from_query_tree(
     override_context: &PlannerOverrideContext,
     query_tree: QueryTree,
     operation_kind: OperationKind,
+    options: &QueryPlannerOptions,
     cancellation_token: &CancellationToken,
 ) -> Result<FetchGraph<MultiTypeFetchStep>, FetchGraphError> {
     let mut fetch_graph = FetchGraph::new(operation_kind);
@@ -1850,7 +1852,7 @@ pub fn build_fetch_graph_from_query_tree(
     // fine to unwrap as we have already checked the length
     fetch_graph.root_index = Some(*root_indexes.first().unwrap());
     let mut fetch_graph = fetch_graph.to_multi_type();
-    fetch_graph.optimize(supergraph, cancellation_token)?;
+    fetch_graph.optimize(supergraph, options, cancellation_token)?;
     fetch_graph.collect_variable_usages()?;
 
     trace!("fetch graph after optimizations:");

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -328,8 +328,6 @@ impl<'a> StepConverter<'a> {
     where
         'a: 'b,
     {
-        let mut best: Option<FoldCandidate<'b>> = None;
-
         let Some(first_branch) = branches.first() else {
             return Ok(None);
         };
@@ -340,26 +338,23 @@ impl<'a> StepConverter<'a> {
             return Ok(None);
         };
 
-        for join_implements in &object_type.join_implements {
-            if join_implements.graph_id != self.subgraph.graph_id {
-                continue;
-            }
+        let mut interface_names = object_type
+            .join_implements
+            .iter()
+            .filter(|join_implements| join_implements.graph_id == self.subgraph.graph_id)
+            .map(|join_implements| join_implements.interface.as_str())
+            .collect::<Vec<_>>();
 
-            let interface_name = join_implements.interface.as_str();
+        interface_names.sort_unstable();
+        interface_names.dedup();
 
-            if best
-                .as_ref()
-                .is_some_and(|best| best.interface_name <= interface_name)
-            {
-                continue;
-            }
-
+        for interface_name in interface_names {
             if let Some(candidate) = self.try_fold_into_interface(interface_name, branches)? {
-                best = Some(candidate);
+                return Ok(Some(candidate));
             }
         }
 
-        Ok(best)
+        Ok(None)
     }
 
     fn try_fold_into_interface<'b>(

--- a/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/fold_concrete_selections_to_interfaces.rs
@@ -38,6 +38,7 @@ use crate::{
         error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
         state::MultiTypeFetchStep,
     },
+    planner::QueryPlannerOptions,
     state::{
         subgraph_state::{SubgraphField, SubgraphState},
         supergraph_state::{OperationKind, SupergraphDefinition, SupergraphState},
@@ -49,6 +50,7 @@ impl FetchGraph<MultiTypeFetchStep> {
     pub(crate) fn fold_concrete_selections_to_interfaces(
         &mut self,
         supergraph: &SupergraphState,
+        options: &QueryPlannerOptions,
     ) -> Result<bool, FetchGraphError> {
         let root_type_name = match self.operation_kind {
             OperationKind::Query => supergraph.query_type.as_str(),
@@ -75,6 +77,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                 root_type_name,
                 supergraph,
                 subgraph,
+                options,
             }
             .rewrite_step(step)?;
         }
@@ -87,6 +90,7 @@ struct StepConverter<'a> {
     root_type_name: &'a str,
     supergraph: &'a SupergraphState,
     subgraph: &'a SubgraphState,
+    options: &'a QueryPlannerOptions,
 }
 
 struct InterfaceInSubgraph<'a> {
@@ -107,6 +111,11 @@ struct FoldedSelection {
     selection_set: SelectionSet,
     condition: Option<Condition>,
     remove_indexes: Vec<usize>,
+}
+
+struct FoldCandidate<'a> {
+    interface_name: &'a str,
+    folded: FoldedSelection,
 }
 
 impl<'a> StepConverter<'a> {
@@ -153,12 +162,14 @@ impl<'a> StepConverter<'a> {
             })
             .collect::<Vec<_>>();
 
-        let Some(folded) = self.try_fold_into_interface(interface_name, branches)? else {
+        let Some(candidate) = self.try_fold(interface_name, &branches)? else {
             return Ok(false);
         };
 
-        step.output
-            .replace_definitions_with_abstract(interface_name, folded.selection_set);
+        step.output.replace_definitions_with_abstract(
+            candidate.interface_name,
+            candidate.folded.selection_set,
+        );
 
         Ok(true)
     }
@@ -247,7 +258,7 @@ impl<'a> StepConverter<'a> {
                 })
                 .collect::<Vec<_>>();
 
-            self.try_fold_into_interface(current_type_name, branches)?
+            self.try_fold(current_type_name, &branches)?
         };
 
         let Some(candidate) = candidate else {
@@ -260,7 +271,7 @@ impl<'a> StepConverter<'a> {
             .drain(..)
             .enumerate()
             .filter_map(|(index, item)| {
-                if candidate.remove_indexes.contains(&index) {
+                if candidate.folded.remove_indexes.contains(&index) {
                     None // drop
                 } else {
                     Some(item) // keep
@@ -268,29 +279,97 @@ impl<'a> StepConverter<'a> {
             })
             .collect();
 
-        if let Some(condition) = candidate.condition {
+        if let Some(condition) = candidate.folded.condition {
             // If the original branches had @skip/@include
             selection_set
                 .items
                 .push(SelectionItem::InlineFragment(InlineFragmentSelection {
-                    type_condition: current_type_name.to_string(),
-                    selections: candidate.selection_set,
+                    type_condition: candidate.interface_name.to_string(),
+                    selections: candidate.folded.selection_set,
                     skip_if: condition.to_skip_if(),
                     include_if: condition.to_include_if(),
                 }));
+        } else if candidate.interface_name != current_type_name {
+            selection_set
+                .items
+                .push(SelectionItem::InlineFragment(InlineFragmentSelection {
+                    type_condition: candidate.interface_name.to_string(),
+                    selections: candidate.folded.selection_set,
+                    skip_if: None,
+                    include_if: None,
+                }));
         } else {
             // Otherwise merge the fields directly into the parent selection set
-            merge_selection_set(selection_set, &candidate.selection_set, false);
+            merge_selection_set(selection_set, &candidate.folded.selection_set, false);
         }
 
         Ok(true)
     }
 
-    fn try_fold_into_interface(
-        &self,
-        interface_name: &str,
-        branches: Vec<ObjectTypeBranch<'_>>,
-    ) -> Result<Option<FoldedSelection>, FetchGraphError> {
+    fn try_fold<'b>(
+        &'a self,
+        default_interface_name: &'b str,
+        branches: &[ObjectTypeBranch<'_>],
+    ) -> Result<Option<FoldCandidate<'b>>, FetchGraphError>
+    where
+        'a: 'b,
+    {
+        if self.options.experimental_abstract_type_folding {
+            self.try_fold_into_any_matching_interface(branches)
+        } else {
+            self.try_fold_into_interface(default_interface_name, branches)
+        }
+    }
+
+    fn try_fold_into_any_matching_interface<'b>(
+        &'a self,
+        branches: &[ObjectTypeBranch<'_>],
+    ) -> Result<Option<FoldCandidate<'b>>, FetchGraphError>
+    where
+        'a: 'b,
+    {
+        let mut best: Option<FoldCandidate<'b>> = None;
+
+        let Some(first_branch) = branches.first() else {
+            return Ok(None);
+        };
+
+        let Some(SupergraphDefinition::Object(object_type)) =
+            self.supergraph.definitions.get(first_branch.type_name)
+        else {
+            return Ok(None);
+        };
+
+        for join_implements in &object_type.join_implements {
+            if join_implements.graph_id != self.subgraph.graph_id {
+                continue;
+            }
+
+            let interface_name = join_implements.interface.as_str();
+
+            if best
+                .as_ref()
+                .is_some_and(|best| best.interface_name <= interface_name)
+            {
+                continue;
+            }
+
+            if let Some(candidate) = self.try_fold_into_interface(interface_name, branches)? {
+                best = Some(candidate);
+            }
+        }
+
+        Ok(best)
+    }
+
+    fn try_fold_into_interface<'b>(
+        &'a self,
+        interface_name: &'b str,
+        branches: &[ObjectTypeBranch<'_>],
+    ) -> Result<Option<FoldCandidate<'b>>, FetchGraphError>
+    where
+        'a: 'b,
+    {
         // Folding 1 branch is pointless
         if branches.len() < 2 {
             return Ok(None);
@@ -308,7 +387,7 @@ impl<'a> StepConverter<'a> {
         let shared_condition = first_branch.condition.clone();
         let mut concrete_types = BTreeSet::new();
 
-        for branch in &branches {
+        for branch in branches {
             // Every branch condition (@skip / @include) must be the same
             if branch.condition != shared_condition {
                 return Ok(None);
@@ -352,13 +431,16 @@ impl<'a> StepConverter<'a> {
             return Ok(None);
         }
 
-        Ok(Some(FoldedSelection {
-            selection_set: selection_set.clone(),
-            condition: shared_condition,
-            remove_indexes: branches
-                .iter()
-                .filter_map(|branch| branch.remove_index)
-                .collect(),
+        Ok(Some(FoldCandidate {
+            interface_name,
+            folded: FoldedSelection {
+                selection_set: selection_set.clone(),
+                condition: shared_condition,
+                remove_indexes: branches
+                    .iter()
+                    .filter_map(|branch| branch.remove_index)
+                    .collect(),
+            },
         }))
     }
 

--- a/lib/query-planner/src/planner/fetch/optimize/mod.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/mod.rs
@@ -15,6 +15,7 @@ use tracing::instrument;
 
 use crate::{
     planner::fetch::{error::FetchGraphError, fetch_graph::FetchGraph, state::MultiTypeFetchStep},
+    planner::QueryPlannerOptions,
     state::supergraph_state::SupergraphState,
     utils::cancellation::CancellationToken,
 };
@@ -24,6 +25,7 @@ impl FetchGraph<MultiTypeFetchStep> {
     pub fn optimize(
         &mut self,
         supergraph_state: &SupergraphState,
+        options: &QueryPlannerOptions,
         cancellation_token: &CancellationToken,
     ) -> Result<(), FetchGraphError> {
         // Run optimization passes repeatedly until the graph stabilizes, as one optimization can create
@@ -41,7 +43,7 @@ impl FetchGraph<MultiTypeFetchStep> {
             self.batch_multi_type()?;
             self.normalize_selection_sets(supergraph_state)?;
             let abstract_type_converted =
-                self.fold_concrete_selections_to_interfaces(supergraph_state)?;
+                self.fold_concrete_selections_to_interfaces(supergraph_state, options)?;
 
             let node_count_after = self.graph.node_count();
             let edge_count_after = self.graph.edge_count();

--- a/lib/query-planner/src/planner/mod.rs
+++ b/lib/query-planner/src/planner/mod.rs
@@ -28,10 +28,16 @@ pub mod query_plan;
 pub mod tree;
 pub mod walker;
 
+#[derive(Debug, Clone, Default)]
+pub struct QueryPlannerOptions {
+    pub experimental_abstract_type_folding: bool,
+}
+
 pub struct Planner {
     graph: Graph,
     pub supergraph: SupergraphState,
     pub consumer_schema: Arc<ConsumerSchema>,
+    options: QueryPlannerOptions,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -53,14 +59,16 @@ pub enum PlannerError {
 impl Planner {
     pub fn new_from_supergraph(
         parsed_supergraph: &schema::Document<'static, String>,
+        options: QueryPlannerOptions,
     ) -> Result<Self, PlannerError> {
         let supergraph_state = SupergraphState::new(parsed_supergraph);
-        Self::new_from_supergraph_state(supergraph_state, parsed_supergraph)
+        Self::new_from_supergraph_state(supergraph_state, parsed_supergraph, options)
     }
 
     pub fn new_from_supergraph_state(
         supergraph_state: SupergraphState,
         parsed_supergraph: &schema::Document<'static, String>,
+        options: QueryPlannerOptions,
     ) -> Result<Self, PlannerError> {
         let graph = Graph::graph_from_supergraph_state(&supergraph_state)?;
         let consumer_schema = ConsumerSchema::new_from_supergraph(parsed_supergraph);
@@ -69,6 +77,7 @@ impl Planner {
             graph,
             consumer_schema: Arc::new(consumer_schema),
             supergraph: supergraph_state,
+            options,
         })
     }
 
@@ -97,6 +106,7 @@ impl Planner {
                 .operation_kind
                 .clone()
                 .unwrap_or(OperationKind::Query),
+            &self.options,
             cancellation_token,
         )?;
         add_variables_to_fetch_steps(&mut fetch_graph, &normalized_operation.variable_definitions)?;

--- a/lib/query-planner/src/tests/alias.rs
+++ b/lib/query-planner/src/tests/alias.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -40,7 +40,7 @@ fn circular_reference_interface() -> Result<(), Box<dyn Error>> {
         }
 "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/circular-reference-interface.supergraph.graphql",
         document,
     )?;
@@ -120,7 +120,8 @@ fn conflict_list_type_in_interface() -> Result<(), Box<dyn Error>> {
         }
 "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r###"
     QueryPlan {
@@ -194,7 +195,8 @@ fn multiple_mismtaches_same_level() -> Result<(), Box<dyn Error>> {
         }
 "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r###"
     QueryPlan {
@@ -284,7 +286,8 @@ fn aliasing_both_parent_and_leaf() -> Result<(), Box<dyn Error>> {
               }
             }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/testing.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/testing.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -369,7 +372,7 @@ fn simple_mismatch_between_union_fields() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/child-type-mismatch.supergraph.graphql",
         document,
     )?;
@@ -546,7 +549,7 @@ fn nested_internal_mismatch_between_fields() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/child-type-mismatch.supergraph.graphql",
         document,
     )?;
@@ -832,7 +835,7 @@ fn deeply_nested_internal_mismatch_between_fields() -> Result<(), Box<dyn Error>
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/child-type-mismatch.supergraph.graphql",
         document,
     )?;
@@ -1253,7 +1256,7 @@ fn deeply_nested_no_conflicts() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/child-type-mismatch.supergraph.graphql",
         document,
     )?;
@@ -1351,7 +1354,7 @@ fn multi_enum_mismatch_across_fragments() -> Result<(), Box<dyn Error>> {
             }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/mismatch-mix-enum-scalar.supergraph.graphql",
         document,
     )?;
@@ -1432,7 +1435,7 @@ fn multi_scalar_mismatch_across_fragments() -> Result<(), Box<dyn Error>> {
             }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/mismatch-mix-enum-scalar.supergraph.graphql",
         document,
     )?;
@@ -1500,7 +1503,8 @@ fn conflict_list_type_in_interface_preserves_client_alias() -> Result<(), Box<dy
         }
 "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r###"
     QueryPlan {
@@ -1552,7 +1556,8 @@ fn conflict_list_type_in_interface_with_distinct_response_keys() -> Result<(), B
         }
 "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mismatch-mix.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r###"
     QueryPlan {

--- a/lib/query-planner/src/tests/arguments.rs
+++ b/lib/query-planner/src/tests/arguments.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -20,7 +20,7 @@ fn fed_audit_requires_with_argument_conflict() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires-with-argument-conflict.supergraph.graphql",
         document,
     )?;
@@ -225,7 +225,7 @@ fn requires_arguments_deeply_nested_requires() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/audit-requires-arguments.supergraph.graphql",
         document,
     )?;
@@ -447,7 +447,7 @@ fn requires_arguments_deeply_nested_requires_with_variable() -> Result<(), Box<d
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/audit-requires-arguments.supergraph.graphql",
         document,
     )?;
@@ -683,7 +683,7 @@ fn requires_arguments_deeply_nested_requires_with_variables_and_fragments(
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/audit-requires-arguments.supergraph.graphql",
         document,
     )?;
@@ -907,7 +907,7 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-requires-args.supergraph.graphql",
         document,
     )?;
@@ -1124,7 +1124,7 @@ fn multiple_plain_field_and_requires_with_args_that_conflicts() -> Result<(), Bo
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-requires-args.supergraph.graphql",
         document,
     )?;
@@ -1342,7 +1342,7 @@ fn multiple_plain_field_and_requires_with_args_that_does_not_conflicts_should_me
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-requires-args.supergraph.graphql",
         document,
     )?;
@@ -1489,7 +1489,7 @@ fn simple_requires_arguments() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-requires-args.supergraph.graphql",
         document,
     )?;
@@ -1637,7 +1637,7 @@ fn requires_with_arguments() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/arguments-requires.supergraph.graphql",
         document,
     )?;
@@ -1734,7 +1734,8 @@ fn arguments_in_different_levels() -> Result<(), Box<dyn Error>> {
 
         }"#,
     );
-    let query_plan = build_query_plan("fixture/spotify-supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/spotify-supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -1793,7 +1794,8 @@ fn arguments_and_variables() -> Result<(), Box<dyn Error>> {
 
         }"#,
     );
-    let query_plan = build_query_plan("fixture/spotify-supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/spotify-supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -1859,7 +1861,7 @@ fn arguments_with_aliases() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/parent-entity-call-complex.supergraph.graphql",
         document,
     )?;
@@ -1990,7 +1992,7 @@ fn arguments_variables_mixed() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/parent-entity-call-complex.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/fragments.rs
+++ b/lib/query-planner/src/tests/fragments.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -29,7 +29,7 @@ fn multiple_inline_fragments_on_same_concrete_type_within_interface_fragment(
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -71,7 +71,7 @@ fn nested_same_name_directives_on_abstract_and_concrete_fragments() -> Result<()
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -115,7 +115,7 @@ fn nested_same_directive_same_arg_on_abstract_and_concrete_fragments() -> Result
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -156,7 +156,7 @@ fn nested_different_directives_on_abstract_and_concrete_fragments() -> Result<()
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -206,7 +206,7 @@ fn parent_directive_only_on_abstract_fragment() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -248,7 +248,7 @@ fn reusable_fragment_with_mixed_include_conditions_on_concrete_parent() -> Resul
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -298,7 +298,7 @@ fn reusable_fragment_with_mixed_include_conditions_on_abstract_parent() -> Resul
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -343,7 +343,8 @@ fn simple_inline_fragment() -> Result<(), Box<dyn Error>> {
               }
             }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/testing.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/testing.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -416,7 +417,8 @@ fn fragment_spread() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/testing.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/testing.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/query-planner/src/tests/include_skip.rs
+++ b/lib/query-planner/src/tests/include_skip.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -17,7 +17,7 @@ fn include_basic_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -97,7 +97,7 @@ fn include_fragment_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -173,7 +173,7 @@ fn skip_basic_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -251,7 +251,7 @@ fn skip_and_include_field_condition_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -333,7 +333,7 @@ fn skip_and_include_fragment_condition_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -411,7 +411,7 @@ fn include_at_root_fetch_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -447,7 +447,7 @@ fn include_fragment_at_root_fetch_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -483,7 +483,7 @@ fn include_interface_at_root_fetch_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -519,7 +519,7 @@ fn include_interface_fragment_at_root_fetch_test() -> Result<(), Box<dyn Error>>
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -563,7 +563,7 @@ fn include_union_fragment_at_root_fetch_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-overfetching.supergraph.graphql",
         document,
     )?;
@@ -672,7 +672,8 @@ fn plans_query_with_nested_directive_only_inline_fragments() -> Result<(), Box<d
         "#,
     );
 
-    let query_plan = build_query_plan("fixture/products-example.supergraph.graphql", document);
+    let query_plan =
+        build_query_plan_with_defaults("fixture/products-example.supergraph.graphql", document);
     assert!(
         query_plan.is_ok(),
         "expected query planning to succeed, got: {:?}",
@@ -748,7 +749,8 @@ fn plans_query_with_field_level_include_skip_conditions() -> Result<(), Box<dyn 
         "#,
     );
 
-    let query_plan = build_query_plan("fixture/products-example.supergraph.graphql", document);
+    let query_plan =
+        build_query_plan_with_defaults("fixture/products-example.supergraph.graphql", document);
     assert!(
         query_plan.is_ok(),
         "expected query planning to succeed, got: {:?}",
@@ -772,7 +774,7 @@ fn qp_include_field_level() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -835,7 +837,7 @@ fn qp_include_field_level_unconditional_before_conditional() -> Result<(), Box<d
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -899,7 +901,7 @@ fn qp_include_field_level_all_merged_fields_conditional() -> Result<(), Box<dyn 
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -961,7 +963,7 @@ fn qp_skip_field_level() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -1024,7 +1026,7 @@ fn qp_skip_field_level_unconditional_before_conditional() -> Result<(), Box<dyn 
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -1088,7 +1090,7 @@ fn qp_skip_field_level_all_merged_fields_conditional() -> Result<(), Box<dyn Err
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -1153,7 +1155,7 @@ fn qp_skip_and_include_field_level_all_merged_fields_conditional() -> Result<(),
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -1220,7 +1222,7 @@ fn qp_mixed_include_skip_field_level_keeps_conditions_scoped() -> Result<(), Box
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-include-skip.supergraph.graphql",
         document,
     )?;
@@ -1304,7 +1306,8 @@ fn qp_nested_include_skip_conditions_in_complex_products_query() -> Result<(), B
       "#,
     );
 
-    let query_plan = build_query_plan("fixture/products-example.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/products-example.supergraph.graphql", document)?;
     let printed = format!("{}", query_plan);
 
     insta::assert_snapshot!(printed, @r#"
@@ -1435,7 +1438,10 @@ fn qp_abstract_interface_mixed_conditions_stay_scoped() -> Result<(), Box<dyn Er
       "#,
     );
 
-    let query_plan = build_query_plan("fixture/tests/abstract-types.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/abstract-types.supergraph.graphql",
+        document,
+    )?;
     let printed = format!("{}", query_plan);
 
     insta::assert_snapshot!(printed, @r#"
@@ -1533,7 +1539,10 @@ fn qp_abstract_interface_shared_condition_can_skip_remote_fetch() -> Result<(), 
       "#,
     );
 
-    let query_plan = build_query_plan("fixture/tests/abstract-types.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/abstract-types.supergraph.graphql",
+        document,
+    )?;
     let printed = format!("{}", query_plan);
 
     insta::assert_snapshot!(printed, @r#"
@@ -1603,7 +1612,7 @@ fn qp_abstract_union_member_conditions_stay_scoped() -> Result<(), Box<dyn Error
       "#,
     );
 
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-overfetching.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/interface.rs
+++ b/lib/query-planner/src/tests/interface.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -21,7 +21,7 @@ fn node_query_with_aliases_on_interface_field() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -70,7 +70,7 @@ fn node_query_with_inline_fragments_on_object_types() -> Result<(), Box<dyn Erro
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -128,7 +128,7 @@ fn node_query_with_cross_type_inline_fragments() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -186,7 +186,7 @@ fn node_query_with_typename_and_cross_type_fragments() -> Result<(), Box<dyn Err
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -235,7 +235,7 @@ fn direct_object_query_chat_by_id() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -269,7 +269,7 @@ fn direct_object_query_account_by_id() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -307,7 +307,7 @@ fn object_query_with_nested_object_field() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -366,7 +366,7 @@ fn object_query_with_nested_list_field() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     )?;
@@ -421,7 +421,7 @@ fn node_query_with_id_on_interface_field() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     );
@@ -452,7 +452,7 @@ fn node_query_with_multiple_type_fragments() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     );
@@ -487,7 +487,7 @@ fn node_query_with_id_and_cross_type_fragment_overlap() -> Result<(), Box<dyn Er
         }
       "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         document,
     );
@@ -513,7 +513,10 @@ fn type_expand_interface_field() -> Result<(), Box<dyn Error>> {
       ,
       "#,
     );
-    let query_plan = build_query_plan("fixture/tests/abstract-types.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/abstract-types.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -588,7 +591,10 @@ fn requires_on_field_with_args_test() -> Result<(), Box<dyn Error>> {
       ,
       "#,
     );
-    let query_plan = build_query_plan("fixture/tests/abstract-types.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/abstract-types.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -691,7 +697,10 @@ fn nested_interface_field_with_inline_fragments() -> Result<(), Box<dyn Error>> 
       ,
       "#,
     );
-    let query_plan = build_query_plan("fixture/tests/abstract-types.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/abstract-types.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -804,7 +813,10 @@ fn nested_interface_field_with_redundant_inline_fragments() -> Result<(), Box<dy
       ,
       "#,
     );
-    let query_plan = build_query_plan("fixture/tests/abstract-types.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/abstract-types.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/query-planner/src/tests/interface_object.rs
+++ b/lib/query-planner/src/tests/interface_object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -30,7 +30,7 @@ fn interface_object_field_local() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -86,7 +86,7 @@ fn interface_object_field_remote() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -142,7 +142,7 @@ fn interface_object_field_local_object_type() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -206,7 +206,7 @@ fn interface_to_object_type_locally() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -248,7 +248,7 @@ fn interface_object_with_inline_fragment_resolving_remote_interface_field_simple
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -327,7 +327,7 @@ fn interface_object_with_inline_fragment_resolving_remote_interface_field(
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -530,7 +530,7 @@ fn interface_field_with_inline_fragment_resolving_remote_interface_object_field(
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -592,7 +592,7 @@ fn interface_object_field_local_direct_resolution() -> Result<(), Box<dyn Error>
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -632,7 +632,7 @@ fn interface_object_field_with_inline_fragment_requiring_typename_check(
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -707,7 +707,7 @@ fn interface_object_field_local_with_remote_typename() -> Result<(), Box<dyn Err
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -768,7 +768,7 @@ fn interface_object_inline_fragment_with_remote_typename() -> Result<(), Box<dyn
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -835,7 +835,7 @@ fn interface_object_local_id_remote_field() -> Result<(), Box<dyn Error>> {
     // but the `Account` is a fake interface, it's an object type with @interfaceObject.
     // It can resolve `id`, but `isActive` lives in some other subgraph.
     // To collect it, we perform an entity call to the interface entity.
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;
@@ -890,7 +890,7 @@ fn interface_object_local_id_remote_field_with_inline_fragment() -> Result<(), B
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple-interface-object.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/interface_object_with_requires.rs
+++ b/lib/query-planner/src/tests/interface_object_with_requires.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -18,7 +18,7 @@ fn interface_object_requiring_interface_fields() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/interface-object-with-requires.supergraph.graphql",
         document,
     )?;
@@ -203,7 +203,7 @@ fn interface_field_from_remote_graph_with_requires() -> Result<(), Box<dyn Error
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/interface-object-with-requires.supergraph.graphql",
         document,
     )?;
@@ -343,7 +343,7 @@ fn inline_fragment_on_interface_object_for_remote_type_field() -> Result<(), Box
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/interface-object-with-requires.supergraph.graphql",
         document,
     )?;
@@ -463,7 +463,7 @@ fn inline_fragment_on_local_type_behind_interface() -> Result<(), Box<dyn Error>
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/interface-object-with-requires.supergraph.graphql",
         document,
     )?;
@@ -517,7 +517,7 @@ fn interface_object_field_with_requires_and_inline_fragment() -> Result<(), Box<
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/interface-object-with-requires.supergraph.graphql",
         document,
     )?;
@@ -715,7 +715,7 @@ fn interface_field_from_remote_graph_with_requires_and_inline_fragment(
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/interface-object-with-requires.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -1,5 +1,6 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    planner::QueryPlannerOptions,
+    tests::testkit::{build_query_plan, build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -31,7 +32,8 @@ fn issue_281_test() -> Result<(), Box<dyn Error>> {
 
         "#,
     );
-    let query_plan = build_query_plan("fixture/issues/281.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/issues/281.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -162,7 +164,8 @@ fn issue_190_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan("fixture/issues/190.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/issues/190.supergraph.graphql", document)?;
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
       Fetch(service: "recommender") {
@@ -201,7 +204,8 @@ fn issue_190_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan("fixture/issues/190.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/issues/190.supergraph.graphql", document)?;
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
       Fetch(service: "recommender") {
@@ -237,7 +241,8 @@ fn issue_190_test() -> Result<(), Box<dyn Error>> {
         }
       "#,
     );
-    let query_plan = build_query_plan("fixture/issues/190.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/issues/190.supergraph.graphql", document)?;
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
       Fetch(service: "recommender") {
@@ -288,7 +293,7 @@ fn issue_939_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let named_fragment_plan = build_query_plan(
+    let named_fragment_plan = build_query_plan_with_defaults(
         "fixture/issues/939.supergraph.graphql",
         named_fragment_document,
     )?;
@@ -316,7 +321,7 @@ fn issue_939_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let inline_fragment_plan = build_query_plan(
+    let inline_fragment_plan = build_query_plan_with_defaults(
         "fixture/issues/939.supergraph.graphql",
         inline_fragment_document,
     )?;
@@ -370,6 +375,105 @@ fn issue_939_test() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn experimental_abstract_type_folding_folds_object_fragments_into_interface(
+) -> Result<(), Box<dyn Error>> {
+    init_logger();
+
+    let document = parse_operation(
+        r#"
+        query SingleNode($id: ID!) {
+          node(id: $id) {
+            ... on MyNode {
+              content {
+                ... on TextContent {
+                  id
+                }
+                ... on TextGroupContent {
+                  id
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/issues/939.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "content") {
+        query ($id:ID!) {
+          node(id: $id) {
+            __typename
+            ... on MyNode {
+              content {
+                __typename
+                ... on TextContent {
+                  id
+                }
+                ... on TextGroupContent {
+                  id
+                }
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    let document = parse_operation(
+        r#"
+        query SingleNode($id: ID!) {
+          node(id: $id) {
+            ... on MyNode {
+              content {
+                ... on TextContent {
+                  id
+                }
+                ... on TextGroupContent {
+                  id
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan(
+        "fixture/issues/939.supergraph.graphql",
+        document,
+        Default::default(),
+        QueryPlannerOptions {
+            experimental_abstract_type_folding: true,
+        },
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "content") {
+        query ($id:ID!) {
+          node(id: $id) {
+            __typename
+            ... on MyNode {
+              content {
+                __typename
+                ... on ITextContent {
+                  id
+                }
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn issue_965_test() -> Result<(), Box<dyn Error>> {
     init_logger();
 
@@ -391,7 +495,7 @@ fn issue_965_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let abstract_named_fragment_plan = build_query_plan(
+    let abstract_named_fragment_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         abstract_named_fragment_document,
     )?;
@@ -412,7 +516,7 @@ fn issue_965_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let concrete_named_fragment_plan = build_query_plan(
+    let concrete_named_fragment_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         concrete_named_fragment_document,
     )?;
@@ -474,7 +578,7 @@ fn issue_965_mixed_nested_fragments_with_directives_test() -> Result<(), Box<dyn
         }
         "#,
     );
-    let abstract_named_fragment_plan = build_query_plan(
+    let abstract_named_fragment_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         abstract_named_fragment_document,
     )?;
@@ -501,7 +605,7 @@ fn issue_965_mixed_nested_fragments_with_directives_test() -> Result<(), Box<dyn
         }
         "#,
     );
-    let concrete_named_fragment_plan = build_query_plan(
+    let concrete_named_fragment_plan = build_query_plan_with_defaults(
         "fixture/tests/corrupted-supergraph-node-id.supergraph.graphql",
         concrete_named_fragment_document,
     )?;

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -664,7 +664,7 @@ fn issue_interface_object_typename() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/issues/infinite-typename-interfaceobject.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/mod.rs
+++ b/lib/query-planner/src/tests/mod.rs
@@ -21,7 +21,7 @@ mod testkit;
 mod union;
 
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 
@@ -32,7 +32,7 @@ fn test_bench_operation() -> Result<(), Box<dyn std::error::Error>> {
         &std::fs::read_to_string("../../bench/operation.graphql")
             .expect("Unable to read input file"),
     );
-    let query_plan = build_query_plan("../../bench/supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults("../../bench/supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/query-planner/src/tests/mutations.rs
+++ b/lib/query-planner/src/tests/mutations.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -21,7 +21,8 @@ fn mutations() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mutations.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mutations.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -124,7 +125,8 @@ fn many_fields_two_same_graph() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mutations.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mutations.supergraph.graphql", document)?;
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
       Sequence {
@@ -163,7 +165,8 @@ fn many_fields_two_same_graph() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan("fixture/tests/mutations.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/mutations.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/query-planner/src/tests/object_entities.rs
+++ b/lib/query-planner/src/tests/object_entities.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -19,7 +19,8 @@ fn testing() -> Result<(), Box<dyn Error>> {
               }
             }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/testing.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/testing.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -163,7 +164,7 @@ fn parent_entity_call() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/parent-entity-call.supergraph.graphql",
         document,
     )?;
@@ -274,7 +275,7 @@ fn parent_entity_call_complex() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/parent-entity-call-complex.supergraph.graphql",
         document,
     )?;
@@ -479,7 +480,7 @@ fn complex_entity_call() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/complex-entity-call.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/override_requires.rs
+++ b/lib/query-planner/src/tests/override_requires.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -30,7 +30,7 @@ fn override_with_requires_many() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/override_requires.supergraph.graphql",
         document,
     )?;
@@ -434,7 +434,7 @@ fn override_with_requires_cname_in_c() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/override_requires.supergraph.graphql",
         document,
     )?;
@@ -578,7 +578,7 @@ fn override_with_requires_cname_in_a() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/override_requires.supergraph.graphql",
         document,
     )?;
@@ -722,7 +722,7 @@ fn override_with_requires_aname_in_a() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/override_requires.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/overrides.rs
+++ b/lib/query-planner/src/tests/overrides.rs
@@ -1,6 +1,6 @@
 use crate::{
     graph::PlannerOverrideContext,
-    tests::testkit::{build_query_plan, build_query_plan_with_context, init_logger},
+    tests::testkit::{build_query_plan, build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -16,7 +16,7 @@ fn single_simple_overrides() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple_overrides.supergraph.graphql",
         document,
     )?;
@@ -60,7 +60,7 @@ fn two_fields_simple_overrides() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple_overrides.supergraph.graphql",
         document,
     )?;
@@ -177,7 +177,7 @@ fn override_object_field_but_interface_is_requested() -> Result<(), Box<dyn Erro
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/override-type-interface.supergraph.graphql",
         document,
     )?;
@@ -233,11 +233,12 @@ fn progressive_override_percentage_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan_with_context(
+    let query_plan = build_query_plan(
         "fixture/tests/simple-progressive-overrides.supergraph.graphql",
         document.clone(),
         // @override(label: "percentage(75)")
         PlannerOverrideContext::from_percentage(50.0),
+        Default::default(),
     )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
@@ -279,11 +280,12 @@ fn progressive_override_percentage_test() -> Result<(), Box<dyn Error>> {
     },
     "#);
 
-    let query_plan = build_query_plan_with_context(
+    let query_plan = build_query_plan(
         "fixture/tests/simple-progressive-overrides.supergraph.graphql",
         document,
         // @override(label: "percentage(75)")
         PlannerOverrideContext::from_percentage(90.0),
+        Default::default(),
     )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
@@ -339,11 +341,12 @@ fn progressive_override_flag_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan_with_context(
+    let query_plan = build_query_plan(
         "fixture/tests/simple-progressive-overrides.supergraph.graphql",
         document.clone(),
         // @override(label: "feed_in_b")
         PlannerOverrideContext::from_flag("feed_in_b".into()),
+        Default::default(),
     )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
@@ -358,11 +361,12 @@ fn progressive_override_flag_test() -> Result<(), Box<dyn Error>> {
     },
     "#);
 
-    let query_plan = build_query_plan_with_context(
+    let query_plan = build_query_plan(
         "fixture/tests/simple-progressive-overrides.supergraph.graphql",
         document,
         // @override(label: "feed_in_b")
         PlannerOverrideContext::from_flag("different_flag".into()),
+        Default::default(),
     )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"

--- a/lib/query-planner/src/tests/provides.rs
+++ b/lib/query-planner/src/tests/provides.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -19,8 +19,10 @@ fn simple_provides() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan =
-        build_query_plan("fixture/tests/simple-provides.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/simple-provides.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -120,8 +122,10 @@ fn nested_provides() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan =
-        build_query_plan("fixture/tests/nested-provides.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/nested-provides.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -171,7 +175,7 @@ fn provides_on_union() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/provides-on-union.supergraph.graphql",
         document,
     )?;
@@ -222,7 +226,7 @@ fn provides_on_union() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/provides-on-union.supergraph.graphql",
         document,
     )?;
@@ -335,7 +339,7 @@ fn provides_on_interface_1_test() -> Result<(), Box<dyn Error>> {
           }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/provides-on-interface.supergraph.graphql",
         document,
     )?;
@@ -382,7 +386,7 @@ fn provides_on_interface_2_test() -> Result<(), Box<dyn Error>> {
           }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/provides-on-interface.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/requires.rs
+++ b/lib/query-planner/src/tests/requires.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -16,7 +16,7 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/two-same-service-calls.supergraph.graphql",
         document,
     )?;
@@ -227,7 +227,7 @@ fn two_same_service_calls() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/two-same-service-calls.supergraph.graphql",
         document,
     )?;
@@ -373,7 +373,7 @@ fn simplest_requires() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simplest-requires.supergraph.graphql",
         document,
     )?;
@@ -475,7 +475,7 @@ fn simplest_requires_with_local_sibling() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires-local-sibling.supergraph.graphql",
         document,
     )?;
@@ -577,8 +577,10 @@ fn simple_requires() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan =
-        build_query_plan("fixture/tests/simple-requires.supergraph.graphql", document)?;
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/simple-requires.supergraph.graphql",
+        document,
+    )?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -683,7 +685,7 @@ fn two_fields_same_subgraph_same_requirement() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/two_fields_same_subgraph_same_requirement.supergraph.graphql",
         document,
     )?;
@@ -793,7 +795,7 @@ fn simple_requires_with_child() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/simple_requires_with_child.supergraph.graphql",
         document,
     )?;
@@ -907,7 +909,8 @@ fn keys_mashup() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/keys-mashup.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/keys-mashup.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {
@@ -1083,7 +1086,8 @@ fn deep_requires() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/deep-requires.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/deep-requires.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/query-planner/src/tests/requires_circular.rs
+++ b/lib/query-planner/src/tests/requires_circular.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -16,7 +16,7 @@ fn requires_circular_1() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires-circular.supergraph.graphql",
         document,
     )?;
@@ -102,7 +102,7 @@ fn requires_circular_2() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires-circular.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/requires_fragments.rs
+++ b/lib/query-planner/src/tests/requires_fragments.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -16,7 +16,7 @@ fn requires_with_fragments_on_interfaces() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires-with-fragments.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/requires_provides.rs
+++ b/lib/query-planner/src/tests/requires_provides.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -24,7 +24,7 @@ fn simple_requires_provides() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires-provides.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/requires_requires.rs
+++ b/lib/query-planner/src/tests/requires_requires.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -15,7 +15,7 @@ fn one() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -166,7 +166,7 @@ fn one_with_one_local() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -318,7 +318,7 @@ fn two_fields_with_the_same_requirements() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -469,7 +469,7 @@ fn one_more() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -664,7 +664,7 @@ fn another_two_fields_with_the_same_requirements() -> Result<(), Box<dyn Error>>
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -860,7 +860,7 @@ fn two_fields() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -1119,7 +1119,7 @@ fn two_fields_same_requirement_different_order() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;
@@ -1385,7 +1385,7 @@ fn many() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/requires_requires.supergraph.graphql",
         document,
     )?;

--- a/lib/query-planner/src/tests/root_types.rs
+++ b/lib/query-planner/src/tests/root_types.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -29,7 +29,8 @@ fn shared_root() -> Result<(), Box<dyn Error>> {
           }
         }"#,
     );
-    let query_plan = build_query_plan("fixture/tests/shared-root.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/shared-root.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/query-planner/src/tests/testkit.rs
+++ b/lib/query-planner/src/tests/testkit.rs
@@ -11,12 +11,12 @@ use graphql_tools::parser::query as query_ast;
 use crate::ast::normalization::normalize_operation;
 use crate::graph::edge::PlannerOverrideContext;
 use crate::graph::Graph;
-use crate::planner::add_variables_to_fetch_steps;
 use crate::planner::best::find_best_combination;
 use crate::planner::fetch::fetch_graph::build_fetch_graph_from_query_tree;
 use crate::planner::plan_nodes::QueryPlan;
 use crate::planner::query_plan::build_query_plan_from_fetch_graph;
 use crate::planner::walker::walk_operation;
+use crate::planner::{add_variables_to_fetch_steps, QueryPlannerOptions};
 use crate::state::supergraph_state::{OperationKind, SupergraphState};
 use crate::utils::cancellation::CancellationToken;
 use crate::utils::parsing::parse_schema;
@@ -54,10 +54,11 @@ pub fn read_supergraph(fixture_path: &str) -> String {
     std::fs::read_to_string(supergraph_path).expect("Unable to read input file")
 }
 
-pub fn build_query_plan_with_context(
+pub fn build_query_plan(
     fixture_path: &str,
     query: query_ast::Document<'static, String>,
     override_context: PlannerOverrideContext,
+    options: QueryPlannerOptions,
 ) -> Result<QueryPlan, Box<dyn Error>> {
     let cancellation_token = CancellationToken::new();
     let schema = parse_schema(&read_supergraph(fixture_path));
@@ -82,6 +83,7 @@ pub fn build_query_plan_with_context(
             .operation_kind
             .clone()
             .unwrap_or(OperationKind::Query),
+        &options,
         &cancellation_token,
     )?;
     add_variables_to_fetch_steps(&mut fetch_graph, &operation.variable_definitions)?;
@@ -92,9 +94,14 @@ pub fn build_query_plan_with_context(
     Ok(plan)
 }
 
-pub fn build_query_plan(
+pub fn build_query_plan_with_defaults(
     fixture_path: &str,
     query: query_ast::Document<'static, String>,
 ) -> Result<QueryPlan, Box<dyn Error>> {
-    build_query_plan_with_context(fixture_path, query, PlannerOverrideContext::default())
+    build_query_plan(
+        fixture_path,
+        query,
+        PlannerOverrideContext::default(),
+        Default::default(),
+    )
 }

--- a/lib/query-planner/src/tests/union.rs
+++ b/lib/query-planner/src/tests/union.rs
@@ -1,5 +1,5 @@
 use crate::{
-    tests::testkit::{build_query_plan, init_logger},
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
     utils::parsing::parse_operation,
 };
 use std::error::Error;
@@ -21,7 +21,7 @@ fn union_member_resolvable() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-intersection.supergraph.graphql",
         document,
     )?;
@@ -59,7 +59,7 @@ fn union_member_unresolvable() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-intersection.supergraph.graphql",
         document,
     )?;
@@ -95,7 +95,7 @@ fn union_member_mix() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-intersection.supergraph.graphql",
         document,
     )?;
@@ -136,7 +136,7 @@ fn union_member_entity_call() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-intersection.supergraph.graphql",
         document,
     )?;
@@ -207,7 +207,7 @@ fn union_member_entity_call_many_local() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-intersection.supergraph.graphql",
         document,
     )?;
@@ -316,7 +316,7 @@ fn union_member_entity_call_many() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-intersection.supergraph.graphql",
         document,
     )?;
@@ -421,7 +421,7 @@ fn union_overfetching_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan(
+    let query_plan = build_query_plan_with_defaults(
         "fixture/tests/union-overfetching.supergraph.graphql",
         document,
     )?;
@@ -537,7 +537,8 @@ fn union_list_test() -> Result<(), Box<dyn Error>> {
         }
         "#,
     );
-    let query_plan = build_query_plan("fixture/tests/union-list.supergraph.graphql", document)?;
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/union-list.supergraph.graphql", document)?;
 
     insta::assert_snapshot!(format!("{}", query_plan), @r#"
     QueryPlan {

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -55,6 +55,10 @@ pub struct EnvVarOverrides {
     // Tracing overrides
     #[envconfig(from = "TELEMETRY_TRACING_SAMPLING_RATE")]
     pub tracing_sampling_rate: Option<f64>,
+
+    // Query planner overrides
+    #[envconfig(from = "QUERY_PLANNER_EXPERIMENTAL_ABSTRACT_TYPE_FOLDING")]
+    pub query_planner_experimental_abstract_type_folding: Option<bool>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -175,6 +179,19 @@ impl EnvVarOverrides {
             config = config.set_override("subscriptions.enabled", subscriptions_enabled)?;
         }
 
+        if let Some(experimental_abstract_type_folding) =
+            self.query_planner_experimental_abstract_type_folding.take()
+        {
+            debug!(
+                "[config-override] 'query_planner.experimental_abstract_type_folding' = {}",
+                experimental_abstract_type_folding
+            );
+            config = config.set_override(
+                "query_planner.experimental_abstract_type_folding",
+                experimental_abstract_type_folding,
+            )?;
+        }
+
         Ok(config)
     }
 }
@@ -229,5 +246,37 @@ telemetry:
         .unwrap();
 
         assert_eq!(config.telemetry.tracing.collect.sampling, 0.1);
+    }
+
+    #[test]
+    fn query_planner_experimental_abstract_type_folding_override_sets_config() {
+        let config = config_from_overrides(EnvVarOverrides {
+            query_planner_experimental_abstract_type_folding: Some(true),
+            ..Default::default()
+        });
+
+        assert!(config.query_planner.experimental_abstract_type_folding);
+    }
+
+    #[test]
+    fn query_planner_experimental_abstract_type_folding_override_wins_over_config_file_value() {
+        let config = EnvVarOverrides {
+            query_planner_experimental_abstract_type_folding: Some(true),
+            ..Default::default()
+        }
+        .apply_overrides(Config::builder().add_source(File::from_str(
+            r#"
+query_planner:
+  experimental_abstract_type_folding: false
+"#,
+            FileFormat::Yaml,
+        )))
+        .unwrap()
+        .build()
+        .unwrap()
+        .try_deserialize::<HiveRouterConfig>()
+        .unwrap();
+
+        assert!(config.query_planner.experimental_abstract_type_folding);
     }
 }

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -22,6 +22,15 @@ pub struct QueryPlannerConfig {
     )]
     #[schemars(with = "String")]
     pub timeout: Duration,
+    /// Enables an experimental feature that folds matching object-type inline fragments
+    /// into an interface fragment, even when that interface is not the field's declared return type.
+    ///
+    /// The fold is only applied when the concrete object branches select the same fields and
+    /// exactly match the interface members in the target subgraph.
+    ///
+    /// Default: false.
+    #[serde(default = "default_experimental_abstract_type_folding")]
+    pub experimental_abstract_type_folding: bool,
 }
 
 impl Default for QueryPlannerConfig {
@@ -29,6 +38,7 @@ impl Default for QueryPlannerConfig {
         Self {
             allow_expose: default_query_planning_allow_expose(),
             timeout: default_query_planning_timeout(),
+            experimental_abstract_type_folding: default_experimental_abstract_type_folding(),
         }
     }
 }
@@ -39,4 +49,8 @@ fn default_query_planning_allow_expose() -> bool {
 
 fn default_query_planning_timeout() -> Duration {
     Duration::from_secs(10)
+}
+
+fn default_experimental_abstract_type_folding() -> bool {
+    false
 }

--- a/lib/router-config/src/query_planner.rs
+++ b/lib/router-config/src/query_planner.rs
@@ -28,6 +28,8 @@ pub struct QueryPlannerConfig {
     /// The fold is only applied when the concrete object branches select the same fields and
     /// exactly match the interface members in the target subgraph.
     ///
+    /// Can also be set via the `QUERY_PLANNER_EXPERIMENTAL_ABSTRACT_TYPE_FOLDING` environment variable.
+    ///
     /// Default: false.
     #[serde(default = "default_experimental_abstract_type_folding")]
     pub experimental_abstract_type_folding: bool,


### PR DESCRIPTION
This PR adds an opt-in query planner optimization behind:

```yaml
query_planner:
  experimental_abstract_type_folding: true
```

or

```rust
QUERY_PLANNER_EXPERIMENTAL_ABSTRACT_TYPE_FOLDING=true
```

The option is disabled by default, so existing query planning behavior stays unchanged unless users explicitly enable it.

The feature folds multiple matching concrete object inline fragments into a shared interface fragment in subgraph fetches, even when that interface is not the declared return type of the parent field.

Example `product-service` subgraph fetch:

```graphql
query {
  products {
    ... on Book  { id title }
    ... on Movie { id title }
  }
}
```

is turned into:

```diff
query {
  products {
-    ... on Book  { id title }
-    ... on Movie { id title }
+    ... on Media { id title }
  }
}
```

The `products` field returns `Product` interface, but one object-type member of this interface called `Album` is not present in the query, therefore `... on Product {...}` is not possible to use (default behavior). With the feature flag enabled, both fragments are folded into `... on Media { ... }`, because `Book` and `Movie` are the only members of the `Media` interface in the `product-service` subgraph.

---

The main internal change is that the query planner now accepts `QueryPlannerOptions`:

```rust
pub struct QueryPlannerOptions {
    pub experimental_abstract_type_folding: bool,
}
```

Those options are stored on `Planner` and passed down into fetch graph optimization, specifically into `fold_concrete_selections_to_interfaces`.

The previous behavior folded concrete object-type fragments only into the expected interface matching return type of the parent field.

Closes #1149