### PR TITLE
feat(router): drop-oldest backpressure for subscriptions instead of k…

### DIFF
--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -37,6 +37,7 @@ use tracing::{debug, trace};
 
 use crate::executors::common::SubgraphExecutionRequest;
 use crate::executors::error::SubgraphExecutorError;
+use crate::executors::subscription_buffer::buffered_drop_latest;
 use crate::utils::consts::CLOSE_BRACE;
 use crate::utils::consts::COLON;
 use crate::utils::consts::COMMA;
@@ -581,60 +582,74 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             ));
         }
 
-        if is_multipart {
-            debug!(
-                subgraph_name = self.subgraph_name,
-                "using multipart HTTP for subscription",
-            );
+        let inner: BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>> =
+            if is_multipart {
+                debug!(
+                    subgraph_name = self.subgraph_name,
+                    "using multipart HTTP for subscription",
+                );
 
-            let boundary = multipart_subscribe::parse_boundary_from_header(content_type)
-                .map_err(|e| SubgraphExecutorError::MultipartBoundaryParseFailure(e.to_string()))?;
-            let stream = multipart_subscribe::parse_to_stream(
-                boundary,
-                body_stream,
-                custom_scalar_paths.clone(),
-            );
+                let boundary = multipart_subscribe::parse_boundary_from_header(content_type)
+                    .map_err(|e| {
+                        SubgraphExecutorError::MultipartBoundaryParseFailure(e.to_string())
+                    })?;
+                let stream = multipart_subscribe::parse_to_stream(
+                    boundary,
+                    body_stream,
+                    custom_scalar_paths.clone(),
+                );
 
-            Ok(Box::pin(async_stream::stream! {
-                trace!("multipart subscription stream started");
-                for await result in stream {
-                    match result {
-                        Ok(response) => {
-                            trace!(response = ?response, "multipart subscription event received");
-                            yield Ok(response);
-                        }
-                        Err(e) => {
-                            yield Err(SubgraphExecutorError::MultipartStreamError(e.to_string()));
-                            return;
-                        }
-                    }
-                }
-            }))
-        } else {
-            debug!(
-                "using SSE for subscription connection to subgraph {} at {}",
-                self.subgraph_name,
-                self.endpoint.to_string(),
-            );
-
-            let stream = sse::parse_to_stream(body_stream, custom_scalar_paths.clone());
-
-            Ok(Box::pin(async_stream::stream! {
-                trace!("SSE subscription stream started");
-                for await result in stream {
-                    match result {
-                        Ok(response) => {
-                            trace!(response = ?response, "SSE subscription event received");
-                            yield Ok(response);
-                        }
-                        Err(e) => {
-                            yield Err(SubgraphExecutorError::SseStreamError(e.to_string()));
-                            return;
+                Box::pin(async_stream::stream! {
+                    trace!("multipart subscription stream started");
+                    for await result in stream {
+                        match result {
+                            Ok(response) => {
+                                trace!(response = ?response, "multipart subscription event received");
+                                yield Ok(response);
+                            }
+                            Err(e) => {
+                                yield Err(SubgraphExecutorError::MultipartStreamError(e.to_string()));
+                                return;
+                            }
                         }
                     }
-                }
-            }))
-        }
+                })
+            } else {
+                debug!(
+                    "using SSE for subscription connection to subgraph {} at {}",
+                    self.subgraph_name,
+                    self.endpoint.to_string(),
+                );
+
+                let stream = sse::parse_to_stream(body_stream, custom_scalar_paths.clone());
+
+                Box::pin(async_stream::stream! {
+                    trace!("SSE subscription stream started");
+                    for await result in stream {
+                        match result {
+                            Ok(response) => {
+                                trace!(response = ?response, "SSE subscription event received");
+                                yield Ok(response);
+                            }
+                            Err(e) => {
+                                yield Err(SubgraphExecutorError::SseStreamError(e.to_string()));
+                                return;
+                            }
+                        }
+                    }
+                })
+            };
+
+        // The router must drain the HTTP body eagerly to match WebSocket back-pressure behaviour,
+        // so wrap the parsed stream in the shared bounded buffer: when per-event plan execution
+        // falls behind, the newest event is dropped (drop-latest) and the subscription is kept
+        // alive, instead of back-pressuring (and slowing) the subgraph.
+        Ok(buffered_drop_latest(
+            inner,
+            self.config.subscriptions.subgraph_buffer_capacity,
+            self.subgraph_name.clone(),
+            self.telemetry_context.clone(),
+        ))
     }
 }
 

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -736,6 +736,7 @@ impl SubgraphExecutorMap {
                     // we use the new constructed ws_endpoint_uri here
                     ws_endpoint_uri,
                     ws_tls_config,
+                    self.telemetry_context.clone(),
                 )
                 .to_boxed_arc();
 

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -737,6 +737,7 @@ impl SubgraphExecutorMap {
                     ws_endpoint_uri,
                     ws_tls_config,
                     self.telemetry_context.clone(),
+                    self.config.subscriptions.subgraph_buffer_capacity,
                 )
                 .to_boxed_arc();
 

--- a/lib/executor/src/executors/mod.rs
+++ b/lib/executor/src/executors/mod.rs
@@ -7,6 +7,7 @@ pub mod http_callback;
 pub mod map;
 pub mod multipart_subscribe;
 pub mod sse;
+pub mod subscription_buffer;
 pub mod tls;
 pub mod websocket;
 pub mod websocket_client;

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use futures::stream::{BoxStream, Stream};
+use futures::StreamExt;
+use hive_router_internal::telemetry::TelemetryContext;
+use ntex::rt;
+use tokio::sync::mpsc;
+
+use crate::executors::error::SubgraphExecutorError;
+use crate::response::subgraph_response::SubgraphResponse;
+
+/// An item produced by a subgraph subscription stream.
+pub type SubscriptionItem = Result<SubgraphResponse<'static>, SubgraphExecutorError>;
+
+/// Forwards a subgraph subscription event into the bounded buffer shared by all subscription
+/// transports.
+///
+/// The router must read events off the subgraph as they arrive (graphql-ws ping/pong liveness and
+/// connection multiplexing forbid back-pressuring a WebSocket socket; HTTP bodies are drained by an
+/// eager pump), so back-pressure is applied here instead: on a full buffer - the downstream
+/// consumer (per-event plan execution) has fallen behind - the incoming event is dropped
+/// (drop-latest), `hive.router.subscription.dropped_events_total` is incremented, and the
+/// subscription is kept alive. Returns `false` only when the receiver is gone, signalling the
+/// producer to stop.
+pub(crate) fn forward_or_drop(
+    tx: &mpsc::Sender<SubscriptionItem>,
+    item: SubscriptionItem,
+    subgraph_name: &str,
+    telemetry_context: &TelemetryContext,
+) -> bool {
+    match tx.try_send(item) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            telemetry_context
+                .metrics
+                .subscription
+                .record_dropped_event(subgraph_name);
+            true
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => false,
+    }
+}
+
+/// Eagerly drains `source` into a bounded buffer and exposes it as a `Send` stream, applying the
+/// shared drop-latest policy via [`forward_or_drop`].
+///
+/// Used for transports whose source stream is already available (HTTP SSE/multipart). The
+/// WebSocket executor drives its own non-`Send` source on the ntex runtime and calls
+/// [`forward_or_drop`] directly, but applies the identical policy.
+pub(crate) fn buffered_drop_latest<S>(
+    source: S,
+    capacity: usize,
+    subgraph_name: String,
+    telemetry_context: Arc<TelemetryContext>,
+) -> BoxStream<'static, SubscriptionItem>
+where
+    S: Stream<Item = SubscriptionItem> + 'static,
+{
+    let (tx, mut rx) = mpsc::channel::<SubscriptionItem>(capacity.max(1));
+
+    drop(rt::spawn(async move {
+        futures::pin_mut!(source);
+        while let Some(item) = source.next().await {
+            if !forward_or_drop(&tx, item, &subgraph_name, &telemetry_context) {
+                break;
+            }
+        }
+    }));
+
+    Box::pin(async_stream::stream! {
+        while let Some(item) = rx.recv().await {
+            yield item;
+        }
+    })
+}

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -1,5 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -8,76 +7,22 @@ use futures::stream::BoxStream;
 use futures_util::StreamExt;
 use hive_router_internal::telemetry::TelemetryContext;
 use ntex::rt;
-use tokio::sync::Notify;
+use tokio::sync::mpsc;
 use tracing::debug;
 
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
 use crate::executors::graphql_transport_ws::build_subscribe_payload;
+use crate::executors::subscription_buffer::{forward_or_drop, SubscriptionItem};
 use crate::executors::websocket_client::{connect, WsClient};
 use crate::response::subgraph_response::SubgraphResponse;
-
-/// A single-slot, drop-oldest channel bridging the subgraph reader task (which runs on the
-/// non-Send ntex runtime) to the Send query-plan execution stream that consumes it.
-///
-/// The reader always overwrites the slot with the latest event. When the consumer falls behind -
-/// e.g. per-event query planning can't keep up with a fast subgraph - the stale event is dropped
-/// and the consumer resumes from the freshest one. The subscription is never terminated for being
-/// slow. Downstream, the shared broadcast applies the same drop-oldest policy across fan-out
-/// clients.
-struct LatestSlot<T> {
-    value: Mutex<Option<T>>,
-    notify: Notify,
-    closed: AtomicBool,
-}
-
-impl<T> LatestSlot<T> {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            value: Mutex::new(None),
-            notify: Notify::new(),
-            closed: AtomicBool::new(false),
-        })
-    }
-
-    /// Store the latest value. Returns `true` if it replaced a previous unconsumed value - i.e.
-    /// the consumer fell behind and that older event was dropped.
-    fn store(&self, value: T) -> bool {
-        let dropped = self.value.lock().unwrap().replace(value).is_some();
-        self.notify.notify_one();
-        dropped
-    }
-
-    /// Signal that no more values will be produced. The consumer stops once the slot is drained.
-    fn close(&self) {
-        self.closed.store(true, Ordering::Release);
-        self.notify.notify_one();
-    }
-
-    /// Await the freshest available value, or `None` once the producer has closed and the slot is
-    /// drained.
-    async fn next(&self) -> Option<T> {
-        loop {
-            // register for notification before reading, so a concurrent store/close happening
-            // between the read and the await is not missed
-            let notified = self.notify.notified();
-            if let Some(value) = self.value.lock().unwrap().take() {
-                return Some(value);
-            }
-            if self.closed.load(Ordering::Acquire) {
-                // a value may have landed between the take above and this check
-                return self.value.lock().unwrap().take();
-            }
-            notified.await;
-        }
-    }
-}
 
 pub struct WsSubgraphExecutor {
     subgraph_name: String,
     endpoint: http::Uri,
     tls_config: Option<Arc<rustls::ClientConfig>>,
     telemetry_context: Arc<TelemetryContext>,
+    buffer_capacity: usize,
 }
 
 impl WsSubgraphExecutor {
@@ -86,12 +31,14 @@ impl WsSubgraphExecutor {
         endpoint: http::Uri,
         tls_config: Option<Arc<rustls::ClientConfig>>,
         telemetry_context: Arc<TelemetryContext>,
+        buffer_capacity: usize,
     ) -> Self {
         Self {
             subgraph_name,
             endpoint,
             tls_config,
             telemetry_context,
+            buffer_capacity,
         }
     }
 }
@@ -183,13 +130,13 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
-        // Bridge the non-Send subgraph reader task to the Send query-plan execution stream with a
-        // drop-oldest slot: if per-event planning falls behind a fast subgraph, stale events are
-        // dropped and we resume from the freshest one, so a slow consumer never terminates the
-        // subscription. Downstream, the shared broadcast applies the same drop-oldest policy
-        // across fan-out clients.
-        let slot = LatestSlot::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>::new();
-        let writer = slot.clone();
+        // The subgraph reader task must drain the WebSocket eagerly (graphql-ws ping/pong liveness
+        // and connection multiplexing forbid back-pressuring the socket), so it forwards events
+        // into a bounded buffer and sheds load there instead: when the consumer - per-event plan
+        // execution - falls behind and the buffer is full, the newest event is dropped
+        // (drop-latest) and the subscription is kept alive. HTTP (SSE/multipart) subscriptions
+        // apply the identical policy via `subscription_buffer::buffered_drop_latest`.
+        let (tx, mut rx) = mpsc::channel::<SubscriptionItem>(self.buffer_capacity.max(1));
 
         let endpoint = self.endpoint.clone();
         let subgraph_name = self.subgraph_name.clone();
@@ -205,61 +152,50 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         );
 
         // no await intentionally. the task runs the subscription in the background and forwards
-        // responses through the slot. The spawned future itself stays local to the ntex runtime,
+        // responses through the bounded buffer. The spawned future stays local to the ntex runtime,
         // so it can hold non-Send websocket client state. this task ends when the websocket stream
-        // completes or the connection fails; on exit it closes the slot so the consumer stops.
+        // completes, the consumer drops the receiver, or the connection fails.
         drop(rt::spawn(async move {
-            async {
-                let connection = match connect(&endpoint, tls_config).await {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        writer.store(Err(SubgraphExecutorError::WebSocketConnectFailure(
-                            endpoint.to_string(),
-                            e.to_string(),
-                        )));
-                        return;
-                    }
-                };
+            let connection = match connect(&endpoint, tls_config).await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketConnectFailure(
+                        endpoint.to_string(),
+                        e.to_string(),
+                    )));
+                    return;
+                }
+            };
 
-                let mut client = match WsClient::init(connection, init_payload).await {
-                    Ok(client) => client,
-                    Err(e) => {
-                        writer.store(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
-                            endpoint.to_string(),
-                            e.to_string(),
-                        )));
-                        return;
-                    }
-                };
+            let mut client = match WsClient::init(connection, init_payload).await {
+                Ok(client) => client,
+                Err(e) => {
+                    let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
+                        endpoint.to_string(),
+                        e.to_string(),
+                    )));
+                    return;
+                }
+            };
 
-                debug!(
-                    "WebSocket subscription connection to subgraph {} at {} established",
-                    subgraph_name, endpoint
-                );
+            debug!(
+                "WebSocket subscription connection to subgraph {} at {} established",
+                subgraph_name, endpoint
+            );
 
-                let mut stream = client
-                    .subscribe(subscribe_payload, custom_scalar_paths)
-                    .await;
+            let mut stream = client
+                .subscribe(subscribe_payload, custom_scalar_paths)
+                .await;
 
-                while let Some(response) = stream.next().await {
-                    if writer.store(Ok(response)) {
-                        // the consumer fell behind and a stale event was dropped
-                        telemetry_context
-                            .metrics
-                            .subscription
-                            .record_dropped_event(&subgraph_name);
-                    }
+            while let Some(response) = stream.next().await {
+                if !forward_or_drop(&tx, Ok(response), &subgraph_name, &telemetry_context) {
+                    break;
                 }
             }
-            .await;
-
-            // producer finished (stream ended or failed) - let the consumer drain and stop
-            writer.close();
         }));
 
-        let reader = slot;
         Ok(Box::pin(async_stream::stream! {
-            while let Some(response) = reader.next().await {
+            while let Some(response) = rx.recv().await {
                 yield response;
             }
         }))

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -1,13 +1,15 @@
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::channel::oneshot;
 use futures::stream::BoxStream;
 use futures_util::StreamExt;
+use hive_router_internal::telemetry::TelemetryContext;
 use ntex::rt;
-use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tokio::sync::Notify;
+use tracing::debug;
 
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
@@ -15,10 +17,67 @@ use crate::executors::graphql_transport_ws::build_subscribe_payload;
 use crate::executors::websocket_client::{connect, WsClient};
 use crate::response::subgraph_response::SubgraphResponse;
 
+/// A single-slot, drop-oldest channel bridging the subgraph reader task (which runs on the
+/// non-Send ntex runtime) to the Send query-plan execution stream that consumes it.
+///
+/// The reader always overwrites the slot with the latest event. When the consumer falls behind -
+/// e.g. per-event query planning can't keep up with a fast subgraph - the stale event is dropped
+/// and the consumer resumes from the freshest one. The subscription is never terminated for being
+/// slow. Downstream, the shared broadcast applies the same drop-oldest policy across fan-out
+/// clients.
+struct LatestSlot<T> {
+    value: Mutex<Option<T>>,
+    notify: Notify,
+    closed: AtomicBool,
+}
+
+impl<T> LatestSlot<T> {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            value: Mutex::new(None),
+            notify: Notify::new(),
+            closed: AtomicBool::new(false),
+        })
+    }
+
+    /// Store the latest value. Returns `true` if it replaced a previous unconsumed value - i.e.
+    /// the consumer fell behind and that older event was dropped.
+    fn store(&self, value: T) -> bool {
+        let dropped = self.value.lock().unwrap().replace(value).is_some();
+        self.notify.notify_one();
+        dropped
+    }
+
+    /// Signal that no more values will be produced. The consumer stops once the slot is drained.
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    /// Await the freshest available value, or `None` once the producer has closed and the slot is
+    /// drained.
+    async fn next(&self) -> Option<T> {
+        loop {
+            // register for notification before reading, so a concurrent store/close happening
+            // between the read and the await is not missed
+            let notified = self.notify.notified();
+            if let Some(value) = self.value.lock().unwrap().take() {
+                return Some(value);
+            }
+            if self.closed.load(Ordering::Acquire) {
+                // a value may have landed between the take above and this check
+                return self.value.lock().unwrap().take();
+            }
+            notified.await;
+        }
+    }
+}
+
 pub struct WsSubgraphExecutor {
     subgraph_name: String,
     endpoint: http::Uri,
     tls_config: Option<Arc<rustls::ClientConfig>>,
+    telemetry_context: Arc<TelemetryContext>,
 }
 
 impl WsSubgraphExecutor {
@@ -26,11 +85,13 @@ impl WsSubgraphExecutor {
         subgraph_name: String,
         endpoint: http::Uri,
         tls_config: Option<Arc<rustls::ClientConfig>>,
+        telemetry_context: Arc<TelemetryContext>,
     ) -> Self {
         Self {
             subgraph_name,
             endpoint,
             tls_config,
+            telemetry_context,
         }
     }
 }
@@ -122,16 +183,18 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
-        // all subscriptions emit events into the shared active subscriptions broadcaster
-        // which itself handles back-pressure by dropping old events when the buffer is full,
-        // so we can use a small buffer here
-        // TODO: do we thererefore need to buffer at all?
-        let (tx, mut rx) =
-            mpsc::channel::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>(16);
+        // Bridge the non-Send subgraph reader task to the Send query-plan execution stream with a
+        // drop-oldest slot: if per-event planning falls behind a fast subgraph, stale events are
+        // dropped and we resume from the freshest one, so a slow consumer never terminates the
+        // subscription. Downstream, the shared broadcast applies the same drop-oldest policy
+        // across fan-out clients.
+        let slot = LatestSlot::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>::new();
+        let writer = slot.clone();
 
         let endpoint = self.endpoint.clone();
         let subgraph_name = self.subgraph_name.clone();
         let tls_config = self.tls_config.clone();
+        let telemetry_context = self.telemetry_context.clone();
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
 
         let (subscribe_payload, init_payload) = build_subscribe_payload(execution_request);
@@ -141,69 +204,62 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             self.subgraph_name, self.endpoint
         );
 
-        // no await intentionally. the task runs the subscription in the background
-        // and sends responses through the channel. The spawned future itself stays local
-        // to ntex runtime, so it can hold non-Send websocket client state.
-        // this task ends when the websocket stream completes, the client drops the receiver,
-        // or back-pressure fills the channel and we terminate the subscription.
+        // no await intentionally. the task runs the subscription in the background and forwards
+        // responses through the slot. The spawned future itself stays local to the ntex runtime,
+        // so it can hold non-Send websocket client state. this task ends when the websocket stream
+        // completes or the connection fails; on exit it closes the slot so the consumer stops.
         drop(rt::spawn(async move {
-            let connection = match connect(&endpoint, tls_config).await {
-                Ok(conn) => conn,
-                Err(e) => {
-                    let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketConnectFailure(
-                        endpoint.to_string(),
-                        e.to_string(),
-                    )));
-                    return;
-                }
-            };
-
-            let mut client = match WsClient::init(connection, init_payload).await {
-                Ok(client) => client,
-                Err(e) => {
-                    let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
-                        endpoint.to_string(),
-                        e.to_string(),
-                    )));
-                    return;
-                }
-            };
-
-            debug!(
-                "WebSocket subscription connection to subgraph {} at {} established",
-                subgraph_name, endpoint
-            );
-
-            let mut stream = client
-                .subscribe(subscribe_payload, custom_scalar_paths)
-                .await;
-
-            while let Some(response) = stream.next().await {
-                match tx.try_send(Ok(response)) {
-                    Ok(()) => (),
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        // if the channel is full it means the consuming client is too slow and unable to keep
-                        // up. we terminate the subscription without an error message because it anyways cant
-                        // go through
-                        warn!(
-                            "Client for subgraph {} at {} subscriptions is too slow",
-                            subgraph_name, endpoint
-                        );
-                        break;
+            async {
+                let connection = match connect(&endpoint, tls_config).await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        writer.store(Err(SubgraphExecutorError::WebSocketConnectFailure(
+                            endpoint.to_string(),
+                            e.to_string(),
+                        )));
+                        return;
                     }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        debug!(
-                            "Client for subgraph {} at {} dropped the receiver",
-                            subgraph_name, endpoint
-                        );
-                        break;
+                };
+
+                let mut client = match WsClient::init(connection, init_payload).await {
+                    Ok(client) => client,
+                    Err(e) => {
+                        writer.store(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
+                            endpoint.to_string(),
+                            e.to_string(),
+                        )));
+                        return;
+                    }
+                };
+
+                debug!(
+                    "WebSocket subscription connection to subgraph {} at {} established",
+                    subgraph_name, endpoint
+                );
+
+                let mut stream = client
+                    .subscribe(subscribe_payload, custom_scalar_paths)
+                    .await;
+
+                while let Some(response) = stream.next().await {
+                    if writer.store(Ok(response)) {
+                        // the consumer fell behind and a stale event was dropped
+                        telemetry_context
+                            .metrics
+                            .subscription
+                            .record_dropped_event(&subgraph_name);
                     }
                 }
             }
+            .await;
+
+            // producer finished (stream ended or failed) - let the consumer drain and stop
+            writer.close();
         }));
 
+        let reader = slot;
         Ok(Box::pin(async_stream::stream! {
-            while let Some(response) = rx.recv().await {
+            while let Some(response) = reader.next().await {
                 yield response;
             }
         }))

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -167,6 +167,8 @@ pub mod names {
     pub const COPROCESSOR_REQUESTS_TOTAL: &str = "hive.router.coprocessor.requests_total";
     pub const COPROCESSOR_DURATION: &str = "hive.router.coprocessor.duration";
     pub const COPROCESSOR_ERRORS_TOTAL: &str = "hive.router.coprocessor.errors_total";
+    pub const SUBSCRIPTION_DROPPED_EVENTS_TOTAL: &str =
+        "hive.router.subscription.dropped_events_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
@@ -333,6 +335,10 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     (
         names::COPROCESSOR_ERRORS_TOTAL,
         &[labels::COPROCESSOR_STAGE],
+    ),
+    (
+        names::SUBSCRIPTION_DROPPED_EVENTS_TOTAL,
+        &[labels::SUBGRAPH_NAME],
     ),
 ];
 

--- a/lib/internal/src/telemetry/metrics/mod.rs
+++ b/lib/internal/src/telemetry/metrics/mod.rs
@@ -9,6 +9,7 @@ pub mod http_client_metrics;
 pub mod http_server_metrics;
 pub mod persisted_documents_metrics;
 pub mod setup;
+pub mod subscription_metrics;
 pub mod supergraph_metrics;
 pub use opentelemetry::metrics::ObservableGauge;
 pub use setup::{build_meter_provider_from_config, MetricsSetup, PrometheusRuntimeConfig};
@@ -23,6 +24,7 @@ use crate::telemetry::metrics::graphql_metrics::GraphQLMetrics;
 use crate::telemetry::metrics::http_client_metrics::HttpClientMetrics;
 use crate::telemetry::metrics::http_server_metrics::HttpServerMetrics;
 use crate::telemetry::metrics::persisted_documents_metrics::PersistedDocumentsMetrics;
+use crate::telemetry::metrics::subscription_metrics::SubscriptionMetrics;
 use crate::telemetry::metrics::supergraph_metrics::SupergraphMetrics;
 
 pub struct Metrics {
@@ -35,6 +37,7 @@ pub struct Metrics {
     pub circuit_breaker: CircuitBreakerMetrics,
     pub persisted_documents: PersistedDocumentsMetrics,
     pub coprocessor: CoprocessorMetrics,
+    pub subscription: SubscriptionMetrics,
 }
 
 impl Metrics {
@@ -49,6 +52,7 @@ impl Metrics {
             circuit_breaker: CircuitBreakerMetrics::new(meter),
             persisted_documents: PersistedDocumentsMetrics::new(meter),
             coprocessor: CoprocessorMetrics::new(meter),
+            subscription: SubscriptionMetrics::new(meter),
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -1,0 +1,51 @@
+use opentelemetry::{
+    metrics::{Counter, Meter},
+    KeyValue,
+};
+
+use crate::telemetry::metrics::catalog::{labels, names};
+
+#[cfg(debug_assertions)]
+use crate::telemetry::metrics::catalog::debug_assert_attrs;
+
+/// Telemetry for GraphQL subscriptions.
+pub struct SubscriptionMetrics {
+    dropped_events_total: Option<Counter<u64>>,
+}
+
+impl SubscriptionMetrics {
+    pub fn new(meter: Option<&Meter>) -> Self {
+        let dropped_events_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::SUBSCRIPTION_DROPPED_EVENTS_TOTAL)
+                .with_unit("{event}")
+                .with_description(
+                    "Number of subscription events dropped because the consumer could not keep \
+                     up with the upstream subgraph (drop-oldest back-pressure).",
+                )
+                .build()
+        });
+
+        Self {
+            dropped_events_total,
+        }
+    }
+
+    /// Records that an upstream subscription event was dropped for a subgraph because the
+    /// consumer fell behind and a newer event replaced it.
+    pub fn record_dropped_event(&self, subgraph_name: &str) {
+        let Some(counter) = &self.dropped_events_total else {
+            return;
+        };
+
+        let attributes = [KeyValue::new(
+            labels::SUBGRAPH_NAME,
+            subgraph_name.to_string(),
+        )];
+
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTION_DROPPED_EVENTS_TOTAL, &attributes);
+
+        counter.add(1, &attributes);
+    }
+}

--- a/lib/router-config/src/subscriptions.rs
+++ b/lib/router-config/src/subscriptions.rs
@@ -29,6 +29,19 @@ pub struct SubscriptionsConfig {
     /// Defaults to 32.
     #[serde(default = "default_broadcast_capacity")]
     pub broadcast_capacity: usize,
+    /// The capacity of the per-subscription buffer for events received from a subgraph before they
+    /// are executed by the router (the query plan is built once when the subscription starts and
+    /// reused for every event, so this covers per-event plan execution, not planning).
+    ///
+    /// Each active subgraph subscription (WebSocket or HTTP SSE/multipart) buffers up to this many
+    /// events. The router must read events from the subgraph as they arrive; if per-event
+    /// execution falls behind and this buffer fills, the newest event is dropped (the subscription
+    /// stays alive) and `hive.router.subscription.dropped_events_total` is incremented. This is
+    /// separate from `broadcast_capacity`, which buffers events fanned out to connected clients.
+    ///
+    /// Defaults to 1024.
+    #[serde(default = "default_subgraph_buffer_capacity")]
+    pub subgraph_buffer_capacity: usize,
     /// Configuration for subgraphs using the HTTP Callback protocol.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub callback: Option<CallbackConfig>,
@@ -84,6 +97,10 @@ pub struct CallbackConfig {
 
 fn default_broadcast_capacity() -> usize {
     32
+}
+
+fn default_subgraph_buffer_capacity() -> usize {
+    1024
 }
 
 fn default_callback_path() -> AbsolutePath {


### PR DESCRIPTION
## Summary

GraphQL subscriptions over a **WebSocket subgraph** could be terminated just because the router briefly fell behind the subgraph's event rate. This replaces that kill-on-slow behavior with a **configurable bounded buffer + drop-latest** policy, and applies the *same* policy to the HTTP (SSE/multipart) subgraph transport so both behave identically. Drops are surfaced via a new counter.

## The problem

`WsSubgraphExecutor::subscribe` bridged the subgraph WebSocket reader (a non-`Send` ntex-local task) to the pipeline through a bounded `mpsc(16)`. On a full channel it logged `"... is too slow"` and **`break`-ed, terminating the subscription**.

Crucially, the consumer of that buffer is **per-event plan *execution***, not planning — the query plan is built once when the subscription starts and reused for every event (`plan.rs:347`); each event runs `execute_query_plan_with_data` (`plan.rs:378`), which for a federated subscription may include **dependent subgraph fetches** + projection. So the buffer fills when downstream federated execution can't keep up with a bursty source, and an otherwise-healthy subscription got killed for it.

## The fix — one policy for both transports

The router **must** read events off the subgraph eagerly:
- **WebSocket:** the socket read is shared infrastructure — it answers graphql-ws/protocol ping/pong (stop reading → server closes the connection) and is built to multiplex subscriptions, so it can't be back-pressured.
- **HTTP SSE/multipart:** drained by an eager pump.

So back-pressure is applied in a **bounded buffer** downstream of the read, with a **drop-latest** overflow policy: when the buffer is full, the newest event is dropped and the subscription stays alive. Never kills.

- New `executors::subscription_buffer` module: `forward_or_drop` (drop-latest + metric) and `buffered_drop_latest` (eager pump → `Send` stream).
- **WS** (`websocket.rs`): bounded `mpsc(N)` fed by the eager reader task; on full → drop-latest + metric. Replaces the previous `LatestSlot`.
- **SSE/multipart** (`http.rs`): wrap the parsed body stream in `buffered_drop_latest`.
- New config `subscriptions.subgraph_buffer_capacity` (**default 1024**), distinct from the downstream `broadcast_capacity`.

## Behavior change to call out

SSE/multipart subgraph subscriptions were previously **lossless** (a slow consumer back-pressured, and thus slowed, the subgraph). They are now **lossy under sustained overload** — same as WS. This is intentional: WS structurally cannot be lossless, so matching the two means SSE adopts drop-latest. With a 1024-deep buffer, drops only occur when downstream execution genuinely can't keep up.

## Observability

New counter **`hive.router.subscription.dropped_events_total`** (labeled by `subgraph.name`), incremented per dropped event on both transports.

## Notes / out of scope

- Inside `WsClient`, `subscription.sender` is an unbounded ntex `mpsc`; the bounded bridge keeps it drained, so it's left as-is (flagged rather than expanded into).
- Client-facing transport (WS vs SSE to the end client) is unaffected — both consume from the same broadcast; this change keys off the *subgraph* transport.

## Test plan

- [ ] WS subgraph emitting faster than downstream execution: subscription **stays open**, `subscription.dropped_events_total{subgraph.name=...}` increments.
- [ ] SSE/multipart subgraph under the same load: now also stays open and increments the counter (previously back-pressured).
- [ ] Healthy subscription that keeps up: **zero** dropped events.
- [ ] Both WS and SSE **clients** still receive events for a subscription.
- [x] `cargo clippy` + `cargo fmt --check` + lib tests green for `hive-router-plan-executor` / `hive-router-config` / `hive-router-internal` (run locally).

> A changeset still needs to be added (behavior change + new config + new metric).
