### PR TITLE
fix(executor): proper handling of `null` and non-null propagation

### DIFF
--- a/.changeset/fix_null_propagation_in_non_null_fields.md
+++ b/.changeset/fix_null_propagation_in_non_null_fields.md
@@ -1,0 +1,20 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Fix null propagation in non-null fields
+
+This change fixes the null propagation logic in non-null fields to match the spec.
+
+From the GraphQL spec:
+
+> Since Non-Null response positions cannot be null, execution errors are propagated to be handled by the parent response position. If the parent response position may be null then it resolves to null, otherwise if it is a Non-Null type, the execution error is further propagated to its parent response position.
+> If a List type wraps a Non-Null type, and one of the response position elements of that list resolves to null, then the entire list response position must resolve to null. If the List type is also wrapped in a Non-Null, the execution error continues to propagate upwards.
+> If every response position from the root of the request to the source of the execution error has a Non-Null type, then the "data" entry in the execution result should be null.
+
+See [Handling Execution Errors](https://spec.graphql.org/September2025/#sec-Handling-Execution-Errors).
+
+Fixes https://github.com/graphql-hive/router/issues/1154
+
+Fixes https://github.com/graphql-hive/router/issues/1110

--- a/bench/subgraphs/accounts.rs
+++ b/bench/subgraphs/accounts.rs
@@ -115,6 +115,34 @@ impl User {
     }
 }
 
+/// A non-null nested type whose only field errors. Used to verify that a `null`
+/// from a non-null nested field bubbles up to the (non-null) parent.
+pub struct NonNullNested;
+
+#[Object]
+impl NonNullNested {
+    async fn field_that_errors(&self) -> async_graphql::Result<String> {
+        Err(async_graphql::Error::new(
+            "NonNullNested.fieldThatErrors always fails",
+        ))
+    }
+}
+
+/// A nullable nested type whose only field errors. Here the `null` stays on the
+/// nullable field rather than bubbling up.
+pub struct NullableNested;
+
+#[Object]
+impl NullableNested {
+    async fn field_that_errors(&self, ctx: &async_graphql::Context<'_>) -> Option<String> {
+        ctx.add_error(async_graphql::ServerError::new(
+            "NullableNested.fieldThatErrors always fails",
+            None,
+        ));
+        None
+    }
+}
+
 pub struct Query;
 
 #[Object(extends = true)]
@@ -129,6 +157,34 @@ impl Query {
 
     async fn users(&self) -> Option<Vec<Option<User>>> {
         Some(USERS.iter().map(|user| Some(user.clone())).collect())
+    }
+
+    /// A nullable root field whose resolver always errors. The subgraph reports
+    /// the error and resolves the field to `null`.
+    async fn nullable_field_that_errors(&self) -> async_graphql::Result<Option<String>> {
+        Err(async_graphql::Error::new(
+            "nullableFieldThatErrors always fails",
+        ))
+    }
+
+    /// A non-null root field whose resolver always errors. Used to verify
+    /// null-propagation for non-null root fields.
+    async fn non_null_field_that_errors(&self) -> async_graphql::Result<String> {
+        Err(async_graphql::Error::new(
+            "nonNullFieldThatErrors always fails",
+        ))
+    }
+
+    /// A non-null nested object; its inner field errors, so the `null` bubbles
+    /// through `NonNullNested!` up to `data`.
+    async fn non_null_nested(&self) -> NonNullNested {
+        NonNullNested
+    }
+
+    /// A nullable nested object; its inner (nullable) field errors, so the `null`
+    /// stays on that field.
+    async fn nullable_nested(&self) -> Option<NullableNested> {
+        Some(NullableNested)
     }
 
     #[graphql(entity)]

--- a/bin/router/src/pipeline/authorization/collector.rs
+++ b/bin/router/src/pipeline/authorization/collector.rs
@@ -165,7 +165,7 @@ pub(super) fn collect_authorization_statuses<'op>(
                 // to trigger null bubbling behavior (which invalidates the entire response).
                 let status = if let Some(field_info) = type_fields.and_then(|f| f.get(&field.name))
                 {
-                    if field_info.is_non_null {
+                    if field_info.nullability.is_non_null() {
                         has_non_null_unauthorized = true;
                         FieldAuthStatus::UnauthorizedNonNullable
                     } else {
@@ -261,7 +261,7 @@ fn process_field_selection<'op, 'ctx>(
 
     let status = if is_authorized {
         FieldAuthStatus::Authorized
-    } else if field_info.is_non_null {
+    } else if field_info.nullability.is_non_null() {
         FieldAuthStatus::UnauthorizedNonNullable
     } else {
         FieldAuthStatus::UnauthorizedNullable

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod issues_e2e_tests {
-    use crate::testkit::{ClientResponseExt, Started, TestRouter};
+    use crate::testkit::{ClientResponseExt, Started, TestRouter, TestSubgraphs};
 
     #[ntex::test]
     /// https://github.com/graphql-hive/federation-gateway-audit `src/test-suites/null-keys`
@@ -1267,6 +1267,606 @@ mod issues_e2e_tests {
               "id": "primary"
             }
           }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1154
+    ///
+    /// Per the GraphQL spec (Handling Field Errors), when a non-null field
+    /// errors, the `null` must bubble up to the nearest nullable ancestor. For a
+    /// non-null *root* field with no nullable ancestor, the `null` propagates all
+    /// the way to `data`, so the response must be `"data": null`.
+    async fn non_null_root_field_error_propagates_to_data() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.non-null-root-field.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // Nullable root field that errors: `null` stays on the field, `data` is
+        // still an object.
+        let nullable_res = router
+            .send_graphql_request("{ nullableFieldThatErrors }", None, None)
+            .await;
+        assert!(nullable_res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(nullable_res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "nullableFieldThatErrors": null
+          },
+          "errors": [
+            {
+              "message": "nullableFieldThatErrors always fails",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 2
+                }
+              ],
+              "path": [
+                "nullableFieldThatErrors"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+
+        // Nested nullable field that errors: `null` stays on the nested field, `data` is
+        // still an object.
+        let nullable_nested_res = router
+            .send_graphql_request("{ nullableNested { fieldThatErrors } }", None, None)
+            .await;
+        assert!(nullable_nested_res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(nullable_nested_res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "nullableNested": {
+              "fieldThatErrors": null
+            }
+          },
+          "errors": [
+            {
+              "message": "NullableNested.fieldThatErrors always fails",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+
+        // Non-null root field that errors: `null` must bubble all the way up to
+        // `data`, so `data` itself becomes `null`.
+        let non_null_res = router
+            .send_graphql_request("{ nonNullFieldThatErrors }", None, None)
+            .await;
+        assert!(non_null_res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(non_null_res.json_body_string_pretty().await, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "nonNullFieldThatErrors always fails",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 2
+                }
+              ],
+              "path": [
+                "nonNullFieldThatErrors"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+
+        // Non-null, nested field that errors: `null` must bubble all the way up.
+        let non_null_res = router
+            .send_graphql_request("{ nonNullNested { fieldThatErrors } }", None, None)
+            .await;
+        assert!(non_null_res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(non_null_res.json_body_string_pretty().await, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "NonNullNested.fieldThatErrors always fails",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 16
+                }
+              ],
+              "path": [
+                "nonNullNested",
+                "fieldThatErrors"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Confirms error + null propagation lands at the nearest nullable position, per the
+    /// GraphQL spec (Handling Field Errors), across three nullability chains.
+    async fn error_and_null_propagation() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.error-and-null-propagation.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "http://{host}/accounts"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // Helper: a subgraph mock for one chain that returns `c: null` + a field error.
+        let mut mock_chain = |chain: &str| {
+            let chain = chain.to_string();
+            server
+                .mock("POST", "/accounts")
+                .match_request(move |r| {
+                    String::from_utf8(r.body().unwrap().clone())
+                        .unwrap()
+                        .contains(&chain)
+                })
+                .with_status(200)
+                .with_header("content-type", "application/json")
+        };
+
+        let _m1 = mock_chain("chain1")
+            .with_body(
+                r#"{"data":{"chain1":{"b":{"c":null}}},
+                    "errors":[{"message":"c failed","path":["chain1","b","c"]}]}"#,
+            )
+            .create();
+        let _m2 = mock_chain("chain2")
+            .with_body(
+                r#"{"data":{"chain2":{"b":{"c":null}}},
+                    "errors":[{"message":"c failed","path":["chain2","b","c"]}]}"#,
+            )
+            .create();
+        let _m3 = mock_chain("chain3")
+            .with_body(
+                r#"{"data":{"chain3":{"b":{"c":null}}},
+                    "errors":[{"message":"c failed","path":["chain3","b","c"]}]}"#,
+            )
+            .create();
+
+        // Chain 1: nullable -> non-null -> nullable. The leaf `c` is nullable, so its
+        // `null` stays put — nothing propagates.
+        let res1 = router
+            .send_graphql_request("{ chain1 { b { c } } }", None, None)
+            .await;
+        insta::assert_snapshot!(res1.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "chain1": {
+              "b": {
+                "c": null
+              }
+            }
+          },
+          "errors": [
+            {
+              "message": "c failed",
+              "path": [
+                "chain1",
+                "b",
+                "c"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+
+        // Chain 2: non-null -> non-null -> non-null. The leaf `c` is Non-Null, so its
+        // `null` bubbles up through every non-null level, all the way to `data`.
+        let res2 = router
+            .send_graphql_request("{ chain2 { b { c } } }", None, None)
+            .await;
+        insta::assert_snapshot!(res2.json_body_string_pretty().await, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "c failed",
+              "path": [
+                "chain2",
+                "b",
+                "c"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+
+        // Chain 3: non-null -> nullable -> non-null. The leaf `c` is non-null and bubbles,
+        // but stops at the nearest nullable ancestor `b`, preserving `chain3`/`data` as-is.
+        let res3 = router
+            .send_graphql_request("{ chain3 { b { c } } }", None, None)
+            .await;
+        insta::assert_snapshot!(res3.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "chain3": {
+              "b": null
+            }
+          },
+          "errors": [
+            {
+              "message": "c failed",
+              "path": [
+                "chain3",
+                "b",
+                "c"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1110
+    ///
+    /// When an entity is fails to resolve, then executor must not leave Non-Null fields as `null`.
+    ///
+    /// Here, `orders` provides only `user.id`; `users` returns `null` for the entity, so
+    /// `User.email: String!` has no value.
+    ///
+    /// That `null` must go up through `user: User!` and `orders: [Order!]!`, collapsing `data` to `null`.
+    async fn issue_1110_unresolved_entity_non_null_propagation() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.1110.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      orders:
+                        url: "http://{host}/orders"
+                      users:
+                        url: "http://{host}/users"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // `orders` resolves the order and provides only the user's key.
+        let _orders = server
+            .mock("POST", "/orders")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":{"orders":[{"id":"1","user":{"__typename":"User","id":"5"}}]}}"#)
+            .create();
+
+        // `users` cannot resolve the referenced entity, so it returns `null` for it.
+        let _users = server
+            .mock("POST", "/users")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":{"_entities":[null]}}"#)
+            .create();
+
+        let res = router
+            .send_graphql_request("{ orders { id user { id name email } } }", None, None)
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // `email: String!` is `null`, so it bubbles `email -> user -> Order`, then all the way up to `data`.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": null
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// null propagation for nested lists.
+    ///
+    /// `grid: [[Int!]]` has a nullable outer
+    /// element but a Non-Null inner element.
+    ///
+    /// A `null` inside an inner list bubbles to that inner list (non-null),
+    /// but the outer list keeps it because its own element is nullable.
+    async fn nested_list_null_propagation() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "accounts": {
+                    "query": {
+                        "grid": [[1, null], [2, 3]]
+                    }
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.error-and-null-propagation.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request("{ grid }", None, None).await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // `[1, null]`: the `null` is a Non-Null inner element -> the inner list collapses
+        // to `null`. The outer list's element is nullable, so that `null` stays in place.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "grid": [
+              null,
+              [
+                2,
+                3
+              ]
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A field error inside a fully Non-Null nested list (`[[Int!]!]!`) bubbles up through
+    /// every level — the inner list, the outer list, and the Non-Null field — collapsing
+    /// `data` itself.
+    async fn nested_list_error_propagates_to_data() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.error-and-null-propagation.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "http://{host}/accounts"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // `matrix[0][1]` is `null` at a Non-Null `Int!`, reported with a field error.
+        let _m = server
+            .mock("POST", "/accounts")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"matrix":[[1,null]]},
+                    "errors":[{"message":"matrix element failed","path":["matrix",0,1]}]}"#,
+            )
+            .create();
+
+        let res = router.send_graphql_request("{ matrix }", None, None).await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "matrix element failed",
+              "path": [
+                "matrix",
+                0,
+                1
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "accounts"
+              }
+            }
+          ]
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A field typed `[[[Int]!]]`: the middle list's element is Non-Null while the outer
+    /// list's element is nullable. A `null` middle element bubbles to its middle list, but
+    /// the outer list keeps that `null` (its own element is nullable).
+    async fn triple_nested_list_null_propagation() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "accounts": {
+                    "query": {
+                        // `[[1], null]`: the `null` is a Non-Null middle element (`[Int]!`).
+                        "cube": [[[1], null], [[2]]]
+                    }
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.error-and-null-propagation.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request("{ cube }", None, None).await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // The `null` bubbles to its middle list (`[[1], null]` -> `null`), but the outer
+        // list keeps it because the outer element is nullable.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "cube": [
+              null,
+              [
+                [
+                  2
+                ]
+              ]
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Null propagation through a Federation `_entities` fetch. `Product.measurements`
+    /// (`[[Int!]!]!`) is resolved in the `metrics` subgraph; one entity comes back with a
+    /// `null` inner element. After the entity merge, that `null` must bubble up through the
+    /// nested Non-Null list to the whole `Product`. Because the `products` list element is
+    /// nullable, the collapsed product becomes `null` and its sibling survives.
+    async fn entity_nested_list_null_propagation() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "products": {
+                    "query": {
+                        "products": [
+                            { "__typename": "Product", "id": "1" },
+                            { "__typename": "Product", "id": "2" }
+                        ]
+                    }
+                },
+                "metrics": {
+                    "entities": [
+                        // Product 1 has a `null` at a Non-Null inner element (`Int!`).
+                        { "__typename": "Product", "id": "1", "measurements": [[1, null]] },
+                        { "__typename": "Product", "id": "2", "measurements": [[2, 3]] }
+                    ]
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.entity-list-propagation.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ products { id measurements } }", None, None)
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // Product 1's `null` bubbles `Int! -> inner list -> outer list -> measurements ->
+        // Product`, collapsing it to `null` (kept, since the list element is nullable).
+        // Product 2 is unaffected.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "products": [
+              null,
+              {
+                "id": "2",
+                "measurements": [
+                  [
+                    2,
+                    3
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+        "#);
+
+        let res = router
+            .send_graphql_request("{ productsNoNulls { id measurements } }", None, None)
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // Product 1's `null` bubbles `Int! -> inner list -> outer list -> measurements ->
+        // Product`, collapsing it to `null` (kept, since the list element is nullable).
+        // Product 2 is unaffected.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": null
         }
         "#);
     }

--- a/e2e/src/issues/supergraph.1110.graphql
+++ b/e2e/src/issues/supergraph.1110.graphql
@@ -1,0 +1,78 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ORDERS @join__graph(name: "orders", url: "http://0.0.0.0:4200/orders")
+  USERS @join__graph(name: "users", url: "http://0.0.0.0:4200/users")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: ORDERS) {
+  orders: [Order!]! @join__field(graph: ORDERS)
+}
+
+type Order @join__type(graph: ORDERS, key: "id") {
+  id: ID!
+  # `orders` subgraph provides the user's key, but cannot resolve the rest of `User`.
+  user: User! @join__field(graph: ORDERS, provides: "id")
+}
+
+type User
+  @join__type(graph: ORDERS, key: "id", resolvable: false)
+  @join__type(graph: USERS, key: "id") {
+  id: ID!
+    @join__field(graph: ORDERS, external: true)
+    @join__field(graph: USERS)
+  name: String @join__field(graph: USERS)
+  email: String! @join__field(graph: USERS)
+}

--- a/e2e/src/issues/supergraph.entity-list-propagation.graphql
+++ b/e2e/src/issues/supergraph.entity-list-propagation.graphql
@@ -1,0 +1,73 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  METRICS @join__graph(name: "metrics", url: "http://0.0.0.0:4200/metrics")
+  PRODUCTS @join__graph(name: "products", url: "http://0.0.0.0:4200/products")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: PRODUCTS) {
+  # Nullable list element, so a collapsed product survives as `null` and siblings remain.
+  products: [Product]! @join__field(graph: PRODUCTS)
+  productsNoNulls: [Product!]! @join__field(graph: PRODUCTS)
+}
+
+type Product
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: METRICS, key: "id") {
+  id: ID!
+  # Resolved in the `metrics` subgraph via an `_entities` fetch. Fully Non-Null nested
+  # list (`[[Int!]!]!`), so a `null` element bubbles up to the whole `Product`.
+  measurements: [[Int!]!]! @join__field(graph: METRICS)
+}

--- a/e2e/src/issues/supergraph.error-and-null-propagation.graphql
+++ b/e2e/src/issues/supergraph.error-and-null-propagation.graphql
@@ -1,0 +1,97 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://0.0.0.0:4200/accounts")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: ACCOUNTS) {
+  # nullable -> non-null -> nullable
+  chain1: Chain1A @join__field(graph: ACCOUNTS)
+  # non-null -> non-null -> non-null
+  chain2: Chain2A! @join__field(graph: ACCOUNTS)
+  # non-null -> nullable -> non-null
+  chain3: Chain3A! @join__field(graph: ACCOUNTS)
+  # outer list element nullable, inner list element non-null (`[[Int!]]`).
+  grid: [[Int!]] @join__field(graph: ACCOUNTS)
+  # every level non-null: a null element bubbles all the way to `data` (`[[Int!]!]!`).
+  matrix: [[Int!]!]! @join__field(graph: ACCOUNTS)
+  # triple-nested list (`[[[Int]!]]`): outer element nullable, middle element non-null,
+  # inner element nullable.
+  cube: [[[Int]!]] @join__field(graph: ACCOUNTS)
+}
+
+# nullable -> non-null -> nullable
+type Chain1A @join__type(graph: ACCOUNTS) {
+  b: Chain1B! @join__field(graph: ACCOUNTS)
+}
+type Chain1B @join__type(graph: ACCOUNTS) {
+  c: String @join__field(graph: ACCOUNTS)
+}
+
+# non-null -> non-null -> non-null
+type Chain2A @join__type(graph: ACCOUNTS) {
+  b: Chain2B! @join__field(graph: ACCOUNTS)
+}
+type Chain2B @join__type(graph: ACCOUNTS) {
+  c: String! @join__field(graph: ACCOUNTS)
+}
+
+# non-null -> nullable -> non-null
+type Chain3A @join__type(graph: ACCOUNTS) {
+  b: Chain3B @join__field(graph: ACCOUNTS)
+}
+type Chain3B @join__type(graph: ACCOUNTS) {
+  c: String! @join__field(graph: ACCOUNTS)
+}

--- a/e2e/src/issues/supergraph.non-null-root-field.graphql
+++ b/e2e/src/issues/supergraph.non-null-root-field.graphql
@@ -1,0 +1,75 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://0.0.0.0:4200/accounts")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: ACCOUNTS) {
+  # root
+  nullableFieldThatErrors: String @join__field(graph: ACCOUNTS)
+  nonNullFieldThatErrors: String! @join__field(graph: ACCOUNTS)
+
+  # nested
+  nonNullNested: NonNullNested! @join__field(graph: ACCOUNTS)
+  nullableNested: NullableNested @join__field(graph: ACCOUNTS)
+}
+
+type NonNullNested @join__type(graph: ACCOUNTS) {
+  fieldThatErrors: String! @join__field(graph: ACCOUNTS)
+}
+
+type NullableNested @join__type(graph: ACCOUNTS) {
+  fieldThatErrors: String @join__field(graph: ACCOUNTS)
+}

--- a/lib/executor/src/introspection/schema.rs
+++ b/lib/executor/src/introspection/schema.rs
@@ -6,10 +6,60 @@ use graphql_tools::parser::{
 };
 use hive_router_query_planner::consumer_schema::ConsumerSchema;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct FieldTypeInfo {
     pub output_type_name: String,
-    pub is_non_null: bool,
+    pub nullability: FieldNullability,
+}
+
+/// The nullability shape of a field's type. Similar to the GraphQL type wrappers.
+#[derive(Debug, Clone)]
+pub enum FieldNullability {
+    Leaf {
+        non_null: bool,
+    },
+    List {
+        non_null: bool,
+        item: Box<FieldNullability>,
+    },
+}
+
+impl FieldNullability {
+    // __typename: String! (https://spec.graphql.org/September2025/#sec-Type-Name-Introspection)
+    #[inline]
+    pub fn type_name() -> Self {
+        FieldNullability::Leaf { non_null: true }
+    }
+
+    fn leaf(non_null: bool) -> Self {
+        FieldNullability::Leaf { non_null }
+    }
+
+    fn list(non_null: bool, item: FieldNullability) -> Self {
+        FieldNullability::List {
+            non_null,
+            item: Box::new(item),
+        }
+    }
+
+    /// Whether this position's value is Non-Null, so a `null` here must bubble to its parent.
+    #[inline]
+    pub fn is_non_null(&self) -> bool {
+        match self {
+            FieldNullability::Leaf { non_null } | FieldNullability::List { non_null, .. } => {
+                *non_null
+            }
+        }
+    }
+
+    /// The element's nullability shape, when this position is a list.
+    #[inline]
+    pub fn list_item(&self) -> Option<&FieldNullability> {
+        match self {
+            FieldNullability::List { item, .. } => Some(item),
+            FieldNullability::Leaf { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -114,7 +164,7 @@ impl SchemaWithMetadata for ConsumerSchema {
                             field.name.to_string(),
                             FieldTypeInfo {
                                 output_type_name: field_type_name,
-                                is_non_null: field.field_type.is_non_null(),
+                                nullability: field.field_type.field_nullability(),
                             },
                         );
                     }
@@ -136,7 +186,7 @@ impl SchemaWithMetadata for ConsumerSchema {
                             field.name.to_string(),
                             FieldTypeInfo {
                                 output_type_name: field_type_name,
-                                is_non_null: field.field_type.is_non_null(),
+                                nullability: field.field_type.field_nullability(),
                             },
                         );
                     }
@@ -196,6 +246,7 @@ impl SchemaWithMetadata for ConsumerSchema {
 
 trait TypeName {
     fn type_name(&self) -> String;
+    fn field_nullability(&self) -> FieldNullability;
 }
 
 impl TypeName for Type<'_, String> {
@@ -206,6 +257,19 @@ impl TypeName for Type<'_, String> {
                 non_null_type.type_name()
             }
             graphql_tools::parser::schema::Type::ListType(list_type) => list_type.type_name(),
+        }
+    }
+
+    fn field_nullability(&self) -> FieldNullability {
+        use graphql_tools::parser::schema::Type;
+
+        match self {
+            Type::NonNullType(inner) => match inner.as_ref() {
+                Type::ListType(item) => FieldNullability::list(true, item.field_nullability()),
+                _ => FieldNullability::leaf(true),
+            },
+            Type::ListType(item) => FieldNullability::list(false, item.field_nullability()),
+            Type::NamedType(_) => FieldNullability::leaf(false),
         }
     }
 }

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -15,7 +15,10 @@ use hive_router_query_planner::{
 };
 
 use crate::projection::error::ProjectionError;
-use crate::{introspection::schema::SchemaMetadata, utils::consts::TYPENAME_FIELD_NAME};
+use crate::{
+    introspection::schema::{FieldNullability, SchemaMetadata},
+    utils::consts::TYPENAME_FIELD_NAME,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeCondition {
@@ -112,6 +115,7 @@ pub struct FieldProjectionPlan {
     pub field_name: String,
     pub response_key: String,
     pub is_typename: bool,
+    pub nullability: FieldNullability,
     /// A condition that checks the name of the parent object.
     /// This is used to ensure that fields inside a fragment (e.g., `... on User`)
     /// are only applied when the parent object's type matches the fragment's type condition.
@@ -622,8 +626,8 @@ impl FieldProjectionPlan {
         let field_name = &field.name;
         let response_key = field.alias.as_ref().unwrap_or(field_name).clone();
 
-        let field_type = if field_name == TYPENAME_FIELD_NAME {
-            "String".to_string()
+        let (field_type, nullability) = if field_name == TYPENAME_FIELD_NAME {
+            ("String".to_string(), FieldNullability::type_name())
         } else {
             let field_map = match schema_metadata.type_fields.get(parent_type_name) {
                 Some(fields) => fields,
@@ -636,7 +640,7 @@ impl FieldProjectionPlan {
                 }
             };
             match field_map.get(field_name) {
-                Some(f) => f.output_type_name.clone(),
+                Some(f) => (f.output_type_name.clone(), f.nullability.clone()),
                 None => {
                     warn!(
                         "Field `{}` not found in type `{}` in schema metadata.",
@@ -718,6 +722,7 @@ impl FieldProjectionPlan {
                 response_key,
                 parent_type_guard,
                 is_typename: field_name == TYPENAME_FIELD_NAME,
+                nullability: nullability.clone(),
                 conditions: final_conditions,
                 // We use Some(vec![]) as it means "project an object, but with no children".
                 // None would be treated as "no projection plan available".
@@ -731,6 +736,7 @@ impl FieldProjectionPlan {
                 response_key,
                 parent_type_guard,
                 is_typename: field_name == TYPENAME_FIELD_NAME,
+                nullability: nullability.clone(),
                 conditions: final_conditions,
                 value: ProjectionValueSource::ResponseData {
                     selections: Self::from_selection_set(
@@ -801,6 +807,7 @@ impl FieldProjectionPlan {
             parent_type_guard: self.parent_type_guard.clone(),
             conditions: self.conditions.clone(),
             is_typename: self.is_typename,
+            nullability: self.nullability.clone(),
             value: new_value,
         }
     }

--- a/lib/executor/src/projection/response.rs
+++ b/lib/executor/src/projection/response.rs
@@ -12,12 +12,26 @@ use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::introspection::schema::SchemaMetadata;
+use crate::introspection::schema::{FieldNullability, SchemaMetadata};
 use crate::json_writer::{write_and_escape_string, write_f64, write_i64, write_u64};
 use crate::utils::consts::{
     CLOSE_BRACE, CLOSE_BRACKET, COLON, COMMA, EMPTY_OBJECT, FALSE, NULL, OPEN_BRACE, OPEN_BRACKET,
     QUOTE, TRUE, TYPENAME_FIELD_NAME,
 };
+
+enum NullPropagationDecision {
+    /// An indicator that the `null` value should be propagated, since the field is non-null
+    PropagateNullValue,
+    /// An indicator that the `null` value should be kept as-is, since the field is nullable.
+    KeepNullValue,
+}
+
+impl NullPropagationDecision {
+    #[inline]
+    fn should_propagate(&self) -> bool {
+        matches!(self, NullPropagationDecision::PropagateNullValue)
+    }
+}
 
 /// Represents a type's name that can be either already resolved or lazily computed.
 /// This avoids computing the type name when it's not needed, which is important for performance.
@@ -98,9 +112,10 @@ pub fn project_by_operation(
     let mut errors = errors;
 
     if let Some(data_map) = data.as_object() {
+        let null_propagation_checkpoint = buffer.len();
         // Start with first as true to add the opening brace
         let mut first = true;
-        project_selection_set_with_map(
+        let null_propagation_decision = project_selection_set_with_map(
             data_map,
             &mut errors,
             selections,
@@ -110,7 +125,11 @@ pub fn project_by_operation(
             &mut first,
             schema_metadata,
         )?;
-        if !first {
+
+        if null_propagation_decision.should_propagate() {
+            buffer.truncate(null_propagation_checkpoint);
+            buffer.put(NULL);
+        } else if !first {
             buffer.put(CLOSE_BRACE);
         } else {
             // If no selections were made, we should return an empty object
@@ -186,6 +205,7 @@ pub fn serialize_value_to_buffer(data: &Value, buffer: &mut Vec<u8>) {
     };
 }
 
+#[allow(clippy::too_many_arguments)]
 fn project_selection_set<'a>(
     data: &'a Value,
     errors: &mut Vec<GraphQLError>,
@@ -194,16 +214,20 @@ fn project_selection_set<'a>(
     buffer: &mut Vec<u8>,
     parent_type_name: TypeName<'a>,
     schema_metadata: &'a SchemaMetadata,
-) -> Result<(), ProjectionError> {
+    nullability: &'a FieldNullability,
+) -> Result<NullPropagationDecision, ProjectionError> {
     match data {
         Value::Array(arr) => {
+            let null_propagation_checkpoint = buffer.len();
+            let list_item_nullability = nullability.list_item();
+            let item_non_null = list_item_nullability.is_some_and(FieldNullability::is_non_null);
             buffer.put(OPEN_BRACKET);
             let mut first = true;
             for item in arr.iter() {
                 if !first {
                     buffer.put(COMMA);
                 }
-                project_selection_set(
+                let needs_null_propagation = project_selection_set(
                     item,
                     errors,
                     selection,
@@ -211,16 +235,28 @@ fn project_selection_set<'a>(
                     buffer,
                     parent_type_name.clone(),
                     schema_metadata,
+                    list_item_nullability.unwrap_or(nullability),
                 )?;
+
+                // A `null` at a Non-Null element of this list propagates to the list itself.
+                if needs_null_propagation.should_propagate() && item_non_null {
+                    buffer.truncate(null_propagation_checkpoint);
+                    buffer.put(NULL);
+                    return Ok(NullPropagationDecision::PropagateNullValue);
+                }
+
                 first = false;
             }
+
             buffer.put(CLOSE_BRACKET);
+            Ok(NullPropagationDecision::KeepNullValue)
         }
         Value::Object(obj) => {
             match &selection.value {
                 ProjectionValueSource::ResponseData {
                     selections: Some(selections),
                 } => {
+                    let null_propagation_checkpoint = buffer.len();
                     let mut first = true;
                     let type_name = TypeName::deferred(
                         selection,
@@ -228,7 +264,7 @@ fn project_selection_set<'a>(
                         parent_type_name,
                         schema_metadata,
                     );
-                    project_selection_set_with_map(
+                    let null_propagation_decision = project_selection_set_with_map(
                         obj,
                         errors,
                         selections,
@@ -238,29 +274,43 @@ fn project_selection_set<'a>(
                         &mut first,
                         schema_metadata,
                     )?;
+
+                    if null_propagation_decision.should_propagate() {
+                        buffer.truncate(null_propagation_checkpoint);
+                        buffer.put(NULL);
+                        return Ok(NullPropagationDecision::PropagateNullValue);
+                    }
+
                     if !first {
                         buffer.put(CLOSE_BRACE);
                     } else {
                         // If no selections were made, we should return an empty object
                         buffer.put(EMPTY_OBJECT);
                     }
+                    Ok(NullPropagationDecision::KeepNullValue)
                 }
                 ProjectionValueSource::ResponseData { selections: None } => {
                     // If the selection has no sub-selections, we serialize the whole object
                     serialize_value_to_buffer(data, buffer);
+                    Ok(NullPropagationDecision::KeepNullValue)
                 }
                 ProjectionValueSource::Null => {
                     // This should not happen as we are in an object case, but just in case
                     buffer.put(NULL);
+                    Ok(NullPropagationDecision::PropagateNullValue)
                 }
             }
+        }
+        Value::Null => {
+            buffer.put(NULL);
+            Ok(NullPropagationDecision::PropagateNullValue)
         }
         _ => {
             // If the data is not an object or array, we serialize it directly
             serialize_value_to_buffer(data, buffer);
+            Ok(NullPropagationDecision::KeepNullValue)
         }
-    };
-    Ok(())
+    }
 }
 
 // TODO: simplfy args
@@ -274,7 +324,7 @@ fn project_selection_set_with_map<'a>(
     buffer: &mut Vec<u8>,
     first: &mut bool,
     schema_metadata: &'a SchemaMetadata,
-) -> Result<(), ProjectionError> {
+) -> Result<NullPropagationDecision, ProjectionError> {
     for plan in plans {
         if let Some(guard) = &plan.parent_type_guard {
             let name = parent_type_name.get()?;
@@ -324,10 +374,10 @@ fn project_selection_set_with_map<'a>(
                 buffer.put(QUOTE);
                 buffer.put(COLON);
 
-                match &plan.value {
+                let null_propagation_decision = match &plan.value {
                     ProjectionValueSource::Null => {
                         buffer.put(NULL);
-                        continue;
+                        NullPropagationDecision::PropagateNullValue
                     }
                     ProjectionValueSource::ResponseData { .. } => {
                         if plan.is_typename {
@@ -335,6 +385,7 @@ fn project_selection_set_with_map<'a>(
                             buffer.put(QUOTE);
                             buffer.put(parent_type_name.get()?.as_bytes());
                             buffer.put(QUOTE);
+                            NullPropagationDecision::KeepNullValue
                         } else if let Some(field_val) = field_val {
                             project_selection_set(
                                 field_val,
@@ -344,12 +395,19 @@ fn project_selection_set_with_map<'a>(
                                 buffer,
                                 parent_type_name.clone(),
                                 schema_metadata,
-                            )?;
+                                &plan.nullability,
+                            )?
                         } else {
                             // If the field is not found in the object, set it to Null
                             buffer.put(NULL);
+                            NullPropagationDecision::PropagateNullValue
                         }
                     }
+                };
+
+                // A `null` value in a non-null position bubbles up
+                if null_propagation_decision.should_propagate() && plan.nullability.is_non_null() {
+                    return Ok(NullPropagationDecision::PropagateNullValue);
                 }
             }
             Err(FieldProjectionConditionError::Fatal(err)) => {
@@ -377,6 +435,9 @@ fn project_selection_set_with_map<'a>(
                 buffer.put(COLON);
                 buffer.put(NULL);
                 errors.push(GraphQLError::from("Value is not a valid enum value"));
+                if plan.nullability.is_non_null() {
+                    return Ok(NullPropagationDecision::PropagateNullValue);
+                }
             }
             Err(FieldProjectionConditionError::InvalidFieldType) => {
                 if *first {
@@ -392,10 +453,14 @@ fn project_selection_set_with_map<'a>(
                 buffer.put(QUOTE);
                 buffer.put(COLON);
                 buffer.put(NULL);
+                if plan.nullability.is_non_null() {
+                    return Ok(NullPropagationDecision::PropagateNullValue);
+                }
             }
         }
     }
-    Ok(())
+
+    Ok(NullPropagationDecision::KeepNullValue)
 }
 
 #[inline]


### PR DESCRIPTION
## Overview

This PR implements null propagation for fields, executed during projection of fields. Since `null` can be returned by a subgraph (for example: in an entity call), we need to validate that the final response conforms to the contract and the definition of each field.

From the GraphQL spec:
> If during [ExecuteCollectedFields](https://spec.graphql.org/September2025/#ExecuteCollectedFields())() a [response position](https://spec.graphql.org/September2025/#response-position) with a non-null type raises an [execution error](https://spec.graphql.org/September2025/#execution-error) then that error must propagate to the parent response position (the entire selection set in the case of a field, or the entire list in the case of a list position), either resolving to null if allowed or being further propagated to a parent response position.

> If this occurs, any sibling response positions which have not yet executed or have not yet yielded a value may be cancelled to avoid unnecessary work.

And:
> Since Non-Null response positions cannot be null, execution errors are propagated to be handled by the parent [response position](https://spec.graphql.org/September2025/#response-position). If the parent response position may be null then it resolves to null, otherwise if it is a Non-Null type, the execution error is further propagated to its parent [response position](https://spec.graphql.org/September2025/#response-position).

> If a List type wraps a Non-Null type, and one of the [response position](https://spec.graphql.org/September2025/#response-position) elements of that list resolves to null, then the entire list [response position](https://spec.graphql.org/September2025/#response-position) must resolve to null. If the List type is also wrapped in a Non-Null, the execution error continues to propagate upwards.

> If every [response position](https://spec.graphql.org/September2025/#response-position) from the root of the request to the source of the execution error has a Non-Null type, then the "data" entry in the [execution result](https://spec.graphql.org/September2025/#execution-result) should be null.

If this occurs, any sibling response positions which have not yet executed or have not yet yielded a value may be cancelled to avoid unnecessary work.

## Overview of the changes 

* In projection plan, we now store a new `struct FieldNullability` instead of `is_non_null: bool`, since we need to know the inner/outer nullability in case of list-fields.
* `project_selection_set` and `project_selection_set_with_map` now returns a `Decision` value that indicates the caller (= parent selection) on the value it used. If we encounter a `null` field in a field that doesn't allow to have null `!`), then the parent will process and collapse. This bubbles up all the way to `data` in case on a chain of non-null fields.

Fixes https://github.com/graphql-hive/router/issues/1154
Fixes https://github.com/graphql-hive/router/issues/1110 