### PR TITLE
[codex] fix projection scoping for disjoint fragments

### DIFF
--- a/.changeset/fix-projection-fragment-scope.md
+++ b/.changeset/fix-projection-fragment-scope.md
@@ -1,0 +1,6 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+Fix response projection scoping for repeated field response keys selected under different fragment type conditions.

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3,6 +3,142 @@ mod issues_e2e_tests {
     use crate::testkit::{ClientResponseExt, Started, TestRouter, TestSubgraphs};
 
     #[ntex::test]
+    async fn projection_keeps_disjoint_fragment_child_selections_scoped() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.projection-disjoint-fragments.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      search:
+                        url: "http://{host}/search"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let search_mock = server
+            .mock("POST", "/search")
+            .match_request(|r| {
+                let body = String::from_utf8(r.body().unwrap().clone()).unwrap();
+
+                body.contains("search")
+                    && body.contains("Collection")
+                    && body.contains("CurrencyV2")
+                    && body.contains("Item")
+                    && body.contains("arch")
+            })
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+                {
+                  "data": {
+                    "search": [
+                      {
+                        "__typename": "Collection",
+                        "id": "collection-1",
+                        "chain": {
+                          "__typename": "Chain",
+                          "identifier": "ethereum"
+                        }
+                      },
+                      {
+                        "__typename": "CurrencyV2",
+                        "id": "currency-1",
+                        "chain": {
+                          "__typename": "Chain",
+                          "identifier": "solana"
+                        }
+                      },
+                      {
+                        "__typename": "Item",
+                        "id": "item-1",
+                        "chain": {
+                          "__typename": "Chain",
+                          "arch": "evm"
+                        }
+                      }
+                    ]
+                  }
+                }
+                "#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                  search {
+                    __typename
+                    ... on Collection {
+                      id
+                      chain {
+                        identifier
+                      }
+                    }
+                    ... on CurrencyV2 {
+                      id
+                      chain {
+                        identifier
+                      }
+                    }
+                    ... on Item {
+                      id
+                      chain {
+                        arch
+                      }
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        search_mock.assert();
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "search": [
+              {
+                "__typename": "Collection",
+                "id": "collection-1",
+                "chain": {
+                  "identifier": "ethereum"
+                }
+              },
+              {
+                "__typename": "CurrencyV2",
+                "id": "currency-1",
+                "chain": {
+                  "identifier": "solana"
+                }
+              },
+              {
+                "__typename": "Item",
+                "id": "item-1",
+                "chain": {
+                  "arch": "evm"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
     /// https://github.com/graphql-hive/federation-gateway-audit `src/test-suites/null-keys`
     async fn federation_audit_null_keys() {
         let mut server = mockito::Server::new_async().await;

--- a/e2e/src/issues/supergraph.projection-disjoint-fragments.graphql
+++ b/e2e/src/issues/supergraph.projection-disjoint-fragments.graphql
@@ -1,0 +1,90 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SEARCH @join__graph(name: "search", url: "http://0.0.0.0:4200/search")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: SEARCH) {
+  search: [SearchResult!]! @join__field(graph: SEARCH)
+}
+
+union SearchResult
+  @join__type(graph: SEARCH)
+  @join__unionMember(graph: SEARCH, member: "Collection")
+  @join__unionMember(graph: SEARCH, member: "CurrencyV2")
+  @join__unionMember(graph: SEARCH, member: "Item") =
+  | Collection
+  | CurrencyV2
+  | Item
+
+type Chain @join__type(graph: SEARCH) {
+  identifier: ID!
+  arch: String!
+}
+
+type Collection @join__type(graph: SEARCH) {
+  id: ID!
+  chain: Chain!
+}
+
+type CurrencyV2 @join__type(graph: SEARCH) {
+  id: ID!
+  chain: Chain!
+}
+
+type Item @join__type(graph: SEARCH) {
+  id: ID!
+  chain: Chain!
+}

--- a/lib/executor/benches/executor_benches.rs
+++ b/lib/executor/benches/executor_benches.rs
@@ -1,11 +1,19 @@
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
-use hive_router_plan_executor::introspection::schema::SchemaWithMetadata;
+use graphql_tools::parser::query::Definition;
+use hive_router_plan_executor::introspection::schema::{SchemaMetadata, SchemaWithMetadata};
 use hive_router_plan_executor::projection::plan::FieldProjectionPlan;
 use hive_router_plan_executor::projection::response::project_by_operation;
 use hive_router_plan_executor::response::value::Value;
-use hive_router_query_planner::ast::normalization::normalize_operation;
-use hive_router_query_planner::utils::parsing::{parse_operation, parse_schema};
+use hive_router_query_planner::{
+    ast::{
+        document::NormalizedDocument,
+        normalization::{create_normalized_document, normalize_operation},
+    },
+    consumer_schema::ConsumerSchema,
+    state::supergraph_state::SupergraphState,
+    utils::parsing::{parse_operation, parse_schema},
+};
 use std::hint::black_box;
 pub mod raw_result;
 
@@ -60,8 +68,115 @@ fn project_data_by_operation_test(c: &mut Criterion) {
     });
 }
 
+fn abstract_interface_schema() -> String {
+    let mut node_fields = String::from("id: ID!\n");
+    for field_index in 0..10 {
+        node_fields.push_str(&format!("f{field_index}: String!\n"));
+    }
+
+    let mut schema = format!("interface Node {{\n{node_fields}}}\n");
+    for type_index in 0..12 {
+        schema.push_str(&format!(
+            "type Node{type_index} implements Node {{\n{node_fields}}}\n"
+        ));
+    }
+    schema.push_str("type Query { nodes: [Node!]! }\n");
+    schema
+}
+
+fn abstract_interface_operation() -> String {
+    let mut operation = String::from("query AbstractProjection { nodes { __typename id");
+    for field_index in 0..10 {
+        operation.push_str(&format!(" f{field_index}"));
+    }
+    operation.push_str(" } }");
+    operation
+}
+
+fn abstract_interface_response() -> String {
+    let mut response = String::from(r#"{"__typename":"Query","nodes":["#);
+    for row_index in 0..4000 {
+        if row_index > 0 {
+            response.push(',');
+        }
+
+        response.push_str(&format!(
+            r#"{{"__typename":"Node{}","id":"id-{}""#,
+            row_index % 12,
+            row_index
+        ));
+
+        for field_index in 0..10 {
+            response.push_str(&format!(
+                r#","f{field_index}":"value-{row_index}-{field_index}""#
+            ));
+        }
+
+        response.push('}');
+    }
+    response.push_str("]}");
+    response
+}
+
+fn abstract_interface_projection_plan() -> (&'static str, Vec<FieldProjectionPlan>, SchemaMetadata)
+{
+    let supergraph = parse_schema(&abstract_interface_schema());
+    let consumer_schema = ConsumerSchema::new_from_supergraph(&supergraph);
+    let schema_metadata = consumer_schema.schema_metadata();
+
+    let mut operation = parse_operation(&abstract_interface_operation());
+    let operation_ast = operation
+        .definitions
+        .iter_mut()
+        .find_map(|def| match def {
+            Definition::Operation(op) => Some(op),
+            _ => None,
+        })
+        .expect("operation definition");
+
+    let supergraph_state = SupergraphState::new(&supergraph);
+    let normalized_operation: NormalizedDocument = create_normalized_document(
+        &supergraph_state,
+        operation_ast.clone(),
+        Some("AbstractProjection".into()),
+    );
+    let (root_type_name, projection_plan) =
+        FieldProjectionPlan::from_operation(&normalized_operation.operation, &schema_metadata);
+
+    (root_type_name, projection_plan, schema_metadata)
+}
+
+fn project_abstract_interface_data(c: &mut Criterion) {
+    let (root_type_name, projection_plan, schema_metadata) = abstract_interface_projection_plan();
+    let result_as_string = abstract_interface_response();
+    let projected_data_as_json: sonic_rs::Value =
+        sonic_rs::from_slice(result_as_string.as_bytes()).unwrap();
+
+    c.bench_function("project_abstract_interface_data", |b| {
+        b.iter_batched(
+            || Value::from(projected_data_as_json.as_ref()),
+            |data| {
+                let result = project_by_operation(
+                    &data,
+                    vec![],
+                    &Default::default(),
+                    black_box(root_type_name),
+                    black_box(&projection_plan),
+                    &None,
+                    result_as_string.len(),
+                    &schema_metadata,
+                )
+                .unwrap();
+                black_box(result);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
 fn all_benchmarks(c: &mut Criterion) {
     project_data_by_operation_test(c);
+    project_abstract_interface_data(c);
 }
 
 criterion_group!(benches, all_benchmarks);

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -220,8 +220,9 @@ impl FieldProjectionPlan {
         )
         .unwrap_or_default();
 
+        let root_parent_types = HashSet::from_iter([root_type_name.to_string()]);
         for plan in &mut plans {
-            Self::remove_redundant_child_guards(plan, schema_metadata);
+            Self::remove_redundant_child_guards(plan, schema_metadata, &root_parent_types);
         }
 
         (root_type_name, plans)
@@ -270,29 +271,90 @@ impl FieldProjectionPlan {
         }
     }
 
-    /// Extracts type names from a TypeCondition for easier comparison
-    fn type_names_from(condition: &TypeCondition) -> Vec<&str> {
-        match condition {
-            TypeCondition::Exact(ty) => vec![ty.as_str()],
-            TypeCondition::OneOf(types) => types.iter().map(|s| s.as_str()).collect(),
+    fn possible_runtime_types(
+        schema_metadata: &SchemaMetadata,
+        type_name: &str,
+    ) -> HashSet<String> {
+        if schema_metadata.is_interface_type(type_name) || schema_metadata.is_union_type(type_name)
+        {
+            schema_metadata
+                .get_possible_types(type_name)
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            HashSet::from_iter([type_name.to_string()])
         }
     }
 
-    /// Recursively removes redundant type guards from child selections.
+    fn possible_field_runtime_types(
+        parent_field: &FieldProjectionPlan,
+        schema_metadata: &SchemaMetadata,
+        parent_type_names: &HashSet<String>,
+    ) -> HashSet<String> {
+        let mut field_runtime_types = HashSet::default();
+
+        for parent_type_name in parent_type_names {
+            let Some(field_info) = schema_metadata
+                .type_fields
+                .get(parent_type_name)
+                .and_then(|fields| fields.get(&parent_field.field_name))
+            else {
+                continue;
+            };
+
+            field_runtime_types.extend(Self::possible_runtime_types(
+                schema_metadata,
+                &field_info.output_type_name,
+            ));
+        }
+
+        field_runtime_types
+    }
+
+    fn guarded_parent_types(
+        parent_type_names: &HashSet<String>,
+        parent_type_guard: &Option<TypeCondition>,
+    ) -> HashSet<String> {
+        let Some(parent_type_guard) = parent_type_guard else {
+            return parent_type_names.clone();
+        };
+
+        parent_type_names
+            .iter()
+            .filter(|type_name| parent_type_guard.matches(type_name))
+            .cloned()
+            .collect()
+    }
+
+    fn type_condition_covers_types(
+        type_condition: &TypeCondition,
+        type_names: &HashSet<String>,
+    ) -> bool {
+        !type_names.is_empty()
+            && type_names
+                .iter()
+                .all(|type_name| type_condition.matches(type_name))
+    }
+
+    /// Recursively removes type guards that are always true at their response position.
     ///
-    /// A type guard is redundant when it covers exactly all possible types that can appear in that position.
-    /// For example, if a field `children` can only return types A or B (based on the parent's type guard),
-    /// and a child selection has guard `OneOf(A, B)`, then that guard is redundant since it will always match.
-    ///
-    /// Every guard has a cost during execution (computes field's output type or name of its parent),
-    /// so removing redundant guards helps optimize the response projection.
-    ///
-    /// This optimization must run after all fragment merging is complete to correctly
-    /// determine the full set of possible types.
+    /// Every guard has a runtime cost during response projection: it resolves the parent
+    /// `__typename` and checks the guard. This cleanup runs after fragment merging, when
+    /// we know the full set of possible parent types for each selection-set position.
+    /// Proper-subset guards created by splitting overlapping fragments are preserved.
     fn remove_redundant_child_guards(
         parent_field: &mut FieldProjectionPlan,
         schema_metadata: &SchemaMetadata,
+        parent_type_names: &HashSet<String>,
     ) {
+        let guarded_parent_types =
+            Self::guarded_parent_types(parent_type_names, &parent_field.parent_type_guard);
+        let possible_child_types = Self::possible_field_runtime_types(
+            parent_field,
+            schema_metadata,
+            &guarded_parent_types,
+        );
+
         let ProjectionValueSource::ResponseData { selections } = &mut parent_field.value else {
             return;
         };
@@ -303,44 +365,14 @@ impl FieldProjectionPlan {
 
         let selections_mut = Arc::make_mut(selections_arc);
 
-        // Compute possible child types only if parent has a type guard
-        let possible_child_types = parent_field.parent_type_guard.as_ref().map(|parent_guard| {
-            let parent_types = Self::type_names_from(parent_guard);
-
-            // For each parent type, lookup what type this field returns
-            HashSet::from_iter(parent_types.iter().filter_map(|parent_type| {
-                schema_metadata
-                    .type_fields
-                    .get(*parent_type)
-                    .and_then(|fields| fields.get(&parent_field.field_name))
-                    .map(|field_info| field_info.output_type_name.as_str())
-            }))
-        });
-
         for child in selections_mut {
-            // Remove redundant guard if this child's guard covers all possible types
-            if let (Some(child_guard), Some(possible_types)) =
-                (&child.parent_type_guard, &possible_child_types)
-            {
-                // Check if guard covers exactly all possible types by comparing as sets
-                let is_redundant = match child_guard {
-                    TypeCondition::Exact(ty) => {
-                        possible_types.len() == 1 && possible_types.contains(ty.as_str())
-                    }
-                    TypeCondition::OneOf(guard_types) => {
-                        guard_types.len() == possible_types.len()
-                            && guard_types
-                                .iter()
-                                .all(|t| possible_types.contains(t.as_str()))
-                    }
-                };
-
-                if is_redundant {
-                    child.parent_type_guard = None;
-                }
+            if child.parent_type_guard.as_ref().is_some_and(|child_guard| {
+                Self::type_condition_covers_types(child_guard, &possible_child_types)
+            }) {
+                child.parent_type_guard = None;
             }
 
-            Self::remove_redundant_child_guards(child, schema_metadata);
+            Self::remove_redundant_child_guards(child, schema_metadata, &possible_child_types);
         }
     }
 
@@ -482,21 +514,202 @@ impl FieldProjectionPlan {
         Self::or_optional(left, right)
     }
 
+    fn type_conditions_overlap(left: &TypeCondition, right: &TypeCondition) -> bool {
+        match (left, right) {
+            (TypeCondition::Exact(left), TypeCondition::Exact(right)) => left == right,
+            (TypeCondition::Exact(exact), TypeCondition::OneOf(types))
+            | (TypeCondition::OneOf(types), TypeCondition::Exact(exact)) => types.contains(exact),
+            (TypeCondition::OneOf(left), TypeCondition::OneOf(right)) => {
+                left.iter().any(|type_name| right.contains(type_name))
+            }
+        }
+    }
+
+    fn type_condition_from_types(types: HashSet<String>) -> Option<TypeCondition> {
+        match types.len() {
+            0 => None,
+            1 => Some(TypeCondition::Exact(
+                types.into_iter().next().expect("set has one element"),
+            )),
+            _ => Some(TypeCondition::OneOf(types)),
+        }
+    }
+
+    fn type_condition_types(condition: &TypeCondition) -> HashSet<String> {
+        match condition {
+            TypeCondition::Exact(type_name) => HashSet::from_iter([type_name.clone()]),
+            TypeCondition::OneOf(type_names) => type_names.clone(),
+        }
+    }
+
+    fn type_condition_intersection(
+        left: &TypeCondition,
+        right: &TypeCondition,
+    ) -> Option<TypeCondition> {
+        let mut left_types = Self::type_condition_types(left);
+        let right_types = Self::type_condition_types(right);
+        left_types.retain(|type_name| right_types.contains(type_name));
+        Self::type_condition_from_types(left_types)
+    }
+
+    fn type_condition_difference(
+        left: &TypeCondition,
+        right: &TypeCondition,
+    ) -> Option<TypeCondition> {
+        let mut left_types = Self::type_condition_types(left);
+        let right_types = Self::type_condition_types(right);
+        left_types.retain(|type_name| !right_types.contains(type_name));
+        Self::type_condition_from_types(left_types)
+    }
+
+    fn guards_can_overlap(left: &Option<TypeCondition>, right: &Option<TypeCondition>) -> bool {
+        match (left, right) {
+            (Some(left), Some(right)) => Self::type_conditions_overlap(left, right),
+            // `None` means the field applies to every parent type.
+            _ => true,
+        }
+    }
+
+    fn abstract_parent_type_guard(
+        schema_metadata: &SchemaMetadata,
+        parent_type_name: &str,
+    ) -> Option<TypeCondition> {
+        if schema_metadata.is_interface_type(parent_type_name)
+            || schema_metadata.is_union_type(parent_type_name)
+        {
+            Self::type_condition_from_types(Self::possible_runtime_types(
+                schema_metadata,
+                parent_type_name,
+            ))
+        } else {
+            None
+        }
+    }
+
+    fn insert_plan(
+        field_selections: &mut IndexMap<String, FieldProjectionPlan>,
+        plan_to_insert: FieldProjectionPlan,
+    ) {
+        let response_key = plan_to_insert.response_key.clone();
+        if !field_selections.contains_key(&response_key) {
+            field_selections.insert(response_key, plan_to_insert);
+            return;
+        }
+
+        let mut index = field_selections.len();
+        loop {
+            // IndexMap keys are internal only; projection writes `response_key`.
+            // `#` is not legal in GraphQL names or aliases, so this cannot collide
+            // with a real response key.
+            let internal_key = format!("{response_key}#{index}");
+            if !field_selections.contains_key(&internal_key) {
+                field_selections.insert(internal_key, plan_to_insert);
+                return;
+            }
+            index += 1;
+        }
+    }
+
+    fn split_overlapping_guarded_plans(
+        field_selections: &mut IndexMap<String, FieldProjectionPlan>,
+        existing_index: usize,
+        plan_to_merge: FieldProjectionPlan,
+    ) {
+        let existing_guard = field_selections
+            .get_index(existing_index)
+            .and_then(|(_, plan)| plan.parent_type_guard.clone())
+            .expect("overlapping guarded plan must have an existing guard");
+        let incoming_guard = plan_to_merge
+            .parent_type_guard
+            .clone()
+            .expect("overlapping guarded plan must have an incoming guard");
+
+        let overlap = Self::type_condition_intersection(&existing_guard, &incoming_guard)
+            .expect("overlapping guarded plans must have an intersection");
+        let (_, existing_plan) = field_selections
+            .shift_remove_index(existing_index)
+            .expect("existing projection plan index must be present");
+
+        if let Some(existing_remainder_guard) =
+            Self::type_condition_difference(&existing_guard, &overlap)
+        {
+            let mut existing_remainder = existing_plan.clone();
+            existing_remainder.parent_type_guard = Some(existing_remainder_guard);
+            Self::merge_plan(field_selections, existing_remainder);
+        }
+
+        if let Some(incoming_remainder_guard) =
+            Self::type_condition_difference(&incoming_guard, &overlap)
+        {
+            let mut incoming_remainder = plan_to_merge.clone();
+            incoming_remainder.parent_type_guard = Some(incoming_remainder_guard);
+            Self::merge_plan(field_selections, incoming_remainder);
+        }
+
+        let mut overlapping_existing = existing_plan;
+        overlapping_existing.parent_type_guard = Some(overlap.clone());
+
+        let mut overlapping_incoming = plan_to_merge;
+        overlapping_incoming.parent_type_guard = Some(overlap);
+
+        Self::merge_matching_plan(&mut overlapping_existing, overlapping_incoming);
+        Self::merge_plan(field_selections, overlapping_existing);
+    }
+
     /// When the same field appears in multiple fragments,
     /// this function combines them into a single plan by:
-    /// - Unioning type guards (e.g., Book + Magazine = OneOf(Book, Magazine))
+    /// - Merging equal or unconditional type guards
+    /// - Splitting overlapping but unequal type guards before child selections are merged
     /// - OR-ing conditions while preserving guard associations
     /// - Recursively merging child selections
     fn merge_plan(
         field_selections: &mut IndexMap<String, FieldProjectionPlan>,
         plan_to_merge: FieldProjectionPlan,
     ) {
-        let Some(existing_plan) = field_selections.get_mut(&plan_to_merge.response_key) else {
-            // First time seeing this field - just insert it
-            field_selections.insert(plan_to_merge.response_key.clone(), plan_to_merge);
+        let existing_index = field_selections.iter().position(|(_, existing_plan)| {
+            existing_plan.response_key == plan_to_merge.response_key
+                && Self::guards_can_overlap(
+                    &existing_plan.parent_type_guard,
+                    &plan_to_merge.parent_type_guard,
+                )
+        });
+
+        let Some(existing_index) = existing_index else {
+            // First time seeing this response key, or the same response key belongs to a
+            // disjoint type branch. Keep disjoint branches separate so child selections from
+            // one concrete type do not leak into another concrete type's field.
+            Self::insert_plan(field_selections, plan_to_merge);
             return;
         };
 
+        let should_split =
+            field_selections
+                .get_index(existing_index)
+                .is_some_and(|(_, existing_plan)| {
+                    matches!(
+                        (&existing_plan.parent_type_guard, &plan_to_merge.parent_type_guard),
+                        (Some(existing_guard), Some(incoming_guard))
+                            if existing_guard != incoming_guard
+                                && Self::type_conditions_overlap(existing_guard, incoming_guard)
+                    )
+                });
+
+        if should_split {
+            Self::split_overlapping_guarded_plans(field_selections, existing_index, plan_to_merge);
+            return;
+        }
+
+        let (_, existing_plan) = field_selections
+            .get_index_mut(existing_index)
+            .expect("existing projection plan key must be present");
+
+        Self::merge_matching_plan(existing_plan, plan_to_merge);
+    }
+
+    fn merge_matching_plan(
+        existing_plan: &mut FieldProjectionPlan,
+        plan_to_merge: FieldProjectionPlan,
+    ) {
         // Capture guards before merging, needed for condition association
         let existing_guard = existing_plan.parent_type_guard.clone();
         let new_guard = plan_to_merge.parent_type_guard.clone();
@@ -663,7 +876,10 @@ impl FieldProjectionPlan {
             )
         };
 
-        let parent_type_guard = parent_condition.as_ref().and_then(Self::get_type_guard);
+        let parent_type_guard = parent_condition
+            .as_ref()
+            .and_then(Self::get_type_guard)
+            .or_else(|| Self::abstract_parent_type_guard(schema_metadata, parent_type_name));
         let inherited_selection_conditions = parent_condition
             .as_ref()
             .and_then(Self::conditions_for_child_selections);

--- a/lib/executor/src/projection/response.rs
+++ b/lib/executor/src/projection/response.rs
@@ -605,6 +605,8 @@ fn resolve_type_name<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use graphql_tools::parser::query::Definition;
     use hive_router_query_planner::{
         ast::{document::NormalizedDocument, normalization::create_normalized_document},
@@ -616,7 +618,10 @@ mod tests {
 
     use crate::{
         introspection::schema::SchemaWithMetadata,
-        projection::{plan::FieldProjectionPlan, response::project_by_operation},
+        projection::{
+            plan::{FieldProjectionPlan, ProjectionValueSource},
+            response::project_by_operation,
+        },
         response::value::Value,
     };
 
@@ -826,6 +831,531 @@ mod tests {
                       "id": "b_child_1"
                     }
                   ]
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn projection_keeps_nested_fields_scoped_to_disjoint_parent_type_guards() {
+        let supergraph = hive_router_query_planner::utils::parsing::parse_schema(
+            r#"
+              union SearchResult = Collection | CurrencyV2 | Item
+
+              type Chain {
+                identifier: ID!
+                arch: String!
+              }
+
+              type Collection {
+                id: ID!
+                chain: Chain!
+              }
+
+              type CurrencyV2 {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Item {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Query {
+                search: [SearchResult!]!
+              }
+        "#,
+        );
+        let consumer_schema = ConsumerSchema::new_from_supergraph(&supergraph);
+        let schema_metadata = consumer_schema.schema_metadata();
+
+        let mut operation = parse_operation(
+            r#"
+              query {
+                search {
+                  __typename
+                  ... on Collection {
+                    id
+                    chain {
+                      identifier
+                    }
+                  }
+                  ... on CurrencyV2 {
+                    id
+                    chain {
+                      identifier
+                    }
+                  }
+                  ... on Item {
+                    id
+                    chain {
+                      arch
+                    }
+                  }
+                }
+              }
+            "#,
+        );
+
+        let operation_ast = operation
+            .definitions
+            .iter_mut()
+            .find_map(|def| match def {
+                Definition::Operation(op) => Some(op),
+                _ => None,
+            })
+            .unwrap();
+
+        let supergraph_state = SupergraphState::new(&supergraph);
+        let normalized_operation: NormalizedDocument = create_normalized_document(
+            &supergraph_state,
+            operation_ast.clone(),
+            Some("SearchQuery".into()),
+        );
+        let (operation_type_name, selections) =
+            FieldProjectionPlan::from_operation(&normalized_operation.operation, &schema_metadata);
+
+        let data_json = json!({
+            "__typename": "Query",
+            "search": [
+                {
+                    "__typename": "Collection",
+                    "id": "collection-1",
+                    "chain": {
+                        "__typename": "Chain",
+                        "identifier": "ethereum"
+                    }
+                },
+                {
+                    "__typename": "CurrencyV2",
+                    "id": "currency-1",
+                    "chain": {
+                        "__typename": "Chain",
+                        "identifier": "solana"
+                    }
+                },
+                {
+                    "__typename": "Item",
+                    "id": "item-1",
+                    "chain": {
+                        "__typename": "Chain",
+                        "arch": "evm"
+                    }
+                }
+            ]
+        });
+        let data = Value::from(data_json.as_ref());
+        let projection = project_by_operation(
+            &data,
+            vec![],
+            &Default::default(),
+            operation_type_name,
+            &selections,
+            &None,
+            1000,
+            &schema_metadata,
+        );
+        let projected_bytes = projection.unwrap();
+        let projected_value: sonic_rs::Value = sonic_rs::from_slice(&projected_bytes).unwrap();
+        let projected_str = sonic_rs::to_string_pretty(&projected_value).unwrap();
+        insta::assert_snapshot!(projected_str, @r#"
+        {
+          "data": {
+            "search": [
+              {
+                "__typename": "Collection",
+                "id": "collection-1",
+                "chain": {
+                  "identifier": "ethereum"
+                }
+              },
+              {
+                "__typename": "CurrencyV2",
+                "id": "currency-1",
+                "chain": {
+                  "identifier": "solana"
+                }
+              },
+              {
+                "__typename": "Item",
+                "id": "item-1",
+                "chain": {
+                  "arch": "evm"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn projection_splits_overlapping_interface_parent_type_guards() {
+        let supergraph = hive_router_query_planner::utils::parsing::parse_schema(
+            r#"
+              interface Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Chain {
+                identifier: ID!
+                arch: String!
+              }
+
+              type A implements Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type B implements Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Query {
+                nodes: [Node!]!
+              }
+        "#,
+        );
+        let consumer_schema = ConsumerSchema::new_from_supergraph(&supergraph);
+        let schema_metadata = consumer_schema.schema_metadata();
+
+        let mut operation = parse_operation(
+            r#"
+              query {
+                nodes {
+                  __typename
+                  ... on Node {
+                    chain {
+                      identifier
+                    }
+                  }
+                  ... on A {
+                    chain {
+                      arch
+                    }
+                  }
+                }
+              }
+            "#,
+        );
+
+        let operation_ast = operation
+            .definitions
+            .iter_mut()
+            .find_map(|def| match def {
+                Definition::Operation(op) => Some(op),
+                _ => None,
+            })
+            .unwrap();
+
+        let supergraph_state = SupergraphState::new(&supergraph);
+        let normalized_operation: NormalizedDocument = create_normalized_document(
+            &supergraph_state,
+            operation_ast.clone(),
+            Some("SearchQuery".into()),
+        );
+        let (operation_type_name, selections) =
+            FieldProjectionPlan::from_operation(&normalized_operation.operation, &schema_metadata);
+
+        let data_json = json!({
+            "__typename": "Query",
+            "nodes": [
+                {
+                    "__typename": "A",
+                    "chain": {
+                        "__typename": "Chain",
+                        "identifier": "a-chain",
+                        "arch": "evm"
+                    }
+                },
+                {
+                    "__typename": "B",
+                    "chain": {
+                        "__typename": "Chain",
+                        "identifier": "b-chain"
+                    }
+                }
+            ]
+        });
+        let data = Value::from(data_json.as_ref());
+        let projection = project_by_operation(
+            &data,
+            vec![],
+            &Default::default(),
+            operation_type_name,
+            &selections,
+            &None,
+            1000,
+            &schema_metadata,
+        );
+        let projected_bytes = projection.unwrap();
+        let projected_value: sonic_rs::Value = sonic_rs::from_slice(&projected_bytes).unwrap();
+        let projected_str = sonic_rs::to_string_pretty(&projected_value).unwrap();
+        insta::assert_snapshot!(projected_str, @r#"
+        {
+          "data": {
+            "nodes": [
+              {
+                "__typename": "A",
+                "chain": {
+                  "identifier": "a-chain",
+                  "arch": "evm"
+                }
+              },
+              {
+                "__typename": "B",
+                "chain": {
+                  "identifier": "b-chain"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn projection_removes_always_true_guards_under_abstract_parent() {
+        let supergraph = hive_router_query_planner::utils::parsing::parse_schema(
+            r#"
+              interface Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Chain {
+                identifier: ID!
+              }
+
+              type A implements Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type B implements Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Query {
+                nodes: [Node!]!
+              }
+        "#,
+        );
+        let consumer_schema = ConsumerSchema::new_from_supergraph(&supergraph);
+        let schema_metadata = consumer_schema.schema_metadata();
+
+        let mut operation = parse_operation(
+            r#"
+              query {
+                nodes {
+                  __typename
+                  id
+                  chain {
+                    identifier
+                  }
+                }
+              }
+            "#,
+        );
+
+        let operation_ast = operation
+            .definitions
+            .iter_mut()
+            .find_map(|def| match def {
+                Definition::Operation(op) => Some(op),
+                _ => None,
+            })
+            .unwrap();
+
+        let supergraph_state = SupergraphState::new(&supergraph);
+        let normalized_operation: NormalizedDocument = create_normalized_document(
+            &supergraph_state,
+            operation_ast.clone(),
+            Some("SearchQuery".into()),
+        );
+        let (_, selections) =
+            FieldProjectionPlan::from_operation(&normalized_operation.operation, &schema_metadata);
+
+        let nodes_plan = selections
+            .iter()
+            .find(|plan| plan.response_key == "nodes")
+            .expect("nodes projection plan");
+        let ProjectionValueSource::ResponseData {
+            selections: Some(nodes_selections),
+        } = &nodes_plan.value
+        else {
+            panic!("nodes should have child selections");
+        };
+
+        for child in nodes_selections.iter() {
+            assert!(
+                child.parent_type_guard.is_none(),
+                "fragment-free abstract child selection should not keep an always-true parent guard: {child:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn projection_splits_direct_interface_field_against_fragment_guard() {
+        let supergraph = hive_router_query_planner::utils::parsing::parse_schema(
+            r#"
+              interface Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Chain {
+                identifier: ID!
+                arch: String!
+              }
+
+              type A implements Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type B implements Node {
+                id: ID!
+                chain: Chain!
+              }
+
+              type Query {
+                nodes: [Node!]!
+              }
+        "#,
+        );
+        let consumer_schema = ConsumerSchema::new_from_supergraph(&supergraph);
+        let schema_metadata = consumer_schema.schema_metadata();
+
+        let mut operation = parse_operation(
+            r#"
+              query SearchQuery($includeArch: Boolean!) {
+                nodes {
+                  __typename
+                  chain {
+                    identifier
+                  }
+                  ... on A @include(if: $includeArch) {
+                    chain {
+                      arch
+                    }
+                  }
+                }
+              }
+            "#,
+        );
+
+        let operation_ast = operation
+            .definitions
+            .iter_mut()
+            .find_map(|def| match def {
+                Definition::Operation(op) => Some(op),
+                _ => None,
+            })
+            .unwrap();
+
+        let supergraph_state = SupergraphState::new(&supergraph);
+        let normalized_operation: NormalizedDocument = create_normalized_document(
+            &supergraph_state,
+            operation_ast.clone(),
+            Some("SearchQuery".into()),
+        );
+        let (operation_type_name, selections) =
+            FieldProjectionPlan::from_operation(&normalized_operation.operation, &schema_metadata);
+
+        let data_json = json!({
+            "__typename": "Query",
+            "nodes": [
+                {
+                    "__typename": "A",
+                    "chain": {
+                        "__typename": "Chain",
+                        "identifier": "a-chain",
+                        "arch": "evm"
+                    }
+                },
+                {
+                    "__typename": "B",
+                    "chain": {
+                        "__typename": "Chain",
+                        "identifier": "b-chain"
+                    }
+                }
+            ]
+        });
+        let data = Value::from(data_json.as_ref());
+
+        let include_arch = Some(HashMap::from([("includeArch".to_string(), json!(true))]));
+        let projected_bytes = project_by_operation(
+            &data,
+            vec![],
+            &Default::default(),
+            operation_type_name,
+            &selections,
+            &include_arch,
+            1000,
+            &schema_metadata,
+        )
+        .unwrap();
+        let projected_value: sonic_rs::Value = sonic_rs::from_slice(&projected_bytes).unwrap();
+        let projected_str = sonic_rs::to_string_pretty(&projected_value).unwrap();
+        insta::assert_snapshot!(projected_str, @r#"
+        {
+          "data": {
+            "nodes": [
+              {
+                "__typename": "A",
+                "chain": {
+                  "identifier": "a-chain",
+                  "arch": "evm"
+                }
+              },
+              {
+                "__typename": "B",
+                "chain": {
+                  "identifier": "b-chain"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+
+        let skip_arch = Some(HashMap::from([("includeArch".to_string(), json!(false))]));
+        let projected_bytes = project_by_operation(
+            &data,
+            vec![],
+            &Default::default(),
+            operation_type_name,
+            &selections,
+            &skip_arch,
+            1000,
+            &schema_metadata,
+        )
+        .unwrap();
+        let projected_value: sonic_rs::Value = sonic_rs::from_slice(&projected_bytes).unwrap();
+        let projected_str = sonic_rs::to_string_pretty(&projected_value).unwrap();
+        insta::assert_snapshot!(projected_str, @r#"
+        {
+          "data": {
+            "nodes": [
+              {
+                "__typename": "A",
+                "chain": {
+                  "identifier": "a-chain"
+                }
+              },
+              {
+                "__typename": "B",
+                "chain": {
+                  "identifier": "b-chain"
                 }
               }
             ]


### PR DESCRIPTION
## Summary

Fix a response projection bug where child selections from one branch could leak into another branch when both branches selected the same response key under different runtime parent type scopes.

This addresses the production regression seen after upgrading Hive Router from `0.0.69` to `0.0.71`, where a valid `searchUniversal` query returned `200 OK` with `{"data":null}` and no GraphQL errors.

## Regression Analysis

The reported query selects several `searchUniversal` union members. The minimal failing shape is:

```graphql
searchUniversal(...) {
  __typename
  ... on Collection {
    chain { identifier }
  }
  ... on CurrencyV2 {
    chain { identifier }
  }
  ... on Item {
    chain { arch }
  }
}
```

The live PR endpoint reproduced the failure. Reducing the query showed:

- `Collection` + `CurrencyV2` branches work.
- Adding the `Item` branch only fails when it includes `chain { arch }`.
- The returned data does not need to contain any `Item` rows for the failure to happen.

That points to response projection rather than request parsing, validation, or subgraph execution.

## Root Cause

`FieldProjectionPlan::merge_plan` merged projection plans by `response_key`. For fields selected under different parent type scopes, that is too broad.

In the reported query, all three branches select a field with response key `chain`, so the projection planner merged their child selections. The effective projected shape became equivalent to applying this to every selected `chain` field:

```graphql
chain {
  identifier
  arch
}
```

That is incorrect. The `arch` selection is scoped by `... on Item` and must not be projected onto `Collection.chain` or `CurrencyV2.chain`.

The same class of bug also exists for overlapping interface scopes:

```graphql
nodes {
  ... on Node { chain { identifier } } # Node expands to A and B at runtime
  ... on A { chain { arch } }
}
```

and for direct interface selections combined with a narrower fragment:

```graphql
nodes {
  chain { identifier }                 # direct field selected on Node
  ... on A { chain { arch } }
}
```

In both cases, `arch` must only apply to `A.chain`. If it leaks onto `B.chain`, a missing non-null `arch` can null-bubble the response.

## Why It Appeared in `0.0.71`

The user-visible regression was exposed by:

`eacf898b597fe518c3f72a7dbd2610bf9a3081e5`
`fix(executor): proper handling of null and non-null propagation (#1162)`

That commit is included in the `0.0.71` release commit:

`3017ea69ee79a1e6211886f276a44fb06b9b136f`
`chore(release): router crates and artifacts (#1160)`

Important nuance: `eacf898` did not create the projection scoping bug. It made null propagation match the schema more correctly. Once `Item.chain.arch` leaked onto `Collection.chain`, the projected `arch` field was missing. Since `Chain.arch` is non-null, the corrected null-propagation logic bubbled that missing non-null value up to `data: null`.

So the latent bug was: branch-scoped child selections were merged too broadly.
The upgrade regression trigger was: correct non-null propagation made the leak visible.

## Fix

Projection merging now scopes same-response-key fields by their parent type guards before child selections are combined.

The merge behavior is now:

- equal guards merge normally;
- concrete-parent unconditional selections keep the existing merge behavior;
- direct selections under abstract parents are initially bounded to that abstract type's possible runtime parent types;
- disjoint explicit guards stay as separate internal projection entries;
- overlapping but unequal explicit guards are split into left-only, intersection, and right-only plans, and only the intersection merges child selections.

For the interface example above, `Node` + `A` becomes:

- `B` with `chain { identifier }`;
- `A` with `chain { identifier arch }`.

That lets projection discriminate by the outer runtime `__typename` and prevents `A`-only children from being applied to `B` objects.

## Runtime Cost

The abstract-parent guard is only needed to disambiguate same-response-key siblings. To avoid paying that guard check on ordinary fragment-free interface/union responses, the cached cleanup pass now removes guards that are always true at their response position.

That means:

- fragment-free abstract selections go back to `None` guards before runtime projection;
- split-produced proper-subset guards, such as `Exact(A)` or `Exact(B)`, are preserved;
- the extra work stays in plan construction, which is normalized-operation cached, rather than the per-response projection hot path.

I also added an executor benchmark covering a fragment-free interface response with 12 implementors, 4000 rows, and 10 selected fields, so this abstract projection path is represented in `executor_benches`.

Implementation notes:

- Guard intersection/difference operates on the schema-derived possible runtime type names used by projection guards.
- Separate internal `IndexMap` keys use a synthetic `response_key#index` form. The projection writer emits `plan.response_key`, not the map key, and `#` is not legal in GraphQL names or aliases, so the synthetic keys cannot collide with or leak into the response.

## Verification

I verified the original failure before the fix by applying only the new projection regression test to the unmodified `0.0.71` release commit (`3017ea6`). It failed with:

```json
{
  "data": null
}
```

With this fix, the same shape projects `Collection`, `CurrencyV2`, and `Item` rows with only the fields selected for their branch.

Added coverage:

- focused projection unit test for disjoint union parent type guards, including an actual `Item` row;
- focused projection unit test for the overlapping interface case: `Node` fragment + `A` fragment;
- focused projection unit test for direct interface field + narrower fragment, including `@include` coverage for the guarded branch;
- focused plan-shape unit test proving fragment-free abstract child selections do not keep always-true guards;
- full router e2e test using a mocked `/search` subgraph and a minimal union supergraph;
- executor benchmark for fragment-free abstract interface projection.

Checks run:

- `command cargo fmt --all --check`
- `command cargo test -p hive-router-plan-executor projection -- --nocapture`
- `command cargo test -p hive-router-plan-executor`
- `command cargo test -p e2e projection_keeps_disjoint_fragment_child_selections_scoped -- --nocapture`
- `command cargo bench -p hive-router-plan-executor --bench executor_benches --no-run`
