### PR TITLE
fix(executor): correctly process abstract types

### DIFF
--- a/.changeset/fix_disjoint_fragments_shared_response_key.md
+++ b/.changeset/fix_disjoint_fragments_shared_response_key.md
@@ -1,0 +1,14 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Fix shared response keys leaking across disjoint fragments
+
+When several fragments on different types selected the same response key with different sub-selections (e.g. `... on Article { meta { title } }` vs `... on Video { meta { wordCount } }`), the response projection merged their child selections together instead of keeping them per type.
+
+As a result, a sub-field selected for one type could leak into the projection of another. 
+
+When that leaked field was Non-Null and absent from the actual type's data, null propagation bubbled up and collapsed the whole response to `data: null`.
+
+Fixes [#1166](https://github.com/graphql-hive/router/pull/1166)

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -1870,4 +1870,1245 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    async fn union_shared_field_different_selections() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.union-shared-field.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"payloads":[
+                    {"__typename":"ApprovalFlowCreated","order":{"id":"1"}},
+                    {"__typename":"ApprovalFlowCompleted","order":{"id":"2"}}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  payloads {
+                    __typename
+                    ... on ApprovalFlowCreated { order { id } }
+                    ... on ApprovalFlowRejected { order { id version orderNumber } }
+                    ... on ApprovalFlowCompleted { order { id } }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "payloads": [
+              {
+                "__typename": "ApprovalFlowCreated",
+                "order": {
+                  "id": "1"
+                }
+              },
+              {
+                "__typename": "ApprovalFlowCompleted",
+                "order": {
+                  "id": "2"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/pull/1166
+    ///
+    /// A union (`SearchResult`) whose members share the response key `chain` but select
+    /// different sub-fields per branch: `Collection`/`CurrencyV2` pick `chain { identifier }`
+    /// while `Item` picks `chain { arch }` (and `Chain.arch` is Non-Null). The `arch`
+    /// selection must NOT leak into the `Collection`/`CurrencyV2` projections — otherwise
+    /// its missing value bubbles up (Non-Null) and collapses the response to `data: null`.
+    async fn issue_1166_disjoint_fragments_shared_field() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.1166-disjoint-fragments.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"searchUniversal":[
+                    {"__typename":"Collection","chain":{"identifier":"c1"}},
+                    {"__typename":"CurrencyV2","chain":{"identifier":"cur1"}},
+                    {"__typename":"Item","chain":{"arch":"x86"}}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  searchUniversal {
+                    __typename
+                    ... on Collection { chain { identifier } }
+                    ... on CurrencyV2 { chain { identifier } }
+                    ... on Item { chain { arch } }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "searchUniversal": [
+              {
+                "__typename": "Collection",
+                "chain": {
+                  "identifier": "c1"
+                }
+              },
+              {
+                "__typename": "CurrencyV2",
+                "chain": {
+                  "identifier": "cur1"
+                }
+              },
+              {
+                "__typename": "Item",
+                "chain": {
+                  "arch": "x86"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Overlapping (not disjoint) type guards sharing a response key. `meta` is selected
+    /// under `... on Article` (`{ title }`) and under the interface `... on HasMeta`
+    /// (`{ wordCount }`); the guards overlap on `Article`. The `Article`-only `title`
+    /// (Non-Null) must NOT leak into the `Video` branch — otherwise its missing value
+    /// bubbles and collapses the response.
+    async fn interface_overlapping_guards_shared_field() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.interface-shared-field.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"search":[
+                    {"__typename":"Article","meta":{"title":"T","wordCount":100}},
+                    {"__typename":"Video","meta":{"wordCount":50}}
+                ],"searchMeta":[
+                    {"__typename":"Article","meta":{"title":"T","wordCount":100}},
+                    {"__typename":"Video","meta":{"wordCount":50}}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  search {
+                    __typename
+                    ... on Article { meta { title } }
+                    ... on HasMeta { meta { wordCount } }
+                  }
+                  searchMeta {
+                    __typename
+                    ... on Article { meta { title } }
+                    ... on HasMeta { meta { wordCount } }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // Both fields scope `meta` per concrete type: `Article` (in both the `Article` and
+        // `HasMeta` scopes) gets `{ title, wordCount }`, `Video` (only `HasMeta`) gets just
+        // `{ wordCount }` — `title` never leaks. `searchMeta` (interface parent, where
+        // `... on HasMeta` inlines to an implicit "any type" guard) resolves the same way.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "search": [
+              {
+                "__typename": "Article",
+                "meta": {
+                  "title": "T",
+                  "wordCount": 100
+                }
+              },
+              {
+                "__typename": "Video",
+                "meta": {
+                  "wordCount": 50
+                }
+              }
+            ],
+            "searchMeta": [
+              {
+                "__typename": "Article",
+                "meta": {
+                  "title": "T",
+                  "wordCount": 100
+                }
+              },
+              {
+                "__typename": "Video",
+                "meta": {
+                  "wordCount": 50
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Nested abstract types: an interface field (`Book.related: Item`) that itself returns
+    /// an interface, with fragments at both levels. Each level must resolve and scope by the
+    /// concrete `__typename` — the inner `Movie` must get `runtime` (not the sibling
+    /// `... on Book { title }`).
+    async fn nested_abstract_type_resolution() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"items":[
+                    {"__typename":"Book","id":"b1","title":"GoT",
+                     "related":{"__typename":"Movie","id":"m1","runtime":120}},
+                    {"__typename":"Movie","id":"m2","runtime":90}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  items {
+                    __typename
+                    ... on Book {
+                      title
+                      related {
+                        __typename
+                        ... on Book { title }
+                        ... on Movie { runtime }
+                      }
+                    }
+                    ... on Movie { runtime }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "__typename": "Book",
+                "title": "GoT",
+                "related": {
+                  "__typename": "Movie",
+                  "runtime": 120
+                }
+              },
+              {
+                "__typename": "Movie",
+                "runtime": 90
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A fragment that validates as a possible spread but does NOT apply to the runtime type:
+    /// `... on Movie { special }` (`special: String!`) against a `Book` object. Its fields —
+    /// including the Non-Null `special` — must be silently skipped, NOT treated as a missing
+    /// Non-Null that bubbles. The `Book` must survive.
+    async fn fragment_validates_but_does_not_apply() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"items":[
+                    {"__typename":"Book","id":"b1"},
+                    {"__typename":"Movie","id":"m2","special":"x"}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  items {
+                    __typename
+                    id
+                    ... on Movie { special }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // `Book` doesn't match `... on Movie`, so `special` (Non-Null) is not collected for it
+        // and must not bubble — the `Book` survives with just its interface fields.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "__typename": "Book",
+                "id": "b1"
+              },
+              {
+                "__typename": "Movie",
+                "id": "m2",
+                "special": "x"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Distributed union: subgraph A owns `feed` and resolves each member's `__typename` + key
+    /// (`id`); subgraph B owns the type-specific fields (`Photo.caption`, `Video.duration`).
+    /// The router must issue per-concrete-type `_entities` fetches to B and merge them back by
+    /// `__typename`, so each member gets exactly its own fields.
+    async fn distributed_union_per_type_entity_fetch() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "feed": [
+                            { "__typename": "Photo", "id": "p1" },
+                            { "__typename": "Video", "id": "v1" },
+                            { "__typename": "Photo", "id": "p2" }
+                        ]
+                    }
+                },
+                "b": {
+                    "entities": [
+                        { "__typename": "Photo", "id": "p1", "caption": "sunset" },
+                        { "__typename": "Video", "id": "v1", "duration": 120 },
+                        { "__typename": "Photo", "id": "p2", "caption": "beach" }
+                    ]
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.distributed-union.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  feed {
+                    __typename
+                    ... on Photo { caption }
+                    ... on Video { duration }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "feed": [
+              {
+                "__typename": "Photo",
+                "caption": "sunset"
+              },
+              {
+                "__typename": "Video",
+                "duration": 120
+              },
+              {
+                "__typename": "Photo",
+                "caption": "beach"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Abstract-type entities with a Non-Null field erroring in one member. Subgraph B's
+    /// `_entities` returns `null` for `Photo.caption` (`String!`) on one entity. That `null`
+    /// must bubble up through the Non-Null leaf, collapsing the `Photo`. Because `feedNullable`
+    /// has a nullable element (`[Media]!`), the collapsed member survives as `null` and its
+    /// siblings (including the other `Photo`) remain intact.
+    async fn abstract_entities_nonnull_error_propagation() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "feedNullable": [
+                            { "__typename": "Photo", "id": "p1" },
+                            { "__typename": "Video", "id": "v1" },
+                            { "__typename": "Photo", "id": "p2" }
+                        ]
+                    }
+                },
+                "b": {
+                    "entities": [
+                        // p1's Non-Null `caption` comes back `null` -> the Photo collapses.
+                        { "__typename": "Photo", "id": "p1", "caption": null },
+                        { "__typename": "Video", "id": "v1", "duration": 120 },
+                        { "__typename": "Photo", "id": "p2", "caption": "beach" }
+                    ]
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.distributed-union.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  feedNullable {
+                    __typename
+                    ... on Photo { caption }
+                    ... on Video { duration }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // p1's `null` caption bubbles to the Photo; nullable list element keeps it as `null`.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "feedNullable": [
+              null,
+              {
+                "__typename": "Video",
+                "duration": 120
+              },
+              {
+                "__typename": "Photo",
+                "caption": "beach"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A2: a shared aliased response key (`v`) that maps to a DIFFERENT source field per
+    /// concrete type (`Book.title` vs `Movie.special`). The fields share a response shape
+    /// (both `String!`), which `FieldsInSetCanMerge` requires, but resolve from different
+    /// sources; the projection must emit `v` from the right source for each object.
+    async fn abstract_aliased_shared_field_per_type() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        // The router aliases both source fields to `v` in the subgraph query
+        // (`... on Book { v: title } ... on Movie { v: special }`), so the subgraph
+        // response is keyed by the alias `v`.
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"items":[
+                    {"__typename":"Book","v":"GoT"},
+                    {"__typename":"Movie","v":"Imax"}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  items {
+                    __typename
+                    ... on Book { v: title }
+                    ... on Movie { v: special }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "__typename": "Book",
+                "v": "GoT"
+              },
+              {
+                "__typename": "Movie",
+                "v": "Imax"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A4: an interface field (`Item.id`) selected directly on the abstract type, combined with
+    /// concrete-only fields in fragments. The directly-selected field applies to every member;
+    /// the fragment fields scope to their concrete type.
+    async fn abstract_direct_interface_field_with_concrete_fragments() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "items": [
+                            { "__typename": "Book", "id": "b1", "title": "GoT" },
+                            { "__typename": "Movie", "id": "m1", "runtime": 90 }
+                        ]
+                    }
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  items {
+                    id
+                    ... on Book { title }
+                    ... on Movie { runtime }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "id": "b1",
+                "title": "GoT"
+              },
+              {
+                "id": "m1",
+                "runtime": 90
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A5: a fragment whose type condition matches NONE of the runtime objects. All items are
+    /// `Book`, but only a `... on Movie` fragment carries selections — it must contribute
+    /// nothing, leaving each `Book` with just its directly-selected fields.
+    async fn abstract_fragment_matches_zero_objects() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "items": [
+                            { "__typename": "Book", "id": "b1", "title": "A" },
+                            { "__typename": "Book", "id": "b2", "title": "B" }
+                        ]
+                    }
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  items {
+                    __typename
+                    id
+                    ... on Movie { runtime }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "__typename": "Book",
+                "id": "b1"
+              },
+              {
+                "__typename": "Book",
+                "id": "b2"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// A6: `@skip`/`@include` under an abstract type. A skipped Non-Null field (`Book.title`,
+    /// `String!`) must NOT be treated as a missing required value — it is simply removed, and
+    /// the `Book` must survive. An excluded fragment (`... on Movie @include(if: false)`)
+    /// contributes nothing.
+    async fn abstract_skip_include_no_overbubble() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "items": [
+                            { "__typename": "Book", "id": "b1", "title": "GoT" },
+                            { "__typename": "Movie", "id": "m1", "runtime": 90 }
+                        ]
+                    }
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"query($skip: Boolean!, $inc: Boolean!) {
+                  items {
+                    __typename
+                    id
+                    ... on Book { title @skip(if: $skip) }
+                    ... on Movie @include(if: $inc) { runtime }
+                  }
+                }"#,
+                Some(sonic_rs::json!({ "skip": true, "inc": false })),
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // `title` is skipped (no bubbling despite `String!`); the `Movie` fragment is excluded.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "__typename": "Book",
+                "id": "b1"
+              },
+              {
+                "__typename": "Movie",
+                "id": "m1"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// B1: a Non-Null abstract list element (`feed: [Media!]!`) whose member fully collapses.
+    /// Subgraph B returns `null` for `Photo.caption` (`String!`); the `null` bubbles to the
+    /// `Photo`, but the element is Non-Null and so is the list, so it bubbles all the way to
+    /// `data: null`.
+    async fn abstract_nonnull_list_element_collapse_to_data_null() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "feed": [
+                            { "__typename": "Photo", "id": "p1" },
+                            { "__typename": "Video", "id": "v1" }
+                        ]
+                    }
+                },
+                "b": {
+                    "entities": [
+                        { "__typename": "Photo", "id": "p1", "caption": null },
+                        { "__typename": "Video", "id": "v1", "duration": 120 }
+                    ]
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.distributed-union.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  feed {
+                    __typename
+                    ... on Photo { caption }
+                    ... on Video { duration }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": null
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// B2: a subgraph field error whose `path` runs through an abstract LIST element
+    /// (`searchMeta[1].meta.wordCount`). The router must preserve the path — including the
+    /// numeric list index and the concrete-type field keys — in the merged response.
+    async fn error_path_through_abstract_list_element() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.interface-shared-field.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"searchMeta":[
+                    {"__typename":"Article","meta":{"wordCount":100}},
+                    {"__typename":"Video","meta":{"wordCount":null}}
+                ]},"errors":[{"message":"wordCount failed","path":["searchMeta",1,"meta","wordCount"]}]}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  searchMeta {
+                    __typename
+                    meta { wordCount }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "searchMeta": [
+              {
+                "__typename": "Article",
+                "meta": {
+                  "wordCount": 100
+                }
+              },
+              {
+                "__typename": "Video",
+                "meta": {
+                  "wordCount": null
+                }
+              }
+            ]
+          },
+          "errors": [
+            {
+              "message": "wordCount failed",
+              "path": [
+                "searchMeta",
+                1,
+                "meta",
+                "wordCount"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "a"
+              }
+            }
+          ]
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// B3: partial `data` + `errors` together. One union member's nullable field
+    /// (`Order.version`) errors; the `null` stays put (nullable), so `data` keeps the full
+    /// shape AND an `errors` entry is present — `data` is NOT collapsed.
+    async fn partial_data_with_errors_on_abstract() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.union-shared-field.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"payloads":[
+                    {"__typename":"ApprovalFlowCreated","order":{"id":"1","version":5}},
+                    {"__typename":"ApprovalFlowCompleted","order":{"id":"2","version":null}}
+                ]},"errors":[{"message":"version failed","path":["payloads",1,"order","version"]}]}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  payloads {
+                    __typename
+                    ... on ApprovalFlowCreated { order { id version } }
+                    ... on ApprovalFlowCompleted { order { id version } }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "payloads": [
+              {
+                "__typename": "ApprovalFlowCreated",
+                "order": {
+                  "id": "1",
+                  "version": 5
+                }
+              },
+              {
+                "__typename": "ApprovalFlowCompleted",
+                "order": {
+                  "id": "2",
+                  "version": null
+                }
+              }
+            ]
+          },
+          "errors": [
+            {
+              "message": "version failed",
+              "path": [
+                "payloads",
+                1,
+                "order",
+                "version"
+              ],
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "a"
+              }
+            }
+          ]
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// B4: `@skip`/`@include` removing a Non-Null field at the root. A skipped Non-Null field
+    /// is removed from the operation entirely and must NOT be treated as a missing required
+    /// value — `data` must keep the rest of the selection.
+    async fn skip_nonnull_root_field_no_overbubble() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(mock_subgraphs(json!({
+                "a": {
+                    "query": {
+                        "items": [
+                            { "__typename": "Book", "id": "b1", "title": "GoT" }
+                        ]
+                    }
+                }
+            })))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"query($skip: Boolean!) {
+                  items {
+                    id
+                    ... on Book { title @skip(if: $skip) }
+                  }
+                }"#,
+                Some(sonic_rs::json!({ "skip": true })),
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "items": [
+              {
+                "id": "b1"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+
+    #[ntex::test]
+    /// Nested abstract overlap: a field (`detail`) is selected BOTH directly on an
+    /// interface (`Thing.detail`) and inside a concrete fragment (`... on Gadget`),
+    /// and `detail`'s own type (`Detail`) is abstract. For a `Gadget`, the two
+    /// `detail` selections merge, and their child `meta` collides as
+    /// `meta(any) { a }` + `meta(RichDetail) { b }`. That overlap must be re-resolved
+    /// per concrete `Detail` type, otherwise a `RichDetail` object matches both and
+    /// `meta` is projected twice (and `b` leaks). The `Widget` (no `... on Gadget`)
+    /// keeps only the interface-level `meta { a }`, even when its `detail` is a
+    /// `RichDetail` — proving the `b` selection stays scoped to the `Gadget` branch.
+    async fn nested_abstract_overlap_reresolves_merged_children() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.nested-abstract-overlap.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      a:
+                        url: "http://{host}/a"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let _a = server
+            .mock("POST", "/a")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"things":[
+                    {"__typename":"Gadget","detail":{"__typename":"RichDetail","meta":{"a":"A1","b":"B1"}}},
+                    {"__typename":"Gadget","detail":{"__typename":"BasicDetail","meta":{"a":"A2"}}},
+                    {"__typename":"Widget","detail":{"__typename":"RichDetail","meta":{"a":"A3","b":"B3"}}}
+                ]}}"#,
+            )
+            .create();
+
+        let res = router
+            .send_graphql_request(
+                r#"{
+                  things {
+                    detail { meta { a } }
+                    ... on Gadget { detail { ... on RichDetail { meta { b } } } }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // Gadget+RichDetail: interface `meta { a }` merges with the Gadget/RichDetail
+        // `meta { b }` -> `{ a, b }` (one `meta`, not two). Gadget+BasicDetail: only
+        // `{ a }`. Widget+RichDetail: only `{ a }` — `b` never leaks past the `Gadget`
+        // branch even though the runtime `detail` is a `RichDetail`.
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "things": [
+              {
+                "detail": {
+                  "meta": {
+                    "a": "A1",
+                    "b": "B1"
+                  }
+                }
+              },
+              {
+                "detail": {
+                  "meta": {
+                    "a": "A2"
+                  }
+                }
+              },
+              {
+                "detail": {
+                  "meta": {
+                    "a": "A3"
+                  }
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/supergraph.1166-disjoint-fragments.graphql
+++ b/e2e/src/issues/supergraph.1166-disjoint-fragments.graphql
@@ -1,0 +1,88 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://0.0.0.0:4200/a")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: A) {
+  searchUniversal: [SearchResult!]! @join__field(graph: A)
+}
+
+union SearchResult
+  @join__type(graph: A)
+  @join__unionMember(graph: A, member: "Collection")
+  @join__unionMember(graph: A, member: "CurrencyV2")
+  @join__unionMember(graph: A, member: "Item") =
+  | Collection
+  | CurrencyV2
+  | Item
+
+type Collection @join__type(graph: A) {
+  chain: Chain! @join__field(graph: A)
+}
+
+type CurrencyV2 @join__type(graph: A) {
+  chain: Chain! @join__field(graph: A)
+}
+
+type Item @join__type(graph: A) {
+  chain: Chain! @join__field(graph: A)
+}
+
+type Chain @join__type(graph: A) {
+  identifier: String @join__field(graph: A)
+  # Non-Null: if leaked into a branch that didn't ask for it, a missing value bubbles.
+  arch: String! @join__field(graph: A)
+}

--- a/e2e/src/issues/supergraph.distributed-union.graphql
+++ b/e2e/src/issues/supergraph.distributed-union.graphql
@@ -1,0 +1,88 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://0.0.0.0:4200/a")
+  B @join__graph(name: "b", url: "http://0.0.0.0:4200/b")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: A) {
+  # Non-null element: distributed happy-path resolution.
+  feed: [Media!]! @join__field(graph: A)
+  # Nullable element: a collapsed member survives as `null`, siblings remain.
+  feedNullable: [Media]! @join__field(graph: A)
+}
+
+# `__typename` + key are resolved in subgraph A; the type-specific fields below
+# come from subgraph B via per-concrete-type `_entities` fetches.
+union Media
+  @join__type(graph: A)
+  @join__unionMember(graph: A, member: "Photo")
+  @join__unionMember(graph: A, member: "Video") =
+  | Photo
+  | Video
+
+type Photo
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id") {
+  id: ID!
+  caption: String! @join__field(graph: B)
+}
+
+type Video
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id") {
+  id: ID!
+  duration: Int! @join__field(graph: B)
+}

--- a/e2e/src/issues/supergraph.interface-shared-field.graphql
+++ b/e2e/src/issues/supergraph.interface-shared-field.graphql
@@ -1,0 +1,90 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://0.0.0.0:4200/a")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: A) {
+  search: [Search!]! @join__field(graph: A)
+  searchMeta: [HasMeta!]! @join__field(graph: A)
+}
+
+union Search
+  @join__type(graph: A)
+  @join__unionMember(graph: A, member: "Article")
+  @join__unionMember(graph: A, member: "Video") =
+  | Article
+  | Video
+
+interface HasMeta @join__type(graph: A) {
+  meta: Meta!
+}
+
+type Article implements HasMeta
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "HasMeta") {
+  meta: Meta! @join__field(graph: A)
+}
+
+type Video implements HasMeta
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "HasMeta") {
+  meta: Meta! @join__field(graph: A)
+}
+
+type Meta @join__type(graph: A) {
+  title: String! @join__field(graph: A)
+  wordCount: Int @join__field(graph: A)
+}

--- a/e2e/src/issues/supergraph.nested-abstract-overlap.graphql
+++ b/e2e/src/issues/supergraph.nested-abstract-overlap.graphql
@@ -1,0 +1,98 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://0.0.0.0:4200/a")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: A) {
+  things: [Thing!]! @join__field(graph: A)
+}
+
+interface Thing @join__type(graph: A) {
+  detail: Detail
+}
+
+type Gadget implements Thing
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "Thing") {
+  detail: Detail @join__field(graph: A)
+}
+
+type Widget implements Thing
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "Thing") {
+  detail: Detail @join__field(graph: A)
+}
+
+interface Detail @join__type(graph: A) {
+  meta: Meta
+}
+
+type BasicDetail implements Detail
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "Detail") {
+  meta: Meta @join__field(graph: A)
+}
+
+type RichDetail implements Detail
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "Detail") {
+  meta: Meta @join__field(graph: A)
+}
+
+type Meta @join__type(graph: A) {
+  a: String @join__field(graph: A)
+  b: String @join__field(graph: A)
+}

--- a/e2e/src/issues/supergraph.nested-abstract.graphql
+++ b/e2e/src/issues/supergraph.nested-abstract.graphql
@@ -1,0 +1,83 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://0.0.0.0:4200/a")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: A) {
+  items: [Item!]! @join__field(graph: A)
+}
+
+interface Item @join__type(graph: A) {
+  id: ID!
+}
+
+type Book implements Item
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "Item") {
+  id: ID! @join__field(graph: A)
+  title: String! @join__field(graph: A)
+  # Nested abstract: a field that itself returns the interface.
+  related: Item @join__field(graph: A)
+}
+
+type Movie implements Item
+  @join__type(graph: A)
+  @join__implements(graph: A, interface: "Item") {
+  id: ID! @join__field(graph: A)
+  runtime: Int! @join__field(graph: A)
+  # Non-Null, used to check it is NOT required when `... on Movie` doesn't apply.
+  special: String! @join__field(graph: A)
+}

--- a/e2e/src/issues/supergraph.union-shared-field.graphql
+++ b/e2e/src/issues/supergraph.union-shared-field.graphql
@@ -1,0 +1,88 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://0.0.0.0:4200/a")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query @join__type(graph: A) {
+  payloads: [Payload!]! @join__field(graph: A)
+}
+
+union Payload
+  @join__type(graph: A)
+  @join__unionMember(graph: A, member: "ApprovalFlowCreated")
+  @join__unionMember(graph: A, member: "ApprovalFlowRejected")
+  @join__unionMember(graph: A, member: "ApprovalFlowCompleted") =
+  | ApprovalFlowCreated
+  | ApprovalFlowRejected
+  | ApprovalFlowCompleted
+
+type ApprovalFlowCreated @join__type(graph: A) {
+  order: Order @join__field(graph: A)
+}
+
+type ApprovalFlowRejected @join__type(graph: A) {
+  order: Order @join__field(graph: A)
+}
+
+type ApprovalFlowCompleted @join__type(graph: A) {
+  order: Order @join__field(graph: A)
+}
+
+type Order @join__type(graph: A) {
+  id: ID! @join__field(graph: A)
+  version: Int @join__field(graph: A)
+  orderNumber: String @join__field(graph: A)
+}

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -110,6 +110,16 @@ pub enum ProjectionValueSource {
     Null,
 }
 
+/// Selections collected while building a plan, grouped by response key.
+///
+/// `key` is the field name
+/// `value` is the list of possible variants, based on different type guards
+///
+/// They are kept apart so their nested selections never bleed into one another, and
+/// [`resolve_variants`](FieldProjectionPlan::resolve_variants) later collapses
+/// them into mutually-exclusive per-concrete-type plans.
+type SelectionVariants = IndexMap<String, Vec<FieldProjectionPlan>>;
+
 #[derive(Debug, Clone)]
 pub struct FieldProjectionPlan {
     pub field_name: String,
@@ -233,7 +243,7 @@ impl FieldProjectionPlan {
         parent_type_name: &str,
         parent_condition: &Option<FieldProjectionCondition>,
     ) -> Option<Vec<FieldProjectionPlan>> {
-        let mut field_selections: IndexMap<String, FieldProjectionPlan> = IndexMap::new();
+        let mut field_selections = SelectionVariants::new();
 
         for selection_item in &selection_set.items {
             match selection_item {
@@ -251,6 +261,7 @@ impl FieldProjectionPlan {
                         inline_fragment,
                         &mut field_selections,
                         schema_metadata,
+                        parent_type_name,
                         parent_condition,
                     );
                 }
@@ -264,9 +275,125 @@ impl FieldProjectionPlan {
         }
 
         if field_selections.is_empty() {
+            return None;
+        }
+
+        let resolved = Self::resolve_variants(field_selections, parent_type_name, schema_metadata);
+
+        if resolved.is_empty() {
             None
         } else {
-            Some(field_selections.into_values().collect())
+            Some(resolved)
+        }
+    }
+
+    /// Collapses each response key's variants into the final selections.
+    ///
+    /// A response key may be selected for multiple parent type with
+    /// different nested selections:
+    ///
+    /// `... on Article { meta { title } }`
+    /// `... on Video { meta { wordCount } }`
+    ///
+    /// `merge_plan` keeps those as separate selections so their nested selections
+    /// never "bleed" into one another.
+    ///
+    /// The end goal here is to merged the variants, so a field `meta` will not
+    /// have 2 plan records, but rather it will be one record, with multiple type guards.
+    ///
+    /// This way, at runtime, the `meta` plan will match exactly one variant, based on the concrete `__typename`
+    fn resolve_variants(
+        field_selections: SelectionVariants,
+        parent_type_name: &str,
+        schema_metadata: &SchemaMetadata,
+    ) -> Vec<FieldProjectionPlan> {
+        let mut concrete_types: Option<Vec<String>> = None;
+        let mut resolved = Vec::new();
+
+        for (_, variants) in field_selections {
+            let already_exclusive = variants.len() == 1
+                || variants
+                    .iter()
+                    .all(|v| matches!(v.parent_type_guard, Some(TypeCondition::Exact(_))));
+            if already_exclusive {
+                resolved.extend(variants);
+                continue;
+            }
+
+            let concrete_types = concrete_types.get_or_insert_with(|| {
+                let mut types: Vec<String> = schema_metadata
+                    .possible_types
+                    .get_possible_types(parent_type_name)
+                    .into_iter()
+                    .filter(|t| schema_metadata.is_object_type(t))
+                    .collect();
+                types.sort();
+                types
+            });
+
+            for concrete_type in concrete_types.iter() {
+                let merged = Self::merge_variants_for_type(
+                    &variants,
+                    concrete_type,
+                    parent_type_name,
+                    schema_metadata,
+                );
+                resolved.extend(merged);
+            }
+        }
+
+        resolved
+    }
+
+    /// Merges every variant whose guard matches `concrete_type` into a single
+    /// plan scoped to `Exact(concrete_type)`. Returns `None` when no variant
+    /// applies to that type.
+    fn merge_variants_for_type(
+        variants: &[FieldProjectionPlan],
+        concrete_type: &str,
+        parent_type_name: &str,
+        schema_metadata: &SchemaMetadata,
+    ) -> Option<FieldProjectionPlan> {
+        let mut merged: Option<FieldProjectionPlan> = None;
+        for variant in variants {
+            let matches = variant
+                .parent_type_guard
+                .as_ref()
+                .is_none_or(|guard| guard.matches(concrete_type));
+            if !matches {
+                continue;
+            }
+            let mut scoped = variant.clone();
+            scoped.parent_type_guard = Some(TypeCondition::Exact(concrete_type.to_string()));
+            match &mut merged {
+                None => merged = Some(scoped),
+                Some(existing) => {
+                    Self::merge_matching(existing, scoped, parent_type_name, schema_metadata)
+                }
+            }
+        }
+        merged
+    }
+
+    fn field_output_type<'a>(
+        schema_metadata: &'a SchemaMetadata,
+        parent_type_name: &'a str,
+        guard: &'a Option<TypeCondition>,
+        field_name: &str,
+    ) -> Option<&'a str> {
+        if field_name == TYPENAME_FIELD_NAME {
+            return None;
+        }
+        let lookup = |candidate: &str| {
+            schema_metadata
+                .type_fields
+                .get(candidate)
+                .and_then(|fields| fields.get(field_name))
+                .map(|info| info.output_type_name.as_str())
+        };
+        match guard {
+            Some(guard) => Self::type_names_from(guard).into_iter().find_map(lookup),
+            None => lookup(parent_type_name),
         }
     }
 
@@ -482,42 +609,58 @@ impl FieldProjectionPlan {
         Self::or_optional(left, right)
     }
 
-    /// When the same field appears in multiple fragments,
-    /// this function combines them into a single plan by:
-    /// - Unioning type guards (e.g., Book + Magazine = OneOf(Book, Magazine))
-    /// - OR-ing conditions while preserving guard associations
-    /// - Recursively merging child selections
+    /// Adds a plan to the selection map. Selections are grouped by response key,
+    /// and within a key kept as separate variants per parent type guard.
+    ///
+    /// `merge_plan` will add a common-field (a field that's relevant to multiple plans) to
+    /// both plans.
+    ///
+    /// A later process, `resolve_variants` processes the common fields and "bubble" it if possible.
     fn merge_plan(
-        field_selections: &mut IndexMap<String, FieldProjectionPlan>,
+        field_selections: &mut SelectionVariants,
         plan_to_merge: FieldProjectionPlan,
+        parent_type_name: &str,
+        schema_metadata: &SchemaMetadata,
     ) {
-        let Some(existing_plan) = field_selections.get_mut(&plan_to_merge.response_key) else {
-            // First time seeing this field - just insert it
-            field_selections.insert(plan_to_merge.response_key.clone(), plan_to_merge);
+        let Some(variants) = field_selections.get_mut(plan_to_merge.response_key.as_str()) else {
+            field_selections.insert(plan_to_merge.response_key.clone(), vec![plan_to_merge]);
             return;
         };
 
-        // Capture guards before merging, needed for condition association
-        let existing_guard = existing_plan.parent_type_guard.clone();
-        let new_guard = plan_to_merge.parent_type_guard.clone();
+        match variants
+            .iter_mut()
+            .find(|v| v.parent_type_guard == plan_to_merge.parent_type_guard)
+        {
+            Some(existing) => {
+                Self::merge_matching(existing, plan_to_merge, parent_type_name, schema_metadata)
+            }
+            None => variants.push(plan_to_merge),
+        }
+    }
 
-        // Merge type guards using OR semantics (union of when to include the field)
-        // - None means "applies to all types" (no type restriction)
-        // - Some(guard) means "applies only to specific types"
-        existing_plan.parent_type_guard = match (
-            existing_plan.parent_type_guard.take(),
-            plan_to_merge.parent_type_guard,
-        ) {
-            (None, _) | (_, None) => None, // None (all types) subsumes any specific guard
-            (Some(left), Some(right)) => Some(left.union(right)),
-        };
-
+    /// Merges a plan into an existing one with the same response key and the same type guard
+    fn merge_matching(
+        existing_plan: &mut FieldProjectionPlan,
+        plan_to_merge: FieldProjectionPlan,
+        parent_type_name: &str,
+        schema_metadata: &SchemaMetadata,
+    ) {
+        // Same guard on both sides, so there is nothing to union here.
         existing_plan.conditions = Self::merge_conditions(
-            &existing_guard,
+            &existing_plan.parent_type_guard,
             existing_plan.conditions.take(),
-            &new_guard,
+            &existing_plan.parent_type_guard,
             plan_to_merge.conditions,
         );
+
+        // Children live one level down, under this field's output type.
+        let child_parent_type = Self::field_output_type(
+            schema_metadata,
+            parent_type_name,
+            &existing_plan.parent_type_guard,
+            &existing_plan.field_name,
+        )
+        .unwrap_or(parent_type_name);
 
         match (&mut existing_plan.value, plan_to_merge.value) {
             (
@@ -535,20 +678,29 @@ impl FieldProjectionPlan {
                             let new_selections_vec = Arc::try_unwrap(new_selections)
                                 .unwrap_or_else(|arc| (*arc).clone());
 
-                            // Convert Vec to Map for efficient merging by response_key
-                            let mut selections_map: IndexMap<String, FieldProjectionPlan> =
-                                selections_mut
-                                    .drain(..)
-                                    .map(|plan| (plan.response_key.clone(), plan))
-                                    .collect();
-
-                            // Recursively merge each child selection
+                            // Merge children, keeping variants per guard separate.
+                            let mut child_selections = SelectionVariants::new();
+                            for child in selections_mut.drain(..) {
+                                child_selections
+                                    .entry(child.response_key.clone())
+                                    .or_default()
+                                    .push(child);
+                            }
                             for new_plan in new_selections_vec {
-                                Self::merge_plan(&mut selections_map, new_plan);
+                                Self::merge_plan(
+                                    &mut child_selections,
+                                    new_plan,
+                                    child_parent_type,
+                                    schema_metadata,
+                                );
                             }
 
-                            // Convert back to Vec for efficient iteration during projection
-                            selections_mut.extend(selections_map.into_values());
+                            // Re-resolve in case merging introduced overlapping variants.
+                            selections_mut.extend(Self::resolve_variants(
+                                child_selections,
+                                child_parent_type,
+                                schema_metadata,
+                            ));
                         }
                         None => *existing_selections = Some(new_selections),
                     }
@@ -618,7 +770,7 @@ impl FieldProjectionPlan {
 
     fn process_field(
         field: &FieldSelection,
-        field_selections: &mut IndexMap<String, FieldProjectionPlan>,
+        field_selections: &mut SelectionVariants,
         schema_metadata: &SchemaMetadata,
         parent_type_name: &str,
         parent_condition: &Option<FieldProjectionCondition>,
@@ -750,13 +902,19 @@ impl FieldProjectionPlan {
             }
         };
 
-        Self::merge_plan(field_selections, new_plan);
+        Self::merge_plan(
+            field_selections,
+            new_plan,
+            parent_type_name,
+            schema_metadata,
+        );
     }
 
     fn process_inline_fragment(
         inline_fragment: &InlineFragmentSelection,
-        field_selections: &mut IndexMap<String, FieldProjectionPlan>,
+        field_selections: &mut SelectionVariants,
         schema_metadata: &SchemaMetadata,
+        parent_type_name: &str,
         parent_condition: &Option<FieldProjectionCondition>,
     ) {
         let inline_fragment_type = &inline_fragment.type_condition;
@@ -795,7 +953,12 @@ impl FieldProjectionPlan {
             }
 
             for selection in inline_fragment_selections {
-                Self::merge_plan(field_selections, selection);
+                Self::merge_plan(
+                    field_selections,
+                    selection,
+                    parent_type_name,
+                    schema_metadata,
+                );
             }
         }
     }
@@ -836,13 +999,16 @@ impl Display for TypeCondition {
             TypeCondition::Exact(type_name) => write!(f, "Exact({})", type_name),
             TypeCondition::OneOf(types) => {
                 write!(f, "OneOf(")?;
-                let types_vec: Vec<_> = types.iter().collect();
+                let mut types_vec: Vec<_> = types.iter().collect();
+                types_vec.sort(); // for consistent output
+
                 for (i, type_name) in types_vec.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
                     write!(f, "{}", type_name)?;
                 }
+
                 write!(f, ")")
             }
         }
@@ -930,4 +1096,457 @@ impl PrettyDisplay for FieldProjectionPlan {
         writeln!(f, "{}}}", indent)?;
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FieldProjectionPlan;
+    use crate::introspection::schema::SchemaWithMetadata;
+    use hive_router_query_planner::{
+        ast::normalization::normalize_operation,
+        consumer_schema::ConsumerSchema,
+        state::supergraph_state::SupergraphState,
+        utils::parsing::{parse_operation, parse_schema},
+    };
+
+    const SCHEMA_1: &str = r#"
+        type Query {
+            search: [SearchResult!]!
+            feed: [Content!]!
+            concrete: ConcreteType
+        }
+
+        type ConcreteType {
+            id: ID!
+            test: String!
+            someEnum: SomeEnum
+            inner: InnerType
+        }
+
+        enum SomeEnum {
+            TEST
+        }
+
+        type InnerType {
+            inner: Boolean
+        }
+
+        union SearchResult = Article | Video
+
+        interface Content {
+            id: ID!
+            meta: Meta!
+        }
+
+        type Article implements Content {
+            id: ID!
+            meta: Meta!
+            headline: String!
+        }
+
+        type Video implements Content {
+            id: ID!
+            meta: Meta!
+            duration: Int!
+        }
+
+        type Photo implements Content {
+            id: ID!
+            meta: Meta!
+        }
+
+        type Meta {
+            title: String
+            wordCount: Int!
+            arch: String!
+        }
+    "#;
+
+    fn plan(schema: &str, query: &str) -> String {
+        let supergraph = parse_schema(schema);
+        let consumer_schema = ConsumerSchema::new_from_supergraph(&supergraph);
+        let schema_metadata = consumer_schema.schema_metadata();
+
+        let operation = parse_operation(query);
+        let supergraph_state = SupergraphState::new(&supergraph);
+        let normalized =
+            normalize_operation(&supergraph_state, &operation, None).expect("failed to normalize");
+        println!("{}", normalized.operation);
+        let (_, selections) =
+            FieldProjectionPlan::from_operation(&normalized.operation, &schema_metadata);
+
+        selections
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn simple_concrete_mixed_fields_defs() {
+        insta::assert_snapshot!(plan(SCHEMA_1,
+            r#"{
+                concrete {
+                    id
+                    test
+                    someEnum
+                    inner {
+                        inner
+                    }
+                }
+            }"#
+        ), @r###"
+        concrete: {
+          selections:
+            id: {
+            }
+            test: {
+            }
+            someEnum: {
+              conditions: EnumValues(TEST)
+            }
+            inner: {
+              selections:
+                inner: {
+                }
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn inline_fragment_on_concrete_type_with_dups() {
+        insta::assert_snapshot!(plan(SCHEMA_1,
+            r#"{
+                concrete {
+                  ... on ConcreteType {
+                    id
+                    inner {
+                        inner
+                    }
+                  }
+                  test
+                  someEnum
+                  inner {
+                      inner
+                  }
+                }
+            }"#
+        ), @r###"
+        concrete: {
+          selections:
+            id: {
+            }
+            inner: {
+              selections:
+                inner: {
+                }
+            }
+            test: {
+            }
+            someEnum: {
+              conditions: EnumValues(TEST)
+            }
+        }
+        "###);
+    }
+
+    /// #1166: union members select the shared key `meta` with disjoint
+    /// sub-fields.
+    #[test]
+    fn union_disjoint_fragments_kept_per_type() {
+        insta::assert_snapshot!(plan(SCHEMA_1,
+            r#"{
+                search {
+                    __typename
+                    ... on Article { meta { title wordCount } }
+                    ... on Video { meta { title arch } }
+                }
+            }"#
+        ), @r###"
+        search: {
+          conditions: FieldType(OneOf(Article, SearchResult, Video))
+          selections:
+            __typename: {
+            }
+            meta: {
+              type guard: Exact(Article)
+              selections:
+                title: {
+                }
+                wordCount: {
+                }
+            }
+            meta: {
+              type guard: Exact(Video)
+              selections:
+                title: {
+                }
+                arch: {
+                }
+            }
+        }
+        "###);
+    }
+
+    /// An "unguarded" selection (no concrete type) of `meta` (on the `Content` interface) overlaps a
+    /// guarded one (`... on Article`).
+    ///
+    /// The overlap is split per concrete type:
+    /// `Article` -> merges both
+    /// `Video`/`Photo` keep only the shared field
+    #[test]
+    fn interface_overlapping_guard_splits_per_type() {
+        insta::assert_snapshot!(plan(SCHEMA_1,
+            r#"{
+                feed {
+                    meta { title }
+                    ... on Article { meta { wordCount } }
+                }
+            }"#
+        ), @r###"
+        feed: {
+          conditions: FieldType(OneOf(Article, Content, Photo, Video))
+          selections:
+            meta: {
+              type guard: Exact(Article)
+              selections:
+                title: {
+                }
+                wordCount: {
+                }
+            }
+            meta: {
+              type guard: Exact(Photo)
+              selections:
+                title: {
+                }
+            }
+            meta: {
+              type guard: Exact(Video)
+              selections:
+                title: {
+                }
+            }
+        }
+        "###);
+    }
+
+    /// Same key, same guard, same selection from two fragments collapses back
+    /// into a single plan (no duplications).
+    ///
+    /// DOTAN: Added this because I was concered that doing split/merge of the plans based of type,
+    /// might end up with duplicate projections, now that it's no longer a single one.
+    #[test]
+    fn same_guard_fragments_merge_into_one() {
+        insta::assert_snapshot!(plan(SCHEMA_1,
+            r#"{
+                search {
+                    ... on Article { meta { title } }
+                    ... on Article { meta { title } }
+                }
+            }"#
+        ), @r###"
+        search: {
+          conditions: FieldType(OneOf(Article, SearchResult, Video))
+          selections:
+            meta: {
+              type guard: Exact(Article)
+              selections:
+                title: {
+                }
+            }
+        }
+        "###);
+    }
+
+    const SCHEMA_2: &str = r#"
+    enum WeightUnit { KG LB G }
+
+    interface Node {
+      id: ID!
+    }
+
+    interface Animal implements Node {
+      id: ID!
+      name: String!
+    }
+
+    interface Pet implements Animal & Node {
+      id: ID!
+      name: String!
+      bestFriend: Animal
+      weight(unit: WeightUnit = KG): Float
+    }
+
+    type Dog implements Pet & Animal & Node {
+      id: ID!
+      name: String!
+      bestFriend: Animal
+      weight(unit: WeightUnit = KG): Float
+      nickname: String
+      tags: [String!]
+    }
+
+    type Cat implements Pet & Animal & Node {
+      id: ID!
+      name: String!
+      bestFriend: Cat                     # covariant override
+      weight(unit: WeightUnit = KG): Float
+      age: Int
+      tags: [String!]
+    }
+
+    type Robot implements Node {
+      id: ID!
+      model: String!
+      weight(unit: WeightUnit = KG): Float
+    }
+
+    union SearchResult = Dog | Cat | Robot
+
+    type Owner implements Node {
+      id: ID!
+      name: String!
+      pets: [Pet!]!
+      primaryPet: Pet
+    }
+
+    type Query {
+      pet: Pet
+      animal: Animal
+      node: Node
+      search: SearchResult
+      searchMany: [SearchResult!]!
+      pets: [Pet!]!
+      owner: Owner
+    }
+    "#;
+
+    /// When the fragment's id merges into the existing id entry, the key keeps the position of its
+    /// first occurrence — it does not move to after nickname.
+    #[test]
+    fn field_order_when_grouping_with_fragments() {
+        let plan = plan(
+            SCHEMA_2,
+            r#"
+        query FieldOrder {
+          animal {
+            name
+            id
+            ... on Dog {
+              id
+              nickname
+            }
+          }
+        }"#,
+        );
+
+        insta::assert_snapshot!(plan, @r###"
+        animal: {
+          conditions: FieldType(OneOf(Animal, Cat, Dog, Pet))
+          selections:
+            name: {
+            }
+            id: {
+              type guard: Exact(Cat)
+            }
+            id: {
+              type guard: Exact(Dog)
+            }
+            nickname: {
+              type guard: Exact(Dog)
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn multiple_aliases() {
+        let plan = plan(
+            SCHEMA_2,
+            r#"
+            query AliasFanout {
+              pet {
+                ... on Dog {
+                  kg: weight(unit: KG)
+                  lb: weight(unit: LB)
+                  g:  weight(unit: G)
+                }
+                ... on Cat {
+                  kg: weight(unit: KG)
+                }
+              }
+            }"#,
+        );
+
+        insta::assert_snapshot!(plan, @r###"
+        pet: {
+          conditions: FieldType(OneOf(Cat, Dog, Pet))
+          selections:
+            kg (alias for weight) {
+              type guard: Exact(Dog)
+            }
+            kg (alias for weight) {
+              type guard: Exact(Cat)
+            }
+            lb (alias for weight) {
+              type guard: Exact(Dog)
+            }
+            g (alias for weight) {
+              type guard: Exact(Dog)
+            }
+        }
+        "###);
+    }
+
+    // #[test]
+    // fn nested_redundant_fragments() {
+    //     let plan = plan(
+    //         SCHEMA_2,
+    //         r#"
+    //         query M_IdentityConditions {
+    //           pet {
+    //             ... on Pet {
+    //               ... on Pet {
+    //                 name
+    //                 ... on Animal { id }
+    //               }
+    //             }
+    //           }
+    //         }"#,
+    //     );
+
+    //     insta::assert_snapshot!(plan, @r###"
+    //     pet: {
+    //       conditions: FieldType(OneOf(Cat, Dog, Pet))
+    //       selections:
+    //         name: {
+    //         }
+    //     }
+    //     "###);
+    // }
+
+    // Directive on a named fragment spread, with a field merged across two fragments
+    // #[test]
+    // fn directive_on_named_fragment_spread_with_field_merged_across_two_fragments() {
+    //     let plan = plan(
+    //         SCHEMA_2,
+    //         r#"
+    //         query SpreadDirective($withName: Boolean!, $deep: Boolean!) {
+    //           node {
+    //             id
+    //             ...AnimalBits @include(if: $withName)
+    //             ... on Dog @skip(if: $deep) { nickname }
+    //           }
+    //         }
+
+    //         fragment AnimalBits on Animal {
+    //           name
+    //           ... on Dog { nickname }
+    //         }"#,
+    //     );
+
+    //     insta::assert_snapshot!(plan, @r###""###);
+    // }
 }

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -2,7 +2,7 @@ use ahash::HashSet;
 use indexmap::IndexMap;
 use std::fmt::{Display, Formatter as FmtFormatter, Result as FmtResult};
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{instrument, trace, warn};
 
 use hive_router_query_planner::{
     ast::{
@@ -116,8 +116,7 @@ pub enum ProjectionValueSource {
 /// `value` is the list of possible variants, based on different type guards
 ///
 /// They are kept apart so their nested selections never bleed into one another, and
-/// [`resolve_variants`](FieldProjectionPlan::resolve_variants) later collapses
-/// them into mutually-exclusive per-concrete-type plans.
+/// `resolve_variants` later collapses them into mutually-exclusive per-concrete-type plans.
 type SelectionVariants = IndexMap<String, Vec<FieldProjectionPlan>>;
 
 #[derive(Debug, Clone)]
@@ -133,6 +132,19 @@ pub struct FieldProjectionPlan {
     pub parent_type_guard: Option<TypeCondition>,
     pub conditions: Option<FieldProjectionCondition>,
     pub value: ProjectionValueSource,
+}
+
+fn debug_plans_vec(plans: &[FieldProjectionPlan]) {
+    for (i, plan) in plans.iter().enumerate() {
+        trace!("plan {}:\n{}", i, plan);
+    }
+}
+
+fn debug_plans_map(plans: &SelectionVariants) {
+    for (i, (key, plans)) in plans.iter().enumerate() {
+        trace!("key {}: {}", i, key);
+        debug_plans_vec(plans);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +223,7 @@ impl FieldProjectionCondition {
 }
 
 impl FieldProjectionPlan {
+    #[instrument(level = "trace", skip_all)]
     pub fn from_operation(
         operation: &OperationDefinition,
         schema_metadata: &SchemaMetadata,
@@ -237,6 +250,11 @@ impl FieldProjectionPlan {
         (root_type_name, plans)
     }
 
+    #[instrument(level = "trace", skip_all, fields(
+      selection_set = %selection_set,
+      parent_type_name,
+      parent_condition = ?parent_condition,
+    ))]
     fn from_selection_set(
         selection_set: &SelectionSet,
         schema_metadata: &SchemaMetadata,
@@ -302,11 +320,17 @@ impl FieldProjectionPlan {
     /// have 2 plan records, but rather it will be one record, with multiple type guards.
     ///
     /// This way, at runtime, the `meta` plan will match exactly one variant, based on the concrete `__typename`
+    #[instrument(level = "trace", skip_all, fields(parent_type_name,))]
     fn resolve_variants(
         field_selections: SelectionVariants,
         parent_type_name: &str,
         schema_metadata: &SchemaMetadata,
     ) -> Vec<FieldProjectionPlan> {
+        #[cfg(debug_assertions)]
+        {
+            trace!("input:\n");
+            debug_plans_map(&field_selections);
+        }
         let mut concrete_types: Option<Vec<String>> = None;
         let mut resolved = Vec::new();
 
@@ -340,6 +364,12 @@ impl FieldProjectionPlan {
                 );
                 resolved.extend(merged);
             }
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            trace!("output:\n");
+            debug_plans_vec(&resolved);
         }
 
         resolved
@@ -616,6 +646,7 @@ impl FieldProjectionPlan {
     /// both plans.
     ///
     /// A later process, `resolve_variants` processes the common fields and "bubble" it if possible.
+    #[instrument(level = "trace", skip_all, fields(parent_type_name))]
     fn merge_plan(
         field_selections: &mut SelectionVariants,
         plan_to_merge: FieldProjectionPlan,
@@ -639,6 +670,7 @@ impl FieldProjectionPlan {
     }
 
     /// Merges a plan into an existing one with the same response key and the same type guard
+    #[instrument(level = "trace", skip_all, fields(parent_type_name))]
     fn merge_matching(
         existing_plan: &mut FieldProjectionPlan,
         plan_to_merge: FieldProjectionPlan,
@@ -768,6 +800,12 @@ impl FieldProjectionPlan {
         }
     }
 
+    #[instrument(level = "trace", skip_all, fields(
+      field_name = field.name,
+      field_alias = field.alias.as_deref(),
+      parent_type_name,
+      parent_condition = ?parent_condition,
+    ))]
     fn process_field(
         field: &FieldSelection,
         field_selections: &mut SelectionVariants,
@@ -910,6 +948,12 @@ impl FieldProjectionPlan {
         );
     }
 
+    #[instrument(level = "trace", skip_all, fields(
+      inline_fragment_type = inline_fragment.type_condition,
+      fragment_str = %inline_fragment.selections,
+      parent_type_name,
+      parent_condition = ?parent_condition,
+    ))]
     fn process_inline_fragment(
         inline_fragment: &InlineFragmentSelection,
         field_selections: &mut SelectionVariants,

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -2,7 +2,7 @@ use ahash::HashSet;
 use indexmap::IndexMap;
 use std::fmt::{Display, Formatter as FmtFormatter, Result as FmtResult};
 use std::sync::Arc;
-use tracing::{instrument, trace, warn};
+use tracing::{instrument, warn};
 
 use hive_router_query_planner::{
     ast::{
@@ -137,14 +137,14 @@ pub struct FieldProjectionPlan {
 #[cfg(debug_assertions)]
 fn debug_plans_vec(plans: &[FieldProjectionPlan]) {
     for (i, plan) in plans.iter().enumerate() {
-        trace!("plan {}:\n{}", i, plan);
+        tracing::trace!("plan {}:\n{}", i, plan);
     }
 }
 
 #[cfg(debug_assertions)]
 fn debug_plans_map(plans: &SelectionVariants) {
     for (i, (key, plans)) in plans.iter().enumerate() {
-        trace!("key {}: {}", i, key);
+        tracing::trace!("key {}: {}", i, key);
         debug_plans_vec(plans);
     }
 }
@@ -330,7 +330,7 @@ impl FieldProjectionPlan {
     ) -> Vec<FieldProjectionPlan> {
         #[cfg(debug_assertions)]
         {
-            trace!("input:\n");
+            tracing::trace!("input:\n");
             debug_plans_map(&field_selections);
         }
         let mut concrete_types: Option<Vec<String>> = None;
@@ -370,7 +370,7 @@ impl FieldProjectionPlan {
 
         #[cfg(debug_assertions)]
         {
-            trace!("output:\n");
+            tracing::trace!("output:\n");
             debug_plans_vec(&resolved);
         }
 

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -134,12 +134,14 @@ pub struct FieldProjectionPlan {
     pub value: ProjectionValueSource,
 }
 
+#[cfg(debug_assertions)]
 fn debug_plans_vec(plans: &[FieldProjectionPlan]) {
     for (i, plan) in plans.iter().enumerate() {
         trace!("plan {}:\n{}", i, plan);
     }
 }
 
+#[cfg(debug_assertions)]
 fn debug_plans_map(plans: &SelectionVariants) {
     for (i, (key, plans)) in plans.iter().enumerate() {
         trace!("key {}: {}", i, key);

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -2515,4 +2515,115 @@ mod tests {
         "#
         );
     }
+
+    // #[test]
+    // fn multiple_directives_and_conditions_and_fragments() {
+    //     let schema = parse_schema(
+    //         r#"
+    //         enum WeightUnit {
+    //           KG
+    //           LB
+    //           G
+    //         }
+
+    //         interface Node {
+    //           id: ID!
+    //         }
+
+    //         interface Animal implements Node {
+    //           id: ID!
+    //           name: String!
+    //         }
+
+    //         interface Pet implements Animal & Node {
+    //           id: ID!
+    //           name: String!
+    //           bestFriend: Animal
+    //           weight(unit: WeightUnit = KG): Float
+    //         }
+
+    //         type Dog implements Pet & Animal & Node {
+    //           id: ID!
+    //           name: String!
+    //           bestFriend: Animal
+    //           weight(unit: WeightUnit = KG): Float
+    //           nickname: String
+    //           tags: [String!]
+    //         }
+
+    //         type Cat implements Pet & Animal & Node {
+    //           id: ID!
+    //           name: String!
+    //           bestFriend: Cat # covariant override
+    //           weight(unit: WeightUnit = KG): Float
+    //           age: Int
+    //           tags: [String!]
+    //         }
+
+    //         type Robot implements Node {
+    //           id: ID!
+    //           model: String!
+    //           weight(unit: WeightUnit = KG): Float
+    //         }
+
+    //         union SearchResult = Dog | Cat | Robot
+
+    //         type Owner implements Node {
+    //           id: ID!
+    //           name: String!
+    //           pets: [Pet!]!
+    //           primaryPet: Pet
+    //         }
+
+    //         type Query {
+    //           pet: Pet
+    //           animal: Animal
+    //           node: Node
+    //           search: SearchResult
+    //           searchMany: [SearchResult!]!
+    //           pets: [Pet!]!
+    //           owner: Owner
+    //         }
+    //         "#,
+    //     );
+    //     let supergraph = SupergraphState::new(&schema);
+
+    //     insta::assert_snapshot!(
+    //         pretty_query(
+    //             normalize_operation(
+    //                 &supergraph,
+    //                 &parse_query(
+    //                     r#"
+    //                     query SpreadDirective($withName: Boolean!, $deep: Boolean!) {
+    //                       node {
+    //                         id
+    //                         ...AnimalBits
+    //                         ... on Dog @skip(if: $deep) { id }
+    //                       }
+    //                     }
+
+    //                     fragment AnimalBits on Animal {
+    //                       name
+    //                       ... on Dog { nickname }
+    //                     }
+    //                     "#,
+    //                 )
+    //                 .expect("to parse"),
+    //                 None,
+    //             )
+    //             .expect("to normalize")
+    //             .to_string()
+    //         ),
+    //         @r###"
+    //     query SpreadDirective($withName: Boolean!, $deep: Boolean!) {
+    //       node {
+    //         id
+    //         ... on Dog @skip(if: $deep) {
+    //           nickname
+    //         }
+    //       }
+    //     }
+    //     "###
+    //     );
+    // }
 }


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1168
Closes https://github.com/graphql-hive/router/pull/1166

## TL;DR

For the given query: 

```graphql
query {
  search {
    __typename
    ... on Article { # type implements HasMeta
      meta {
        title
      }
    }
    ... on HasMeta { # interface
      meta {
        wordCount
      }
    }
  }
```

the projection flow produces the following:

```
search: {
  conditions: FieldType(OneOf(Article, Video, Search))
  selections:
    __typename: {
    }
    meta: {
      type guard: OneOf(Article, Video)
      conditions: ParentType(OneOf(Video, Article))
      selections:
        title: {
        }
        wordCount: {
        }
    }
}
```

While the correct result needs to be a `meta` field collected per concrete type:

```
search: {
  conditions: FieldType(OneOf(Article, Video, Search))
  selections:
    __typename: {
    }
    meta: {
      type guard: Exact(Article)
      selections:
        title: {
        }
        wordCount: {
        }
    }
    meta: {
      type guard: Exact(Video)
      selections:
        wordCount: {
        }
    }
}
```

The `meta` field needs to be distiguished based on the concrete type and have the correct guard. 

# TODO 
- [x] reproduce 
- [x] figure out how to fix
- [x] add more tests that covers this scenario 
- [x] confirm `interface` case 
- [x] fix for `interface` as well 
- [x] run `differential` to confirm no regressions 