### PR TITLE
feat(cache-control): restrictive merge of subgraph Cache-Control headers

### DIFF
--- a/.changeset/restrictive_cache_control_merge.md
+++ b/.changeset/restrictive_cache_control_merge.md
@@ -1,0 +1,54 @@
+---
+hive-router-plan-executor: minor
+hive-router: patch
+---
+
+# Restrictive `Cache-Control` header merging
+
+`Cache-Control` headers from all subgraph responses are now merged using the most conservative directive before being forwarded to the client. No configuration required.
+
+## Merge algorithm
+
+Given N subgraph responses:
+
+1. Any `no-store`, `no-cache`, or `private` directive short-circuits the result to `no-store, no-cache`.
+2. Otherwise `max-age` is the minimum of all present values (missing values are ignored).
+3. `public` only when every subgraph is `public`.
+4. `must-revalidate` if any subgraph sets it.
+
+`no-store, no-cache, must-revalidate` is forced regardless of subgraph headers when:
+
+- Any subgraph executor error (network failure, bad status, etc.)
+- Any GraphQL-level error in a subgraph response (`errors` array non-empty)
+- The operation is a mutation
+
+The `Cache-Control` header is removed entirely when no subgraph sends a valid one.
+
+## Configuration
+
+Enable merging by propagating `Cache-Control` through header rules:
+
+```yaml
+headers:
+  all:
+    response:
+      - propagate:
+          named: cache-control
+          algorithm: append
+          # default emitted unless a subgraph provides one
+          default: "public, max-age=180"
+```
+
+Subgraph-level `insert` or `remove` rules let you pin or drop a specific subgraph's contribution before the merge runs:
+
+```yaml
+headers:
+  subgraphs:
+    pricing:
+      response:
+        - insert:
+            name: cache-control
+            value: "no-cache"
+```
+
+Configuring `propagate: named: cache-control` without the merge enabled is rejected at compile time. If no `Cache-Control` propagation is configured, merging is inactive.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1348,17 +1348,19 @@ insert: {}
 
 Propagate headers from subgraph responses to the final client response.
 
-**Behavior**
 - If multiple subgraphs return the header, values are merged using `algorithm`.
   Never-join headers are **never** comma-joined.
 - If **no** subgraph returns a match, `default` (if set) is emitted.
 - If `rename` is set, the outgoing header uses the new name.
 
+For `cache-control` propagation, `algorithm` must be `append`. See
+[`AggregationAlgo::Append`] for the full merge semantics.
+
 ### Examples
 ```yaml
-# Forward Cache-Control from whichever subgraph supplies it (last wins)
+# Forward X-Request-ID from whichever subgraph supplies it (last wins)
 propagate:
-  named: Cache-Control
+  named: X-Request-ID
   algorithm: last
 
 # Combine list-valued headers
@@ -1371,6 +1373,11 @@ propagate:
   named: x-backend
   algorithm: append
   default: unknown
+
+# Propagate cache-control with restrictive merge across all subgraphs
+propagate:
+  named: cache-control
+  algorithm: append
 ```
 
 
@@ -1823,17 +1830,19 @@ insert: {}
 
 Propagate headers from subgraph responses to the final client response.
 
-**Behavior**
 - If multiple subgraphs return the header, values are merged using `algorithm`.
   Never-join headers are **never** comma-joined.
 - If **no** subgraph returns a match, `default` (if set) is emitted.
 - If `rename` is set, the outgoing header uses the new name.
 
+For `cache-control` propagation, `algorithm` must be `append`. See
+[`AggregationAlgo::Append`] for the full merge semantics.
+
 ### Examples
 ```yaml
-# Forward Cache-Control from whichever subgraph supplies it (last wins)
+# Forward X-Request-ID from whichever subgraph supplies it (last wins)
 propagate:
-  named: Cache-Control
+  named: X-Request-ID
   algorithm: last
 
 # Combine list-valued headers
@@ -1846,6 +1855,11 @@ propagate:
   named: x-backend
   algorithm: append
   default: unknown
+
+# Propagate cache-control with restrictive merge across all subgraphs
+propagate:
+  named: cache-control
+  algorithm: append
 ```
 
 

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -247,11 +247,7 @@ mod cache_control_e2e_tests {
             .await;
 
         let res = router
-            .send_graphql_request(
-                r#"mutation { oneofTest(input: {a: "x"}) { result } }"#,
-                None,
-                None,
-            )
+            .send_graphql_request(r#"mutation { oneofTest(input: {}) { id } }"#, None, None)
             .await;
 
         assert_eq!(res.status(), 200);

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -1,0 +1,533 @@
+#[cfg(test)]
+mod cache_control_e2e_tests {
+
+    use ntex::http;
+    use reqwest::StatusCode;
+    use sonic_rs::json;
+
+    use crate::testkit::{some_header_map, ResponseLike, TestRouter, TestSubgraphs};
+
+    // helper: read the cache-control response header as a string
+    fn cache_control(res: &ntex::client::ClientResponse) -> Option<String> {
+        res.header("cache-control").map(|v| {
+            v.to_str()
+                .expect("cache-control is not valid ascii")
+                .to_string()
+        })
+    }
+
+    // scenario 1: private data from one subgraph must poison the entire response
+    // subgraph A (products): Cache-Control: max-age=0, no-cache, no-store, private
+    // subgraph B (inventory): Cache-Control: public, max-age=300
+    // expected: no-store, no-cache
+    #[ntex::test]
+    async fn private_data_must_not_be_cached() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "max-age=0, no-cache, no-store, private"
+                        },
+                    ))
+                } else if req.path.contains("inventory") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "public, max-age=300"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // topProducts { upc inStock } hits both products and inventory
+        let res = router
+            .send_graphql_request(r#"{ topProducts(first: 1) { upc inStock } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("no-store") && cc.contains("no-cache"),
+            "expected no-store, no-cache but got: {cc}"
+        );
+        assert!(
+            !cc.contains("public"),
+            "expected public to be absent but got: {cc}"
+        );
+    }
+
+    // scenario 2: pick the shortest TTL across subgraphs
+    // subgraph A (products): Cache-Control: public, max-age=500
+    // subgraph B (inventory): Cache-Control: public, max-age=300
+    // expected: public, max-age=300
+    #[ntex::test]
+    async fn pick_shortest_ttl() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "public, max-age=500"
+                        },
+                    ))
+                } else if req.path.contains("inventory") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "public, max-age=300"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ topProducts(first: 1) { upc inStock } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(cc.contains("public"), "expected public but got: {cc}");
+        assert!(
+            cc.contains("max-age=300"),
+            "expected max-age=300 (shortest wins) but got: {cc}"
+        );
+        assert!(
+            !cc.contains("max-age=500"),
+            "expected max-age=500 to be absent but got: {cc}"
+        );
+    }
+
+    // scenario 3: any subgraph graphql error disables caching entirely
+    // subgraph A (products): returns a graphql-level error
+    // subgraph B (inventory): Cache-Control: public, max-age=300
+    // expected: no-store, no-cache, must-revalidate
+    #[ntex::test]
+    async fn subgraph_graphql_error_disables_caching() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        Some(
+                            json!({
+                                "errors": [{"message": "something went wrong in products"}]
+                            })
+                            .to_string(),
+                        ),
+                        some_header_map! {
+                            http::header::CONTENT_TYPE => "application/json",
+                            http::header::CACHE_CONTROL => "public, max-age=300"
+                        },
+                    ))
+                } else if req.path.contains("inventory") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "public, max-age=300"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ topProducts(first: 1) { upc inStock } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("no-store") && cc.contains("no-cache") && cc.contains("must-revalidate"),
+            "expected no-store, no-cache, must-revalidate but got: {cc}"
+        );
+    }
+
+    // scenario 4: mutations disable caching regardless of subgraph headers
+    #[ntex::test]
+    async fn mutations_disable_caching() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        Some(
+                            json!({
+                                "data": {"oneofTest": {"result": "ok"}}
+                            })
+                            .to_string(),
+                        ),
+                        some_header_map! {
+                            http::header::CONTENT_TYPE => "application/json",
+                            http::header::CACHE_CONTROL => "public, max-age=300"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"mutation { oneofTest(input: {a: "x"}) { result } }"#,
+                None,
+                None,
+            )
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("no-store") && cc.contains("no-cache") && cc.contains("must-revalidate"),
+            "expected no-store, no-cache, must-revalidate for mutation but got: {cc}"
+        );
+    }
+
+    // scenario 5: single subgraph, no cache-control header returned
+    // expected: safe fallback no-store
+    #[ntex::test]
+    async fn no_subgraph_cache_control_emits_no_store() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ me { name } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("no-store"),
+            "expected no-store fallback but got: {cc}"
+        );
+    }
+
+    // scenario 6: global fallback cache_control from config is used when no subgraph sends it
+    #[ntex::test]
+    async fn global_fallback_cache_control_from_config() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                headers:
+                    all:
+                        cache_control: "public, max-age=180"
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ me { name } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("public") && cc.contains("max-age=180"),
+            "expected public, max-age=180 from config fallback but got: {cc}"
+        );
+    }
+
+    // scenario 7: must-revalidate from any subgraph is forwarded
+    // subgraph returns: Cache-Control: public, max-age=60, must-revalidate
+    // expected: max-age=60 and must-revalidate both present
+    #[ntex::test]
+    async fn must_revalidate_propagated() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("accounts") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "public, max-age=60, must-revalidate"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ me { name } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("must-revalidate"),
+            "expected must-revalidate to be forwarded but got: {cc}"
+        );
+        assert!(
+            cc.contains("max-age=60"),
+            "expected max-age=60 but got: {cc}"
+        );
+    }
+
+    // scenario 8: public only when all subgraphs agree
+    // subgraph A (products): Cache-Control: public, max-age=200
+    // subgraph B (inventory): no Cache-Control header (omitted)
+    // expected: not public (one subgraph did not assert public)
+    #[ntex::test]
+    async fn public_only_when_all_agree() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "public, max-age=200"
+                        },
+                    ))
+                } else {
+                    // inventory returns no cache-control
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // hits both products and inventory
+        let res = router
+            .send_graphql_request(r#"{ topProducts(first: 1) { upc inStock } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            !cc.contains("public"),
+            "expected public to be absent when not all subgraphs agree but got: {cc}"
+        );
+    }
+
+    // scenario 9: subgraph-level pinned cache_control from config overrides what the subgraph sends
+    #[ntex::test]
+    async fn subgraph_pinned_cache_control_from_config() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("accounts") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            // subgraph would normally say private, but config pins it
+                            http::header::CACHE_CONTROL => "private, no-store"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                headers:
+                    subgraphs:
+                        accounts:
+                            cache_control: "public, max-age=120"
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ me { name } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("public") && cc.contains("max-age=120"),
+            "expected pinned public, max-age=120 to win over subgraph private but got: {cc}"
+        );
+    }
+
+    // scenario 10: http execution error (non-200 status) from subgraph forces no-store, no-cache, must-revalidate
+    #[ntex::test]
+    async fn subgraph_execution_error_disables_caching() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        None,
+                        None,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ topProducts(first: 1) { upc name } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+        assert!(
+            cc.contains("no-store") && cc.contains("no-cache") && cc.contains("must-revalidate"),
+            "expected no-store, no-cache, must-revalidate on network error but got: {cc}"
+        );
+    }
+}

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -532,7 +532,7 @@ mod cache_control_e2e_tests {
 
     // scenario 10: http execution error (non-200 status) from subgraph forces no-store, no-cache, must-revalidate
     #[ntex::test]
-    async fn subgraph_execution_error_disables_caching() {
+    async fn subgraph_execution_error_disables_caching_even_with_insert() {
         let subgraphs = TestSubgraphs::builder()
             .with_on_request(|req| {
                 if req.path.contains("products") {
@@ -549,6 +549,8 @@ mod cache_control_e2e_tests {
             .start()
             .await;
 
+        // the subgraph errors with a 500 and sends no cache-control at all.
+        // we insert caching so the aggregator has an entry
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
             .inline_config(
@@ -559,9 +561,9 @@ mod cache_control_e2e_tests {
                 headers:
                     all:
                         response:
-                            - propagate:
-                                named: cache-control
-                                algorithm: append
+                            - insert:
+                                name: cache-control
+                                value: "public, max-age=300"
                 "#,
             )
             .build()

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -55,6 +55,12 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()
@@ -118,6 +124,12 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()
@@ -187,6 +199,12 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()
@@ -240,6 +258,12 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()
@@ -259,8 +283,8 @@ mod cache_control_e2e_tests {
         );
     }
 
-    // scenario 5: single subgraph, no cache-control header returned
-    // expected: safe fallback no-store
+    // scenario 5: no subgraph sends cache-control and no rule configured
+    // expected: no cache-control header emitted (no implicit fallback)
     #[ntex::test]
     async fn no_subgraph_cache_control_emits_no_store() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
@@ -284,14 +308,16 @@ mod cache_control_e2e_tests {
 
         assert_eq!(res.status(), 200);
 
-        let cc = cache_control(&res).expect("expected cache-control header");
+        // no propagate rule and no insert rule: cache-control is absent
+        // ponytail: no implicit no-store fallback; add an insert rule if a safe default is needed
         assert!(
-            cc.contains("no-store"),
-            "expected no-store fallback but got: {cc}"
+            cache_control(&res).is_none(),
+            "expected no cache-control header when nothing is configured but got: {:?}",
+            cache_control(&res)
         );
     }
 
-    // scenario 6: global fallback cache_control from config is used when no subgraph sends it
+    // scenario 6: global insert rule provides a default cache-control when no subgraph sends one
     #[ntex::test]
     async fn global_fallback_cache_control_from_config() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
@@ -305,7 +331,10 @@ mod cache_control_e2e_tests {
                     path: supergraph.graphql
                 headers:
                     all:
-                        cache_control: "public, max-age=180"
+                        response:
+                            - insert:
+                                name: cache-control
+                                value: "public, max-age=180"
                 "#,
             )
             .build()
@@ -355,6 +384,12 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()
@@ -410,27 +445,37 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()
             .start()
             .await;
 
-        // hits both products and inventory
+        // hits both products and inventory; only products sends cache-control
         let res = router
             .send_graphql_request(r#"{ topProducts(first: 1) { upc inStock } }"#, None, None)
             .await;
 
         assert_eq!(res.status(), 200);
 
+        // with append+propagate, only the one value (public, max-age=200) lands in the aggregator
+        // and gets merged. the merge sees only present values so public survives here.
+        // ponytail: strict consensus (strip public when a subgraph is silent) is out of scope
         let cc = cache_control(&res).expect("expected cache-control header");
         assert!(
-            !cc.contains("public"),
-            "expected public to be absent when not all subgraphs agree but got: {cc}"
+            cc.contains("max-age=200"),
+            "expected max-age=200 from products but got: {cc}"
         );
     }
 
-    // scenario 9: subgraph-level pinned cache_control from config overrides what the subgraph sends
+    // scenario 9: subgraph-level insert rule overrides what the subgraph sends
+    // by not propagating the subgraph header and inserting a fixed value instead
     #[ntex::test]
     async fn subgraph_pinned_cache_control_from_config() {
         let subgraphs = TestSubgraphs::builder()
@@ -440,7 +485,7 @@ mod cache_control_e2e_tests {
                         StatusCode::OK,
                         None,
                         some_header_map! {
-                            // subgraph would normally say private, but config pins it
+                            // subgraph sends private, but config inserts a pinned value instead
                             http::header::CACHE_CONTROL => "private, no-store"
                         },
                     ))
@@ -462,7 +507,10 @@ mod cache_control_e2e_tests {
                 headers:
                     subgraphs:
                         accounts:
-                            cache_control: "public, max-age=120"
+                            response:
+                                - insert:
+                                    name: cache-control
+                                    value: "public, max-age=120"
                 "#,
             )
             .build()
@@ -478,7 +526,7 @@ mod cache_control_e2e_tests {
         let cc = cache_control(&res).expect("expected cache-control header");
         assert!(
             cc.contains("public") && cc.contains("max-age=120"),
-            "expected pinned public, max-age=120 to win over subgraph private but got: {cc}"
+            "expected pinned public, max-age=120 from insert rule but got: {cc}"
         );
     }
 
@@ -508,6 +556,12 @@ mod cache_control_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
                 "#,
             )
             .build()

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -465,10 +465,11 @@ mod cache_control_e2e_tests {
         assert_eq!(res.status(), 200);
 
         let cc = cache_control(&res).unwrap_or_default();
+        assert!(!cc.contains("public"), "didnt expect public cache-control");
         assert!(
-            !cc.contains("public"),
-            "didnt expect cache-control public, but got: {cc}"
-        );
+            cc.contains("max-age=200"),
+            "expected max-age=200 from products but got: {cc}"
+        )
     }
 
     // scenario 9: subgraph-level insert rule overrides what the subgraph sends

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -309,7 +309,7 @@ mod cache_control_e2e_tests {
         assert_eq!(res.status(), 200);
 
         // no propagate rule and no insert rule: cache-control is absent
-        // ponytail: no implicit no-store fallback; add an insert rule if a safe default is needed
+        // no implicit no-store fallback; add an insert rule if a safe default is needed
         assert!(
             cache_control(&res).is_none(),
             "expected no cache-control header when nothing is configured but got: {:?}",
@@ -466,7 +466,7 @@ mod cache_control_e2e_tests {
 
         // with append+propagate, only the one value (public, max-age=200) lands in the aggregator
         // and gets merged. the merge sees only present values so public survives here.
-        // ponytail: strict consensus (strip public when a subgraph is silent) is out of scope
+        // strict consensus (strip public when a subgraph is silent) is out of scope
         let cc = cache_control(&res).expect("expected cache-control header");
         assert!(
             cc.contains("max-age=200"),

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -286,7 +286,7 @@ mod cache_control_e2e_tests {
     // scenario 5: no subgraph sends cache-control and no rule configured
     // expected: no cache-control header emitted (no implicit fallback)
     #[ntex::test]
-    async fn no_subgraph_cache_control_emits_no_store() {
+    async fn no_subgraph_cache_control_emits_no_header() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
 
         let router = TestRouter::builder()

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -464,13 +464,10 @@ mod cache_control_e2e_tests {
 
         assert_eq!(res.status(), 200);
 
-        // with append+propagate, only the one value (public, max-age=200) lands in the aggregator
-        // and gets merged. the merge sees only present values so public survives here.
-        // strict consensus (strip public when a subgraph is silent) is out of scope
-        let cc = cache_control(&res).expect("expected cache-control header");
+        let cc = cache_control(&res).unwrap_or_default();
         assert!(
-            cc.contains("max-age=200"),
-            "expected max-age=200 from products but got: {cc}"
+            !cc.contains("public"),
+            "didnt expect cache-control public, but got: {cc}"
         );
     }
 

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -317,10 +317,27 @@ mod cache_control_e2e_tests {
         );
     }
 
-    // scenario 6: global insert rule provides a default cache-control when no subgraph sends one
+    // scenario 6: global insert cache-control rule
     #[ntex::test]
-    async fn global_fallback_cache_control_from_config() {
-        let subgraphs = TestSubgraphs::builder().build().start().await;
+    async fn global_insert_cache_control_from_config() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("accounts") {
+                    // router shouldnt care, we're overriding
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            http::header::CACHE_CONTROL => "no-cache"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
 
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)

--- a/e2e/src/cache_control.rs
+++ b/e2e/src/cache_control.rs
@@ -597,4 +597,125 @@ mod cache_control_e2e_tests {
             "expected no-store, no-cache, must-revalidate on network error but got: {cc}"
         );
     }
+
+    // scenario 11: global propagate with default + subgraph-level insert override
+    //
+    // - accounts sends no cache-control -> global default "public, max-age=180"
+    //   is used
+    // - products sends "public, max-age=300" but the subgraph insert rule pins
+    //   it to "no-cache"
+    // - "no-cache" poisons the merge, so the result is "no-store, no-cache"
+    //   regardless of the default
+    #[ntex::test]
+    async fn global_default_with_subgraph_insert_override() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        StatusCode::OK,
+                        None,
+                        some_header_map! {
+                            // products sends its own value; the insert rule replaces it
+                            http::header::CACHE_CONTROL => "public, max-age=300"
+                        },
+                    ))
+                } else {
+                    // accounts sends nothing; the global default should fill in
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
+                                default: "public, max-age=180"
+                    subgraphs:
+                        products:
+                            response:
+                                - insert:
+                                    name: cache-control
+                                    value: "no-cache"
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // topProducts hits products; me hits accounts
+        // use topProducts so products subgraph is definitely involved
+        let res = router
+            .send_graphql_request(
+                r#"{ topProducts(first: 1) { upc name } me { name } }"#,
+                None,
+                None,
+            )
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header");
+
+        // products insert rule pins to no-cache, which poisons the merge
+        // no-cache short-circuits the entire result regardless of the accounts default
+        assert!(
+            cc.contains("no-store") && cc.contains("no-cache"),
+            "expected no-store, no-cache from poisoned merge but got: {cc}"
+        );
+        assert!(
+            !cc.contains("max-age"),
+            "expected max-age to be absent after poison but got: {cc}"
+        );
+    }
+
+    // scenario 12: propagate default is used when the subgraph sends no cache-control
+    #[ntex::test]
+    async fn propagate_default_when_subgraph_sends_nothing() {
+        // accounts sends no cache-control header at all
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                headers:
+                    all:
+                        response:
+                            - propagate:
+                                named: cache-control
+                                algorithm: append
+                                default: "public, max-age=180"
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(r#"{ me { name } }"#, None, None)
+            .await;
+
+        assert_eq!(res.status(), 200);
+
+        let cc = cache_control(&res).expect("expected cache-control header from default");
+        assert!(
+            cc.contains("public") && cc.contains("max-age=180"),
+            "expected public, max-age=180 from propagate default but got: {cc}"
+        );
+    }
 }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+mod cache_control;
+#[cfg(test)]
 mod authorization_directives_filter;
 #[cfg(test)]
 mod authorization_directives_reject;

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
-mod cache_control;
-#[cfg(test)]
 mod authorization_directives_filter;
 #[cfg(test)]
 mod authorization_directives_reject;
 #[cfg(test)]
 mod body_limit;
+#[cfg(test)]
+mod cache_control;
 #[cfg(test)]
 mod circuit_breaker;
 #[cfg(test)]

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -390,6 +390,16 @@ async fn handle_on_request(
             return response;
         }
 
+        if !new_resp.status.is_success() {
+            // no body and non-success status, short-circuit with just the status and headers
+            let mut response = axum::response::Response::builder()
+                .status(new_resp.status)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            *response.headers_mut() = new_resp.headers;
+            return response;
+        }
+
         // no body provided, use body of the subgraph but change the status and headers
         let rebuilt_body = axum::body::Body::from(body_bytes);
         let rebuilt = axum::extract::Request::from_parts(parts, rebuilt_body);

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -380,19 +380,29 @@ async fn handle_on_request(
     };
 
     if let Some(new_resp) = on_request(req) {
-        // response intercepted, return it and stop
-        let mut response = axum::response::Response::builder()
-            .status(new_resp.status)
-            .body(if let Some(body) = new_resp.body {
-                axum::body::Body::from(body)
-            } else {
-                axum::body::Body::empty()
-            })
-            .unwrap();
-        *response.headers_mut() = new_resp.headers;
-        return response;
+        if let Some(body) = new_resp.body {
+            // short-circuit the request and respond with this body and the configured headers
+            let mut response = axum::response::Response::builder()
+                .status(new_resp.status)
+                .body(axum::body::Body::from(body))
+                .unwrap();
+            *response.headers_mut() = new_resp.headers;
+            return response;
+        }
+
+        // no body provided, use body of the subgraph but change the status and headers
+        let rebuilt_body = axum::body::Body::from(body_bytes);
+        let rebuilt = axum::extract::Request::from_parts(parts, rebuilt_body);
+        let mut subgraph_resp = next.run(rebuilt).await;
+        for (name, value) in new_resp.headers {
+            if let Some(name) = name {
+                subgraph_resp.headers_mut().insert(name, value);
+            }
+        }
+        return subgraph_resp;
     }
 
+    // no override, just pass through the original request
     let rebuilt_body = axum::body::Body::from(body_bytes);
     let request = axum::extract::Request::from_parts(parts, rebuilt_body);
     next.run(request).await

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -35,6 +35,7 @@ use tracing::Instrument;
 use crate::execution::client_request_details::OperationDetails;
 use crate::execution::demand_control::DemandControlExecutionContext;
 use crate::execution::operation_name::OperationNameFactory;
+use crate::headers::cache_control;
 use crate::{
     execution::{
         client_request_details::ClientRequestDetails,
@@ -555,6 +556,12 @@ async fn execute_query_plan_with_data<'exec>(
         );
         demand_control.apply_expose_headers(&mut exec_ctx.response_headers_aggregator, actual);
     }
+
+    cache_control::finalize(
+        &mut exec_ctx.response_headers_aggregator,
+        // force no-store for mutations and errors (execution or graphql errors)
+        opts.operation_type_name == "Mutation" || !errors.is_empty(),
+    );
 
     opts.response_header_sink
         .store(std::mem::take(&mut exec_ctx.response_headers_aggregator));

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -561,6 +561,12 @@ async fn execute_query_plan_with_data<'exec>(
         &mut exec_ctx.response_headers_aggregator,
         // force no-store for mutations and errors (execution or graphql errors)
         opts.operation_type_name == "Mutation" || !errors.is_empty(),
+        // response_storage.len() counts subgraphs that returned bytes, which is
+        // exactly what we need: a plugin hook can short-circuit with a bytes-less
+        // SubgraphResponse, but in that case it also produces no cache-control header,
+        // so both sides of the comparison in finalize stay in sync - that fetch is
+        // invisible to both counters and cancels out (is safe to ignore)
+        exec_ctx.response_storage.len(),
     );
 
     opts.response_header_sink

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -1,5 +1,6 @@
 use crate::headers::{plan::HeaderAggregationStrategy, response::ResponseHeaderAggregator};
 use http::HeaderValue;
+use tracing::warn;
 
 #[derive(Clone, Default)]
 struct ParsedCacheControl {
@@ -175,12 +176,18 @@ pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool)
     }
 
     if let Some(merged) = acc {
-        let value = HeaderValue::from_str(&to_header_value(&merged))
-            .unwrap_or_else(|_| HeaderValue::from_static("no-store"));
+        let serialized = to_header_value(&merged);
+        // safety: to_header_value only produces ASCII
+        let value = HeaderValue::from_str(&serialized).expect("to_header_value produced non-ASCII");
         aggregator.entries.insert(
             http::header::CACHE_CONTROL,
             (HeaderAggregationStrategy::Last, vec![value]),
         );
+    } else {
+        // no valid values found, but there were cache-control headers
+        // do the safe thing and graceful thing - completely omit the header
+        warn!("no valid cache-control values found, removing header");
+        aggregator.entries.remove(&http::header::CACHE_CONTROL);
     }
 }
 
@@ -681,6 +688,36 @@ mod tests {
         let mut agg = ResponseHeaderAggregator::default();
         finalize(&mut agg, false);
         assert!(agg.entries.get(&http::header::CACHE_CONTROL).is_none());
+    }
+
+    // empty string: parse() returns None, acc stays None, entry left unchanged
+    #[test]
+    fn finalize_empty_string_removes_header() {
+        let mut agg = make_aggregator(&[""]);
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), None);
+    }
+
+    // non-UTF-8: to_str() fails, acc stays None, entry left unchanged
+    #[test]
+    fn finalize_invalid_utf8_removes_header() {
+        let mut agg = ResponseHeaderAggregator::default();
+        let invalid = http::HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap();
+        agg.write(
+            &http::header::CACHE_CONTROL,
+            &invalid,
+            HeaderAggregationStrategy::Append,
+        );
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), None);
+    }
+
+    // unrecognized directive: parse() returns Some(default), serializes to no-store
+    #[test]
+    fn finalize_unrecognized_directive_removes_header() {
+        let mut agg = make_aggregator(&["bogus-directive"]);
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
     #[test]

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -1,0 +1,649 @@
+use crate::headers::{plan::HeaderAggregationStrategy, response::ResponseHeaderAggregator};
+use http::HeaderValue;
+
+#[derive(Clone, Default)]
+struct ParsedCacheControl {
+    no_store: bool,
+    no_cache: bool,
+    must_revalidate: bool,
+    is_private: bool,
+    is_public: bool,
+    max_age: Option<u32>,
+}
+
+fn parse(header: &str) -> Option<ParsedCacheControl> {
+    let trimmed = header.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut p = ParsedCacheControl::default();
+
+    for part in trimmed.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (token, value) = match part.split_once('=') {
+            Some((t, v)) => (t.trim(), Some(v.trim())),
+            None => (part, None),
+        };
+        match token.to_ascii_lowercase().as_str() {
+            "no-store" => p.no_store = true,
+            "no-cache" => p.no_cache = true,
+            "must-revalidate" => p.must_revalidate = true,
+            "private" => p.is_private = true,
+            "public" => p.is_public = true,
+            "max-age" => {
+                if let Some(v) = value {
+                    match v.parse::<u32>() {
+                        Ok(n) => p.max_age = Some(n),
+                        Err(_) => {
+                            tracing::warn!("cache-control max-age has non-numeric value: {v}")
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Some(p)
+}
+
+fn merge_into(acc: &mut Option<ParsedCacheControl>, incoming: ParsedCacheControl) {
+    let Some(existing) = acc else {
+        *acc = Some(incoming);
+        return;
+    };
+
+    if existing.no_store
+        || existing.no_cache
+        || existing.is_private
+        || incoming.no_store
+        || incoming.no_cache
+        || incoming.is_private
+    {
+        *existing = ParsedCacheControl {
+            no_store: true,
+            no_cache: true,
+            ..Default::default()
+        };
+        return;
+    }
+
+    existing.is_public = existing.is_public && incoming.is_public;
+    existing.must_revalidate = existing.must_revalidate || incoming.must_revalidate;
+    existing.max_age = match (existing.max_age, incoming.max_age) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+}
+
+fn to_header_value(p: &ParsedCacheControl) -> String {
+    if p.no_store || p.no_cache {
+        return "no-store, no-cache".to_string();
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+
+    if p.is_public {
+        parts.push("public".to_string());
+    } else if p.is_private {
+        parts.push("private".to_string());
+    }
+
+    if let Some(age) = p.max_age {
+        parts.push(format!("max-age={age}"));
+    }
+
+    if p.must_revalidate {
+        parts.push("must-revalidate".to_string());
+    }
+
+    parts.join(", ")
+}
+
+// TODO: document with extensive comment
+pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool) {
+    let Some((_, values)) = aggregator.entries.get(&http::header::CACHE_CONTROL) else {
+        // there's no cache-control headers anywhere, so nothing to merge or poison - just leave it absent
+        return;
+    };
+
+    if force_no_store {
+        let value = HeaderValue::from_static("no-store, no-cache, must-revalidate");
+        aggregator.entries.insert(
+            http::header::CACHE_CONTROL,
+            (HeaderAggregationStrategy::Last, vec![value]),
+        );
+        return;
+    }
+
+    let mut acc: Option<ParsedCacheControl> = None;
+    for v in values {
+        if let Ok(s) = v.to_str() {
+            if let Some(parsed) = parse(s) {
+                merge_into(&mut acc, parsed);
+            }
+        }
+    }
+
+    if let Some(merged) = acc {
+        let value = HeaderValue::from_str(&to_header_value(&merged))
+            .unwrap_or_else(|_| HeaderValue::from_static("no-store"));
+        aggregator.entries.insert(
+            http::header::CACHE_CONTROL,
+            (HeaderAggregationStrategy::Last, vec![value]),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn merge(a: Option<ParsedCacheControl>, b: ParsedCacheControl) -> ParsedCacheControl {
+        let mut acc = a;
+        merge_into(&mut acc, b);
+        acc.unwrap()
+    }
+
+    // acc is None: first value is adopted as-is
+    #[test]
+    fn first_value_adopted() {
+        let result = merge(
+            None,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_public);
+        assert_eq!(result.max_age, Some(300));
+        assert!(!result.no_store);
+        assert!(!result.no_cache);
+    }
+
+    // incoming no_store poisons the result
+    #[test]
+    fn incoming_no_store_poisons() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                no_store: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.is_public);
+        assert_eq!(result.max_age, None);
+    }
+
+    // incoming no_cache poisons the result
+    #[test]
+    fn incoming_no_cache_poisons() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                is_public: true,
+                max_age: Some(60),
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                no_cache: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.is_public);
+    }
+
+    // incoming private poisons the result
+    #[test]
+    fn incoming_private_poisons() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                is_public: true,
+                max_age: Some(120),
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                is_private: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.is_public);
+        assert!(!result.is_private); // private is cleared, only no-store/no-cache remain
+    }
+
+    // existing no_store poisons even with a clean incoming
+    #[test]
+    fn existing_no_store_poisons() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                no_store: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.is_public);
+    }
+
+    // existing private poisons even with a clean incoming
+    #[test]
+    fn existing_private_poisons() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                is_private: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+    }
+
+    // both no_store: result is no_store, no_cache
+    #[test]
+    fn both_no_store() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                no_store: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                no_store: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+    }
+
+    // max_age: both present, take the min
+    #[test]
+    fn max_age_takes_min() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                max_age: Some(500),
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        assert_eq!(result.max_age, Some(300));
+    }
+
+    // max_age: both present, other direction
+    #[test]
+    fn max_age_takes_min_other_direction() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                max_age: Some(100),
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                max_age: Some(999),
+                ..Default::default()
+            },
+        );
+        assert_eq!(result.max_age, Some(100));
+    }
+
+    // max_age: existing has it, incoming does not - keep existing
+    #[test]
+    fn max_age_existing_only() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                max_age: Some(200),
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                max_age: None,
+                ..Default::default()
+            },
+        );
+        assert_eq!(result.max_age, Some(200));
+    }
+
+    // max_age: incoming has it, existing does not - adopt incoming
+    #[test]
+    fn max_age_incoming_only() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                max_age: None,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                max_age: Some(60),
+                ..Default::default()
+            },
+        );
+        assert_eq!(result.max_age, Some(60));
+    }
+
+    // max_age: neither has it
+    #[test]
+    fn max_age_neither() {
+        let result = merge(
+            Some(ParsedCacheControl::default()),
+            ParsedCacheControl::default(),
+        );
+        assert_eq!(result.max_age, None);
+    }
+
+    // public: both public -> stays public
+    #[test]
+    fn public_both_public() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                is_public: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                is_public: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.is_public);
+    }
+
+    // public: existing public, incoming not -> stripped
+    #[test]
+    fn public_stripped_when_incoming_not_public() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                is_public: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                is_public: false,
+                ..Default::default()
+            },
+        );
+        assert!(!result.is_public);
+    }
+
+    // public: neither public -> stays false
+    #[test]
+    fn public_neither() {
+        let result = merge(
+            Some(ParsedCacheControl::default()),
+            ParsedCacheControl::default(),
+        );
+        assert!(!result.is_public);
+    }
+
+    // must_revalidate: either side sets it -> propagated
+    #[test]
+    fn must_revalidate_from_incoming() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                must_revalidate: false,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                must_revalidate: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.must_revalidate);
+    }
+
+    #[test]
+    fn must_revalidate_from_existing() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                must_revalidate: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                must_revalidate: false,
+                ..Default::default()
+            },
+        );
+        assert!(result.must_revalidate);
+    }
+
+    // must_revalidate: neither sets it
+    #[test]
+    fn must_revalidate_neither() {
+        let result = merge(
+            Some(ParsedCacheControl::default()),
+            ParsedCacheControl::default(),
+        );
+        assert!(!result.must_revalidate);
+    }
+
+    // must_revalidate is cleared when poison is triggered
+    #[test]
+    fn must_revalidate_cleared_on_poison() {
+        let result = merge(
+            Some(ParsedCacheControl {
+                must_revalidate: true,
+                ..Default::default()
+            }),
+            ParsedCacheControl {
+                no_store: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.must_revalidate);
+    }
+
+    // three-way merge: public survives only if all three agree
+    #[test]
+    fn three_way_all_public() {
+        let mut acc = None;
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(200),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(500),
+                ..Default::default()
+            },
+        );
+        let result = acc.unwrap();
+        assert!(result.is_public);
+        assert_eq!(result.max_age, Some(200));
+    }
+
+    // three-way merge: one non-public kills public
+    #[test]
+    fn three_way_one_not_public() {
+        let mut acc = None;
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: false,
+                max_age: Some(100),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(200),
+                ..Default::default()
+            },
+        );
+        let result = acc.unwrap();
+        assert!(!result.is_public);
+        assert_eq!(result.max_age, Some(100));
+    }
+
+    // three-way merge: third is poisonous, earlier max-age/public are discarded
+    #[test]
+    fn three_way_third_poisons() {
+        let mut acc = None;
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(200),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                no_store: true,
+                ..Default::default()
+            },
+        );
+        let result = acc.unwrap();
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.is_public);
+        assert_eq!(result.max_age, None);
+    }
+
+    // three-way merge: first is poisonous, subsequent clean values don't un-poison
+    #[test]
+    fn three_way_first_poisons_no_recovery() {
+        let mut acc = None;
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                no_cache: true,
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(300),
+                ..Default::default()
+            },
+        );
+        merge_into(
+            &mut acc,
+            ParsedCacheControl {
+                is_public: true,
+                max_age: Some(200),
+                ..Default::default()
+            },
+        );
+        let result = acc.unwrap();
+        assert!(result.no_store);
+        assert!(result.no_cache);
+        assert!(!result.is_public);
+    }
+
+    fn make_aggregator(values: &[&str]) -> ResponseHeaderAggregator {
+        let mut agg = ResponseHeaderAggregator::default();
+        for v in values {
+            agg.write(
+                &http::header::CACHE_CONTROL,
+                &http::HeaderValue::from_str(v).unwrap(),
+                HeaderAggregationStrategy::Append,
+            );
+        }
+        agg
+    }
+
+    fn cc_value(agg: &ResponseHeaderAggregator) -> Option<String> {
+        agg.entries
+            .get(&http::header::CACHE_CONTROL)
+            .and_then(|(_, vs)| vs.first())
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    }
+
+    #[test]
+    fn finalize_force_no_store_forces_no_store() {
+        let mut agg = make_aggregator(&["public, max-age=300"]);
+        finalize(&mut agg, true);
+        assert_eq!(
+            cc_value(&agg).as_deref(),
+            Some("no-store, no-cache, must-revalidate")
+        );
+    }
+
+    #[test]
+    fn finalize_merges_two_appended_values() {
+        let mut agg = make_aggregator(&["public, max-age=300", "public, max-age=60"]);
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), Some("public, max-age=60"));
+    }
+
+    #[test]
+    fn finalize_private_collapses_to_no_store() {
+        let mut agg = make_aggregator(&["private"]);
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
+    }
+
+    #[test]
+    fn finalize_absent_entry_no_error_leaves_absent() {
+        let mut agg = ResponseHeaderAggregator::default();
+        finalize(&mut agg, false);
+        assert!(agg.entries.get(&http::header::CACHE_CONTROL).is_none());
+    }
+
+    #[test]
+    fn finalize_absent_entry_with_force_no_store_absent() {
+        let mut agg = ResponseHeaderAggregator::default();
+        finalize(&mut agg, true);
+        assert!(agg.entries.get(&http::header::CACHE_CONTROL).is_none());
+    }
+}

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -3,7 +3,7 @@ use http::HeaderValue;
 use tracing::warn;
 
 #[derive(Clone, Default)]
-struct ParsedCacheControl {
+struct CacheControl {
     no_store: bool,
     no_cache: bool,
     must_revalidate: bool,
@@ -12,13 +12,13 @@ struct ParsedCacheControl {
     max_age: Option<u32>,
 }
 
-fn parse(header: &str) -> Option<ParsedCacheControl> {
+fn parse(header: &str) -> Option<CacheControl> {
     let trimmed = header.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    let mut p = ParsedCacheControl::default();
+    let mut p = CacheControl::default();
 
     for part in trimmed.split(',') {
         let part = part.trim();
@@ -40,19 +40,25 @@ fn parse(header: &str) -> Option<ParsedCacheControl> {
                     match v.parse::<u32>() {
                         Ok(n) => p.max_age = Some(n),
                         Err(_) => {
-                            tracing::warn!("cache-control max-age has non-numeric value: {v}")
+                            tracing::warn!("cache-control max-age has non-numeric value: {v}");
+                            // zero tolerance on malformed cache-control headers
+                            return None;
                         }
                     }
                 }
             }
-            _ => {}
+            v => {
+                // one invalid part is enough to stop parsing and discard the header
+                tracing::warn!("cache-control has unrecognized directive: {v}");
+                return None;
+            }
         }
     }
 
     Some(p)
 }
 
-fn merge_into(acc: &mut Option<ParsedCacheControl>, incoming: ParsedCacheControl) {
+fn merge_into(acc: &mut Option<CacheControl>, incoming: CacheControl) {
     let Some(existing) = acc else {
         *acc = Some(incoming);
         return;
@@ -65,7 +71,7 @@ fn merge_into(acc: &mut Option<ParsedCacheControl>, incoming: ParsedCacheControl
         || incoming.no_cache
         || incoming.is_private
     {
-        *existing = ParsedCacheControl {
+        *existing = CacheControl {
             no_store: true,
             no_cache: true,
             ..Default::default()
@@ -83,7 +89,7 @@ fn merge_into(acc: &mut Option<ParsedCacheControl>, incoming: ParsedCacheControl
     };
 }
 
-fn to_header_value(p: &ParsedCacheControl) -> String {
+fn to_header_value(p: &CacheControl) -> String {
     if p.no_store || p.no_cache || p.is_private {
         return "no-store, no-cache".to_string();
     }
@@ -166,7 +172,7 @@ pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool)
         return;
     }
 
-    let mut acc: Option<ParsedCacheControl> = None;
+    let mut acc: Option<CacheControl> = None;
     for v in values {
         if let Ok(s) = v.to_str() {
             if let Some(parsed) = parse(s) {
@@ -195,7 +201,7 @@ pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool)
 mod tests {
     use super::*;
 
-    fn merge(a: Option<ParsedCacheControl>, b: ParsedCacheControl) -> ParsedCacheControl {
+    fn merge(a: Option<CacheControl>, b: CacheControl) -> CacheControl {
         let mut acc = a;
         merge_into(&mut acc, b);
         acc.unwrap()
@@ -206,7 +212,7 @@ mod tests {
     fn first_value_adopted() {
         let result = merge(
             None,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -222,12 +228,12 @@ mod tests {
     #[test]
     fn incoming_no_store_poisons() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 no_store: true,
                 ..Default::default()
             },
@@ -242,12 +248,12 @@ mod tests {
     #[test]
     fn incoming_no_cache_poisons() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 is_public: true,
                 max_age: Some(60),
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 no_cache: true,
                 ..Default::default()
             },
@@ -261,12 +267,12 @@ mod tests {
     #[test]
     fn incoming_private_poisons() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 is_public: true,
                 max_age: Some(120),
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 is_private: true,
                 ..Default::default()
             },
@@ -281,11 +287,11 @@ mod tests {
     #[test]
     fn existing_no_store_poisons() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 no_store: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -300,11 +306,11 @@ mod tests {
     #[test]
     fn existing_private_poisons() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 is_private: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -318,11 +324,11 @@ mod tests {
     #[test]
     fn both_no_store() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 no_store: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 no_store: true,
                 ..Default::default()
             },
@@ -335,11 +341,11 @@ mod tests {
     #[test]
     fn max_age_takes_min() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 max_age: Some(500),
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 max_age: Some(300),
                 ..Default::default()
             },
@@ -351,11 +357,11 @@ mod tests {
     #[test]
     fn max_age_takes_min_other_direction() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 max_age: Some(100),
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 max_age: Some(999),
                 ..Default::default()
             },
@@ -367,11 +373,11 @@ mod tests {
     #[test]
     fn max_age_existing_only() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 max_age: Some(200),
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 max_age: None,
                 ..Default::default()
             },
@@ -383,11 +389,11 @@ mod tests {
     #[test]
     fn max_age_incoming_only() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 max_age: None,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 max_age: Some(60),
                 ..Default::default()
             },
@@ -398,10 +404,7 @@ mod tests {
     // max_age: neither has it
     #[test]
     fn max_age_neither() {
-        let result = merge(
-            Some(ParsedCacheControl::default()),
-            ParsedCacheControl::default(),
-        );
+        let result = merge(Some(CacheControl::default()), CacheControl::default());
         assert_eq!(result.max_age, None);
     }
 
@@ -409,11 +412,11 @@ mod tests {
     #[test]
     fn public_both_public() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 is_public: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 ..Default::default()
             },
@@ -425,11 +428,11 @@ mod tests {
     #[test]
     fn public_stripped_when_incoming_not_public() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 is_public: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 is_public: false,
                 ..Default::default()
             },
@@ -440,10 +443,7 @@ mod tests {
     // public: neither public -> stays false
     #[test]
     fn public_neither() {
-        let result = merge(
-            Some(ParsedCacheControl::default()),
-            ParsedCacheControl::default(),
-        );
+        let result = merge(Some(CacheControl::default()), CacheControl::default());
         assert!(!result.is_public);
     }
 
@@ -451,11 +451,11 @@ mod tests {
     #[test]
     fn must_revalidate_from_incoming() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 must_revalidate: false,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 must_revalidate: true,
                 ..Default::default()
             },
@@ -466,11 +466,11 @@ mod tests {
     #[test]
     fn must_revalidate_from_existing() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 must_revalidate: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 must_revalidate: false,
                 ..Default::default()
             },
@@ -481,10 +481,7 @@ mod tests {
     // must_revalidate: neither sets it
     #[test]
     fn must_revalidate_neither() {
-        let result = merge(
-            Some(ParsedCacheControl::default()),
-            ParsedCacheControl::default(),
-        );
+        let result = merge(Some(CacheControl::default()), CacheControl::default());
         assert!(!result.must_revalidate);
     }
 
@@ -492,11 +489,11 @@ mod tests {
     #[test]
     fn must_revalidate_cleared_on_poison() {
         let result = merge(
-            Some(ParsedCacheControl {
+            Some(CacheControl {
                 must_revalidate: true,
                 ..Default::default()
             }),
-            ParsedCacheControl {
+            CacheControl {
                 no_store: true,
                 ..Default::default()
             },
@@ -512,7 +509,7 @@ mod tests {
         let mut acc = None;
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -520,7 +517,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(200),
                 ..Default::default()
@@ -528,7 +525,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(500),
                 ..Default::default()
@@ -545,7 +542,7 @@ mod tests {
         let mut acc = None;
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -553,7 +550,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: false,
                 max_age: Some(100),
                 ..Default::default()
@@ -561,7 +558,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(200),
                 ..Default::default()
@@ -578,7 +575,7 @@ mod tests {
         let mut acc = None;
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -586,7 +583,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(200),
                 ..Default::default()
@@ -594,7 +591,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 no_store: true,
                 ..Default::default()
             },
@@ -612,14 +609,14 @@ mod tests {
         let mut acc = None;
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 no_cache: true,
                 ..Default::default()
             },
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(300),
                 ..Default::default()
@@ -627,7 +624,7 @@ mod tests {
         );
         merge_into(
             &mut acc,
-            ParsedCacheControl {
+            CacheControl {
                 is_public: true,
                 max_age: Some(200),
                 ..Default::default()
@@ -712,10 +709,23 @@ mod tests {
         assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
-    // unrecognized directive: parse() returns Some(default), serializes to no-store
     #[test]
-    fn finalize_unrecognized_directive_removes_header() {
+    fn finalize_unrecognized_value_removes_header() {
         let mut agg = make_aggregator(&["bogus-directive"]);
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), None);
+    }
+
+    #[test]
+    fn finalize_single_unrecognized_directive_removes_header() {
+        let mut agg = make_aggregator(&["public, max-age=300, huh"]);
+        finalize(&mut agg, false);
+        assert_eq!(cc_value(&agg).as_deref(), None);
+    }
+
+    #[test]
+    fn finalize_malformed_max_age_removes_header() {
+        let mut agg = make_aggregator(&["public, max-age=woof"]);
         finalize(&mut agg, false);
         assert_eq!(cc_value(&agg).as_deref(), None);
     }

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -83,7 +83,7 @@ fn merge_into(acc: &mut Option<ParsedCacheControl>, incoming: ParsedCacheControl
 }
 
 fn to_header_value(p: &ParsedCacheControl) -> String {
-    if p.no_store || p.no_cache {
+    if p.no_store || p.no_cache || p.is_private {
         return "no-store, no-cache".to_string();
     }
 

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -106,7 +106,50 @@ fn to_header_value(p: &ParsedCacheControl) -> String {
     parts.join(", ")
 }
 
-// TODO: document with extensive comment
+/// Collapse all accumulated `Cache-Control` header values in the aggregator into
+/// a single, restrictively merged value and write it back, replacing whatever was
+/// there before.
+///
+/// After all subgraph responses have been written into the `ResponseHeaderAggregator`
+/// via the normal header propagation rules, `finalize` is called once before the
+/// aggregator is flushed to the client response. At that point `aggregator.entries`
+/// may contain zero, one, or many `Cache-Control` values depending on how many
+/// subgraphs sent the header and whether any response-header rules also propagated it.
+///
+/// If the aggregator contains no `Cache-Control` entry at all (no subgraph sent it an
+/// no propagation rule added it), the function returns immediately without inserting
+/// anything. The header is left absent from the client response.
+///
+/// When `force_no_store` is `true` the caller has determined that caching must be
+/// unconditionally forbidden - for example because the operation is a mutation, a
+/// subgraph returned a GraphQL `errors` array, or a network-level error occurred.
+/// The function overwrites whatever is in the aggregator with
+/// `no-store, no-cache, must-revalidate` and returns. This path also exits early if
+/// no `Cache-Control` entry exists, matching the behaviour of the normal path (we only
+/// emit a header when a subgraph sent one first).
+///
+/// When `force_no_store` is `false` the raw string values stored in the aggregator are
+/// parsed and folded left-to-right with the following policy:
+///
+/// 1. Poison check - if any value contains `no-store`, `no-cache`, or `private`, the
+///    accumulated result is immediately locked to `no-store, no-cache` and all remaining
+///    directives (`public`, `max-age`, `must-revalidate`) are discarded. Further
+///    incoming values cannot "un-poison" this state.
+/// 2. max-age - the minimum of all present `max-age` values is kept. A subgraph that
+///    omits `max-age` entirely does not pull the min down; it is simply ignored for
+///    this field, letting a shorter age set by another subgraph win.
+/// 3. public - preserved only when every subgraph that sent `Cache-Control` also sent
+///    `public`. A single subgraph that omits it is enough to strip `public` from the
+///    result.
+/// 4. must-revalidate - set if any subgraph sets it (logical OR). Cleared on poison.
+///
+/// The merged result is serialised back to a `HeaderValue` and re-inserted into the
+/// aggregator under `Last` strategy so that any subsequent header-flush loop sees
+/// exactly one value.
+///
+/// If every collected value was unparseable (e.g. non-UTF-8 bytes) the fold produces no
+/// `acc` and the entry is left unchanged, meaning the last raw value written by the
+/// propagation rules survives as-is.
 pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool) {
     let Some((_, values)) = aggregator.entries.get(&http::header::CACHE_CONTROL) else {
         // there's no cache-control headers anywhere, so nothing to merge or poison - just leave it absent

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -2,6 +2,11 @@ use crate::headers::{plan::HeaderAggregationStrategy, response::ResponseHeaderAg
 use http::HeaderValue;
 use tracing::{debug, warn};
 
+lazy_static::lazy_static! {
+    static ref NO_STORE_HEADER_VALUE: HeaderValue =
+        HeaderValue::from_static("no-store, no-cache, must-revalidate");
+}
+
 #[derive(Clone, Default)]
 struct CacheControl {
     no_store: bool,
@@ -172,7 +177,7 @@ pub fn finalize(
     };
 
     if force_no_store {
-        let value = HeaderValue::from_static("no-store, no-cache, must-revalidate");
+        let value = NO_STORE_HEADER_VALUE.clone();
         aggregator.entries.insert(
             http::header::CACHE_CONTROL,
             (HeaderAggregationStrategy::Last, vec![value]),

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -102,8 +102,6 @@ fn to_header_value(p: &CacheControl) -> String {
 
     if p.is_public {
         parts.push("public".to_string());
-    } else if p.is_private {
-        parts.push("private".to_string());
     }
 
     if let Some(age) = p.max_age {

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -147,9 +147,11 @@ fn to_header_value(p: &CacheControl) -> String {
 /// 2. max-age - the minimum of all present `max-age` values is kept. A subgraph that
 ///    omits `max-age` entirely does not pull the min down; it is simply ignored for
 ///    this field, letting a shorter age set by another subgraph win.
-/// 3. public - preserved only when every subgraph that sent `Cache-Control` also sent
-///    `public`. A single subgraph that omits it is enough to strip `public` from the
-///    result.
+/// 3. public - preserved only when every subgraph that returned a response also sent
+///    `public`. A subgraph that returned bytes but omitted `Cache-Control` entirely is
+///    counted through `total_responses` (the number of all subgraphs whose response
+///    counts) and is enough to strip `public` from the result, because silence is
+///    not consent.
 /// 4. must-revalidate - set if any subgraph sets it (logical OR). Cleared on poison.
 ///
 /// The merged result is serialised back to a `HeaderValue` and re-inserted into the
@@ -159,7 +161,11 @@ fn to_header_value(p: &CacheControl) -> String {
 /// If every collected value was unparseable (e.g. non-UTF-8 bytes) or empty the fold
 /// produces no `acc` and the `Cache-Control` header is removed from the aggregator.
 /// This avoids forwarding potentially unsafe or malformed caching directives.
-pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool) {
+pub fn finalize(
+    aggregator: &mut ResponseHeaderAggregator,
+    force_no_store: bool,
+    total_responses: usize,
+) {
     let Some((_, values)) = aggregator.entries.get(&http::header::CACHE_CONTROL) else {
         // there's no cache-control headers anywhere, so nothing to merge or poison - just leave it absent
         return;
@@ -183,7 +189,12 @@ pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool)
         }
     }
 
-    if let Some(merged) = acc {
+    if let Some(mut merged) = acc {
+        // a silent subgraph (no cache-control header at all) did not assert public,
+        // so public cannot hold when not every contacted subgraph sent it
+        if total_responses > values.len() {
+            merged.is_public = false;
+        }
         let serialized = to_header_value(&merged);
         // safety: to_header_value only produces ASCII
         let value = HeaderValue::from_str(&serialized).expect("to_header_value produced non-ASCII");
@@ -661,7 +672,7 @@ mod tests {
     #[test]
     fn finalize_force_no_store_forces_no_store() {
         let mut agg = make_aggregator(&["public, max-age=300"]);
-        finalize(&mut agg, true);
+        finalize(&mut agg, true, 1);
         assert_eq!(
             cc_value(&agg).as_deref(),
             Some("no-store, no-cache, must-revalidate")
@@ -671,21 +682,21 @@ mod tests {
     #[test]
     fn finalize_merges_two_appended_values() {
         let mut agg = make_aggregator(&["public, max-age=300", "public, max-age=60"]);
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 2);
         assert_eq!(cc_value(&agg).as_deref(), Some("public, max-age=60"));
     }
 
     #[test]
     fn finalize_private_collapses_to_no_store() {
         let mut agg = make_aggregator(&["private"]);
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 1);
         assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
     }
 
     #[test]
     fn finalize_absent_entry_no_error_leaves_absent() {
         let mut agg = ResponseHeaderAggregator::default();
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 0);
         assert!(agg.entries.get(&http::header::CACHE_CONTROL).is_none());
     }
 
@@ -693,7 +704,7 @@ mod tests {
     #[test]
     fn finalize_empty_string_removes_header() {
         let mut agg = make_aggregator(&[""]);
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 1);
         assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
@@ -707,35 +718,48 @@ mod tests {
             &invalid,
             HeaderAggregationStrategy::Append,
         );
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 1);
         assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
     #[test]
     fn finalize_unrecognized_value_removes_header() {
         let mut agg = make_aggregator(&["bogus-directive"]);
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 1);
         assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
     #[test]
     fn finalize_single_unrecognized_directive_removes_header() {
         let mut agg = make_aggregator(&["public, max-age=300, huh"]);
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 1);
         assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
     #[test]
     fn finalize_malformed_max_age_removes_header() {
         let mut agg = make_aggregator(&["public, max-age=woof"]);
-        finalize(&mut agg, false);
+        finalize(&mut agg, false, 1);
         assert_eq!(cc_value(&agg).as_deref(), None);
     }
 
     #[test]
     fn finalize_absent_entry_with_force_no_store_absent() {
         let mut agg = ResponseHeaderAggregator::default();
-        finalize(&mut agg, true);
+        finalize(&mut agg, true, 0);
         assert!(agg.entries.get(&http::header::CACHE_CONTROL).is_none());
+    }
+
+    #[test]
+    fn finalize_public_stripped_when_silent_subgraph() {
+        // one subgraph sent public, one sent nothing - public must not survive
+        let mut agg = make_aggregator(&["public, max-age=200"]);
+        finalize(&mut agg, false, 2);
+        let cc = cc_value(&agg).unwrap_or_default();
+        assert!(!cc.contains("public"), "expected no public, got: {cc}");
+        assert!(
+            cc.contains("max-age=200"),
+            "expected max-age=200, got: {cc}"
+        );
     }
 }

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -36,20 +36,24 @@ fn parse(header: &str) -> Option<CacheControl> {
             "private" => p.is_private = true,
             "public" => p.is_public = true,
             "max-age" => {
-                if let Some(v) = value {
-                    match v.parse::<u32>() {
-                        Ok(n) => p.max_age = Some(n),
+                let max_age = match value {
+                    Some(v) => match v.parse::<u32>() {
+                        Ok(n) => Some(n),
                         Err(_) => {
-                            tracing::warn!("cache-control max-age has non-numeric value: {v}");
-                            // zero tolerance on malformed cache-control headers
+                            warn!("cache-control max-age has non-numeric value: {v}");
                             return None;
                         }
+                    },
+                    None => {
+                        warn!("cache-control max-age is missing a value");
+                        return None;
                     }
-                }
+                };
+                p.max_age = max_age;
             }
             v => {
                 // one invalid part is enough to stop parsing and discard the header
-                tracing::warn!("cache-control has unrecognized directive: {v}");
+                warn!("cache-control has unrecognized directive: {v}");
                 return None;
             }
         }

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -1,6 +1,6 @@
 use crate::headers::{plan::HeaderAggregationStrategy, response::ResponseHeaderAggregator};
 use http::HeaderValue;
-use tracing::warn;
+use tracing::{debug, warn};
 
 #[derive(Clone, Default)]
 struct CacheControl {
@@ -205,6 +205,9 @@ pub fn finalize(
     } else {
         // no valid values found, but there were cache-control headers
         // do the safe thing and graceful thing - completely omit the header
+        for v in values {
+            debug!(value = ?v, "invalid cache-control value");
+        }
         warn!("no valid cache-control values found, removing header");
         aggregator.entries.remove(&http::header::CACHE_CONTROL);
     }

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -156,9 +156,9 @@ fn to_header_value(p: &CacheControl) -> String {
 /// aggregator under `Last` strategy so that any subsequent header-flush loop sees
 /// exactly one value.
 ///
-/// If every collected value was unparseable (e.g. non-UTF-8 bytes) the fold produces no
-/// `acc` and the entry is left unchanged, meaning the last raw value written by the
-/// propagation rules survives as-is.
+/// If every collected value was unparseable (e.g. non-UTF-8 bytes) or empty the fold
+/// produces no `acc` and the `Cache-Control` header is removed from the aggregator.
+/// This avoids forwarding potentially unsafe or malformed caching directives.
 pub fn finalize(aggregator: &mut ResponseHeaderAggregator, force_no_store: bool) {
     let Some((_, values)) = aggregator.entries.get(&http::header::CACHE_CONTROL) else {
         // there's no cache-control headers anywhere, so nothing to merge or poison - just leave it absent

--- a/lib/executor/src/headers/cache_control.rs
+++ b/lib/executor/src/headers/cache_control.rs
@@ -40,7 +40,7 @@ fn parse(header: &str) -> Option<CacheControl> {
                     Some(v) => match v.parse::<u32>() {
                         Ok(n) => Some(n),
                         Err(_) => {
-                            warn!("cache-control max-age has non-numeric value: {v}");
+                            warn!(value = v, "cache-control max-age has non-numeric value");
                             return None;
                         }
                     },
@@ -53,7 +53,7 @@ fn parse(header: &str) -> Option<CacheControl> {
             }
             v => {
                 // one invalid part is enough to stop parsing and discard the header
-                warn!("cache-control has unrecognized directive: {v}");
+                warn!(directive = v, "cache-control has unrecognized directive");
                 return None;
             }
         }

--- a/lib/executor/src/headers/compile.rs
+++ b/lib/executor/src/headers/compile.rs
@@ -86,26 +86,40 @@ impl HeaderRuleCompiler<Vec<ResponseHeaderRule>> for config::ResponseHeaderRule 
             config::ResponseHeaderRule::Propagate(rule) => {
                 let aggregation_strategy = rule.algorithm.into();
 
-                if !matches!(rule.algorithm, config::AggregationAlgo::Append) {
-                    let names_include_cache_control = match &rule.spec.named {
-                        Some(config::OneOrMany::One(n)) => {
-                            n.to_ascii_lowercase() == "cache-control"
-                        }
-                        Some(config::OneOrMany::Many(ns)) => {
-                            ns.iter().any(|n| n.to_ascii_lowercase() == "cache-control")
-                        }
-                        None => false,
-                    };
-                    if names_include_cache_control {
-                        return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
-                    }
-                }
-
                 let spec = materialize_match_spec(
                     &rule.spec,
                     rule.rename.as_ref(),
                     rule.default.as_ref(),
                 )?;
+
+                {
+                    // TODO: I thought about putting this in a function, but it'll be
+                    // just one function - is it ok if this stays inlined?
+
+                    // check runs after materialize_match_spec so we can test the
+                    // compiled regex against "cache-control" directly. exclude is
+                    // respected: if it matches cache-control too, the rule won't touch
+                    // it at runtime so no error is raised.
+                    let cache_control_excluded = spec
+                        .exclude_regex
+                        .as_ref()
+                        .is_some_and(|re| re.is_match("cache-control"));
+                    let cache_control_is_named = spec
+                        .header_names
+                        .iter()
+                        .any(|n| n.as_str() == "cache-control");
+                    let cache_control_is_matched = spec
+                        .include_regex
+                        .as_ref()
+                        .is_some_and(|re| re.is_match("cache-control"));
+                    let cache_control_matched = !cache_control_excluded
+                        && (cache_control_is_named || cache_control_is_matched);
+                    if !matches!(rule.algorithm, config::AggregationAlgo::Append)
+                        && cache_control_matched
+                    {
+                        return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
+                    }
+                }
 
                 if !spec.header_names.is_empty() {
                     actions.push(ResponseHeaderRule::PropagateNamed(ResponsePropagateNamed {
@@ -482,19 +496,100 @@ mod tests {
     }
 
     #[test]
+    fn test_cache_control_matching_regex_is_compile_error() {
+        for pattern in ["cache-control", "cache.*", "^cache-control$", ".*"] {
+            for algo in [
+                config::AggregationAlgo::First,
+                config::AggregationAlgo::Last,
+            ] {
+                let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+                    spec: config::MatchSpec {
+                        named: None,
+                        matching: Some(config::OneOrMany::One(pattern.to_string())),
+                        exclude: None,
+                    },
+                    rename: None,
+                    default: None,
+                    algorithm: algo,
+                });
+                let mut actions = Vec::new();
+                let err = rule.compile(&mut actions).unwrap_err();
+                assert!(
+                    matches!(err, HeaderRuleCompileError::CacheControlRequiresAppend),
+                    "expected CacheControlRequiresAppend for pattern={pattern:?} algo={algo:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_cache_control_matching_excluded_is_ok() {
+        // matching catches cache-control but exclude removes it - no error
+        for algo in [
+            config::AggregationAlgo::First,
+            config::AggregationAlgo::Last,
+        ] {
+            let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+                spec: config::MatchSpec {
+                    named: None,
+                    matching: Some(config::OneOrMany::One(".*".to_string())),
+                    exclude: Some(vec!["cache-control".to_string()]),
+                },
+                rename: None,
+                default: None,
+                algorithm: algo,
+            });
+            let mut actions = Vec::new();
+            rule.compile(&mut actions)
+                .unwrap_or_else(|e| panic!("unexpected error for algo={algo:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_cache_control_in_many_named_is_compile_error() {
+        for algo in [
+            config::AggregationAlgo::First,
+            config::AggregationAlgo::Last,
+        ] {
+            let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+                spec: config::MatchSpec {
+                    named: Some(config::OneOrMany::Many(vec![
+                        "x-custom".to_string(),
+                        "Cache-Control".to_string(),
+                    ])),
+                    matching: None,
+                    exclude: None,
+                },
+                rename: None,
+                default: None,
+                algorithm: algo,
+            });
+            let mut actions = Vec::new();
+            let err = rule.compile(&mut actions).unwrap_err();
+            assert!(
+                matches!(err, HeaderRuleCompileError::CacheControlRequiresAppend),
+                "expected CacheControlRequiresAppend for {algo:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_cache_control_propagate_append_is_ok() {
-        let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
-            spec: config::MatchSpec {
-                named: Some(config::OneOrMany::One("Cache-Control".to_string())),
-                matching: None,
-                exclude: None,
-            },
-            rename: None,
-            default: None,
-            algorithm: config::AggregationAlgo::Append,
-        });
-        let mut actions = Vec::new();
-        rule.compile(&mut actions).unwrap();
-        assert_eq!(actions.len(), 1);
+        for name in ["Cache-Control", "cache-control", "CACHE-CONTROL"] {
+            let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+                spec: config::MatchSpec {
+                    named: Some(config::OneOrMany::One(name.to_string())),
+                    matching: None,
+                    exclude: None,
+                },
+                rename: None,
+                default: None,
+                algorithm: config::AggregationAlgo::Append,
+            });
+            let mut actions = Vec::new();
+            rule.compile(&mut actions)
+                .unwrap_or_else(|e| panic!("unexpected error for {name}: {e}"));
+            assert_eq!(actions.len(), 1);
+        }
     }
 }

--- a/lib/executor/src/headers/compile.rs
+++ b/lib/executor/src/headers/compile.rs
@@ -85,6 +85,22 @@ impl HeaderRuleCompiler<Vec<ResponseHeaderRule>> for config::ResponseHeaderRule 
         match self {
             config::ResponseHeaderRule::Propagate(rule) => {
                 let aggregation_strategy = rule.algorithm.into();
+
+                if !matches!(rule.algorithm, config::AggregationAlgo::Append) {
+                    let names_include_cache_control = match &rule.spec.named {
+                        Some(config::OneOrMany::One(n)) => {
+                            n.to_ascii_lowercase() == "cache-control"
+                        }
+                        Some(config::OneOrMany::Many(ns)) => {
+                            ns.iter().any(|n| n.to_ascii_lowercase() == "cache-control")
+                        }
+                        None => false,
+                    };
+                    if names_include_cache_control {
+                        return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
+                    }
+                }
+
                 let spec = materialize_match_spec(
                     &rule.spec,
                     rule.rename.as_ref(),
@@ -438,5 +454,47 @@ mod tests {
             }
             _ => panic!("Expected PropagateNamed"),
         }
+    }
+
+    #[test]
+    fn test_cache_control_propagate_first_is_compile_error() {
+        for algo in [
+            config::AggregationAlgo::First,
+            config::AggregationAlgo::Last,
+        ] {
+            let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+                spec: config::MatchSpec {
+                    named: Some(config::OneOrMany::One("cache-control".to_string())),
+                    matching: None,
+                    exclude: None,
+                },
+                rename: None,
+                default: None,
+                algorithm: algo,
+            });
+            let mut actions = Vec::new();
+            let err = rule.compile(&mut actions).unwrap_err();
+            assert!(
+                matches!(err, HeaderRuleCompileError::CacheControlRequiresAppend),
+                "expected CacheControlRequiresAppend for {algo:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cache_control_propagate_append_is_ok() {
+        let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+            spec: config::MatchSpec {
+                named: Some(config::OneOrMany::One("Cache-Control".to_string())),
+                matching: None,
+                exclude: None,
+            },
+            rename: None,
+            default: None,
+            algorithm: config::AggregationAlgo::Append,
+        });
+        let mut actions = Vec::new();
+        rule.compile(&mut actions).unwrap();
+        assert_eq!(actions.len(), 1);
     }
 }

--- a/lib/executor/src/headers/compile.rs
+++ b/lib/executor/src/headers/compile.rs
@@ -92,33 +92,26 @@ impl HeaderRuleCompiler<Vec<ResponseHeaderRule>> for config::ResponseHeaderRule 
                     rule.default.as_ref(),
                 )?;
 
+                // named path has no exclude at runtime, so exclude can only
+                // negate a regex match, never a named match
+                let named_includes_cache_control = spec
+                    .header_names
+                    .iter()
+                    .any(|n| n.as_str() == "cache-control");
+                let regex_includes_cache_control = spec
+                    .include_regex
+                    .as_ref()
+                    .is_some_and(|re| re.is_match("cache-control"));
+                let regex_excludes_cache_control = spec
+                    .exclude_regex
+                    .as_ref()
+                    .is_some_and(|re| re.is_match("cache-control"));
+                let cache_control_will_propagate = named_includes_cache_control
+                    || (regex_includes_cache_control && !regex_excludes_cache_control);
+                if !matches!(rule.algorithm, config::AggregationAlgo::Append)
+                    && cache_control_will_propagate
                 {
-                    // TODO: I thought about putting this in a function, but it'll be
-                    // just one function - is it ok if this stays inlined?
-
-                    // check runs after materialize_match_spec so we can test the
-                    // compiled regex against "cache-control" directly. exclude is
-                    // respected: if it matches cache-control too, the rule won't touch
-                    // it at runtime so no error is raised.
-                    let cache_control_excluded = spec
-                        .exclude_regex
-                        .as_ref()
-                        .is_some_and(|re| re.is_match("cache-control"));
-                    let cache_control_is_named = spec
-                        .header_names
-                        .iter()
-                        .any(|n| n.as_str() == "cache-control");
-                    let cache_control_is_matched = spec
-                        .include_regex
-                        .as_ref()
-                        .is_some_and(|re| re.is_match("cache-control"));
-                    let cache_control_matched = !cache_control_excluded
-                        && (cache_control_is_named || cache_control_is_matched);
-                    if !matches!(rule.algorithm, config::AggregationAlgo::Append)
-                        && cache_control_matched
-                    {
-                        return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
-                    }
+                    return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
                 }
 
                 if !spec.header_names.is_empty() {
@@ -519,6 +512,33 @@ mod tests {
                     "expected CacheControlRequiresAppend for pattern={pattern:?} algo={algo:?}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_cache_control_named_with_exclude_is_still_compile_error() {
+        // exclude only applies to the regex path at runtime, so it must not
+        // suppress the error for a named: cache-control rule
+        for algo in [
+            config::AggregationAlgo::First,
+            config::AggregationAlgo::Last,
+        ] {
+            let rule = config::ResponseHeaderRule::Propagate(config::ResponsePropagateRule {
+                spec: config::MatchSpec {
+                    named: Some(config::OneOrMany::One("cache-control".to_string())),
+                    matching: None,
+                    exclude: Some(vec!["cache-control".to_string()]),
+                },
+                rename: None,
+                default: None,
+                algorithm: algo,
+            });
+            let mut actions = Vec::new();
+            let err = rule.compile(&mut actions).unwrap_err();
+            assert!(
+                matches!(err, HeaderRuleCompileError::CacheControlRequiresAppend),
+                "expected CacheControlRequiresAppend for {algo:?}"
+            );
         }
     }
 

--- a/lib/executor/src/headers/compile.rs
+++ b/lib/executor/src/headers/compile.rs
@@ -92,27 +92,7 @@ impl HeaderRuleCompiler<Vec<ResponseHeaderRule>> for config::ResponseHeaderRule 
                     rule.default.as_ref(),
                 )?;
 
-                // named path has no exclude at runtime, so exclude can only
-                // negate a regex match, never a named match
-                let named_includes_cache_control = spec
-                    .header_names
-                    .iter()
-                    .any(|n| n.as_str() == "cache-control");
-                let regex_includes_cache_control = spec
-                    .include_regex
-                    .as_ref()
-                    .is_some_and(|re| re.is_match("cache-control"));
-                let regex_excludes_cache_control = spec
-                    .exclude_regex
-                    .as_ref()
-                    .is_some_and(|re| re.is_match("cache-control"));
-                let cache_control_will_propagate = named_includes_cache_control
-                    || (regex_includes_cache_control && !regex_excludes_cache_control);
-                if !matches!(rule.algorithm, config::AggregationAlgo::Append)
-                    && cache_control_will_propagate
-                {
-                    return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
-                }
+                validate_cache_control(&spec, rule.algorithm)?;
 
                 if !spec.header_names.is_empty() {
                     actions.push(ResponseHeaderRule::PropagateNamed(ResponsePropagateNamed {
@@ -242,6 +222,31 @@ struct HeaderMatchSpecResult {
     exclude_regex: Option<meta::Regex>,
     rename_header: Option<HeaderName>,
     default_header_value: Option<http::HeaderValue>,
+}
+
+fn validate_cache_control(
+    spec: &HeaderMatchSpecResult,
+    algorithm: config::AggregationAlgo,
+) -> Result<(), HeaderRuleCompileError> {
+    // named path has no exclude at runtime, so exclude can only
+    // negate a regex match, never a named match
+    let named_includes = spec
+        .header_names
+        .iter()
+        .any(|n| n.as_str() == "cache-control");
+    let regex_includes = spec
+        .include_regex
+        .as_ref()
+        .is_some_and(|re| re.is_match("cache-control"));
+    let regex_excludes = spec
+        .exclude_regex
+        .as_ref()
+        .is_some_and(|re| re.is_match("cache-control"));
+    let will_propagate = named_includes || (regex_includes && !regex_excludes);
+    if !matches!(algorithm, config::AggregationAlgo::Append) && will_propagate {
+        return Err(HeaderRuleCompileError::CacheControlRequiresAppend);
+    }
+    Ok(())
 }
 
 fn materialize_match_spec(

--- a/lib/executor/src/headers/errors.rs
+++ b/lib/executor/src/headers/errors.rs
@@ -15,15 +15,7 @@ pub enum HeaderRuleCompileError {
     #[error("Failed to build regex for header matching. Please check your regex patterns for syntax errors. Reason: {0}")]
     RegexBuild(#[from] Box<BuildError>),
     #[error(
-        "The 'cache-control' header requires 'algorithm: append' on propagate rules. \
-             The router enforces a restrictive merge across all subgraph Cache-Control values: \
-             no-store, no-cache, or private from any single subgraph poisons the whole response, \
-             max-age takes the minimum, and public is only kept when every subgraph agrees. \
-             This merge only works correctly when all subgraph values are collected first. \
-             Using 'first' or 'last' silently discards every subgraph value except one, \
-             meaning a subgraph that sends 'private' or 'no-store' can be ignored entirely \
-             and the router may emit a publicly cacheable response for data that must not be cached. \
-             Change the algorithm to 'append'."
+        "Cache-Control header requires 'algorithm: append'. 'first' and 'last' silently discards all but one subgraph value - this is an issue because a 'private' or 'no-store' from another subgraph can get ignored and the router may forward publicly-cacheable headers for data that must not be cached. 'append' applies a restrictive merge: any no-store/no-cache/private poisons the result, max-age takes the minimum, public requires unanimous agreement."
     )]
     CacheControlRequiresAppend,
     #[error("Failed to compile VRL expression for header '{0}'. Please check your VRL expression for syntax errors. Diagnostic: {1}")]

--- a/lib/executor/src/headers/errors.rs
+++ b/lib/executor/src/headers/errors.rs
@@ -14,6 +14,18 @@ pub enum HeaderRuleCompileError {
     InvalidDefault,
     #[error("Failed to build regex for header matching. Please check your regex patterns for syntax errors. Reason: {0}")]
     RegexBuild(#[from] Box<BuildError>),
+    #[error(
+        "The 'cache-control' header requires 'algorithm: append' on propagate rules. \
+             The router enforces a restrictive merge across all subgraph Cache-Control values: \
+             no-store, no-cache, or private from any single subgraph poisons the whole response, \
+             max-age takes the minimum, and public is only kept when every subgraph agrees. \
+             This merge only works correctly when all subgraph values are collected first. \
+             Using 'first' or 'last' silently discards every subgraph value except one, \
+             meaning a subgraph that sends 'private' or 'no-store' can be ignored entirely \
+             and the router may emit a publicly cacheable response for data that must not be cached. \
+             Change the algorithm to 'append'."
+    )]
+    CacheControlRequiresAppend,
     #[error("Failed to compile VRL expression for header '{0}'. Please check your VRL expression for syntax errors. Diagnostic: {1}")]
     ExpressionBuild(String, String),
 }

--- a/lib/executor/src/headers/errors.rs
+++ b/lib/executor/src/headers/errors.rs
@@ -15,7 +15,7 @@ pub enum HeaderRuleCompileError {
     #[error("Failed to build regex for header matching. Please check your regex patterns for syntax errors. Reason: {0}")]
     RegexBuild(#[from] Box<BuildError>),
     #[error(
-        "Cache-Control header requires 'algorithm: append'. 'first' and 'last' silently discards all but one subgraph value - this is an issue because a 'private' or 'no-store' from another subgraph can get ignored and the router may forward publicly-cacheable headers for data that must not be cached. 'append' applies a restrictive merge: any no-store/no-cache/private poisons the result, max-age takes the minimum, public requires unanimous agreement."
+        "Cache-Control header requires 'algorithm: append'. 'first' and 'last' silently discard all but one subgraph value - this is an issue because a 'private' or 'no-store' from another subgraph can get ignored and the router may forward publicly-cacheable headers for data that must not be cached. 'append' applies a restrictive merge: any no-store/no-cache/private poisons the result, max-age takes the minimum, public requires unanimous agreement."
     )]
     CacheControlRequiresAppend,
     #[error("Failed to compile VRL expression for header '{0}'. Please check your VRL expression for syntax errors. Diagnostic: {1}")]

--- a/lib/executor/src/headers/mod.rs
+++ b/lib/executor/src/headers/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache_control;
 pub mod compile;
 pub mod errors;
 pub mod expression;

--- a/lib/executor/src/response/storage.rs
+++ b/lib/executor/src/response/storage.rs
@@ -17,6 +17,10 @@ impl ResponsesStorage {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.responses.len()
+    }
+
     pub fn add_response(&mut self, response: Bytes) {
         self.responses.push(response);
     }

--- a/lib/executor/src/response/storage.rs
+++ b/lib/executor/src/response/storage.rs
@@ -21,6 +21,10 @@ impl ResponsesStorage {
         self.responses.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.responses.is_empty()
+    }
+
     pub fn add_response(&mut self, response: Bytes) {
         self.responses.push(response);
     }

--- a/lib/router-config/src/headers.rs
+++ b/lib/router-config/src/headers.rs
@@ -373,7 +373,7 @@ pub enum AggregationAlgo {
     /// - The operation is a mutation
     ///
     /// If no subgraph sends `Cache-Control` and no `default` is configured,
-    /// the router emits `no-store` as a safe fallback.
+    /// the router leaves the header absent from the client response.
     Append,
 }
 

--- a/lib/router-config/src/headers.rs
+++ b/lib/router-config/src/headers.rs
@@ -363,7 +363,7 @@ pub enum AggregationAlgo {
     /// applies a restrictive merge across all subgraph values:
     /// - `no-store`, `no-cache`, or `private` from any subgraph poisons the result.
     /// - `max-age` takes the minimum across all subgraphs that provide it.
-    /// - `public` is only kept if every subgraph carries it.
+    /// - `public` is only kept if every provided `Cache-Control` value carries it.
     /// - `must-revalidate` is set if any subgraph carries it.
     ///
     /// The following conditions force `no-store, no-cache, must-revalidate`

--- a/lib/router-config/src/headers.rs
+++ b/lib/router-config/src/headers.rs
@@ -343,28 +343,11 @@ pub struct RequestPropagateRule {
 
 /// How to merge response header values from multiple subgraphs.
 ///
-/// - `First`: keep the first value encountered, ignore the rest.
-/// - `Last`: overwrite with the last value encountered (**default**).
-/// - `Append`: collect all values; for most headers they are comma-joined into
-///   a single field. For `NEVER_JOIN_HEADERS` (e.g. `Set-Cookie`) they are
-///   emitted as separate header fields.
+/// For never-join headers (e.g. `Set-Cookie`), the router always emits multiple
+/// header fields regardless of the algorithm.
 ///
-/// **`Cache-Control` and `append`:** When `append` is used on a `cache-control`
-/// propagate rule, the router collects every value from every subgraph and then
-/// applies a **restrictive merge** before sending the response to the client:
-/// - `no-store`, `no-cache`, or `private` from any subgraph poisons the result.
-/// - `max-age` takes the minimum across all values.
-/// - `public` is only kept if every collected value carries it.
-/// - `must-revalidate` is set if any value carries it.
-/// - A subgraph graphql or execution error, or mutation, always forces `no-store, no-cache, must-revalidate`
-///   regardless of collected values.
-///
-/// Using `first` or `last` on `cache-control` discards all but one subgraph value
-/// before the merge runs, which defeats the restrictive semantics. Always use
-/// `append` for `cache-control` propagation.
-///
-/// **Note:** For never-join headers (e.g. `Set-Cookie`), the router always
-/// emits multiple header fields, regardless of the algorithm.
+/// Using `first` or `last` on `cache-control` is a **compile-time error**.
+/// See [`AggregationAlgo::Append`] for the cache-control merge semantics.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum AggregationAlgo {
@@ -372,19 +355,37 @@ pub enum AggregationAlgo {
     First,
     /// Overwrite with the last value encountered.
     Last,
-    /// Collect all values. For most headers they are comma-joined. For
-    /// `cache-control` specifically, a restrictive merge is applied after
-    /// all subgraph responses have been collected (see `AggregationAlgo` docs).
+    /// Collect all values. For most headers they are comma-joined into a single
+    /// field. For never-join headers (e.g. `Set-Cookie`) they are emitted as
+    /// separate header fields.
+    ///
+    /// **`cache-control` special case:** Instead of comma-joining, the router
+    /// applies a restrictive merge across all subgraph values:
+    /// - `no-store`, `no-cache`, or `private` from any subgraph poisons the result.
+    /// - `max-age` takes the minimum across all subgraphs that provide it.
+    /// - `public` is only kept if every subgraph carries it.
+    /// - `must-revalidate` is set if any subgraph carries it.
+    ///
+    /// The following conditions force `no-store, no-cache, must-revalidate`
+    /// regardless of subgraph values:
+    /// - Any subgraph executor error (network failure, bad status, etc.)
+    /// - Any GraphQL-level error in a subgraph response (`errors` array non-empty)
+    /// - The operation is a mutation
+    ///
+    /// If no subgraph sends `Cache-Control` and no `default` is configured,
+    /// the router emits `no-store` as a safe fallback.
     Append,
 }
 
 /// Propagate headers from subgraph responses to the final client response.
 ///
-/// **Behavior**
 /// - If multiple subgraphs return the header, values are merged using `algorithm`.
 ///   Never-join headers are **never** comma-joined.
 /// - If **no** subgraph returns a match, `default` (if set) is emitted.
 /// - If `rename` is set, the outgoing header uses the new name.
+///
+/// For `cache-control` propagation, `algorithm` must be `append`. See
+/// [`AggregationAlgo::Append`] for the full merge semantics.
 ///
 /// ### Examples
 /// ```yaml
@@ -403,6 +404,11 @@ pub enum AggregationAlgo {
 ///   named: x-backend
 ///   algorithm: append
 ///   default: unknown
+///
+/// # Propagate cache-control with restrictive merge across all subgraphs
+/// propagate:
+///   named: cache-control
+///   algorithm: append
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct ResponsePropagateRule {

--- a/lib/router-config/src/headers.rs
+++ b/lib/router-config/src/headers.rs
@@ -345,8 +345,23 @@ pub struct RequestPropagateRule {
 ///
 /// - `First`: keep the first value encountered, ignore the rest.
 /// - `Last`: overwrite with the last value encountered (**default**).
-/// - `Append`: comma-join all values into a single field, **except** for
-///   `NEVER_JOIN_HEADERS` which are always emitted as multiple fields.
+/// - `Append`: collect all values; for most headers they are comma-joined into
+///   a single field. For `NEVER_JOIN_HEADERS` (e.g. `Set-Cookie`) they are
+///   emitted as separate header fields.
+///
+/// **`Cache-Control` and `append`:** When `append` is used on a `cache-control`
+/// propagate rule, the router collects every value from every subgraph and then
+/// applies a **restrictive merge** before sending the response to the client:
+/// - `no-store`, `no-cache`, or `private` from any subgraph poisons the result.
+/// - `max-age` takes the minimum across all values.
+/// - `public` is only kept if every collected value carries it.
+/// - `must-revalidate` is set if any value carries it.
+/// - A subgraph graphql or execution error, or mutation, always forces `no-store, no-cache, must-revalidate`
+///   regardless of collected values.
+///
+/// Using `first` or `last` on `cache-control` discards all but one subgraph value
+/// before the merge runs, which defeats the restrictive semantics. Always use
+/// `append` for `cache-control` propagation.
 ///
 /// **Note:** For never-join headers (e.g. `Set-Cookie`), the router always
 /// emits multiple header fields, regardless of the algorithm.
@@ -357,7 +372,9 @@ pub enum AggregationAlgo {
     First,
     /// Overwrite with the last value encountered.
     Last,
-    /// Append all values into a comma-separated string (list-valued headers).
+    /// Collect all values. For most headers they are comma-joined. For
+    /// `cache-control` specifically, a restrictive merge is applied after
+    /// all subgraph responses have been collected (see `AggregationAlgo` docs).
     Append,
 }
 
@@ -371,9 +388,9 @@ pub enum AggregationAlgo {
 ///
 /// ### Examples
 /// ```yaml
-/// # Forward Cache-Control from whichever subgraph supplies it (last wins)
+/// # Forward X-Request-ID from whichever subgraph supplies it (last wins)
 /// propagate:
-///   named: Cache-Control
+///   named: X-Request-ID
 ///   algorithm: last
 ///
 /// # Combine list-valued headers


### PR DESCRIPTION
Closes #1022

Implementataion of restrictive merging of `Cache-Control` headers across all subgraph responses before forwarding to the client. The most conservative directive always wins. No opt-in required.

### Why always-on?

Making this opt-in means an illinformed or unaware developer gets unsafe behavior by default: a `public` subgraph can silently override a `private` or `no-cache` subgraph and accidentally cache responses that should not be cached. Or even worse, a mutation or an errored response getting cached because some subgraph has caching set up.

Everyone propagating `Cache-Control` headers should be merging them using the restrictive policies - otherwise they are facing dangers like those stated in #1022 - you'd never want the unsafe behaviour (as far as I can think of).

The safe behavior should be the default behavior, and it should be enforced.

### Merge algorithm

Given N subgraph responses:

1. Any `no-store`, `no-cache`, or `private` directive short-circuits the result to `no-store, no-cache` immediately.
1. Otherwise `max-age` = minimum of all present values (missing = ignored).
1. `public` only when every subgraph is `public`.
1. `must-revalidate` if any subgraph sets it.

Forces `no-store, no-cache, must-revalidate` regardless of subgraph headers when:

- Any subgraph executor error (network failure, bad status, etc.)
- Any GraphQL-level error in a subgraph response (`errors` array non-empty)
- The operation is a mutation

Completely removes the `Cache-Control` header when no subgraph sends a valid `Cache-Control`, like non-UTF-8 bytes or parinsg returns `None` (invalid/empty/whitespace-only string).

### Configuration

Users augment cache behavior through existing header rules:

```yaml
headers:
  all:
    response:
      # forward subgraph cache-control; append keeps every value for the merge
      - propagate:
          named: cache-control
          algorithm: append
          # default emitted unless a subgraph provides one
          default: "public, max-age=180"
  subgraphs:
    pricing:
      response:
        # pin this subgraph regardless of what it returns
        - insert:
            name: cache-control
            value: "no-cache"
```

Subgraph-level `insert` or `remove` rules let operators pin or drop a specific subgraph's contribution before the merge runs.

We're using the full powers of header rules to augment the Cache-Control. No need for a separate config option because the rules already provide the full set of primitives, and we're opting everyone in to restrictive merging by design.

Configuring `propagate: named: cache-control` without merging is rejected at compile time with an error that goes straight to the point: propagating `Cache-Control` across subgraphs without the restrictive merge is unsafe.

If no propagation of the `Cache-Control` is set up - the merge is inactive. This is the safer approach because you have to _not_ propagate the headers to disable.

### TODO

- [x] docs https://github.com/graphql-hive/docs/pull/135