### PR TITLE
fix(query-planner): added missing `__typename` in case of subgraph re-entry

### DIFF
--- a/.changeset/fix_missing_typename_with_requires_re_entry.md
+++ b/.changeset/fix_missing_typename_with_requires_re_entry.md
@@ -1,0 +1,13 @@
+---
+hive-router-query-planner: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Fix missing `__typename` with `@requires` re-entry
+
+Resolving a field with `@requires` makes the planner re-enter the entity's subgraph through `_entities`, using a representation built from the entity's data. That representation must carry the entity's `__typename`, since `_entities` routes on it.
+
+The fetch that produces the entity now always selects its `__typename`, so the re-entry representation is complete.
+
+Fixes [#1070](https://github.com/graphql-hive/router/issues/1070)

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3111,4 +3111,113 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1070
+    ///
+    /// Entity representations sent to `_entities` must always include `__typename`,
+    /// even when the end-user did not select it. Resolving `bestOffer` (a `@requires`
+    /// field) triggers an `_entities` fetch on `ProductSearchResultResponse`; a real
+    /// subgraph rejects a representation without `__typename` ("the _entities resolver
+    /// tried to load an entity for type 'undefined'"), so the mock mirrors that and
+    /// `bestOffer` (Non-Null) collapses the response when the type name is missing.
+    async fn issue_1070_entity_representation_includes_typename() {
+        use crate::testkit::{RequestLike, ResponseLike};
+        use serde_json::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req: RequestLike| {
+                let body: serde_json::Value = serde_json::from_slice(req.body.as_ref()?).ok()?;
+                let query = body.get("query")?.as_str()?;
+                let is_entities = query.contains("_entities");
+
+                let data = match req.path.trim_start_matches('/') {
+                    "subgraph-a" if is_entities => {
+                        let reps = body.pointer("/variables/representations")?.as_array()?;
+                        let entities: Vec<serde_json::Value> = reps
+                            .iter()
+                            .map(|r| {
+                                if r.get("__typename").and_then(|t| t.as_str())
+                                    == Some("ProductSearchResultResponse")
+                                {
+                                    json!({ "__typename": "ProductSearchResultResponse", "bestOffer": { "price": 121 } })
+                                } else {
+                                    json!(null)
+                                }
+                            })
+                            .collect();
+                        json!({ "_entities": entities })
+                    }
+                    "subgraph-a" => json!({
+                        "productSearchResult": {
+                            "__typename": "ProductSearchResultResponse",
+                            "searchCriteria": { "__typename": "ProductSearchCriteria", "partialCriteria": "partialCriteria" }
+                        }
+                    }),
+                    "subgraph-b" => json!({
+                        "_entities": [{ "__typename": "ProductSearchCriteria", "fullCriteria": "full(partialCriteria)" }]
+                    }),
+                    _ => return None,
+                };
+
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::OK,
+                    Some(json!({ "data": data }).to_string()),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.1070.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      subgraph-a:
+                        url: "{subgraphs_url}/subgraph-a"
+                      subgraph-b:
+                        url: "{subgraphs_url}/subgraph-b"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"query ReproQuery {
+                  productSearchResult(partialCriteria: "partialCriteria") {
+                    bestOffer {
+                      price
+                    }
+                  }
+                }"#,
+                None,
+                None,
+            )
+            .await;
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "productSearchResult": {
+              "bestOffer": {
+                "price": 121
+              }
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3114,13 +3114,6 @@ mod issues_e2e_tests {
 
     #[ntex::test]
     /// https://github.com/graphql-hive/router/issues/1070
-    ///
-    /// Entity representations sent to `_entities` must always include `__typename`,
-    /// even when the end-user did not select it. Resolving `bestOffer` (a `@requires`
-    /// field) triggers an `_entities` fetch on `ProductSearchResultResponse`; a real
-    /// subgraph rejects a representation without `__typename` ("the _entities resolver
-    /// tried to load an entity for type 'undefined'"), so the mock mirrors that and
-    /// `bestOffer` (Non-Null) collapses the response when the type name is missing.
     async fn issue_1070_entity_representation_includes_typename() {
         use crate::testkit::{RequestLike, ResponseLike};
         use serde_json::json;

--- a/e2e/src/issues/supergraph.1070.graphql
+++ b/e2e/src/issues/supergraph.1070.graphql
@@ -1,0 +1,74 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+{
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH_A @join__graph(name: "subgraph-a", url: "http://subgraph-a/graphql")
+  SUBGRAPH_B @join__graph(name: "subgraph-b", url: "http://subgraph-b/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type ProductOffer
+  @join__type(graph: SUBGRAPH_A)
+{
+  price: Int!
+}
+
+type ProductSearchCriteria
+  @join__type(graph: SUBGRAPH_A, key: "partialCriteria")
+  @join__type(graph: SUBGRAPH_B, key: "partialCriteria")
+  @inaccessible
+{
+  partialCriteria: String!
+  fullCriteria: String! @join__field(graph: SUBGRAPH_A, external: true) @join__field(graph: SUBGRAPH_B)
+}
+
+type ProductSearchResultResponse
+  @join__type(graph: SUBGRAPH_A, key: "searchCriteria { partialCriteria }")
+  @join__type(graph: SUBGRAPH_A, key: "searchCriteria { partialCriteria }", extension: true)
+{
+  searchCriteria: ProductSearchCriteria! @inaccessible
+  bestOffer: ProductOffer! @join__field(graph: SUBGRAPH_A, requires: "searchCriteria {\n  fullCriteria\n}")
+}
+
+type Query
+  @join__type(graph: SUBGRAPH_A)
+  @join__type(graph: SUBGRAPH_B)
+{
+  productSearchResult(partialCriteria: String!): ProductSearchResultResponse! @join__field(graph: SUBGRAPH_A)
+}

--- a/lib/query-planner/fixture/tests/nested-key-requires-reentry.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/nested-key-requires-reentry.supergraph.graphql
@@ -1,0 +1,74 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+{
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH_A @join__graph(name: "subgraph-a", url: "http://subgraph-a/graphql")
+  SUBGRAPH_B @join__graph(name: "subgraph-b", url: "http://subgraph-b/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type ProductOffer
+  @join__type(graph: SUBGRAPH_A)
+{
+  price: Int!
+}
+
+type ProductSearchCriteria
+  @join__type(graph: SUBGRAPH_A, key: "partialCriteria")
+  @join__type(graph: SUBGRAPH_B, key: "partialCriteria")
+  @inaccessible
+{
+  partialCriteria: String!
+  fullCriteria: String! @join__field(graph: SUBGRAPH_A, external: true) @join__field(graph: SUBGRAPH_B)
+}
+
+type ProductSearchResultResponse
+  @join__type(graph: SUBGRAPH_A, key: "searchCriteria { partialCriteria }")
+  @join__type(graph: SUBGRAPH_A, key: "searchCriteria { partialCriteria }", extension: true)
+{
+  searchCriteria: ProductSearchCriteria! @inaccessible
+  bestOffer: ProductOffer! @join__field(graph: SUBGRAPH_A, requires: "searchCriteria {\n  fullCriteria\n}")
+}
+
+type Query
+  @join__type(graph: SUBGRAPH_A)
+  @join__type(graph: SUBGRAPH_B)
+{
+  productSearchResult(partialCriteria: String!): ProductSearchResultResponse! @join__field(graph: SUBGRAPH_A)
+}

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1371,7 +1371,7 @@ fn process_requires_field_edge(
         // If the parent's output resolves a different type, then it's a root type.
         // We can use that as a parent.
         true => parent_fetch_step_index,
-        // If the parent's output resolves the same type, it manes we're in an entity call.
+        // If the parent's output resolves the same type, it means we're in an entity call.
         // We need to move up, as the entity call was created to fetch regular fields of the type
         // (those without @requires).
         //
@@ -1491,6 +1491,10 @@ fn process_requires_field_edge(
         key_to_reenter_at,
         key_to_reenter_subgraph.clone().selection_set,
     )?;
+
+    real_parent_fetch_step
+        .output
+        .add_selection_typename(key_to_reenter_at)?;
 
     fetch_graph.connect(real_parent_fetch_step_index, step_for_requirements_index);
 

--- a/lib/query-planner/src/tests/arguments.rs
+++ b/lib/query-planner/src/tests/arguments.rs
@@ -918,8 +918,8 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
         Fetch(service: "a") {
           {
             test {
-              id
               __typename
+              id
             }
           }
         },
@@ -993,7 +993,7 @@ fn multiple_requires_with_args_that_conflicts() -> Result<(), Box<dyn Error>> {
             "kind": "Fetch",
             "serviceName": "a",
             "operationKind": "query",
-            "operation": "{test{id __typename}}"
+            "operation": "{test{__typename id}}"
           },
           {
             "kind": "Flatten",
@@ -1500,8 +1500,8 @@ fn simple_requires_arguments() -> Result<(), Box<dyn Error>> {
         Fetch(service: "a") {
           {
             test {
-              id
               __typename
+              id
             }
           }
         },
@@ -1550,7 +1550,7 @@ fn simple_requires_arguments() -> Result<(), Box<dyn Error>> {
             "kind": "Fetch",
             "serviceName": "a",
             "operationKind": "query",
-            "operation": "{test{id __typename}}"
+            "operation": "{test{__typename id}}"
           },
           {
             "kind": "Flatten",

--- a/lib/query-planner/src/tests/override_requires.rs
+++ b/lib/query-planner/src/tests/override_requires.rs
@@ -445,8 +445,8 @@ fn override_with_requires_cname_in_c() -> Result<(), Box<dyn Error>> {
         Fetch(service: "c") {
           {
             userInC {
-              id
               __typename
+              id
             }
           }
         },
@@ -494,7 +494,7 @@ fn override_with_requires_cname_in_c() -> Result<(), Box<dyn Error>> {
             "kind": "Fetch",
             "serviceName": "c",
             "operationKind": "query",
-            "operation": "{userInC{id __typename}}"
+            "operation": "{userInC{__typename id}}"
           },
           {
             "kind": "Flatten",
@@ -733,8 +733,8 @@ fn override_with_requires_aname_in_a() -> Result<(), Box<dyn Error>> {
         Fetch(service: "a") {
           {
             userInA {
-              id
               __typename
+              id
             }
           }
         },
@@ -782,7 +782,7 @@ fn override_with_requires_aname_in_a() -> Result<(), Box<dyn Error>> {
             "kind": "Fetch",
             "serviceName": "a",
             "operationKind": "query",
-            "operation": "{userInA{id __typename}}"
+            "operation": "{userInA{__typename id}}"
           },
           {
             "kind": "Flatten",

--- a/lib/query-planner/src/tests/requires.rs
+++ b/lib/query-planner/src/tests/requires.rs
@@ -27,8 +27,8 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
         Fetch(service: "inventory") {
           {
             products {
-              upc
               __typename
+              upc
             }
           }
         },
@@ -238,8 +238,8 @@ fn two_same_service_calls() -> Result<(), Box<dyn Error>> {
         Fetch(service: "inventory") {
           {
             products {
-              upc
               __typename
+              upc
             }
           }
         },
@@ -1148,6 +1148,83 @@ fn deep_requires() -> Result<(), Box<dyn Error>> {
               ... on Post {
                 author {
                   id
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+/// related: https://github.com/graphql-hive/router/issues/1070
+///
+/// this test confirms that a re-entry `_entities`
+fn requires_reentry_selects_entity_typename() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          productSearchResult(partialCriteria: "partialCriteria") {
+            bestOffer {
+              price
+            }
+          }
+        }"#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/nested-key-requires-reentry.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "subgraph-a") {
+          {
+            productSearchResult(partialCriteria: "partialCriteria") {
+              __typename
+              searchCriteria {
+                partialCriteria
+                __typename
+              }
+            }
+          }
+        },
+        Flatten(path: "productSearchResult.searchCriteria") {
+          Fetch(service: "subgraph-b") {
+            {
+              ... on ProductSearchCriteria {
+                __typename
+                partialCriteria
+              }
+            } =>
+            {
+              ... on ProductSearchCriteria {
+                fullCriteria
+              }
+            }
+          },
+        },
+        Flatten(path: "productSearchResult") {
+          Fetch(service: "subgraph-a") {
+            {
+              ... on ProductSearchResultResponse {
+                __typename
+                searchCriteria {
+                  fullCriteria
+                  partialCriteria
+                }
+              }
+            } =>
+            {
+              ... on ProductSearchResultResponse {
+                bestOffer {
+                  price
                 }
               }
             }

--- a/lib/query-planner/src/tests/requires.rs
+++ b/lib/query-planner/src/tests/requires.rs
@@ -101,7 +101,7 @@ fn two_same_service_calls_with_args_conflicts() -> Result<(), Box<dyn Error>> {
             "kind": "Fetch",
             "serviceName": "inventory",
             "operationKind": "query",
-            "operation": "{products{upc __typename}}"
+            "operation": "{products{__typename upc}}"
           },
           {
             "kind": "Flatten",
@@ -287,7 +287,7 @@ fn two_same_service_calls() -> Result<(), Box<dyn Error>> {
             "kind": "Fetch",
             "serviceName": "inventory",
             "operationKind": "query",
-            "operation": "{products{upc __typename}}"
+            "operation": "{products{__typename upc}}"
           },
           {
             "kind": "Flatten",

--- a/lib/query-planner/src/tests/requires_circular.rs
+++ b/lib/query-planner/src/tests/requires_circular.rs
@@ -113,8 +113,8 @@ fn requires_circular_2() -> Result<(), Box<dyn Error>> {
         Fetch(service: "a") {
           {
             feed {
-              id
               __typename
+              id
             }
           }
         },


### PR DESCRIPTION
Closes https://github.com/graphql-hive/router/pull/1080 
Related https://github.com/graphql-hive/router/issues/1070 

TL;DR: a `__typename` was missing, and the executor runs those operations as-is, so it ended up without a value for the `__typename` in that case. This leads to a `null` value in the response, and can also fail a whole response whe null-propagation kicks in. 