### PR TITLE
fix(router): avoid socket drops when rejecting requests due to body size limit

### DIFF
--- a/.changeset/improve_error_handling_when_body_limit_reached.md
+++ b/.changeset/improve_error_handling_when_body_limit_reached.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+# Improve error handling when body limit reached
+
+When rejecting a request whose `Content-Length` exceeds `max_request_body_size`, the router now drains a small bounded part of the request body before responding.
+
+This lets the connection close cleanly so the client reliably receives the `413 Payload Too Large` response instead of a connection-reset/transport error.

--- a/lib/internal/src/http.rs
+++ b/lib/internal/src/http.rs
@@ -143,6 +143,20 @@ pub fn read_request_body_size(req: &HttpRequest) -> Option<u64> {
     req.extensions().get::<RequestBodySize>().map(|size| size.0)
 }
 
+/// Limit for draining a rejected request body. Keeps the connection
+/// reusable for typical over-limit requests without reading the whole thing
+const MAX_DRAIN_BYTES: usize = 64 * 1024;
+
+async fn drain_body_stream(body_stream: &mut web::types::Payload) {
+    let mut drained = 0usize;
+    while drained < MAX_DRAIN_BYTES {
+        match body_stream.try_next().await {
+            Ok(Some(chunk)) => drained += chunk.len(),
+            _ => break,
+        }
+    }
+}
+
 #[inline]
 pub async fn read_body_stream<R: RequestLike>(
     req: &R,
@@ -160,6 +174,17 @@ pub async fn read_body_stream<R: RequestLike>(
                 .map_err(|_| ReadBodyStreamError::InvalidContentLengthHeader)?;
             if content_length > max_size {
                 write_request_body_size(req, content_length as u64);
+
+                // Drain just small amount of the request body before rejecting,
+                // so the server can close the connection cleanly.
+                //
+                // Returning without consuming the body makes ntex reset the socket,
+                // and the client might read that as a socket error instead of the router's 413
+                // response.
+                //
+                // Note: `drain_body_stream` reads only a small amount of the body,
+                // so the client will not be blocked while draining.
+                drain_body_stream(&mut body_stream).await;
                 return Err(ReadBodyStreamError::PayloadTooLargeContentLength(max_size));
             }
             Some(content_length)

--- a/lib/internal/src/http.rs
+++ b/lib/internal/src/http.rs
@@ -148,10 +148,17 @@ pub fn read_request_body_size(req: &HttpRequest) -> Option<u64> {
 const MAX_DRAIN_BYTES: usize = 64 * 1024;
 
 async fn drain_body_stream(body_stream: &mut web::types::Payload) {
-    let mut drained = 0usize;
+    let mut drained: usize = 0;
+
     while drained < MAX_DRAIN_BYTES {
         match body_stream.try_next().await {
-            Ok(Some(chunk)) => drained += chunk.len(),
+            Ok(Some(chunk)) => {
+                if chunk.is_empty() {
+                    break;
+                }
+
+                drained = drained.saturating_add(chunk.len());
+            }
             _ => break,
         }
     }


### PR DESCRIPTION
This should fix the flakey `should_return_payload_too_large_if_content_length_header_exceeds_the_limit`. 

At the moment, we reject "too quickly" (or, without reading the body at all), and this could cause a socket drop. The reason it looks like 500 is because ntex's client in tests is using a "fake 500" in those cases of broken pipe / dropped socket. 

This change reads the body, but only a small portion of it, so the client will start streaming it, but then rejected.