### PR TITLE
fix(query-planner, executor): missing top-level field referencing logic

### DIFF
--- a/.changeset/fix_root_type_re_entry.md
+++ b/.changeset/fix_root_type_re_entry.md
@@ -1,0 +1,16 @@
+---
+hive-router: patch
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+node-addon: patch
+---
+
+# Fix root type re-entry
+
+When a field re-exposes a root type from a nested position (e.g. a mutation field
+returning a type with a `query: Query` field), the query planner could not resolve
+selections that live in a different subgraph, and the executor merged whatever it
+did fetch at the response root instead of the nested path — so those fields
+resolved to `null`, or failed to resolve fully. 
+
+Fixes [#1164](https://github.com/graphql-hive/router/issues/1164)

--- a/bench/subgraphs/products.rs
+++ b/bench/subgraphs/products.rs
@@ -95,6 +95,21 @@ pub struct Query;
 
 pub struct Mutation;
 
+pub struct ReentryTestPayload {
+    pub ok: bool,
+}
+
+#[Object]
+impl ReentryTestPayload {
+    async fn ok(&self) -> bool {
+        self.ok
+    }
+
+    async fn query(&self) -> Query {
+        Query
+    }
+}
+
 #[Object(extends = true)]
 impl Query {
     async fn top_products(
@@ -145,6 +160,11 @@ impl Mutation {
         tmp_file_on_disk.write_all(&buf).await.unwrap();
         path
     }
+
+    async fn reentry_test(&self) -> ReentryTestPayload {
+        ReentryTestPayload { ok: true }
+    }
+
     async fn oneof_test(&self, input: OneOfTestInput) -> OneOfTestResult {
         OneOfTestResult {
             string: input.string,

--- a/e2e/src/file_supergraph.rs
+++ b/e2e/src/file_supergraph.rs
@@ -46,7 +46,7 @@ mod file_supergraph_e2e_tests {
             .unwrap()
             .as_array()
             .unwrap();
-        assert_eq!(types_arr.len(), 22);
+        assert_eq!(types_arr.len(), 23);
     }
 
     #[ntex::test]

--- a/e2e/src/hive_cdn_supergraph.rs
+++ b/e2e/src/hive_cdn_supergraph.rs
@@ -255,7 +255,7 @@ mod hive_cdn_supergraph_e2e_tests {
             .unwrap()
             .as_array()
             .unwrap();
-        assert_eq!(types_arr.len(), 22);
+        assert_eq!(types_arr.len(), 23);
     }
 
     #[ntex::test]

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3213,4 +3213,167 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1164
+    ///
+    /// Root re-entry that lands on a union (`Viewer = User | Error`).
+    /// This test verifies that cross-subgraph root re-entry works correctly, even after making the "jump".
+    async fn issue_1164_root_re_entry_into_union() {
+        use crate::testkit::mock_subgraphs::mock_subgraphs;
+        use serde_json::json;
+
+        async fn run(viewer: serde_json::Value) -> String {
+            let subgraphs = TestSubgraphs::builder()
+                .with_on_request(mock_subgraphs(json!({
+                    "A": {
+                        "query": { "viewer": viewer }
+                    },
+                    "B": {
+                        "mutation": { "test": { "query": { "__typename": "Query" } } },
+                    }
+                })))
+                .build()
+                .start()
+                .await;
+
+            let url = subgraphs.url();
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(format!(
+                    r#"
+                         supergraph:
+                           source: file
+                           path: src/issues/supergraph.1164-with-union.graphql
+                         override_subgraph_urls:
+                           subgraphs:
+                             A:
+                               url: "{url}/A"
+                             B:
+                               url: "{url}/B"
+                         "#,
+                ))
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request(
+                    r#"
+                       mutation {
+                         test {
+                           query {
+                             viewer {
+                               ... on User {
+                                 id
+                                 name
+                               }
+                               ... on Error {
+                                 message
+                               }
+                             }
+                           }
+                         }
+                       }
+                       "#,
+                    None,
+                    None,
+                )
+                .await;
+            assert!(res.status().is_success(), "Expected 200 OK");
+            res.json_body_string_pretty().await
+        }
+
+        insta::assert_snapshot!(run(json!({ "__typename": "User", "id": "1", "name": "Jane" })).await, @r#"
+           {
+             "data": {
+               "test": {
+                 "query": {
+                   "viewer": {
+                     "id": "1",
+                     "name": "Jane"
+                   }
+                 }
+               }
+             }
+           }
+           "#);
+
+        // `viewer` resolves to an `Error`: `message` from A.
+        insta::assert_snapshot!(run(json!({ "__typename": "Error", "message": "boom" })).await, @r#"
+           {
+             "data": {
+               "test": {
+                 "query": {
+                   "viewer": {
+                     "message": "boom"
+                   }
+                 }
+               }
+             }
+           }
+           "#);
+    }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1164
+    ///
+    /// In this edge-case, we perform a mutation to "PRODUCTS" subgraph, and then do query re-entry for `me` which lives
+    /// in another subgraph.
+    /// No other fields from "Query/PRODUCTS" are included in the response.
+    ///
+    /// In this edge-case, we need to ensure to fetch the re-entry field from the current subgraph, even if it's empty, by
+    /// including it in the `query { __typename }` explicitly.
+    async fn issue_1164_root_re_entry_empty_current_subgraph() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                mutation {
+                  reentryTest { # Nothing from "Query/PRODUCTS" is included in the response
+                    query {
+                      me {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "reentryTest": {
+              "query": {
+                "me": {
+                  "id": "1",
+                  "name": "Uri Goldshtein"
+                }
+              }
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/supergraph.1164-with-union.graphql
+++ b/e2e/src/issues/supergraph.1164-with-union.graphql
@@ -1,0 +1,104 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH_A @join__graph(name: "A", url: "http://service/A")
+  SUBGRAPH_B @join__graph(name: "B", url: "http://service/B")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Error @join__type(graph: SUBGRAPH_A) @join__type(graph: SUBGRAPH_B) {
+  message: String!
+}
+
+type User
+  @join__type(graph: SUBGRAPH_A, key: "id")
+  @join__type(graph: SUBGRAPH_B, key: "id") {
+  id: ID! @join__field(graph: SUBGRAPH_A) @join__field(graph: SUBGRAPH_B)
+  name: String! @join__field(graph: SUBGRAPH_A)
+}
+
+union Viewer
+  @join__type(graph: SUBGRAPH_A)
+  @join__unionMember(graph: SUBGRAPH_A, member: "User")
+  @join__unionMember(graph: SUBGRAPH_A, member: "Error") =
+  | User
+  | Error
+
+type Query @join__type(graph: SUBGRAPH_A) @join__type(graph: SUBGRAPH_B) {
+  version: Version
+  viewer: Viewer! @join__field(graph: SUBGRAPH_A)
+}
+
+type TestResult @join__type(graph: SUBGRAPH_B) {
+  recordId: ID
+  errors: [String!]!
+  query: Query
+}
+
+type Mutation @join__type(graph: SUBGRAPH_A) @join__type(graph: SUBGRAPH_B) {
+  test: TestResult @join__field(graph: SUBGRAPH_B)
+}
+
+type Version @join__type(graph: SUBGRAPH_A) @join__type(graph: SUBGRAPH_B) {
+  a: String! @join__field(graph: SUBGRAPH_A)
+  b: String! @join__field(graph: SUBGRAPH_B)
+}

--- a/e2e/supergraph.graphql
+++ b/e2e/supergraph.graphql
@@ -129,12 +129,18 @@ type User
 
 scalar Upload
 
-type Mutation
-  @join__type(graph: PRODUCTS) {
+type Mutation @join__type(graph: PRODUCTS) {
   upload(file: Upload): String @join__field(graph: PRODUCTS)
 
   oneofTest(input: OneOfTestInput!): OneOfTestResult
     @join__field(graph: PRODUCTS)
+
+  reentryTest: ReentryTest @join__field(graph: PRODUCTS)
+}
+
+type ReentryTest @join__type(graph: PRODUCTS) {
+  ok: Boolean
+  query: Query
 }
 
 directive @oneOf on INPUT_OBJECT

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -17,7 +17,7 @@ use hive_router_internal::telemetry::traces::spans::graphql::{
     GraphQLOperationSpan, GraphQLSpanOperationIdentity, GraphQLSubgraphOperationSpan,
 };
 use hive_router_query_planner::ast::operation::SubgraphFetchOperation;
-use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
+use hive_router_query_planner::planner::plan_nodes::{CustomScalarPaths, FetchNode, FlattenNode};
 use hive_router_query_planner::planner::query_plan::QUERY_PLAN_KIND;
 use hive_router_query_planner::{
     ast::operation::OperationDefinition,
@@ -679,6 +679,9 @@ pub enum ExecutionJob<'exec> {
         operation: &'exec SubgraphFetchOperation,
         response: SubgraphResponse<'exec>,
         output_rewrites: Option<&'exec [FetchRewrite]>,
+        // By default, this job is merged at the root. When this is set, we merge at
+        // a specific path instead of the root (used for root re-entry fetches)
+        merge_path: Option<&'exec FlattenNodePath>,
     },
     FlattenFetch {
         subgraph_name: &'exec str,
@@ -752,7 +755,7 @@ impl<'exec> ExecutionJob<'exec> {
 
     fn affected_path(&self) -> Option<&'exec FlattenNodePath> {
         match self {
-            ExecutionJob::Fetch { .. } => None,
+            ExecutionJob::Fetch { merge_path, .. } => *merge_path,
             ExecutionJob::FlattenFetch {
                 flatten_node_path, ..
             } => Some(flatten_node_path),
@@ -823,6 +826,27 @@ impl<'exec> Executor<'exec> {
                 }
             }
         }
+    }
+
+    fn prepare_root_reentry_fetch_job<'wave>(
+        &'wave self,
+        flatten_node: &'exec FlattenNode,
+        fetch_node: &'exec FetchNode,
+    ) -> BoxFuture<'wave, Result<ExecutionJob<'exec>, PlanExecutionError>> {
+        self.prepare_execution_job(PrepareExecutionJobOpts {
+            subgraph_name: &fetch_node.service_name,
+            variable_usages: fetch_node.variable_usages.as_ref(),
+            operation_name: self
+                .operation_name_factory
+                .generate(&fetch_node.service_name, fetch_node.id),
+            operation_kind: fetch_node.operation_kind.as_ref(),
+            operation: &fetch_node.operation,
+            output_rewrites: fetch_node.output_rewrites.as_deref(),
+            custom_scalar_paths: fetch_node.custom_scalar_paths.as_ref(),
+            raw_variable_values: None,
+            affected_path: Some(&flatten_node.path),
+        })
+        .boxed()
     }
 
     /**
@@ -900,7 +924,13 @@ impl<'exec> Executor<'exec> {
                     PlanNode::Fetch(fetch_node) => fetch_node,
                     _ => return None,
                 };
-                let requires_nodes = fetch_node.requires.as_ref()?;
+
+                // If there are no requirements in the node (no _entities call), then we only need to make
+                // a regular call. This happens when we perform subgraph re-entry.
+                // So we can just create the fetch step future with the info we have
+                let Some(requires_nodes) = fetch_node.requires.as_ref() else {
+                    return Some(self.prepare_root_reentry_fetch_job(flatten_node, fetch_node));
+                };
 
                 let mut index = 0;
                 let normalized_path = flatten_node.path.as_slice();
@@ -1076,6 +1106,7 @@ impl<'exec> Executor<'exec> {
                     ExecutionJob::Fetch {
                         mut response,
                         output_rewrites,
+                        merge_path,
                         ..
                     } => {
                         if let Some(response_bytes) = response.bytes {
@@ -1089,7 +1120,24 @@ impl<'exec> Executor<'exec> {
                                 );
                             }
                         }
-                        deep_merge(&mut ctx.data, response.data);
+
+                        match merge_path {
+                            // Root fetch
+                            None => deep_merge(&mut ctx.data, response.data),
+                            // Root re-entry
+                            Some(merge_path) => {
+                                let source = response.data;
+                                traverse_and_callback_mut(
+                                    &mut ctx.data,
+                                    merge_path.as_slice(),
+                                    self.schema_metadata,
+                                    None,
+                                    &mut |target, _error_path| {
+                                        deep_merge(target, source.clone());
+                                    },
+                                );
+                            }
+                        }
 
                         ctx.handle_errors(subgraph_name, affected_path, response.errors, None);
                     }
@@ -1590,6 +1638,7 @@ impl<'exec> Executor<'exec> {
                 operation: opts.operation,
                 response,
                 output_rewrites: opts.output_rewrites,
+                merge_path: opts.affected_path,
             })
         }
         .inspect_err(|err: &PlanExecutionError| {

--- a/lib/query-planner/fixture/tests/root-reentry.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/root-reentry.supergraph.graphql
@@ -1,0 +1,115 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) {
+  query: Query
+  mutation: Mutation
+}
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+  contextArguments: [join__ContextArgument!]
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(
+  graphs: [join__Graph!]
+  name: String!
+  args: join__DirectiveArguments
+) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  ONE @join__graph(name: "one", url: "http://example.com/one")
+  TWO @join__graph(name: "two", url: "http://example.com/two")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+type Query @join__type(graph: ONE) @join__type(graph: TWO) {
+  system: Query!
+  inner: Inner!
+  user(id: ID!): User @join__field(graph: ONE)
+  healthCheck: Boolean! @join__field(graph: TWO)
+}
+
+type Mutation @join__type(graph: ONE) @join__type(graph: TWO) {
+  doSomethingElse: DoSomethingElse! @join__field(graph: ONE)
+  doSomething: DoSomething! @join__field(graph: TWO)
+}
+
+type DoSomethingElse @join__type(graph: ONE) {
+  ok: Boolean!
+}
+
+type Inner @join__type(graph: ONE) @join__type(graph: TWO) {
+  toQuery: Query!
+  toMutation: Mutation!
+}
+
+type User @join__type(graph: ONE) {
+  id: ID!
+  name: String!
+}
+
+type DoSomething @join__type(graph: TWO) {
+  ok: Boolean!
+  query: Query
+}

--- a/lib/query-planner/src/graph/edge.rs
+++ b/lib/query-planner/src/graph/edge.rs
@@ -43,6 +43,14 @@ pub struct FieldMove {
     pub overridden_by: Option<(String, Option<OverrideLabel>)>,
 }
 
+/// Represent a simple file move
+#[derive(Debug, PartialEq)]
+pub struct ReentryMove {
+    pub name: String,
+    pub type_name: String,
+    pub is_list: bool,
+}
+
 impl FieldMove {
     pub fn satisfies_override_rules(&self, ctx: &PlannerOverrideContext) -> bool {
         // Field is being progressively overridden by another subgraph
@@ -149,13 +157,11 @@ impl Display for OverrideLabel {
 }
 
 pub enum Edge {
-    /// A special edge between the root Node and then root entry point to the graph
-    /// With this helper, you can jump from Query::RootQuery --SomeSubgraph-> Query/SomeSubgraph --> --field--> SomeType/SomeSubgraph
     SubgraphEntrypoint {
-        field_names: Vec<String>,
         name: SubgraphName,
     },
     FieldMove(Box<FieldMove>),
+    ReentryMove(ReentryMove),
     EntityMove(EntityMove),
     /// join__implements
     AbstractMove(String),
@@ -226,9 +232,18 @@ impl Edge {
         }))
     }
 
+    pub fn create_reentry_move(name: String, type_name: String, is_list: bool) -> Self {
+        Self::ReentryMove(ReentryMove {
+            name: name.clone(),
+            type_name: type_name.clone(),
+            is_list,
+        })
+    }
+
     pub fn display_name(&self) -> &str {
         match self {
             Self::FieldMove(fm) => &fm.name,
+            Self::ReentryMove(fm) => &fm.name,
             Self::EntityMove(EntityMove { key, .. }) => key,
             Self::AbstractMove(id) => id,
             Self::Selfie(_) => "selfie",
@@ -272,6 +287,7 @@ impl Display for Edge {
             Edge::Selfie(_) => write!(f, "🤳"),
             Edge::FieldMove(field_move) => write!(f, "{}", field_move.name),
             Edge::InterfaceObjectTypeMove(m) => write!(f, "🔎 {}", m.object_type_name),
+            Edge::ReentryMove(fm) => write!(f, "🔁 {}", fm.name),
         }?;
 
         if let Some(reqs) = self.requirements() {
@@ -285,7 +301,8 @@ impl Display for Edge {
 impl Debug for Edge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Edge::SubgraphEntrypoint { name, .. } => write!(f, "subgraph({})", name.0),
+            Edge::SubgraphEntrypoint { name, .. } => write!(f, "🚪 subgraph({})", name.0),
+            Edge::ReentryMove(fm) => write!(f, "🔁 {}", fm.name),
             Edge::FieldMove(fm) => {
                 // Start with the field name
                 let mut result = write!(f, "{}", &fm.name);
@@ -341,6 +358,7 @@ impl PartialEq for Edge {
                 },
             ) => graph_id == other_graph_id,
             (Edge::FieldMove(fm1), Edge::FieldMove(fm2)) => fm1 == fm2,
+            (Edge::ReentryMove(rm1), Edge::ReentryMove(rm2)) => rm1 == rm2,
             (
                 Edge::EntityMove(EntityMove { key, .. }),
                 Edge::EntityMove(EntityMove { key: other_key, .. }),

--- a/lib/query-planner/src/graph/mod.rs
+++ b/lib/query-planner/src/graph/mod.rs
@@ -13,6 +13,8 @@ use std::{
 };
 
 use super::ast::normalization::utils::extract_type_condition;
+use super::graph::{edge::Edge, node::Node};
+use crate::planner::walker::utils::get_entrypoints;
 use crate::{
     ast::type_aware_selection::TypeAwareSelection,
     federation_spec::FederationRules,
@@ -30,8 +32,6 @@ use petgraph::{
     Directed, Direction, Graph as Petgraph,
 };
 use tracing::{instrument, trace};
-
-use super::graph::{edge::Edge, node::Node};
 
 type InnerGraph = Petgraph<Node, Edge, Directed>;
 
@@ -195,9 +195,9 @@ impl Graph {
         let edge = self.edge(edge_index).unwrap();
 
         if without_source {
-            format!("-({})- {}", edge, to.display_name())
+            format!("-({})- {}", edge, to)
         } else {
-            format!("{} -({})- {}", from.display_name(), edge, to.display_name())
+            format!("{} -({})- {}", from, edge, to)
         }
     }
 
@@ -541,17 +541,15 @@ impl Graph {
                         }
                         .ok_or(GraphError::MissingRootType(root_type.clone()))?;
 
-                        let tail = self.upsert_node(Node::new_node(
+                        let tail = self.upsert_node(Node::new_root_node(
                             def_name,
                             state.resolve_graph_id(graph_id)?,
-                            state.is_interface_object_in_subgraph(def_name, graph_id),
                         ));
 
                         self.upsert_edge(
                             head,
                             tail,
                             Edge::SubgraphEntrypoint {
-                                field_names: relevant_fields,
                                 name: state.resolve_graph_id(graph_id)?,
                             },
                         );
@@ -850,24 +848,18 @@ impl Graph {
                         target_type
                     );
 
+                    let current_subgraph_resolved_id = state.resolve_graph_id(graph_id)?;
+
                     let head = self.upsert_node(Node::new_node(
                         def_name,
-                        state.resolve_graph_id(graph_id)?,
+                        current_subgraph_resolved_id.clone(),
                         state.is_interface_object_in_subgraph(def_name, graph_id),
                     ));
                     let tail = self.upsert_node(Node::new_node(
                         target_type,
-                        state.resolve_graph_id(graph_id)?,
+                        current_subgraph_resolved_id.clone(),
                         state.is_interface_object_in_subgraph(target_type, graph_id),
                     ));
-
-                    trace!(
-                        "[x] Creating field move edge '{}.{}/{}' (type: {})",
-                        def_name,
-                        field_name,
-                        graph_id,
-                        target_type
-                    );
 
                     self.upsert_edge(
                         head,
@@ -889,10 +881,53 @@ impl Graph {
                                 }
                                 None => join_field.clone(),
                             }),
-                            requirements,
+                            requirements.clone(),
                             overridden_by.clone(),
                         ),
                     );
+
+                    // If the target type is a root type, we handle it differently and checking if a re-entry is needed.
+                    // Our goal is to find all "Query/subgraph" entrypoints
+                    if let Some(root_entrypoints) = state
+                        .maybe_root_type(target_type)
+                        .and_then(|root_kind| get_entrypoints(self, &root_kind).ok())
+                        .map(|edge_references| {
+                            edge_references
+                                .iter()
+                                .map(|edge_ref| edge_ref.target())
+                                .collect::<Vec<_>>()
+                        })
+                    {
+                        for target_node_index in root_entrypoints {
+                            let target_node = self.graph.node_weight(target_node_index).unwrap(); // safe because we know it's already there
+
+                            let Some(graph_id) = target_node.graph_id() else {
+                                continue;
+                            };
+
+                            if graph_id == current_subgraph_resolved_id.0 {
+                                continue;
+                            }
+
+                            trace!(
+                                "[x] Creating root re-entry field move edge '{}.{}/{}' (type: {})",
+                                def_name,
+                                field_name,
+                                graph_id,
+                                target_node.display_name()
+                            );
+
+                            self.upsert_edge(
+                                head,
+                                target_node_index,
+                                Edge::create_reentry_move(
+                                    field_name.clone(),
+                                    def_name.clone(),
+                                    field_definition.field_type.is_list(),
+                                ),
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/lib/query-planner/src/graph/node.rs
+++ b/lib/query-planner/src/graph/node.rs
@@ -17,6 +17,8 @@ pub struct UnionMembersData {
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum SubgraphTypeSpecialization {
+    /// Root/entrypoint type for a subgraph.
+    Root,
     /// Node was created due to @provides path.
     Provides(u64),
     /// Node represents a union member tail for a specific subgraph.
@@ -62,6 +64,9 @@ impl Node {
             Node::SubscriptionRoot(name) => format!("root({})", name),
             Node::SubgraphType(st) => match &st.specialization {
                 Some(spec) => match spec {
+                    SubgraphTypeSpecialization::Root => {
+                        format!("{}/{}", st.name, st.subgraph.0)
+                    }
                     SubgraphTypeSpecialization::Provides(provides_id) => {
                         format!("{}/{}/{}", st.name, st.subgraph.0, provides_id)
                     }
@@ -106,6 +111,15 @@ impl Node {
             subgraph,
             is_interface_object,
             specialization: None,
+        })
+    }
+
+    pub fn new_root_node(name: &str, subgraph: SubgraphName) -> Node {
+        Node::SubgraphType(SubgraphType {
+            name: name.to_string(),
+            subgraph,
+            is_interface_object: false,
+            specialization: Some(SubgraphTypeSpecialization::Root),
         })
     }
 

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -2,7 +2,9 @@ use crate::ast::merge_path::{Condition, FieldPathSegment, MergePath, Segment};
 use crate::ast::selection_item::SelectionItem;
 use crate::ast::selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet};
 use crate::ast::type_aware_selection::TypeAwareSelection;
-use crate::graph::edge::{Edge, FieldMove, InterfaceObjectTypeMove, PlannerOverrideContext};
+use crate::graph::edge::{
+    Edge, FieldMove, InterfaceObjectTypeMove, PlannerOverrideContext, ReentryMove,
+};
 use crate::graph::node::Node;
 use crate::graph::Graph;
 use crate::planner::fetch::fetch_step_data::{FetchStepData, FetchStepFlags, FetchStepKind};
@@ -358,15 +360,17 @@ fn create_fetch_step_for_root_move(
     subgraph_name: &SubgraphName,
     type_name: &str,
     mutation_field_position: MutationFieldPosition,
+    response_path: &MergePath,
+    condition: Option<&Condition>,
 ) -> NodeIndex {
     let idx = fetch_graph.add_step(FetchStepData {
         id: fetch_graph.create_fetch_id(),
         service_name: subgraph_name.clone(),
-        response_path: MergePath::default(),
+        response_path: response_path.clone(),
         input: FetchStepSelections::new(type_name),
         output: FetchStepSelections::new(type_name),
         flags: FetchStepFlags::empty(),
-        condition: None,
+        condition: condition.cloned(),
         kind: FetchStepKind::Root,
         variable_usages: None,
         variable_definitions: None,
@@ -1028,6 +1032,8 @@ fn process_subgraph_entrypoint_edge(
         subgraph_name,
         type_name,
         query_node.mutation_field_position,
+        &MergePath::default(),
+        None,
     );
 
     fetch_graph.connect(parent_fetch_step_index, fetch_step_index);
@@ -1042,6 +1048,120 @@ fn process_subgraph_entrypoint_edge(
         &MergePath::default(),
         &MergePath::default(),
         None,
+        None,
+        created_from_requires,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[instrument(level = "trace",skip_all, fields(
+  parent_fetch_step_index = parent_fetch_step_index.index(),
+))]
+fn process_subgraph_reentry(
+    graph: &Graph,
+    fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
+    edge_index: EdgeIndex,
+    override_context: &PlannerOverrideContext,
+    query_node: &QueryTreeNode,
+    parent_fetch_step_index: NodeIndex,
+    created_from_requires: bool,
+    reentry_move: &ReentryMove,
+    response_path: &MergePath,
+    fetch_path: &MergePath,
+    requiring_fetch_step_index: Option<NodeIndex>,
+    condition: Option<&Condition>,
+) -> Result<Vec<NodeIndex>, FetchGraphError> {
+    let node_index = graph.get_edge_tail(&edge_index).unwrap();
+    let node = graph.node(node_index).unwrap();
+
+    let (type_name, subgraph_name) = match node {
+        Node::SubgraphType(subgraph_type) => (&subgraph_type.name, &subgraph_type.subgraph),
+        _ => return Err(FetchGraphError::ExpectedSubgraphType),
+    };
+
+    // The re-entry field is part of the parent's response shape, but its children resolve in a
+    // separate (re-entered) fetch. Record the field in the parent output with a `__typename`
+    // so the parent operation stays valid.
+    //
+    let condition_in_path = if let Some(condition) = condition {
+        fetch_path.inner.iter().any(|segment| {
+            matches!(
+                segment,
+                Segment::TypeCondition(_, Some(c)) | Segment::Field(_, _, Some(c)) if c == condition
+            )
+        })
+    } else {
+        false
+    };
+
+    let ancestor_of_condition = match condition {
+        Some(c) => fetch_graph.is_ancestor_of_condition(parent_fetch_step_index, c),
+        None => false,
+    };
+
+    let should_strip_condition = condition_in_path || ancestor_of_condition;
+    let parent_fetch_step = fetch_graph.get_step_data_mut(parent_fetch_step_index)?;
+    parent_fetch_step.output.add_at_path(
+        fetch_path,
+        SelectionSet {
+            items: vec![SelectionItem::Field(FieldSelection {
+                name: reentry_move.name.to_string(),
+                alias: query_node.selection_alias().map(|a| a.to_string()),
+                selections: SelectionSet {
+                    items: vec![SelectionItem::Field(FieldSelection::new_typename())],
+                },
+                arguments: query_node.selection_arguments().cloned(),
+                skip_if: condition.and_then(|c| {
+                    if should_strip_condition {
+                        None
+                    } else {
+                        c.to_skip_if()
+                    }
+                }),
+                include_if: condition.and_then(|c| {
+                    if should_strip_condition {
+                        None
+                    } else {
+                        c.to_include_if()
+                    }
+                }),
+                omit_from_response: false,
+            })],
+        },
+    )?;
+
+    let segment_field = FieldPathSegment::new(
+        reentry_move.name.to_string(),
+        query_node.selection_alias().map(|a| a.to_string()),
+    );
+    let mut child_response_path = response_path.push(Segment::Field(segment_field, 0, None));
+    if reentry_move.is_list {
+        child_response_path = child_response_path.push(Segment::List);
+    }
+
+    let fetch_step_index = create_fetch_step_for_root_move(
+        fetch_graph,
+        parent_fetch_step_index,
+        subgraph_name,
+        type_name,
+        query_node.mutation_field_position,
+        &child_response_path,
+        condition,
+    );
+
+    fetch_graph.connect(parent_fetch_step_index, fetch_step_index);
+
+    process_children_for_fetch_steps(
+        graph,
+        fetch_graph,
+        supergraph,
+        override_context,
+        query_node,
+        fetch_step_index,
+        &child_response_path,
+        &MergePath::default(),
+        requiring_fetch_step_index,
         None,
         created_from_requires,
     )
@@ -1738,6 +1858,21 @@ fn process_query_node(
                 edge_index,
                 condition,
                 created_from_requires,
+            ),
+            Edge::ReentryMove(field) => process_subgraph_reentry(
+                graph,
+                fetch_graph,
+                supergraph,
+                edge_index,
+                override_context,
+                query_node,
+                parent_fetch_step_index,
+                created_from_requires,
+                field,
+                response_path,
+                fetch_path,
+                requiring_fetch_step_index,
+                condition,
             ),
             Edge::FieldMove(field) => match field.requirements.is_some() {
                 true => process_requires_field_edge(

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod error;
 mod excluded;
 pub(crate) mod path;
 pub(crate) mod pathfinder;
-mod utils;
+pub(crate) mod utils;
 
 use std::collections::VecDeque;
 

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -201,7 +201,7 @@ impl<'graph> OperationPath<'graph> {
                 .union_context
                 .as_ref()
                 .map(|scope| scope.narrow_to_member(member_type_name)),
-            Edge::EntityMove(_) | Edge::InterfaceObjectTypeMove(_) => None,
+            Edge::EntityMove(_) | Edge::InterfaceObjectTypeMove(_) | Edge::ReentryMove(_) => None,
             _ => self.union_context.clone(),
         };
 

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -494,9 +494,10 @@ impl<'graph> PathSearch<'graph> {
 
         let edges_iter: Box<dyn Iterator<Item = _>> = match target {
             NavigationTarget::Field(field) => {
-                Box::new(graph.edges_from(path_tail_index).filter(
-                    move |e| matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name),
-                ))
+                Box::new(graph.edges_from(path_tail_index).filter(move |e| {
+                    matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name)
+                        || matches!(e.weight(), Edge::ReentryMove(r) if r.name == field.name)
+                }))
             }
             NavigationTarget::ConcreteType(type_name, _condition) => Box::new(
                 graph

--- a/lib/query-planner/src/state/supergraph_state.rs
+++ b/lib/query-planner/src/state/supergraph_state.rs
@@ -223,6 +223,18 @@ impl SupergraphState {
         instance
     }
 
+    pub fn maybe_root_type(&self, type_name: &str) -> Option<OperationKind> {
+        if self.query_type == type_name {
+            Some(OperationKind::Query)
+        } else if self.mutation_type.as_deref() == Some(type_name) {
+            Some(OperationKind::Mutation)
+        } else if self.subscription_type.as_deref() == Some(type_name) {
+            Some(OperationKind::Subscription)
+        } else {
+            None
+        }
+    }
+
     pub fn resolve_graph_id(&self, graph_id: &str) -> Result<SubgraphName, SupergraphStateError> {
         self.known_subgraphs
             .get(graph_id)

--- a/lib/query-planner/src/tests/mod.rs
+++ b/lib/query-planner/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod requires_circular;
 mod requires_fragments;
 mod requires_provides;
 mod requires_requires;
+mod root_reentry;
 mod root_types;
 mod testkit;
 mod union;

--- a/lib/query-planner/src/tests/root_reentry.rs
+++ b/lib/query-planner/src/tests/root_reentry.rs
@@ -1,0 +1,468 @@
+use crate::{
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
+    utils::parsing::parse_operation,
+};
+use std::error::Error;
+
+#[test]
+pub fn mutation_referencing_query() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        mutation {
+          doSomething {
+            ok
+            query {
+              healthCheck
+              user(id: 1) {
+                name
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "two") {
+          mutation {
+            doSomething {
+              ok
+              query {
+                healthCheck
+                __typename
+              }
+            }
+          }
+        },
+        Flatten(path: "doSomething.query") {
+          Fetch(service: "one") {
+            {
+              user(id: 1) {
+                name
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+pub fn mutation_referencing_query_with_alias() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        mutation {
+          doSomething {
+            ok
+            info: query {
+              healthCheck
+              user(id: 1) {
+                name
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "two") {
+          mutation {
+            doSomething {
+              ok
+              info: query {
+                healthCheck
+                __typename
+              }
+            }
+          }
+        },
+        Flatten(path: "doSomething.info") {
+          Fetch(service: "one") {
+            {
+              user(id: 1) {
+                name
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+pub fn mutation_referencing_query_with_condition() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        mutation($withQuery: Boolean!) {
+          doSomething {
+            ok
+            query @include(if: $withQuery) {
+              healthCheck
+              user(id: 1) {
+                name
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "two") {
+          mutation ($withQuery:Boolean!) {
+            doSomething {
+              ok
+              query @include(if: $withQuery) {
+                healthCheck
+                __typename
+              }
+            }
+          }
+        },
+        Include(if: $withQuery) {
+          Flatten(path: "doSomething.query") {
+            Fetch(service: "one") {
+              {
+                user(id: 1) {
+                  name
+                }
+              }
+            },
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+pub fn query_referencing_query() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          healthCheck
+          user(id: 1) {
+            name
+          }
+          system {
+            healthCheck
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "one") {
+          {
+            user(id: 1) {
+              name
+            }
+          }
+        },
+        Fetch(service: "two") {
+          {
+            healthCheck
+            system {
+              healthCheck
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+pub fn query_referencing_query_cross_subgraphs() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          healthCheck
+          user(id: 1) {
+            name
+          }
+          system {
+            healthCheck
+            user(id: 1) {
+              name
+            }
+            system {
+              healthCheck
+              user(id: 1) {
+                name
+              }
+              system {
+                healthCheck
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Parallel {
+        Fetch(service: "one") {
+          {
+            user(id: 1) {
+              ...a
+            }
+            system {
+              user(id: 1) {
+                ...a
+              }
+              system {
+                user(id: 1) {
+                  ...a
+                }
+              }
+            }
+          }
+          fragment a on User {
+            name
+          }
+        },
+        Fetch(service: "two") {
+          {
+            healthCheck
+            system {
+              healthCheck
+              system {
+                healthCheck
+                system {
+                  healthCheck
+                }
+              }
+            }
+          }
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+pub fn query_referncing_through_inner() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          user(id: 1) {
+            id
+            name
+          }
+          inner {
+            toQuery {
+              user(id: 1) {
+                id
+                name
+              }
+            }
+            toMutation {
+              doSomething {
+                ok
+                query {
+                  healthCheck
+                  user(id: 1) {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Parallel {
+          Fetch(service: "two") {
+            {
+              inner {
+                toMutation {
+                  doSomething {
+                    ok
+                    query {
+                      healthCheck
+                      __typename
+                    }
+                  }
+                }
+              }
+            }
+          },
+          Fetch(service: "one") {
+            {
+              user(id: 1) {
+                ...a
+              }
+              inner {
+                toQuery {
+                  user(id: 1) {
+                    ...a
+                  }
+                }
+              }
+            }
+            fragment a on User {
+              id
+              name
+            }
+          },
+        },
+        Flatten(path: "inner.toMutation.doSomething.query") {
+          Fetch(service: "one") {
+            {
+              user(id: 1) {
+                name
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+// Start with a mutation to subgraph "two", then all re-entry fields are resolved from "one"
+#[test]
+pub fn mutation_then_full_reentry_jump() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+      mutation {
+        doSomething { # two
+          query { # jump to one
+            user(id: 1) { # one
+              name # one
+            }
+          }
+        }
+      }
+      "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "two") {
+          mutation {
+            doSomething {
+              query {
+                __typename
+              }
+            }
+          }
+        },
+        Flatten(path: "doSomething.query") {
+          Fetch(service: "one") {
+            {
+              user(id: 1) {
+                name
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+// Start with a mutation to subgraph "two", then all mixed fetch from both subgraphs
+#[test]
+pub fn mutation_then_mixed_query() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+      mutation {
+        doSomething { # two
+          ok # two
+          query { # one+two
+            healthCheck # two
+            user(id: 1) { # one
+              name # one
+            }
+          }
+        }
+      }
+      "#,
+    );
+    let query_plan =
+        build_query_plan_with_defaults("fixture/tests/root-reentry.supergraph.graphql", document)?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "two") {
+          mutation {
+            doSomething {
+              ok
+              query {
+                healthCheck
+                __typename
+              }
+            }
+          }
+        },
+        Flatten(path: "doSomething.query") {
+          Fetch(service: "one") {
+            {
+              user(id: 1) {
+                name
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/1164 

## Backgorund

A field can re-expose a root operation type from a nested position — like a mutation field returning `DoSomething { ok, query: Query }`.
When the nested re-entry selected fields owned by a different subgraph than the one resolving the parent, the field resolved to `null`.

## Fix in query-planner

Previously, a field returning a root type only got a `FieldMove` edge into the same subgraph's root, so the walker could never hop to another subgraph to satisfy the nested selection. This step is also wrapped with `Flatten` because it's not going to be merged into the root, like other root calls. 

## Fix in executor

The executor's `Flatten` handler assumed every flattened fetch is an `_entities` call `requires` — so the re-entry request was never sent (falling back to `None).

## TODO 

- [x] figure out graph and pathfinder 
- [x] figure out how to have re-entry in fetch-graph 
- [x] test qp 
- [x] test e2e 
- [x] fix in executor
- [x] unit tests in planner 