### PR TITLE
fix(query-planner, graphql-tools): traverse fragments linearly during cycle validation and inlining

### DIFF
--- a/.changeset/traverse_fragments_linearly_during_cycle_validation_and_inlining.md
+++ b/.changeset/traverse_fragments_linearly_during_cycle_validation_and_inlining.md
@@ -9,4 +9,8 @@ hive-router-internal: patch
 hive-apollo-router-plugin: patch
 ---
 
-# Traverse fragments linearly during cycle validation and inlining
+# Fix: Traverse fragments linearly during cycle validation and inlining
+
+GraphQL fragments can spread other fragments, e.g. `fragment A on T { ...B }`. When fragments form a long acyclic chain (A spreads B, B spreads C, and so on for thousands of links), we walked that chain with plain recursion. 
+
+This change prevents the stack from being filled in such cases. 

--- a/.changeset/traverse_fragments_linearly_during_cycle_validation_and_inlining.md
+++ b/.changeset/traverse_fragments_linearly_during_cycle_validation_and_inlining.md
@@ -1,0 +1,12 @@
+---
+hive-router-query-planner: patch
+graphql-tools: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+hive-console-sdk: patch
+hive-router-internal: patch
+hive-apollo-router-plugin: patch
+---
+
+# Traverse fragments linearly during cycle validation and inlining

--- a/e2e/src/max_depth.rs
+++ b/e2e/src/max_depth.rs
@@ -1,5 +1,17 @@
 #[cfg(test)]
 mod max_depth_e2e_tests {
+    // builds `query { ...F1 } fragment F1 on Query { ...F2 } ... fragment FN on Query { __typename }`
+    // brace depth never exceeds 2, so the tokenizer's recursion_limit=50 is irrelevant.
+    // each spread without flatten_fragments adds 1 to the validated depth, so N fragments -> depth N.
+    fn acyclic_fragment_chain(n: usize) -> String {
+        let mut s = String::from("query { ...F1 }\n");
+        for i in 1..n {
+            s.push_str(&format!("fragment F{i} on Query {{ ...F{} }}\n", i + 1));
+        }
+        s.push_str(&format!("fragment F{n} on Query {{ __typename }}\n"));
+        s
+    }
+
     use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
 
     const QUERY: &'static str = r#"
@@ -134,6 +146,107 @@ mod max_depth_e2e_tests {
               }
             }
           ]
+        }
+        "###);
+    }
+
+    #[ntex::test]
+    async fn rejects_acyclic_fragment_chain_exceeding_max_depth() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                limits:
+                    max_depth:
+                        n: 10
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // N=200 fragments, each `on Query { ...FN+1 }` - brace depth <=2, but validated depth=200
+        let query = acyclic_fragment_chain(200);
+        let res = router.send_graphql_request(&query, None, None).await;
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        {
+          "errors": [
+            {
+              "message": "Query depth limit exceeded.",
+              "extensions": {
+                "code": "MAX_DEPTH_EXCEEDED"
+              }
+            }
+          ]
+        }
+        "###);
+    }
+
+    #[ntex::test]
+    async fn acyclic_fragment_chain_without_max_depth_does_not_crash_router() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // N=50_000 acyclic fragment chain, brace depth <=2 (bypasses tokenizer limit),
+        // but normalization recurses N-deep and overflows the stack
+        let query = acyclic_fragment_chain(50_000);
+        let res = router.send_graphql_request(&query, None, None).await;
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        {
+          "errors": [
+            {
+              "message": "Query depth limit exceeded.",
+              "extensions": {
+                "code": "MAX_DEPTH_EXCEEDED"
+              }
+            }
+          ]
+        }
+        "###);
+    }
+
+    #[ntex::test]
+    async fn allows_short_acyclic_fragment_chain_within_max_depth() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                limits:
+                    max_depth:
+                        n: 10
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // N=3 fragments, depth=3, well within n=10
+        let query = acyclic_fragment_chain(3);
+        let res = router.send_graphql_request(&query, None, None).await;
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        {
+          "data": {
+            "__typename": "Query"
+          }
         }
         "###);
     }

--- a/e2e/src/max_depth.rs
+++ b/e2e/src/max_depth.rs
@@ -1,17 +1,5 @@
 #[cfg(test)]
 mod max_depth_e2e_tests {
-    // builds `query { ...F1 } fragment F1 on Query { ...F2 } ... fragment FN on Query { __typename }`
-    // brace depth never exceeds 2, so the tokenizer's recursion_limit=50 is irrelevant.
-    // each spread without flatten_fragments adds 1 to the validated depth, so N fragments -> depth N.
-    fn acyclic_fragment_chain(n: usize) -> String {
-        let mut s = String::from("query { ...F1 }\n");
-        for i in 1..n {
-            s.push_str(&format!("fragment F{i} on Query {{ ...F{} }}\n", i + 1));
-        }
-        s.push_str(&format!("fragment F{n} on Query {{ __typename }}\n"));
-        s
-    }
-
     use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
 
     const QUERY: &'static str = r#"
@@ -146,107 +134,6 @@ mod max_depth_e2e_tests {
               }
             }
           ]
-        }
-        "###);
-    }
-
-    #[ntex::test]
-    async fn rejects_acyclic_fragment_chain_exceeding_max_depth() {
-        let subgraphs = TestSubgraphs::builder().build().start().await;
-        let router = TestRouter::builder()
-            .with_subgraphs(&subgraphs)
-            .inline_config(
-                r#"
-                supergraph:
-                    source: file
-                    path: supergraph.graphql
-                limits:
-                    max_depth:
-                        n: 10
-                "#,
-            )
-            .build()
-            .start()
-            .await;
-
-        // N=200 fragments, each `on Query { ...FN+1 }` - brace depth <=2, but validated depth=200
-        let query = acyclic_fragment_chain(200);
-        let res = router.send_graphql_request(&query, None, None).await;
-        insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
-        {
-          "errors": [
-            {
-              "message": "Query depth limit exceeded.",
-              "extensions": {
-                "code": "MAX_DEPTH_EXCEEDED"
-              }
-            }
-          ]
-        }
-        "###);
-    }
-
-    #[ntex::test]
-    async fn acyclic_fragment_chain_without_max_depth_does_not_crash_router() {
-        let subgraphs = TestSubgraphs::builder().build().start().await;
-        let router = TestRouter::builder()
-            .with_subgraphs(&subgraphs)
-            .inline_config(
-                r#"
-                supergraph:
-                    source: file
-                    path: supergraph.graphql
-                "#,
-            )
-            .build()
-            .start()
-            .await;
-
-        // N=50_000 acyclic fragment chain, brace depth <=2 (bypasses tokenizer limit),
-        // but normalization recurses N-deep and overflows the stack
-        let query = acyclic_fragment_chain(50_000);
-        let res = router.send_graphql_request(&query, None, None).await;
-        insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
-        {
-          "errors": [
-            {
-              "message": "Query depth limit exceeded.",
-              "extensions": {
-                "code": "MAX_DEPTH_EXCEEDED"
-              }
-            }
-          ]
-        }
-        "###);
-    }
-
-    #[ntex::test]
-    async fn allows_short_acyclic_fragment_chain_within_max_depth() {
-        let subgraphs = TestSubgraphs::builder().build().start().await;
-        let router = TestRouter::builder()
-            .with_subgraphs(&subgraphs)
-            .inline_config(
-                r#"
-                supergraph:
-                    source: file
-                    path: supergraph.graphql
-                limits:
-                    max_depth:
-                        n: 10
-                "#,
-            )
-            .build()
-            .start()
-            .await;
-
-        // N=3 fragments, depth=3, well within n=10
-        let query = acyclic_fragment_chain(3);
-        let res = router.send_graphql_request(&query, None, None).await;
-        insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
-        {
-          "data": {
-            "__typename": "Query"
-          }
         }
         "###);
     }

--- a/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
+++ b/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
@@ -79,20 +79,21 @@ impl NoFragmentsCycle {
                     }
                 }
                 Frame::EnterSpread(spread_node) => {
-                    let spread_name = spread_node.fragment_name.clone();
-                    spread_paths.push(spread_node);
+                    let spread_name = &spread_node.fragment_name;
 
-                    match spread_path_index_by_name.get(&spread_name) {
+                    match spread_path_index_by_name.get(spread_name) {
                         None => {
                             if let Some(spread_def) = known_fragments.get(spread_name.as_str()) {
-                                // PopSpread runs after the child subtree is fully explored
+                                // descend into the target; PopSpread restores spread_paths once the
+                                // whole child subtree is explored.
+                                spread_paths.push(spread_node);
                                 stack.push(Frame::PopSpread);
                                 stack.push(Frame::EnterFragment(spread_def));
-                            } else {
-                                spread_paths.pop();
                             }
                         }
                         Some(cycle_index) => {
+                            // include the closing spread so the reported path ends where it loops.
+                            spread_paths.push(spread_node);
                             let cycle_path = &spread_paths[*cycle_index..];
                             let via_path = match cycle_path.len() {
                                 0 => vec![],

--- a/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
+++ b/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
@@ -35,7 +35,7 @@ impl NoFragmentsCycle {
         &mut self,
         root: &'a FragmentDefinition,
         spread_paths: &mut Vec<&'a FragmentSpread>,
-        spread_path_index_by_name: &mut HashMap<String, usize>,
+        spread_path_index_by_name: &mut HashMap<&'a str, usize>,
         known_fragments: &'a HashMap<&'a str, &'a FragmentDefinition>,
         error_context: &mut ValidationErrorContext,
     ) {
@@ -44,9 +44,9 @@ impl NoFragmentsCycle {
         // target fragment or reports a cycle, Frame::PopSpread undoes that push on the way back.
         enum Frame<'a> {
             EnterFragment(&'a FragmentDefinition),
-            ExitFragment(String), // removes fragment from spread_path_index_by_name
+            ExitFragment(&'a str), // removes fragment from spread_path_index_by_name
             EnterSpread(&'a FragmentSpread), // push spread onto spread_paths
-            PopSpread,            // pop spread from spread_paths
+            PopSpread,             // pop spread from spread_paths
         }
 
         let mut stack: Vec<Frame<'a>> = vec![Frame::EnterFragment(root)];
@@ -54,7 +54,7 @@ impl NoFragmentsCycle {
         while let Some(frame) = stack.pop() {
             match frame {
                 Frame::ExitFragment(name) => {
-                    spread_path_index_by_name.remove(&name);
+                    spread_path_index_by_name.remove(name);
                 }
                 Frame::PopSpread => {
                     spread_paths.pop();
@@ -70,8 +70,8 @@ impl NoFragmentsCycle {
                         continue;
                     }
 
-                    spread_path_index_by_name.insert(fragment.name.clone(), spread_paths.len());
-                    stack.push(Frame::ExitFragment(fragment.name.clone()));
+                    spread_path_index_by_name.insert(fragment.name.as_str(), spread_paths.len());
+                    stack.push(Frame::ExitFragment(fragment.name.as_str()));
 
                     // push spreads in reverse so they execute left-to-right
                     for spread_node in spread_nodes.into_iter().rev() {
@@ -81,7 +81,7 @@ impl NoFragmentsCycle {
                 Frame::EnterSpread(spread_node) => {
                     let spread_name = &spread_node.fragment_name;
 
-                    match spread_path_index_by_name.get(spread_name) {
+                    match spread_path_index_by_name.get(spread_name.as_str()) {
                         None => {
                             if let Some(spread_def) = known_fragments.get(spread_name.as_str()) {
                                 // descend into the target; PopSpread restores spread_paths once the
@@ -135,7 +135,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoFragmentsCycle {
         fragment: &FragmentDefinition,
     ) {
         let mut spread_paths: Vec<&FragmentSpread> = vec![];
-        let mut spread_path_index_by_name: HashMap<String, usize> = HashMap::new();
+        let mut spread_path_index_by_name: HashMap<&str, usize> = HashMap::new();
 
         self.detect_cycles(
             fragment,

--- a/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
+++ b/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
@@ -33,73 +33,96 @@ impl NoFragmentsCycle {
     /// the graph to find all possible cycles.
     fn detect_cycles<'a>(
         &mut self,
-        fragment: &'a FragmentDefinition,
+        root: &'a FragmentDefinition,
         spread_paths: &mut Vec<&'a FragmentSpread>,
         spread_path_index_by_name: &mut HashMap<String, usize>,
         known_fragments: &'a HashMap<&'a str, &'a FragmentDefinition>,
         error_context: &mut ValidationErrorContext,
     ) {
-        if self.visited_fragments.contains(&fragment.name) {
-            return;
+        // iterative DFS to avoid stack overflow on deep acyclic chains.
+        // Frame::EnterSpread pushes one spread onto spread_paths then either recurses into the
+        // target fragment or reports a cycle, Frame::PopSpread undoes that push on the way back.
+        enum Frame<'a> {
+            EnterFragment(&'a FragmentDefinition),
+            ExitFragment(String), // removes fragment from spread_path_index_by_name
+            EnterSpread(&'a FragmentSpread), // push spread onto spread_paths
+            PopSpread,            // pop spread from spread_paths
         }
 
-        self.visited_fragments.insert(fragment.name.clone());
+        let mut stack: Vec<Frame<'a>> = vec![Frame::EnterFragment(root)];
 
-        let spread_nodes = fragment.selection_set.get_recursive_fragment_spreads();
+        while let Some(frame) = stack.pop() {
+            match frame {
+                Frame::ExitFragment(name) => {
+                    spread_path_index_by_name.remove(&name);
+                }
+                Frame::PopSpread => {
+                    spread_paths.pop();
+                }
+                Frame::EnterFragment(fragment) => {
+                    if self.visited_fragments.contains(&fragment.name) {
+                        continue;
+                    }
+                    self.visited_fragments.insert(fragment.name.clone());
 
-        if spread_nodes.is_empty() {
-            return;
-        }
+                    let spread_nodes = fragment.selection_set.get_recursive_fragment_spreads();
+                    if spread_nodes.is_empty() {
+                        continue;
+                    }
 
-        spread_path_index_by_name.insert(fragment.name.clone(), spread_paths.len());
+                    spread_path_index_by_name.insert(fragment.name.clone(), spread_paths.len());
+                    stack.push(Frame::ExitFragment(fragment.name.clone()));
 
-        for spread_node in spread_nodes {
-            let spread_name = spread_node.fragment_name.clone();
-            spread_paths.push(spread_node);
-
-            match spread_path_index_by_name.get(&spread_name) {
-                None => {
-                    if let Some(spread_def) = known_fragments.get(spread_name.as_str()) {
-                        self.detect_cycles(
-                            spread_def,
-                            spread_paths,
-                            spread_path_index_by_name,
-                            known_fragments,
-                            error_context,
-                        );
+                    // push spreads in reverse so they execute left-to-right
+                    for spread_node in spread_nodes.into_iter().rev() {
+                        stack.push(Frame::EnterSpread(spread_node));
                     }
                 }
-                Some(cycle_index) => {
-                    let cycle_path = &spread_paths[*cycle_index..];
-                    let via_path = match cycle_path.len() {
-                        0 => vec![],
-                        _ => cycle_path[0..cycle_path.len() - 1]
-                            .iter()
-                            .map(|s| format!("\"{}\"", s.node_name().unwrap()))
-                            .collect::<Vec<String>>(),
-                    };
+                Frame::EnterSpread(spread_node) => {
+                    let spread_name = spread_node.fragment_name.clone();
+                    spread_paths.push(spread_node);
 
-                    error_context.report_error(ValidationError {
-                        error_code: self.error_code(),
-                        locations: cycle_path.iter().map(|f| f.position).collect(),
-                        message: match via_path.len() {
-                            0 => {
-                                format!("Cannot spread fragment \"{}\" within itself.", spread_name)
+                    match spread_path_index_by_name.get(&spread_name) {
+                        None => {
+                            if let Some(spread_def) = known_fragments.get(spread_name.as_str()) {
+                                // PopSpread runs after the child subtree is fully explored
+                                stack.push(Frame::PopSpread);
+                                stack.push(Frame::EnterFragment(spread_def));
+                            } else {
+                                spread_paths.pop();
                             }
-                            _ => format!(
-                                "Cannot spread fragment \"{}\" within itself via {}.",
-                                spread_name,
-                                via_path.join(", ")
-                            ),
-                        },
-                    })
+                        }
+                        Some(cycle_index) => {
+                            let cycle_path = &spread_paths[*cycle_index..];
+                            let via_path = match cycle_path.len() {
+                                0 => vec![],
+                                _ => cycle_path[0..cycle_path.len() - 1]
+                                    .iter()
+                                    .map(|s| format!("\"{}\"", s.node_name().unwrap()))
+                                    .collect::<Vec<String>>(),
+                            };
+
+                            error_context.report_error(ValidationError {
+                                error_code: self.error_code(),
+                                locations: cycle_path.iter().map(|f| f.position).collect(),
+                                message: match via_path.len() {
+                                    0 => format!(
+                                        "Cannot spread fragment \"{}\" within itself.",
+                                        spread_name
+                                    ),
+                                    _ => format!(
+                                        "Cannot spread fragment \"{}\" within itself via {}.",
+                                        spread_name,
+                                        via_path.join(", ")
+                                    ),
+                                },
+                            });
+                            spread_paths.pop();
+                        }
+                    }
                 }
             }
-
-            spread_paths.pop();
         }
-
-        spread_path_index_by_name.remove(&fragment.name);
     }
 }
 

--- a/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
+++ b/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
@@ -99,7 +99,13 @@ impl NoFragmentsCycle {
                                 0 => vec![],
                                 _ => cycle_path[0..cycle_path.len() - 1]
                                     .iter()
-                                    .map(|s| format!("\"{}\"", s.node_name().unwrap()))
+                                    .map(|s| {
+                                        format!(
+                                            "\"{}\"",
+                                            s.node_name()
+                                                .expect("fragment spread must have a name")
+                                        )
+                                    })
                                     .collect::<Vec<String>>(),
                             };
 

--- a/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
+++ b/lib/graphql-tools/src/validation/rules/no_fragments_cycle.rs
@@ -462,6 +462,25 @@ fn no_spreading_itself_deeply_two_paths_alt_traverse_order() {
 }
 
 #[test]
+fn acyclic_fragment_chain_does_not_overflow_stack() {
+    use crate::validation::test_utils::*;
+
+    let mut plan = create_plan_from_rule(Box::new(NoFragmentsCycle::new()));
+
+    let n = 10_000;
+    let mut doc = String::from("");
+    for i in 1..n {
+        doc.push_str(&format!("fragment F{i} on Dog {{ ...F{} }}\n", i + 1));
+    }
+    doc.push_str(&format!("fragment F{n} on Dog {{ name }}\n"));
+
+    // must return without overflowing the stack
+    let errors = test_operation_with_schema(&doc, TEST_SCHEMA, &mut plan);
+    let mes = get_messages(&errors);
+    assert_eq!(mes.len(), 0);
+}
+
+#[test]
 fn no_spreading_itself_deeply_and_immediately() {
     use crate::validation::test_utils::*;
 

--- a/lib/query-planner/src/ast/normalization/error.rs
+++ b/lib/query-planner/src/ast/normalization/error.rs
@@ -26,4 +26,7 @@ pub enum NormalizationError {
 
     #[error("Fragment definition for '{fragment_name}' not found.")]
     FragmentDefinitionNotFound { fragment_name: String },
+
+    #[error("Cyclic fragment spread detected for '{fragment_name}'.")]
+    CyclicFragmentSpread { fragment_name: String },
 }

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -2750,4 +2750,75 @@ mod tests {
         // must return without overflowing; Ok or Err (i.e. no crash) both mean we survived
         let _ = normalize_operation(&supergraph, &parsed, None);
     }
+
+    #[test]
+    fn cyclic_fragment_self_reference_returns_error() {
+        // fragment A on Query { ...A } — inlineable single-spread self-cycle
+        let schema = parse_schema(
+            r#"
+            type Query {
+              field: String
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+        let parsed = parse_query::<String>(
+            r#"
+            query { ...A }
+            fragment A on Query { ...A }
+            "#,
+        )
+        .expect("to parse")
+        .into_static();
+
+        // run in a thread with a deadline so an infinite loop fails fast
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = normalize_operation(&supergraph, &parsed, None);
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("normalize_operation hung on a self-referential fragment cycle");
+        assert!(
+            result.is_err(),
+            "expected an error for a cyclic fragment, got Ok"
+        );
+    }
+
+    #[test]
+    fn cyclic_fragment_mutual_reference_returns_error() {
+        // fragment A on Query { ...B }, fragment B on Query { ...A } — mutual inlineable cycle
+        let schema = parse_schema(
+            r#"
+            type Query {
+              field: String
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+        let parsed = parse_query::<String>(
+            r#"
+            query { ...A }
+            fragment A on Query { ...B }
+            fragment B on Query { ...A }
+            "#,
+        )
+        .expect("to parse")
+        .into_static();
+
+        // run in a thread with a deadline so an infinite loop fails fast
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = normalize_operation(&supergraph, &parsed, None);
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("normalize_operation hung on a mutual fragment cycle");
+        assert!(
+            result.is_err(),
+            "expected an error for a cyclic fragment, got Ok"
+        );
+    }
 }

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -2729,7 +2729,7 @@ mod tests {
         let schema = parse_schema(
             r#"
             type Query {
-              __typename: String
+              field: String
             }
             "#,
         );

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -2735,7 +2735,7 @@ mod tests {
         );
         let supergraph = SupergraphState::new(&schema);
 
-        // very cyclcal fragment chain that would overflow the stack if protections were not in place
+        // very long acyclic fragment chain that would overflow the stack if protections were not in place
         let n = 10_000;
         let mut doc = String::from("query { ...F1 }\n");
         for i in 1..n {

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -2723,4 +2723,31 @@ mod tests {
         "
         );
     }
+
+    #[test]
+    fn acyclic_fragment_chain_does_not_overflow_stack() {
+        let schema = parse_schema(
+            r#"
+            type Query {
+              __typename: String
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+
+        // very cyclcal fragment chain that would overflow the stack if protections were not in place
+        let n = 10_000;
+        let mut doc = String::from("query { ...F1 }\n");
+        for i in 1..n {
+            doc.push_str(&format!("fragment F{i} on Query {{ ...F{} }}\n", i + 1));
+        }
+        doc.push_str(&format!("fragment F{n} on Query {{ __typename }}\n"));
+
+        let parsed = parse_query::<String>(&doc)
+            .expect("valid graphql")
+            .into_static();
+
+        // must return without overflowing; Ok or Err (i.e. no crash) both mean we survived
+        let _ = normalize_operation(&supergraph, &parsed, None);
+    }
 }

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -71,6 +71,10 @@ fn handle_selection_set<'a>(
                 // `spread` stays a borrow throughout, retargeting into `fragment_map` per link so
                 // no FragmentSpread gets cloned while advancing.
                 let mut spread = &spread;
+                // each step follows exactly one spread, so a cycle-free walk visits each fragment
+                // at most once - a chain longer than the total fragment count must contain a cycle
+                let max_chain = fragment_map.len();
+                let mut chain_len = 0usize;
                 let fragment_def = loop {
                     let def = fragment_map.get(&spread.fragment_name).ok_or_else(|| {
                         NormalizationError::FragmentDefinitionNotFound {
@@ -88,6 +92,12 @@ fn handle_selection_set<'a>(
                         if let [Selection::FragmentSpread(next)] =
                             def.selection_set.items.as_slice()
                         {
+                            chain_len += 1;
+                            if chain_len > max_chain {
+                                return Err(NormalizationError::CyclicFragmentSpread {
+                                    fragment_name: spread.fragment_name.clone(),
+                                });
+                            }
                             spread = next;
                             continue;
                         }

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -65,9 +65,12 @@ fn handle_selection_set<'a>(
                 )?;
                 new_items.push(Selection::Field(field));
             }
-            Selection::FragmentSpread(mut spread) => {
+            Selection::FragmentSpread(spread) => {
                 // walk the spread chain iteratively so a long acyclic chain (...F1 -> ...F2 -> ...)
                 // can't blow the stack. we only recurse on a fragment body that has real content.
+                // `spread` stays a borrow throughout, retargeting into `fragment_map` per link so
+                // no FragmentSpread gets cloned while advancing.
+                let mut spread = &spread;
                 let fragment_def = loop {
                     let def = fragment_map.get(&spread.fragment_name).ok_or_else(|| {
                         NormalizationError::FragmentDefinitionNotFound {
@@ -84,7 +87,7 @@ fn handle_selection_set<'a>(
                     if inlineable {
                         if let [Selection::FragmentSpread(next)] = def.selection_set.items.as_slice()
                         {
-                            spread = next.clone();
+                            spread = next;
                             continue;
                         }
                     }

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -66,38 +66,63 @@ fn handle_selection_set<'a>(
                 new_items.push(Selection::Field(field));
             }
             Selection::FragmentSpread(spread) => {
-                let fragment_def = fragment_map.get(&spread.fragment_name).ok_or_else(|| {
-                    NormalizationError::FragmentDefinitionNotFound {
-                        fragment_name: spread.fragment_name.clone(),
+                // iteratively resolve the fragment spread chain to avoid stack overflow on long
+                // acyclic chains. each iteration peels one same-type same-spread level off the chain
+                // until we hit a field boundary, a type mismatch, a directive, or a leaf.
+                let mut current_spread_name = spread.fragment_name.clone();
+                let mut current_directives = spread.directives.clone();
+                let mut current_position = spread.position;
+                let current_parent_tc = parent_type_condition.cloned();
+
+                loop {
+                    let fragment_def = fragment_map.get(&current_spread_name).ok_or_else(|| {
+                        NormalizationError::FragmentDefinitionNotFound {
+                            fragment_name: current_spread_name.clone(),
+                        }
+                    })?;
+
+                    if current_parent_tc.as_ref() == Some(&fragment_def.type_condition)
+                        && current_directives.is_empty()
+                    {
+                        // same type, no directives: the original code would inline and recurse.
+                        // check if the entire body is a single fragment spread with no fields,
+                        // in which case we can just advance the chain iteratively.
+                        let items = &fragment_def.selection_set.items;
+                        if items.len() == 1 {
+                            if let Selection::FragmentSpread(next_spread) = &items[0] {
+                                // pure chain link: advance without recursing
+                                current_spread_name = next_spread.fragment_name.clone();
+                                current_directives = next_spread.directives.clone();
+                                current_position = next_spread.position;
+                                // parent type condition stays the same
+                                continue;
+                            }
+                        }
+                        // body has real content: inline it and recurse normally (bounded by
+                        // field depth, which is bounded by max_depth validation)
+                        let mut inlined = fragment_def.selection_set.clone();
+                        handle_selection_set(
+                            &mut inlined,
+                            fragment_map,
+                            current_parent_tc.as_ref(),
+                        )?;
+                        new_items.extend(inlined.items);
+                    } else {
+                        // type mismatch or has directives: wrap in an inline fragment
+                        let mut inline_fragment = InlineFragment {
+                            position: current_position,
+                            type_condition: Some(fragment_def.type_condition.clone()),
+                            directives: current_directives.clone(),
+                            selection_set: fragment_def.selection_set.clone(),
+                        };
+                        handle_selection_set(
+                            &mut inline_fragment.selection_set,
+                            fragment_map,
+                            inline_fragment.type_condition.as_ref(),
+                        )?;
+                        new_items.push(Selection::InlineFragment(inline_fragment));
                     }
-                })?;
-
-                if parent_type_condition == Some(&fragment_def.type_condition)
-                    // `...Frag @include(...)` stores `@include` on the spread itself.
-                    // In the code below, we inline the fragment's selections,
-                    // so any directives would be lost.
-                    && spread.directives.is_empty()
-                {
-                    // If the fragment's type condition matches the top type condition,
-                    // we can inline its selections directly.
-                    let mut selection_set = fragment_def.selection_set.clone();
-                    handle_selection_set(&mut selection_set, fragment_map, parent_type_condition)?;
-                    new_items.extend(selection_set.items);
-                } else {
-                    let mut inline_fragment = InlineFragment {
-                        position: spread.position,
-                        type_condition: Some(fragment_def.type_condition.clone()),
-                        directives: spread.directives.clone(),
-                        selection_set: fragment_def.selection_set.clone(),
-                    };
-
-                    handle_selection_set(
-                        &mut inline_fragment.selection_set,
-                        fragment_map,
-                        inline_fragment.type_condition.as_ref(),
-                    )?;
-
-                    new_items.push(Selection::InlineFragment(inline_fragment));
+                    break;
                 }
             }
             Selection::InlineFragment(mut inline_fragment) => {

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -96,9 +96,13 @@ fn handle_selection_set<'a>(
                 };
 
                 if parent_type_condition == Some(&fragment_def.type_condition)
+                    // `...Frag @include(...)` stores `@include` on the spread itself.
+                    // In the code below, we inline the fragment's selections,
+                    // so any directives would be lost.
                     && spread.directives.is_empty()
                 {
-                    // same type, no directives: inline the body directly.
+                    // If the fragment's type condition matches the top type condition,
+                    // we can inline its selections directly.
                     let mut inlined = fragment_def.selection_set.clone();
                     handle_selection_set(&mut inlined, fragment_map, parent_type_condition)?;
                     new_items.extend(inlined.items);

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -65,64 +65,53 @@ fn handle_selection_set<'a>(
                 )?;
                 new_items.push(Selection::Field(field));
             }
-            Selection::FragmentSpread(spread) => {
-                // iteratively resolve the fragment spread chain to avoid stack overflow on long
-                // acyclic chains. each iteration peels one same-type same-spread level off the chain
-                // until we hit a field boundary, a type mismatch, a directive, or a leaf.
-                let mut current_spread_name = spread.fragment_name.clone();
-                let mut current_directives = spread.directives.clone();
-                let mut current_position = spread.position;
-                let current_parent_tc = parent_type_condition.cloned();
-
-                loop {
-                    let fragment_def = fragment_map.get(&current_spread_name).ok_or_else(|| {
+            Selection::FragmentSpread(mut spread) => {
+                // walk the spread chain iteratively so a long acyclic chain (...F1 -> ...F2 -> ...)
+                // can't blow the stack. we only recurse on a fragment body that has real content.
+                let fragment_def = loop {
+                    let def = fragment_map.get(&spread.fragment_name).ok_or_else(|| {
                         NormalizationError::FragmentDefinitionNotFound {
-                            fragment_name: current_spread_name.clone(),
+                            fragment_name: spread.fragment_name.clone(),
                         }
                     })?;
 
-                    if current_parent_tc.as_ref() == Some(&fragment_def.type_condition)
-                        && current_directives.is_empty()
-                    {
-                        // same type, no directives: the original code would inline and recurse.
-                        // check if the entire body is a single fragment spread with no fields,
-                        // in which case we can just advance the chain iteratively.
-                        let items = &fragment_def.selection_set.items;
-                        if items.len() == 1 {
-                            if let Selection::FragmentSpread(next_spread) = &items[0] {
-                                // pure chain link: advance without recursing
-                                current_spread_name = next_spread.fragment_name.clone();
-                                current_directives = next_spread.directives.clone();
-                                current_position = next_spread.position;
-                                // parent type condition stays the same
-                                continue;
-                            }
+                    // can only inline (vs wrap) when the type matches and there are no directives
+                    // that would otherwise be lost.
+                    let inlineable = parent_type_condition == Some(&def.type_condition)
+                        && spread.directives.is_empty();
+
+                    // pure chain link `fragment F on T { ...G }`: advance instead of recursing.
+                    if inlineable {
+                        if let [Selection::FragmentSpread(next)] = def.selection_set.items.as_slice()
+                        {
+                            spread = next.clone();
+                            continue;
                         }
-                        // body has real content: inline it and recurse normally (bounded by
-                        // field depth, which is bounded by max_depth validation)
-                        let mut inlined = fragment_def.selection_set.clone();
-                        handle_selection_set(
-                            &mut inlined,
-                            fragment_map,
-                            current_parent_tc.as_ref(),
-                        )?;
-                        new_items.extend(inlined.items);
-                    } else {
-                        // type mismatch or has directives: wrap in an inline fragment
-                        let mut inline_fragment = InlineFragment {
-                            position: current_position,
-                            type_condition: Some(fragment_def.type_condition.clone()),
-                            directives: current_directives.clone(),
-                            selection_set: fragment_def.selection_set.clone(),
-                        };
-                        handle_selection_set(
-                            &mut inline_fragment.selection_set,
-                            fragment_map,
-                            inline_fragment.type_condition.as_ref(),
-                        )?;
-                        new_items.push(Selection::InlineFragment(inline_fragment));
                     }
-                    break;
+                    break def;
+                };
+
+                if parent_type_condition == Some(&fragment_def.type_condition)
+                    && spread.directives.is_empty()
+                {
+                    // same type, no directives: inline the body directly.
+                    let mut inlined = fragment_def.selection_set.clone();
+                    handle_selection_set(&mut inlined, fragment_map, parent_type_condition)?;
+                    new_items.extend(inlined.items);
+                } else {
+                    // type mismatch or has directives: wrap in an inline fragment.
+                    let mut inline_fragment = InlineFragment {
+                        position: spread.position,
+                        type_condition: Some(fragment_def.type_condition.clone()),
+                        directives: spread.directives.clone(),
+                        selection_set: fragment_def.selection_set.clone(),
+                    };
+                    handle_selection_set(
+                        &mut inline_fragment.selection_set,
+                        fragment_map,
+                        inline_fragment.type_condition.as_ref(),
+                    )?;
+                    new_items.push(Selection::InlineFragment(inline_fragment));
                 }
             }
             Selection::InlineFragment(mut inline_fragment) => {

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -71,8 +71,24 @@ fn handle_selection_set<'a>(
                 // `spread` stays a borrow throughout, retargeting into `fragment_map` per link so
                 // no FragmentSpread gets cloned while advancing.
                 let mut spread = &spread;
-                // each step follows exactly one spread, so a cycle-free walk visits each fragment
-                // at most once - a chain longer than the total fragment count must contain a cycle
+                // each chain step follows exactly one spread into one fragment, so a single walk
+                // can visit each fragment at most once before it must either terminate or revisit -
+                // if chain_len exceeds the number of known fragments, a name must have repeated,
+                // which means we're in a cycle.
+                //
+                // example - acyclic chain (chain_len reaches 2, fragment_map.len() == 3, ok):
+                //   fragment A on T { ...B }  fragment B on T { ...C }  fragment C on T { field }
+                //
+                // example - self-cycle (chain_len reaches 2, fragment_map.len() == 1, err):
+                //   fragment A on T { ...A }
+                //
+                // example - mutual cycle (chain_len reaches 3, fragment_map.len() == 2, err):
+                //   fragment A on T { ...B }  fragment B on T { ...A }
+                //
+                // spreading the same fragment multiple times does not break the check because each
+                // spread site starts its own independent walk with its own chain_len reset to 0 -
+                // the counter is local to one chain traversal, not shared across the selection set:
+                //   query { ...A ...A }  fragment A on T { field }  <- two walks, each chain_len=0
                 let max_chain = fragment_map.len();
                 let mut chain_len = 0usize;
                 let fragment_def = loop {

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -85,7 +85,8 @@ fn handle_selection_set<'a>(
 
                     // pure chain link `fragment F on T { ...G }`: advance instead of recursing.
                     if inlineable {
-                        if let [Selection::FragmentSpread(next)] = def.selection_set.items.as_slice()
+                        if let [Selection::FragmentSpread(next)] =
+                            def.selection_set.items.as_slice()
                         {
                             spread = next;
                             continue;


### PR DESCRIPTION
GraphQL fragments can spread other fragments, e.g. `fragment A on T { ...B }`. When fragments form a long acyclic chain (`A` spreads `B`, `B` spreads `C`, and so on for thousands of links), we walked that chain with plain recursion during:

1. Fragment cycle validation - the rule that rejects fragments that spread themselves in a loop.
2. Fragment inlining during normalization - the step that replaces `...A` spreads with the actual fields they point to.

Each link in the chain added another call frame. With a long enough chain, the recursion exhausted the call stack and crashed the whole process with a stack overflow, instead of returning a normal result or error. A malicious query could trigger this and crash the router.

The fix in both places is the same: stop filling a stack for every link, and instead use a plain `loop` that processes one link at a time. A loop reuses the same stack frame over and over, so the chain length no longer matters - whether it's 10 links or 10 million, the stack stays the same size.

### The test

The `acyclic_fragment_chain_does_not_overflow_stack` unit test builds a 10,000-fragment chain:

```graphql
query { ...F1 }
fragment F1 on Query { ...F2 }
fragment F2 on Query { ...F3 }
...
fragment F10000 on Query { __typename }
```

This is acyclic (it terminates at `__typename`), so it's a perfectly valid query that should normalize without error. The test is deliberately lenient (it accepts both Ok or Err) because it only proves "no crash".

Though the result of this acyclic chain is `Ok`, normalizing:

```graphql
query { ...F1 }
fragment F1 on Query { ...F2 }
fragment F2 on Query { ...F3 }
fragment F3 on Query { ...F4 }
fragment F4 on Query { __typename }
```

to:

```graphql
{ __typename }
```

### Wait, is returning `Ok` safe even for something huge, like 10,000,000 cyclse?

Yes, in the sense that matters: it will not crash or corrupt anything. The fix in this PR turned an unbounded stack usage (which crashed) into bounded, linear work: each link is one lookup plus one pointer update, processed in a loop that reuses the same stack space. Ten million links means ten million quick iterations - slow, but finishes and doesn't crash.

However, "won't crash" is not the same as "free". A 10mil chain is effectively a 10mil line query, and processing it still costs real time and memory (the whole document has to be parsed and held in RAM).

Guarding against a client sending an enormous query in the first place is a separate concern, and the router already has the right tool for it: the `max_tokens` limit. A query with millions of fragments is millions of tokens, so with a token limit configured it's rejected at parse time and never reaches normalization at all.

### Why existing limits didn't catch it

A fragment chain has almost no depth. `max_depth` measures field nesting, not how many fragments are chained. A chain of 10,000 fragment spreads that ends in a single field has a measured depth of 1. With `flatten_fragments` enabled, a fragment spread adds `0` to the depth count, so even a configured limit would never trip on this shape.

### TODO

- [ ] there are alternatives to this fix that would remove changes to the normalization and/or the frag cycle detection: 
    1. count fragments towards `max_depth` 
    2. introduce a new validation rule (must run before fragment cycle detection)
    3. integrate this into frag cycle detection (have a hard-coded depth limit)
- [ ] as stated in https://github.com/graphql-hive/router/pull/1197#discussion_r3472900146, the framgent inlining does not detect cycles and could cause a hang. I implemented an O(1) check in the normalization that detects cycles. the question is: do we want this here? there was no protection before my either and a cycle would cause a stack overflow. one key thing that https://github.com/graphql-hive/router/pull/1197#discussion_r3472900146 mentions is that cycle prevention runs before normalization - but a user might introduce a cycle after coprocessor body mutations which could crash the router.