### PR TITLE
fix(router): use hive cdn env vars for persisted documents

### DIFF
--- a/.changeset/fix_env_vars_passed_to_persisted_documents.md
+++ b/.changeset/fix_env_vars_passed_to_persisted_documents.md
@@ -1,0 +1,8 @@
+---
+hive-router-config: patch
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Fix env vars passed to persisted_documents

--- a/bin/router/src/pipeline/persisted_documents/resolve/hive.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/hive.rs
@@ -140,12 +140,20 @@ impl HiveCDNResolver {
     pub fn from_storage_config(
         config: &PersistedDocumentsHiveStorageConfig,
     ) -> Result<Self, HiveResolverError> {
-        let endpoints: Vec<String> = config
-            .endpoint
-            .clone()
-            .ok_or(HiveResolverError::MissingEndpoint)?
-            .into();
-        let key = config.key.clone().ok_or(HiveResolverError::MissingKey)?;
+        let endpoints: Vec<String> = std::env::var("HIVE_CDN_ENDPOINT")
+            .map(|v| {
+                v.split(",")
+                    .map(|s| s.trim().to_string())
+                    .collect::<Vec<_>>()
+            })
+            .ok()
+            .or_else(|| config.endpoint.as_ref().map(|e| e.values().to_vec()))
+            .ok_or(HiveResolverError::MissingEndpoint)?;
+
+        let key = std::env::var("HIVE_CDN_KEY")
+            .ok()
+            .or_else(|| config.key.clone())
+            .ok_or(HiveResolverError::MissingKey)?;
 
         let circuit_breaker = CircuitBreakerBuilder::default()
             .error_threshold(config.circuit_breaker.error_threshold)

--- a/bin/router/src/pipeline/persisted_documents/resolve/hive.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/hive.rs
@@ -141,20 +141,22 @@ impl HiveCDNResolver {
         config: &PersistedDocumentsHiveStorageConfig,
     ) -> Result<Self, HiveResolverError> {
         let endpoints: Vec<String> = std::env::var("HIVE_CDN_ENDPOINT")
+            .ok()
             .map(|v| {
-                v.split(",")
+                v.split(',')
                     .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
                     .collect::<Vec<_>>()
             })
-            .ok()
+            .filter(|v| !v.is_empty())
             .or_else(|| config.endpoint.as_ref().map(|e| e.values().to_vec()))
             .ok_or(HiveResolverError::MissingEndpoint)?;
 
         let key = std::env::var("HIVE_CDN_KEY")
             .ok()
+            .filter(|v| !v.trim().is_empty())
             .or_else(|| config.key.clone())
             .ok_or(HiveResolverError::MissingKey)?;
-
         let circuit_breaker = CircuitBreakerBuilder::default()
             .error_threshold(config.circuit_breaker.error_threshold)
             .volume_threshold(config.circuit_breaker.volume_threshold)

--- a/lib/router-config/src/primitives/single_or_multiple.rs
+++ b/lib/router-config/src/primitives/single_or_multiple.rs
@@ -12,6 +12,15 @@ pub enum SingleOrMultiple<T> {
     Multiple(Vec<T>),
 }
 
+impl<T> SingleOrMultiple<T> {
+    pub fn values(&self) -> &[T] {
+        match self {
+            SingleOrMultiple::Single(value) => std::slice::from_ref(value),
+            SingleOrMultiple::Multiple(values) => values,
+        }
+    }
+}
+
 impl<'de, T: DeserializeOwned> Deserialize<'de> for SingleOrMultiple<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
Ideally, we could've use the `env_overrides` setup, but we can't, because it needs to be conditional (set the override only if persisted documents is enabled -> otherwise it fails because other required fields are missing). 

To workaround that, it's now loaded manually, or else fallbacks the config.