### PR TITLE
feat(router): add subscription and websocket metrics

### DIFF
--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -430,7 +430,7 @@ pub async fn graphql_request_handler(
             },
         );
 
-        shared_response.into_response(response_mode)
+        shared_response.into_response(response_mode, &shared_state.telemetry_context.metrics)
     }
     .instrument(span_clone)
     .await

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -98,6 +98,10 @@ async fn ws_service(
     request_context: SharedRequestContext,
 ) -> Result<impl Service<ws::Frame, Response = Option<ws::Message>, Error = io::Error>, web::Error>
 {
+    // Tracks the active WebSocket connection in metrics; only set for accepted connections so
+    // rejected handshakes are not counted. Moved into `on_shutdown` so it is dropped (and the
+    // gauge decremented) when the connection closes.
+    let mut connection_metrics_guard = None;
     if !has_accepted_subprotocol {
         debug!("WebSocket connection rejecting due to unacceptable subprotocol");
         let _ = sink.send(CloseCode::SubprotocolNotAcceptable.into()).await;
@@ -106,6 +110,13 @@ async fn ws_service(
         // would result in an abrupt termination of the connection
     } else {
         debug!("WebSocket connection accepted");
+        connection_metrics_guard = Some(
+            shared_state
+                .telemetry_context
+                .metrics
+                .subscriptions
+                .track_connection(),
+        );
     }
 
     let ws_uri: Rc<http::Uri> = Rc::new(
@@ -166,6 +177,8 @@ async fn ws_service(
     });
 
     let on_shutdown = fn_shutdown(async move || {
+        // drop the connection metrics guard, decrementing the active-connections gauge
+        drop(connection_metrics_guard);
         // stop heartbeat and handshake timeout tasks on shutdown
         let _ = heartbeat_tx.send(());
         if let Some(tx) = state.borrow_mut().acknowledged_tx.take() {
@@ -569,6 +582,14 @@ async fn handle_text_frame(
                             id: id.clone(),
                         };
 
+                        // tracks the active subscription in metrics (active gauge +
+                        // subscribe/unsubscribe counters); lives as long as the spawned task.
+                        let metrics_guard = shared_state
+                            .telemetry_context
+                            .metrics
+                            .subscriptions
+                            .track_subscription();
+
                         let mut receiver = response
                             .receiver
                             .unwrap_or_else(|| response.body.subscribe());
@@ -582,6 +603,7 @@ async fn handle_text_frame(
                         // making cancellation impossible
                         rt::spawn(async move {
                             let _guard = guard;
+                            let _metrics_guard = metrics_guard;
                             let mut cancelled = false;
 
                             loop {

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -7,6 +7,7 @@ use hive_router_config::traffic_shaping::{
 use hive_router_config::HiveRouterConfig;
 use hive_router_internal::expressions::{BooleanOrProgram, ExpressionCompileError};
 use hive_router_internal::inflight::{InFlightCleanupGuard, InFlightMap};
+use hive_router_internal::telemetry::metrics::Metrics;
 use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::coprocessor::{CoprocessorError, CoprocessorRuntime};
 use hive_router_plan_executor::execution::plan::FailedExecutionResult;
@@ -106,6 +107,7 @@ impl SharedRouterResponse {
     pub fn into_response(
         self,
         response_mode: &ResponseMode,
+        metrics: &Metrics,
     ) -> Result<web::HttpResponse, PipelineError> {
         match self {
             SharedRouterResponse::Single(single) => Ok(single.into()),
@@ -113,7 +115,7 @@ impl SharedRouterResponse {
                 let stream_content_type = response_mode
                     .stream_content_type()
                     .ok_or(PipelineError::SubscriptionsTransportNotSupported)?;
-                Ok(stream.into_response(stream_content_type))
+                Ok(stream.into_response(stream_content_type, metrics))
             }
         }
     }
@@ -163,12 +165,21 @@ impl Clone for SharedRouterStreamResponse {
 }
 
 impl SharedRouterStreamResponse {
-    pub fn into_response(self, stream_content_type: &StreamContentType) -> web::HttpResponse {
+    pub fn into_response(
+        self,
+        stream_content_type: &StreamContentType,
+        metrics: &Metrics,
+    ) -> web::HttpResponse {
         // leader already has a pre-subscribed receiver to avoid missing
         // any potential events emitted. joiners, on the other hand, subscribe
         let mut receiver = self.receiver.unwrap_or_else(|| self.body.subscribe());
 
+        // tracks the active subscription in metrics (active gauge + subscribe/unsubscribe
+        // counters); moved into the stream so it is dropped when the client stream ends.
+        let metrics_guard = metrics.subscriptions.track_subscription();
+
         let stream = Box::pin(async_stream::stream! {
+            let _metrics_guard = metrics_guard;
             loop {
                 match receiver.recv().await {
                     Ok(SubscriptionEvent::Raw(data)) => {

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -621,6 +621,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
                 buffer_capacity,
                 self.subgraph_name.clone(),
                 self.endpoint.to_string(),
+                self.telemetry_context.metrics.clone(),
             ))
         } else {
             debug!(
@@ -654,6 +655,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
                 buffer_capacity,
                 self.subgraph_name.clone(),
                 self.endpoint.to_string(),
+                self.telemetry_context.metrics.clone(),
             ))
         }
     }

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -489,19 +489,20 @@ impl SubgraphExecutorMap {
         // Track the active upstream subscription (tagged by subgraph). The guard increments the
         // active gauge + subscribe counter now and decrements + records unsubscribe when the
         // returned stream is dropped, covering all subscription transports at this single
-        // chokepoint.
+        // chokepoint. We keep it alive via a zero-overhead `map` combinator rather than an
+        // `async_stream` generator to avoid per-message state-machine overhead on this hot path.
         let guard = self
             .telemetry_context
             .metrics
             .subscriptions
             .track_subgraph_subscription(subgraph_name);
 
-        Ok(Box::pin(async_stream::stream! {
-            let _guard = guard;
-            for await item in stream {
-                yield item;
-            }
-        }))
+        Ok(Box::pin(futures::StreamExt::map(stream, move |item| {
+            // reference the guard so the `move` closure captures it, keeping the subscription
+            // tracked until the returned stream is dropped
+            let _ = &guard;
+            item
+        })))
     }
 
     fn resolve_subgraph_timeout(

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -462,7 +462,7 @@ impl SubgraphExecutorMap {
             .get(subgraph_name)
             .map(|r| r.value().clone());
 
-        match circuit_breaker {
+        let stream = match circuit_breaker {
             Some(SubgraphCircuitBreaker { recloser, .. }) => {
                 let circuit_breaker_metrics = &self.telemetry_context.metrics.circuit_breaker;
                 recloser
@@ -481,10 +481,27 @@ impl SubgraphExecutorMap {
                             Err(SubgraphExecutorError::CircuitBreakerRejected)
                         }
                     })
-                    .await
+                    .await?
             }
-            None => subscribe_fut.await,
-        }
+            None => subscribe_fut.await?,
+        };
+
+        // Track the active upstream subscription (tagged by subgraph). The guard increments the
+        // active gauge + subscribe counter now and decrements + records unsubscribe when the
+        // returned stream is dropped, covering all subscription transports at this single
+        // chokepoint.
+        let guard = self
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .track_subgraph_subscription(subgraph_name);
+
+        Ok(Box::pin(async_stream::stream! {
+            let _guard = guard;
+            for await item in stream {
+                yield item;
+            }
+        }))
     }
 
     fn resolve_subgraph_timeout(
@@ -737,6 +754,7 @@ impl SubgraphExecutorMap {
                     ws_endpoint_uri,
                     ws_tls_config,
                     self.config.subscriptions.subgraph_buffer_capacity,
+                    self.telemetry_context.clone(),
                 )
                 .to_boxed_arc();
 

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use futures::stream::{BoxStream, Stream};
 use futures_util::StreamExt;
+use hive_router_internal::telemetry::metrics::Metrics;
 use ntex::rt;
 use tokio::sync::mpsc;
-use tracing::{error, warn};
+use tracing::{error, trace};
 
 use crate::executors::error::SubgraphExecutorError;
 use crate::response::subgraph_response::SubgraphResponse;
@@ -22,6 +25,7 @@ pub async fn drain_into<S>(
     tx: mpsc::Sender<SubscriptionItem>,
     subgraph_name: &str,
     endpoint: &str,
+    metrics: &Metrics,
 ) where
     S: Stream<Item = SubscriptionItem> + Unpin,
 {
@@ -30,10 +34,12 @@ pub async fn drain_into<S>(
             Ok(()) => (),
             Err(mpsc::error::TrySendError::Full(_)) => {
                 // drop the message but keep the subscription alive, same as broadcast::Lagged
-                warn!(
+                trace!(
                     "Consumer for subgraph {} at {} is too slow, dropping message",
-                    subgraph_name, endpoint
+                    subgraph_name,
+                    endpoint
                 );
+                metrics.subscriptions.record_dropped_message(subgraph_name);
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 error!(
@@ -68,6 +74,7 @@ pub fn buffered<S>(
     buffer_size: usize,
     subgraph_name: String,
     endpoint: String,
+    metrics: Arc<Metrics>,
 ) -> BoxStream<'static, SubscriptionItem>
 where
     S: Stream<Item = SubscriptionItem> + Unpin + 'static,
@@ -77,7 +84,7 @@ where
     // ntex::rt::spawn keeps the drainer on the local ntex runtime, matching the rest of the
     // subscription pipeline.
     drop(rt::spawn(async move {
-        drain_into(source, tx, &subgraph_name, &endpoint).await;
+        drain_into(source, tx, &subgraph_name, &endpoint, &metrics).await;
     }));
 
     receiver_stream(rx)

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use futures::channel::oneshot;
 use futures::stream::BoxStream;
 use futures_util::StreamExt;
+use hive_router_internal::telemetry::TelemetryContext;
 use ntex::rt;
 use tokio::sync::mpsc;
 use tracing::debug;
@@ -21,6 +22,7 @@ pub struct WsSubgraphExecutor {
     endpoint: http::Uri,
     tls_config: Option<Arc<rustls::ClientConfig>>,
     buffer_capacity: usize,
+    telemetry_context: Arc<TelemetryContext>,
 }
 
 impl WsSubgraphExecutor {
@@ -29,12 +31,14 @@ impl WsSubgraphExecutor {
         endpoint: http::Uri,
         tls_config: Option<Arc<rustls::ClientConfig>>,
         buffer_capacity: usize,
+        telemetry_context: Arc<TelemetryContext>,
     ) -> Self {
         Self {
             subgraph_name,
             endpoint,
             tls_config,
             buffer_capacity,
+            telemetry_context,
         }
     }
 }
@@ -136,6 +140,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let subgraph_name = self.subgraph_name.clone();
         let tls_config = self.tls_config.clone();
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
+        let metrics = self.telemetry_context.metrics.clone();
 
         let (subscribe_payload, init_payload) = build_subscribe_payload(execution_request);
 
@@ -183,7 +188,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 .await
                 .map(Ok);
 
-            drain_into(stream, tx, &subgraph_name, &endpoint.to_string()).await;
+            drain_into(stream, tx, &subgraph_name, &endpoint.to_string(), &metrics).await;
         }));
 
         Ok(receiver_stream(rx))

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -62,6 +62,20 @@ pub mod values {
         }
     }
 
+    #[derive(Clone, Copy, Debug, strum::IntoStaticStr)]
+    pub enum SubscriptionOperation {
+        #[strum(serialize = "subscribe")]
+        Subscribe,
+        #[strum(serialize = "unsubscribe")]
+        Unsubscribe,
+    }
+
+    impl SubscriptionOperation {
+        pub fn as_str(self) -> &'static str {
+            self.into()
+        }
+    }
+
     /// Circuit breaker state exposed via metrics.
     ///
     /// The internal recloser state has three values (Closed, HalfOpen, Open),
@@ -118,6 +132,7 @@ pub mod labels {
     pub const COPROCESSOR_STAGE: &str = "coprocessor.stage";
     pub const CIRCUIT_BREAKER_FROM_STATE: &str = "circuit_breaker.from_state";
     pub const CIRCUIT_BREAKER_TO_STATE: &str = "circuit_breaker.to_state";
+    pub const SUBSCRIPTION_OPERATION: &str = "subscription.operation";
 }
 
 pub mod units {
@@ -167,6 +182,16 @@ pub mod names {
     pub const COPROCESSOR_REQUESTS_TOTAL: &str = "hive.router.coprocessor.requests_total";
     pub const COPROCESSOR_DURATION: &str = "hive.router.coprocessor.duration";
     pub const COPROCESSOR_ERRORS_TOTAL: &str = "hive.router.coprocessor.errors_total";
+    // Client -> Router subscriptions (the router's server side).
+    pub const SUBSCRIPTIONS_ACTIVE: &str = "hive.router.subscriptions.active";
+    pub const WEBSOCKET_CONNECTIONS_ACTIVE: &str = "hive.router.websocket.connections.active";
+    pub const SUBSCRIPTIONS_OPERATIONS_TOTAL: &str = "hive.router.subscriptions.operations_total";
+    // Router -> Subgraph subscriptions (the router's client side), labeled by subgraph.
+    pub const SUBGRAPH_SUBSCRIPTIONS_ACTIVE: &str = "hive.router.subgraph.subscriptions.active";
+    pub const SUBGRAPH_SUBSCRIPTIONS_OPERATIONS_TOTAL: &str =
+        "hive.router.subgraph.subscriptions.operations_total";
+    pub const SUBGRAPH_SUBSCRIPTIONS_DROPPED_MESSAGES_TOTAL: &str =
+        "hive.router.subgraph.subscriptions.dropped_messages_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
@@ -333,6 +358,24 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     (
         names::COPROCESSOR_ERRORS_TOTAL,
         &[labels::COPROCESSOR_STAGE],
+    ),
+    (names::SUBSCRIPTIONS_ACTIVE, &[]),
+    (names::WEBSOCKET_CONNECTIONS_ACTIVE, &[]),
+    (
+        names::SUBSCRIPTIONS_OPERATIONS_TOTAL,
+        &[labels::SUBSCRIPTION_OPERATION],
+    ),
+    (
+        names::SUBGRAPH_SUBSCRIPTIONS_ACTIVE,
+        &[labels::SUBGRAPH_NAME],
+    ),
+    (
+        names::SUBGRAPH_SUBSCRIPTIONS_OPERATIONS_TOTAL,
+        &[labels::SUBGRAPH_NAME, labels::SUBSCRIPTION_OPERATION],
+    ),
+    (
+        names::SUBGRAPH_SUBSCRIPTIONS_DROPPED_MESSAGES_TOTAL,
+        &[labels::SUBGRAPH_NAME],
     ),
 ];
 

--- a/lib/internal/src/telemetry/metrics/mod.rs
+++ b/lib/internal/src/telemetry/metrics/mod.rs
@@ -9,6 +9,7 @@ pub mod http_client_metrics;
 pub mod http_server_metrics;
 pub mod persisted_documents_metrics;
 pub mod setup;
+pub mod subscriptions_metrics;
 pub mod supergraph_metrics;
 pub use opentelemetry::metrics::ObservableGauge;
 pub use setup::{build_meter_provider_from_config, MetricsSetup, PrometheusRuntimeConfig};
@@ -23,6 +24,7 @@ use crate::telemetry::metrics::graphql_metrics::GraphQLMetrics;
 use crate::telemetry::metrics::http_client_metrics::HttpClientMetrics;
 use crate::telemetry::metrics::http_server_metrics::HttpServerMetrics;
 use crate::telemetry::metrics::persisted_documents_metrics::PersistedDocumentsMetrics;
+use crate::telemetry::metrics::subscriptions_metrics::SubscriptionsMetrics;
 use crate::telemetry::metrics::supergraph_metrics::SupergraphMetrics;
 
 pub struct Metrics {
@@ -35,6 +37,7 @@ pub struct Metrics {
     pub circuit_breaker: CircuitBreakerMetrics,
     pub persisted_documents: PersistedDocumentsMetrics,
     pub coprocessor: CoprocessorMetrics,
+    pub subscriptions: SubscriptionsMetrics,
 }
 
 impl Metrics {
@@ -49,6 +52,7 @@ impl Metrics {
             circuit_breaker: CircuitBreakerMetrics::new(meter),
             persisted_documents: PersistedDocumentsMetrics::new(meter),
             coprocessor: CoprocessorMetrics::new(meter),
+            subscriptions: SubscriptionsMetrics::new(meter),
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscriptions_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscriptions_metrics.rs
@@ -1,0 +1,252 @@
+use opentelemetry::{
+    metrics::{Counter, Meter, UpDownCounter},
+    KeyValue,
+};
+
+#[cfg(debug_assertions)]
+use crate::telemetry::metrics::catalog::debug_assert_attrs;
+use crate::telemetry::metrics::catalog::{labels, names, values::SubscriptionOperation};
+
+#[derive(Clone)]
+struct SubscriptionsInstruments {
+    // Client -> Router (the router's server side).
+    /// Active client subscriptions across all transports (WS + HTTP streaming).
+    active_subscriptions: Option<UpDownCounter<i64>>,
+    /// Active accepted WebSocket connections (clients).
+    active_connections: Option<UpDownCounter<i64>>,
+    /// Count of client subscribe/unsubscribe operations.
+    operations_total: Option<Counter<u64>>,
+    // Router -> Subgraph (the router's client side), labeled by subgraph.
+    /// Active upstream subscriptions to subgraphs.
+    subgraph_active_subscriptions: Option<UpDownCounter<i64>>,
+    /// Count of upstream subscribe/unsubscribe operations against subgraphs.
+    subgraph_operations_total: Option<Counter<u64>>,
+    /// Messages dropped because the downstream consumer fell behind the subgraph.
+    subgraph_dropped_messages_total: Option<Counter<u64>>,
+}
+
+pub struct SubscriptionsMetrics {
+    instruments: SubscriptionsInstruments,
+}
+
+impl SubscriptionsMetrics {
+    pub fn new(meter: Option<&Meter>) -> Self {
+        let active_subscriptions = meter.map(|meter| {
+            meter
+                .i64_up_down_counter(names::SUBSCRIPTIONS_ACTIVE)
+                .with_unit("{subscription}")
+                .with_description("Number of active GraphQL subscriptions")
+                .build()
+        });
+
+        let active_connections = meter.map(|meter| {
+            meter
+                .i64_up_down_counter(names::WEBSOCKET_CONNECTIONS_ACTIVE)
+                .with_unit("{connection}")
+                .with_description("Number of active WebSocket connections")
+                .build()
+        });
+
+        let operations_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::SUBSCRIPTIONS_OPERATIONS_TOTAL)
+                .with_unit("{operation}")
+                .with_description("Total number of subscribe/unsubscribe operations")
+                .build()
+        });
+
+        let subgraph_active_subscriptions = meter.map(|meter| {
+            meter
+                .i64_up_down_counter(names::SUBGRAPH_SUBSCRIPTIONS_ACTIVE)
+                .with_unit("{subscription}")
+                .with_description("Number of active subscriptions to subgraphs")
+                .build()
+        });
+
+        let subgraph_operations_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::SUBGRAPH_SUBSCRIPTIONS_OPERATIONS_TOTAL)
+                .with_unit("{operation}")
+                .with_description(
+                    "Total number of subscribe/unsubscribe operations against subgraphs",
+                )
+                .build()
+        });
+
+        let subgraph_dropped_messages_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::SUBGRAPH_SUBSCRIPTIONS_DROPPED_MESSAGES_TOTAL)
+                .with_unit("{message}")
+                .with_description(
+                    "Total number of subscription messages dropped because the consumer \
+                     could not keep up with the subgraph",
+                )
+                .build()
+        });
+
+        Self {
+            instruments: SubscriptionsInstruments {
+                active_subscriptions,
+                active_connections,
+                operations_total,
+                subgraph_active_subscriptions,
+                subgraph_operations_total,
+                subgraph_dropped_messages_total,
+            },
+        }
+    }
+
+    /// Track an active WebSocket connection. Increments the active-connections gauge now and
+    /// decrements it when the returned guard is dropped (connection closed).
+    pub fn track_connection(&self) -> WsConnectionGuard {
+        if let Some(gauge) = &self.instruments.active_connections {
+            gauge.add(1, &[]);
+        }
+        WsConnectionGuard {
+            gauge: self.instruments.active_connections.clone(),
+        }
+    }
+
+    /// Track an active client subscription. Increments the active-subscriptions gauge and the
+    /// `subscribe` operation counter now; decrements the gauge and increments the `unsubscribe`
+    /// operation counter when the returned guard is dropped (subscription ended).
+    pub fn track_subscription(&self) -> SubscriptionMetricsGuard {
+        if let Some(gauge) = &self.instruments.active_subscriptions {
+            gauge.add(1, &[]);
+        }
+        self.record_operation(SubscriptionOperation::Subscribe);
+        SubscriptionMetricsGuard {
+            gauge: self.instruments.active_subscriptions.clone(),
+            operations_total: self.instruments.operations_total.clone(),
+        }
+    }
+
+    /// Track an active upstream subscription to a subgraph. Increments the active-subscriptions
+    /// gauge and the `subscribe` operation counter (both tagged with the subgraph name) now;
+    /// decrements the gauge and increments the `unsubscribe` operation counter when the returned
+    /// guard is dropped (upstream subscription ended).
+    pub fn track_subgraph_subscription(&self, subgraph_name: &str) -> SubgraphSubscriptionGuard {
+        if let Some(gauge) = &self.instruments.subgraph_active_subscriptions {
+            gauge.add(
+                1,
+                &[KeyValue::new(
+                    labels::SUBGRAPH_NAME,
+                    subgraph_name.to_string(),
+                )],
+            );
+        }
+        if let Some(counter) = &self.instruments.subgraph_operations_total {
+            record_subgraph_operation_on(counter, subgraph_name, SubscriptionOperation::Subscribe);
+        }
+        SubgraphSubscriptionGuard {
+            gauge: self.instruments.subgraph_active_subscriptions.clone(),
+            operations_total: self.instruments.subgraph_operations_total.clone(),
+            subgraph_name: subgraph_name.to_string(),
+        }
+    }
+
+    /// Record a subscription message dropped because the consumer fell behind the subgraph.
+    pub fn record_dropped_message(&self, subgraph_name: &str) {
+        if let Some(counter) = &self.instruments.subgraph_dropped_messages_total {
+            let attributes = [KeyValue::new(
+                labels::SUBGRAPH_NAME,
+                subgraph_name.to_string(),
+            )];
+            #[cfg(debug_assertions)]
+            debug_assert_attrs(
+                names::SUBGRAPH_SUBSCRIPTIONS_DROPPED_MESSAGES_TOTAL,
+                &attributes,
+            );
+            counter.add(1, &attributes);
+        }
+    }
+
+    fn record_operation(&self, operation: SubscriptionOperation) {
+        if let Some(counter) = &self.instruments.operations_total {
+            record_operation_on(counter, operation);
+        }
+    }
+}
+
+fn record_operation_on(counter: &Counter<u64>, operation: SubscriptionOperation) {
+    let attributes = [KeyValue::new(
+        labels::SUBSCRIPTION_OPERATION,
+        operation.as_str(),
+    )];
+    #[cfg(debug_assertions)]
+    debug_assert_attrs(names::SUBSCRIPTIONS_OPERATIONS_TOTAL, &attributes);
+    counter.add(1, &attributes);
+}
+
+fn record_subgraph_operation_on(
+    counter: &Counter<u64>,
+    subgraph_name: &str,
+    operation: SubscriptionOperation,
+) {
+    let attributes = [
+        KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+        KeyValue::new(labels::SUBSCRIPTION_OPERATION, operation.as_str()),
+    ];
+    #[cfg(debug_assertions)]
+    debug_assert_attrs(names::SUBGRAPH_SUBSCRIPTIONS_OPERATIONS_TOTAL, &attributes);
+    counter.add(1, &attributes);
+}
+
+/// Decrements the active-connections gauge when dropped.
+pub struct WsConnectionGuard {
+    gauge: Option<UpDownCounter<i64>>,
+}
+
+impl Drop for WsConnectionGuard {
+    fn drop(&mut self) {
+        if let Some(gauge) = &self.gauge {
+            gauge.add(-1, &[]);
+        }
+    }
+}
+
+/// Decrements the active-subscriptions gauge and records an `unsubscribe` operation when dropped.
+pub struct SubscriptionMetricsGuard {
+    gauge: Option<UpDownCounter<i64>>,
+    operations_total: Option<Counter<u64>>,
+}
+
+impl Drop for SubscriptionMetricsGuard {
+    fn drop(&mut self) {
+        if let Some(gauge) = &self.gauge {
+            gauge.add(-1, &[]);
+        }
+        if let Some(counter) = &self.operations_total {
+            record_operation_on(counter, SubscriptionOperation::Unsubscribe);
+        }
+    }
+}
+
+/// Decrements the subgraph active-subscriptions gauge and records an `unsubscribe` operation
+/// (both tagged with the subgraph name) when dropped.
+pub struct SubgraphSubscriptionGuard {
+    gauge: Option<UpDownCounter<i64>>,
+    operations_total: Option<Counter<u64>>,
+    subgraph_name: String,
+}
+
+impl Drop for SubgraphSubscriptionGuard {
+    fn drop(&mut self) {
+        if let Some(gauge) = &self.gauge {
+            gauge.add(
+                -1,
+                &[KeyValue::new(
+                    labels::SUBGRAPH_NAME,
+                    self.subgraph_name.clone(),
+                )],
+            );
+        }
+        if let Some(counter) = &self.operations_total {
+            record_subgraph_operation_on(
+                counter,
+                &self.subgraph_name,
+                SubscriptionOperation::Unsubscribe,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds observability for GraphQL subscriptions and WebSocket clients. There was previously no way to see how many subscriptions/clients are active, how often clients subscribe/unsubscribe, or how often the router drops events because it can't keep up with a subgraph (that was only a `warn!` log).

Metrics are split by direction:

**Client → Router** (the router's server side):
| Metric | Type | Labels |
|---|---|---|
| `hive.router.subscriptions.active` | UpDownCounter | — |
| `hive.router.websocket.connections.active` | UpDownCounter | — |
| `hive.router.subscriptions.operations_total` | Counter | `subscription.operation` (`subscribe`/`unsubscribe`) |

**Router → Subgraph** (the router's client side), all tagged with `subgraph.name`:
| Metric | Type | Labels |
|---|---|---|
| `hive.router.subgraph.subscriptions.active` | UpDownCounter | `subgraph.name` |
| `hive.router.subgraph.subscriptions.operations_total` | Counter | `subgraph.name`, `subscription.operation` |
| `hive.router.subgraph.subscriptions.dropped_messages_total` | Counter | `subgraph.name` |

## How

- **Client-side** metrics use RAII guards at the two consumer sites — the WS `Subscribe` handler (`websocket_server.rs`) and the HTTP streaming response (`shared_state.rs::into_response`, SSE/multipart) — so the active gauge decrements and the `unsubscribe` counter fires on disconnect/stream-end. Covers all client transports.
- **Upstream** metrics are tracked at the single `SubgraphExecutorMap::subscribe` chokepoint (`map.rs`), wrapping the returned stream so one guard covers every subgraph subscription transport (WS, multipart/SSE, HTTP callback).
- **Dropped messages** replaces the per-drop `warn!` in `subscription_buffer.rs::drain_into` (now demoted to `trace!`) with the subgraph-tagged counter.
- All metrics follow the existing OTel catalog pattern (`METRIC_SPECS` + debug-assert on attributes).

## Notes

- With subscription dedup active, the **upstream** active count reflects deduped subgraph subscriptions (one per shared upstream) while the **client** active count reflects every client subscription including joiners — the correct semantic for each side, but the two gauges won't match 1:1.
- Metrics are no-ops when telemetry is disabled (instruments are `None` internally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)