### PR TITLE
fix(query-planner): prevent `@requires` creating a circular dependency across subgraphs

### DIFF
--- a/.changeset/infinite_recursion_requires_keys.md
+++ b/.changeset/infinite_recursion_requires_keys.md
@@ -1,0 +1,10 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Prevent @requires creating a circular dependency across subgraphs
+
+The Query Planner could hit a timeout when a field with `@requires` needed to move to another subgraph, and the move required the same fields.

--- a/lib/query-planner/fixture/issues/recursion-bomb.supergraph.graphql
+++ b/lib/query-planner/fixture/issues/recursion-bomb.supergraph.graphql
@@ -114,8 +114,6 @@ type Group
     @join__field(graph: S7)
     @join__field(graph: S8)
     @join__field(graph: S9)
-    @join__field(graph: S54)
-    @join__field(graph: S56)
     @join__field(graph: S10)
 }
 

--- a/lib/query-planner/fixture/issues/recursion-bomb.supergraph.graphql
+++ b/lib/query-planner/fixture/issues/recursion-bomb.supergraph.graphql
@@ -1,0 +1,129 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+scalar join__FieldSet
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+enum join__Graph {
+  S1 @join__graph(name: "s1", url: "")
+  S2 @join__graph(name: "s2", url: "")
+  S3 @join__graph(name: "s3", url: "")
+  S4 @join__graph(name: "s4", url: "")
+  S5 @join__graph(name: "s5", url: "")
+  S6 @join__graph(name: "s6", url: "")
+  S7 @join__graph(name: "s7", url: "")
+  S8 @join__graph(name: "s8", url: "")
+  S9 @join__graph(name: "s9", url: "")
+  S10 @join__graph(name: "s10", url: "")
+}
+
+type Query @join__type(graph: S3) {
+  list: List @join__field(graph: S3)
+}
+
+type Item
+  @join__type(graph: S1, key: "group { id } id")
+  @join__type(graph: S2, key: "group { id } id")
+  @join__type(graph: S3, key: "group { id }")
+  @join__type(graph: S4, key: "group { id } id")
+  @join__type(graph: S5, key: "group { id }")
+  @join__type(graph: S6, key: "group { id } id")
+  @join__type(graph: S7, key: "group { id } id")
+  @join__type(graph: S8, key: "group { id }")
+  @join__type(graph: S9, key: "group { id } id")
+  @join__type(graph: S10, key: "group { id } id") {
+  group: Group!
+    @join__field(graph: S1)
+    @join__field(graph: S2)
+    @join__field(graph: S3)
+    @join__field(graph: S4)
+    @join__field(graph: S5)
+    @join__field(graph: S6)
+    @join__field(graph: S7)
+    @join__field(graph: S8)
+    @join__field(graph: S9)
+    @join__field(graph: S10)
+  id: String!
+    @join__field(graph: S1)
+    @join__field(graph: S2)
+    @join__field(graph: S3)
+    @join__field(graph: S4)
+    @join__field(graph: S6)
+    @join__field(graph: S7)
+    @join__field(graph: S9)
+    @join__field(graph: S10)
+  tag: Tag! @join__field(graph: S3) @join__field(graph: S5, external: true)
+  value: String @join__field(graph: S5, requires: "tag{id}")
+}
+
+type Group
+  @join__type(graph: S1)
+  @join__type(graph: S2)
+  @join__type(graph: S3)
+  @join__type(graph: S4)
+  @join__type(graph: S5)
+  @join__type(graph: S6)
+  @join__type(graph: S7)
+  @join__type(graph: S8)
+  @join__type(graph: S9)
+  @join__type(graph: S10) {
+  id: String!
+    @join__field(graph: S1)
+    @join__field(graph: S2)
+    @join__field(graph: S3)
+    @join__field(graph: S4)
+    @join__field(graph: S5)
+    @join__field(graph: S6)
+    @join__field(graph: S7)
+    @join__field(graph: S8)
+    @join__field(graph: S9)
+    @join__field(graph: S54)
+    @join__field(graph: S56)
+    @join__field(graph: S10)
+}
+
+type List @join__type(graph: S3) {
+  group: Group!
+  items: [Item!]!
+}
+
+type Tag @join__type(graph: S3) {
+  id: String! @join__field(graph: S3)
+}

--- a/lib/query-planner/fixture/issues/requires-circular-keys.supergraph.graphql
+++ b/lib/query-planner/fixture/issues/requires-circular-keys.supergraph.graphql
@@ -1,0 +1,150 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+enum join__Graph {
+  SOURCE @join__graph(name: "source", url: "")
+  VALUE @join__graph(name: "value", url: "")
+  DIRECT_KEY @join__graph(name: "direct-key", url: "")
+  OBJECT_FRAGMENT_KEY @join__graph(name: "object-fragment-key", url: "")
+  INTERFACE_FRAGMENT_KEY @join__graph(name: "interface-fragment-key", url: "")
+  INTERFACE_KEY @join__graph(name: "interface-key", url: "")
+  NESTED_FIELD_KEY @join__graph(name: "nested-field-key", url: "")
+}
+
+type Query @join__type(graph: SOURCE) {
+  list: List @join__field(graph: SOURCE)
+}
+
+type List @join__type(graph: SOURCE) {
+  items: [Item!]! @join__field(graph: SOURCE)
+  taggedItems: [Tagged!]! @join__field(graph: SOURCE)
+}
+
+interface Tagged
+  @join__type(graph: SOURCE, key: "group { id }")
+  @join__type(graph: VALUE, key: "group { id }")
+  @join__type(graph: DIRECT_KEY)
+  @join__type(graph: OBJECT_FRAGMENT_KEY)
+  @join__type(graph: INTERFACE_FRAGMENT_KEY)
+  @join__type(graph: INTERFACE_KEY, key: "tag { id }") {
+  group: Group!
+    @join__field(graph: SOURCE)
+    @join__field(graph: VALUE)
+  tag: Tag!
+    @join__field(graph: SOURCE)
+    @join__field(graph: VALUE)
+    @join__field(graph: INTERFACE_KEY, external: true)
+}
+
+type Item implements Tagged
+  @join__implements(graph: SOURCE, interface: "Tagged")
+  @join__implements(graph: VALUE, interface: "Tagged")
+  @join__implements(graph: DIRECT_KEY, interface: "Tagged")
+  @join__implements(graph: OBJECT_FRAGMENT_KEY, interface: "Tagged")
+  @join__implements(graph: INTERFACE_FRAGMENT_KEY, interface: "Tagged")
+  @join__implements(graph: INTERFACE_KEY, interface: "Tagged")
+  @join__implements(graph: NESTED_FIELD_KEY, interface: "Tagged")
+  @join__type(graph: SOURCE, key: "group { id }")
+  @join__type(graph: VALUE, key: "group { id }")
+  @join__type(graph: DIRECT_KEY, key: "tag { id }")
+  @join__type(graph: OBJECT_FRAGMENT_KEY, key: "... on Item { tag { id } }")
+  @join__type(graph: INTERFACE_FRAGMENT_KEY, key: "... on Tagged { tag { id } }")
+  @join__type(graph: INTERFACE_KEY)
+  @join__type(graph: NESTED_FIELD_KEY, key: "group { tag }") {
+  group: Group!
+    @join__field(graph: SOURCE)
+    @join__field(graph: VALUE)
+    @join__field(graph: NESTED_FIELD_KEY)
+  tag: Tag!
+    @join__field(graph: SOURCE)
+    @join__field(graph: VALUE, external: true)
+    @join__field(graph: DIRECT_KEY, external: true)
+    @join__field(graph: OBJECT_FRAGMENT_KEY, external: true)
+    @join__field(graph: INTERFACE_FRAGMENT_KEY, external: true)
+    @join__field(graph: INTERFACE_KEY, external: true)
+    @join__field(graph: NESTED_FIELD_KEY, external: true)
+  value: String @join__field(graph: VALUE, requires: "tag { id }")
+  valueRequiresObjectFragment: String
+    @join__field(graph: VALUE, requires: "... on Item { tag { id } }")
+  valueRequiresInterfaceFragment: String
+    @join__field(graph: VALUE, requires: "... on Tagged { tag { id } }")
+  valueRequiresInlineFragment: String
+    @join__field(graph: VALUE, requires: "... { tag { id } }")
+  valueInterfaceKey: String @join__field(graph: VALUE, requires: "tag { id }")
+  valueNestedField: String @join__field(graph: NESTED_FIELD_KEY, requires: "tag { id }")
+}
+
+type Group
+  @join__type(graph: SOURCE)
+  @join__type(graph: VALUE)
+  @join__type(graph: NESTED_FIELD_KEY) {
+  id: ID!
+    @join__field(graph: SOURCE)
+    @join__field(graph: VALUE)
+    @join__field(graph: NESTED_FIELD_KEY)
+  tag: String!
+    @join__field(graph: SOURCE)
+    @join__field(graph: NESTED_FIELD_KEY)
+}
+
+type Tag
+  @join__type(graph: SOURCE)
+  @join__type(graph: VALUE)
+  @join__type(graph: DIRECT_KEY)
+  @join__type(graph: OBJECT_FRAGMENT_KEY)
+  @join__type(graph: INTERFACE_FRAGMENT_KEY)
+  @join__type(graph: INTERFACE_KEY)
+  @join__type(graph: NESTED_FIELD_KEY) {
+  id: ID!
+    @join__field(graph: SOURCE)
+    @join__field(graph: VALUE)
+    @join__field(graph: DIRECT_KEY)
+    @join__field(graph: OBJECT_FRAGMENT_KEY)
+    @join__field(graph: INTERFACE_FRAGMENT_KEY)
+    @join__field(graph: INTERFACE_KEY)
+    @join__field(graph: NESTED_FIELD_KEY)
+}

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -575,6 +575,7 @@ fn ensure_fetch_step_for_requirement(
 fn process_children_for_fetch_steps(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -593,6 +594,7 @@ fn process_children_for_fetch_steps(
         leaf_fetch_step_indexes.extend(process_query_node(
             graph,
             fetch_graph,
+            supergraph,
             override_context,
             sub_step,
             Some(parent_fetch_step_index),
@@ -617,6 +619,7 @@ fn process_children_for_fetch_steps(
 fn process_requirements_for_fetch_steps(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -633,6 +636,7 @@ fn process_requirements_for_fetch_steps(
         process_query_node(
             graph,
             fetch_graph,
+            supergraph,
             override_context,
             req_query_node,
             Some(parent_fetch_step_index),
@@ -652,6 +656,7 @@ fn process_requirements_for_fetch_steps(
 fn process_noop_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: Option<NodeIndex>,
@@ -668,6 +673,7 @@ fn process_noop_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         fetch_step_index,
@@ -689,6 +695,7 @@ fn process_noop_edge(
 fn process_entity_move_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -789,6 +796,7 @@ fn process_entity_move_edge(
     process_requirements_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         parent_fetch_step_index,
@@ -801,6 +809,7 @@ fn process_entity_move_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         fetch_step_index,
@@ -822,6 +831,7 @@ fn process_entity_move_edge(
 fn process_interface_object_type_move_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -888,6 +898,7 @@ fn process_interface_object_type_move_edge(
     step_for_children.input.add(&requirement.selection_set)?;
     let key_to_reenter_subgraph = find_satisfiable_key(
         graph,
+        supergraph,
         override_context,
         query_node.requirements.first().unwrap(),
     )?;
@@ -958,6 +969,7 @@ fn process_interface_object_type_move_edge(
     let leaf_fetch_step_indexes = process_query_node(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node.requirements.first().unwrap(),
         Some(step_for_requirements_index),
@@ -980,6 +992,7 @@ fn process_interface_object_type_move_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         step_for_children_index,
@@ -1001,6 +1014,7 @@ fn process_interface_object_type_move_edge(
 fn process_subgraph_entrypoint_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -1021,6 +1035,7 @@ fn process_subgraph_entrypoint_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         fetch_step_index,
@@ -1044,6 +1059,7 @@ fn process_subgraph_entrypoint_edge(
 fn process_selfie_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -1105,6 +1121,7 @@ fn process_selfie_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         parent_fetch_step_index,
@@ -1128,6 +1145,7 @@ fn process_selfie_edge(
 fn process_abstract_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -1171,6 +1189,7 @@ fn process_abstract_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         parent_fetch_step_index,
@@ -1199,6 +1218,7 @@ fn process_abstract_edge(
 fn process_plain_field_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -1303,6 +1323,7 @@ fn process_plain_field_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         parent_fetch_step_index,
@@ -1322,6 +1343,7 @@ fn process_plain_field_edge(
 fn process_requires_field_edge(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: NodeIndex,
@@ -1358,6 +1380,7 @@ fn process_requires_field_edge(
 
     let key_to_reenter_subgraph = find_satisfiable_key(
         graph,
+        supergraph,
         override_context,
         query_node.requirements.first().unwrap(),
     )?;
@@ -1523,6 +1546,7 @@ fn process_requires_field_edge(
     let leaf_fetch_step_indexes = process_query_node(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node.requirements.first().unwrap(),
         Some(step_for_requirements_index),
@@ -1565,6 +1589,7 @@ fn process_requires_field_edge(
     process_children_for_fetch_steps(
         graph,
         fetch_graph,
+        supergraph,
         override_context,
         query_node,
         step_for_children_index,
@@ -1605,6 +1630,7 @@ fn process_requires_field_edge(
 ))]
 fn find_satisfiable_key<'a>(
     graph: &'a Graph,
+    supergraph: &'a SupergraphState,
     override_context: &'a PlannerOverrideContext,
     query_node: &QueryTreeNode,
 ) -> Result<&'a TypeAwareSelection, FetchGraphError> {
@@ -1623,6 +1649,7 @@ fn find_satisfiable_key<'a>(
     for edge_ref in entity_moves_edges_to_self {
         if can_satisfy_edge(
             graph,
+            supergraph,
             override_context,
             &edge_ref,
             &OperationPath {
@@ -1660,6 +1687,7 @@ fn find_satisfiable_key<'a>(
 fn process_query_node(
     graph: &Graph,
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
+    supergraph: &SupergraphState,
     override_context: &PlannerOverrideContext,
     query_node: &QueryTreeNode,
     parent_fetch_step_index: Option<NodeIndex>,
@@ -1688,6 +1716,7 @@ fn process_query_node(
                 process_subgraph_entrypoint_edge(
                     graph,
                     fetch_graph,
+                    supergraph,
                     override_context,
                     query_node,
                     parent_fetch_step_index,
@@ -1699,6 +1728,7 @@ fn process_query_node(
             Edge::EntityMove(_) => process_entity_move_edge(
                 graph,
                 fetch_graph,
+                supergraph,
                 override_context,
                 query_node,
                 parent_fetch_step_index,
@@ -1713,6 +1743,7 @@ fn process_query_node(
                 true => process_requires_field_edge(
                     graph,
                     fetch_graph,
+                    supergraph,
                     override_context,
                     query_node,
                     parent_fetch_step_index,
@@ -1726,6 +1757,7 @@ fn process_query_node(
                 false => process_plain_field_edge(
                     graph,
                     fetch_graph,
+                    supergraph,
                     override_context,
                     query_node,
                     parent_fetch_step_index,
@@ -1740,6 +1772,7 @@ fn process_query_node(
             Edge::Selfie(type_name) => process_selfie_edge(
                 graph,
                 fetch_graph,
+                supergraph,
                 override_context,
                 query_node,
                 parent_fetch_step_index,
@@ -1752,6 +1785,7 @@ fn process_query_node(
             Edge::AbstractMove(type_name) => process_abstract_edge(
                 graph,
                 fetch_graph,
+                supergraph,
                 override_context,
                 query_node,
                 parent_fetch_step_index,
@@ -1766,6 +1800,7 @@ fn process_query_node(
             }) => process_interface_object_type_move_edge(
                 graph,
                 fetch_graph,
+                supergraph,
                 override_context,
                 query_node,
                 parent_fetch_step_index,
@@ -1782,6 +1817,7 @@ fn process_query_node(
         process_noop_edge(
             graph,
             fetch_graph,
+            supergraph,
             override_context,
             query_node,
             parent_fetch_step_index,
@@ -1827,6 +1863,7 @@ pub fn build_fetch_graph_from_query_tree(
     process_query_node(
         graph,
         &mut fetch_graph,
+        supergraph,
         override_context,
         &query_tree.root,
         None,

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -279,6 +279,7 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
             // Find a direct path that references the same type as the current tail,
             let direct_path = find_self_referencing_direct_path(
                 graph,
+                supergraph,
                 override_context,
                 path,
                 &fragment.type_condition,
@@ -320,6 +321,7 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
 
         let mut direct_paths = find_direct_paths(
             graph,
+            supergraph,
             override_context,
             path,
             &NavigationTarget::ConcreteType(&fragment.type_condition, fragment.into()),
@@ -335,6 +337,7 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
         if fields_to_resolve_locally.is_empty() {
             let mut indirect_paths = find_indirect_paths(
                 graph,
+                supergraph,
                 override_context,
                 path,
                 &NavigationTarget::ConcreteType(&fragment.type_condition, fragment.into()),
@@ -373,6 +376,7 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
             let _enter = path_span.enter();
             let direct_paths = find_direct_paths(
                 graph,
+                supergraph,
                 override_context,
                 path,
                 &NavigationTarget::Field(&FieldSelection::new_typename()),
@@ -551,6 +555,7 @@ fn process_field<'graph, 'op: 'graph>(
         let excluded = ExcludedFromLookup::new();
         let direct_paths = find_direct_paths(
             graph,
+            supergraph,
             override_context,
             path,
             &NavigationTarget::Field(field),
@@ -570,6 +575,7 @@ fn process_field<'graph, 'op: 'graph>(
         if !fields_to_resolve_locally.contains(&field.name) && !found_direct_paths_to_leaf {
             let indirect_paths = find_indirect_paths(
                 graph,
+                supergraph,
                 override_context,
                 path,
                 &NavigationTarget::Field(field),

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -22,6 +22,7 @@ use crate::{
         tree::query_tree_node::QueryTreeNode,
         walker::best_path::{find_best_paths, BestPathTracker},
     },
+    state::supergraph_state::SupergraphState,
 };
 
 use super::{error::WalkOperationError, excluded::ExcludedFromLookup, path::OperationPath};
@@ -100,6 +101,7 @@ impl<'op> From<&'op NavigationTarget<'op>> for NavigationTargetKey<'op> {
 
 struct PathSearch<'graph> {
     graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
     override_context: &'graph PlannerOverrideContext,
     cancellation_token: &'graph CancellationToken,
     /// Edges currently being checked in this path search.
@@ -110,11 +112,13 @@ struct PathSearch<'graph> {
 impl<'graph> PathSearch<'graph> {
     fn new(
         graph: &'graph Graph,
+        supergraph: &'graph SupergraphState,
         override_context: &'graph PlannerOverrideContext,
         cancellation_token: &'graph CancellationToken,
     ) -> Self {
         Self {
             graph,
+            supergraph,
             override_context,
             cancellation_token,
             active_edge_checks: ActiveEdgeChecks::new(),
@@ -128,17 +132,60 @@ impl<'graph> PathSearch<'graph> {
 ))]
 pub fn find_indirect_paths<'graph>(
     graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
     override_context: &'graph PlannerOverrideContext,
     path: &OperationPath<'graph>,
     target: &NavigationTarget<'_>,
     excluded: &ExcludedFromLookup<'graph>,
     cancellation_token: &'graph CancellationToken,
 ) -> Result<Vec<OperationPath<'graph>>, WalkOperationError> {
-    PathSearch::new(graph, override_context, cancellation_token)
+    PathSearch::new(graph, supergraph, override_context, cancellation_token)
         .find_indirect_paths(path, target, excluded)
 }
 
 impl<'graph> PathSearch<'graph> {
+    fn type_condition_matches(&self, current_type_name: &str, type_condition: &str) -> bool {
+        // ... on Item { tag { id } }
+        // when current type is Item.
+        if current_type_name == type_condition {
+            return true;
+        }
+
+        // ... on Tagged { tag { id } }
+        // when current type is object type Item, and Item implements Tagged
+        self.supergraph
+            .interface_to_object_types
+            .get(type_condition)
+            .is_some_and(|object_types| object_types.contains(current_type_name))
+    }
+
+    fn requirements_includes_field(
+        &self,
+        requirements: &TypeAwareSelection,
+        current_type_name: &str,
+        target_field_name: &str,
+    ) -> bool {
+        if !self.type_condition_matches(current_type_name, &requirements.type_name) {
+            return false;
+        }
+
+        requirements.selection_set.items.iter().any(|item| {
+            match item {
+                SelectionItem::Field(field) => field.name == target_field_name,
+                SelectionItem::InlineFragment(fragment) => {
+                    if !self.type_condition_matches(current_type_name, &fragment.type_condition) {
+                        return false;
+                    }
+                    fragment.selections.items.iter().any(|item| {
+                        matches!(item, SelectionItem::Field(field) if field.name == target_field_name)
+                    })
+                }
+                // Fragment spreads are inlined by normalization
+                SelectionItem::FragmentSpread(_) => false,
+          }
+        })
+    }
+
     fn find_indirect_paths(
         &mut self,
         path: &OperationPath<'graph>,
@@ -224,12 +271,11 @@ impl<'graph> PathSearch<'graph> {
                 }) = target
                 {
                     if let Some(requirements) = edge.requirements() {
-                        if requirements
-                            .selection_set
-                            .items
-                            .iter()
-                            .any(|item| matches!(item, SelectionItem::Field(f) if &f.name == target_field_name))
-                        {
+                        if self.requirements_includes_field(
+                            requirements,
+                            tail_node.name_str(),
+                            target_field_name,
+                        ) {
                             continue;
                         }
                     }
@@ -381,6 +427,7 @@ impl<'graph> PathSearch<'graph> {
 
 pub fn find_self_referencing_direct_path<'graph>(
     graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
     override_context: &'graph PlannerOverrideContext,
     path: &OperationPath<'graph>,
     type_name: &'graph str,
@@ -388,7 +435,7 @@ pub fn find_self_referencing_direct_path<'graph>(
     cancellation_token: &'graph CancellationToken,
 ) -> Result<OperationPath<'graph>, WalkOperationError> {
     let path_tail_index = path.tail();
-    let mut path_search = PathSearch::new(graph, override_context, cancellation_token);
+    let mut path_search = PathSearch::new(graph, supergraph, override_context, cancellation_token);
 
     for edge_ref in graph
         .edges_from(path_tail_index)
@@ -418,12 +465,14 @@ pub fn find_self_referencing_direct_path<'graph>(
 ))]
 pub fn find_direct_paths<'graph>(
     graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
     override_context: &'graph PlannerOverrideContext,
     path: &OperationPath<'graph>,
     target: &NavigationTarget<'_>,
     cancellation_token: &'graph CancellationToken,
 ) -> Result<Vec<OperationPath<'graph>>, WalkOperationError> {
-    PathSearch::new(graph, override_context, cancellation_token).find_direct_paths(path, target)
+    PathSearch::new(graph, supergraph, override_context, cancellation_token)
+        .find_direct_paths(path, target)
 }
 
 impl<'graph> PathSearch<'graph> {
@@ -479,8 +528,10 @@ impl<'graph> PathSearch<'graph> {
   path = path.pretty_print(graph),
   edge = edge_ref.weight().display_name(),
 ))]
+#[allow(clippy::too_many_arguments)]
 pub fn can_satisfy_edge<'graph>(
     graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
     override_context: &'graph PlannerOverrideContext,
     edge_ref: &EdgeReference<'graph>,
     path: &OperationPath<'graph>,
@@ -488,7 +539,7 @@ pub fn can_satisfy_edge<'graph>(
     use_only_direct_edges: bool,
     cancellation_token: &'graph CancellationToken,
 ) -> Result<Option<Vec<OperationPath<'graph>>>, WalkOperationError> {
-    PathSearch::new(graph, override_context, cancellation_token).can_satisfy_edge(
+    PathSearch::new(graph, supergraph, override_context, cancellation_token).can_satisfy_edge(
         edge_ref,
         path,
         excluded,
@@ -745,12 +796,17 @@ impl<'graph> PathSearch<'graph> {
         let mut direct_path_results: Vec<Vec<OperationPath<'graph>>> =
             Vec::with_capacity(requirement.paths.len());
         for path in requirement.paths.iter() {
-            direct_path_results.push(self.find_direct_paths(
-                path,
-                // @skip/@include can't be used in @requires and @provides,
-                // that's why we pass no condition
-                &NavigationTarget::ConcreteType(type_name, None),
-            )?);
+            let current_type_name = self.graph.node(path.tail())?.name_str();
+            if self.type_condition_matches(current_type_name, type_name) {
+                direct_path_results.push(vec![path.clone()]);
+            } else {
+                direct_path_results.push(self.find_direct_paths(
+                    path,
+                    // @skip/@include can't be used in @requires and @provides,
+                    // that's why we pass no condition
+                    &NavigationTarget::ConcreteType(type_name, None),
+                )?);
+            }
         }
 
         // Collect all Vec<OperationPath<'graph>> results from find_indirect_paths

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -797,6 +797,9 @@ impl<'graph> PathSearch<'graph> {
             Vec::with_capacity(requirement.paths.len());
         for path in requirement.paths.iter() {
             let current_type_name = self.graph.node(path.tail())?.name_str();
+            // If the current type already matches the fragment condition, we can keep
+            // using the same path. For example, `Item` matches `... on Tagged` when
+            // `Item implements Tagged`, so there is no need to find an edge to `Tagged`.
             if self.type_condition_matches(current_type_name, type_name) {
                 direct_path_results.push(vec![path.clone()]);
             } else {

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -213,6 +213,28 @@ impl<'graph> PathSearch<'graph> {
                     continue;
                 }
 
+                // If we're searching for a field and this edge's
+                // requirements include the same field,
+                // the edge cannot help us, we skip it.
+                // We allow other entity-move edge to be used instead,
+                // that will be used to collect the required fields.
+                if let NavigationTarget::Field(FieldSelection {
+                    name: target_field_name,
+                    ..
+                }) = target
+                {
+                    if let Some(requirements) = edge.requirements() {
+                        if requirements
+                            .selection_set
+                            .items
+                            .iter()
+                            .any(|item| matches!(item, SelectionItem::Field(f) if &f.name == target_field_name))
+                        {
+                            continue;
+                        }
+                    }
+                }
+
                 // A huge win for performance, is when you do less work :D
                 // We can ignore an edge that has already been visited with the same key fields / requirements.
                 // The way entity-move edges are created, where every graph points to every other graph:

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -722,3 +722,58 @@ fn recursion_bomb_test() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn requires_circular_keys_test() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let queries = [
+            r#"
+            {
+              list {
+                items {
+                  value
+                  valueRequiresObjectFragment
+                  valueRequiresInterfaceFragment
+                  valueRequiresInlineFragment
+                  valueNestedField
+                }
+              }
+            }
+            "#,
+            r#"
+            {
+              list {
+                taggedItems {
+                  ... on Item {
+                    valueInterfaceKey
+                  }
+                }
+              }
+            }
+            "#,
+        ];
+
+        let result = queries.iter().try_for_each(|query| {
+            let document = parse_operation(query);
+            build_query_plan_with_defaults(
+                "fixture/issues/requires-circular-keys.supergraph.graphql",
+                document,
+            )
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+        });
+
+        let _ = tx.send(result);
+    });
+
+    let result = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("query planner timed out");
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+
+    Ok(())
+}

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -104,35 +104,36 @@ fn issue_281_test() -> Result<(), Box<dyn Error>> {
             }
           }
         },
-        Flatten(path: "viewer.review|[UserReview].product") {
-          Fetch(service: "c") {
-            {
-              ... on Product {
-                __typename
-                pid
+        Parallel {
+          Flatten(path: "viewer.review|[UserReview].product") {
+            Fetch(service: "c") {
+              {
+                ... on Product {
+                  __typename
+                  pid
+                }
+              } =>
+              {
+                ... on Product {
+                  c
+                }
               }
-            } =>
-            {
-              ... on Product {
-                c
-                pid
-              }
-            }
+            },
           },
-        },
-        Flatten(path: "viewer.review|[UserReview].product") {
-          Fetch(service: "d") {
-            {
-              ... on Product {
-                __typename
-                pid
+          Flatten(path: "viewer.review|[UserReview].product") {
+            Fetch(service: "d") {
+              {
+                ... on Product {
+                  __typename
+                  pid
+                }
+              } =>
+              {
+                ... on Product {
+                  d
+                }
               }
-            } =>
-            {
-              ... on Product {
-                d
-              }
-            }
+            },
           },
         },
       },

--- a/lib/query-planner/src/tests/issues.rs
+++ b/lib/query-planner/src/tests/issues.rs
@@ -4,6 +4,9 @@ use crate::{
     utils::parsing::parse_operation,
 };
 use std::error::Error;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 #[test]
 fn issue_281_test() -> Result<(), Box<dyn Error>> {
@@ -680,6 +683,41 @@ fn issue_interface_object_typename() -> Result<(), Box<dyn Error>> {
       },
     },
     "#);
+
+    Ok(())
+}
+
+#[test]
+fn recursion_bomb_test() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        {
+          list {
+            items {
+              value
+            }
+          }
+        }
+        "#,
+    );
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let ok = build_query_plan_with_defaults(
+            "fixture/issues/recursion-bomb.supergraph.graphql",
+            document,
+        )
+        .is_ok();
+
+        let _ = tx.send(ok);
+    });
+
+    let ok = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("query planner timed out");
+
+    assert!(ok);
 
     Ok(())
 }


### PR DESCRIPTION
The path finder could enter an infinite loop when:
1. A field with `@requires` needs to entity-move to another subgraph
2. The entity-move edge's requirements include the field being resolved
3. This creates a circular dependency: "to get field X, use edge requiring X"

The fix detects this cycle by skipping edges whose requirements include the
target field being searched, allowing alternative entity-move paths to be used.