### PR TITLE
First batch of QP performance improvements

### DIFF
--- a/lib/query-planner/src/ast/merge_path.rs
+++ b/lib/query-planner/src/ast/merge_path.rs
@@ -48,7 +48,7 @@ impl From<&FieldSelection> for FieldPathSegment {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq, Hash)]
 pub enum Condition {
     Skip(String),
     Include(String),

--- a/lib/query-planner/src/graph/node.rs
+++ b/lib/query-planner/src/graph/node.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 use crate::state::supergraph_state::SubgraphName;
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnionMembersData {
     /// Represents the type owning the field
     pub type_name: String,

--- a/lib/query-planner/src/planner/best.rs
+++ b/lib/query-planner/src/planner/best.rs
@@ -6,12 +6,7 @@
 //!
 //! A naive search to find the best combination would be exponentially slow (we were there...),
 //! as the number of possible plans is the product of the number of choices for each part of
-//! the query. This module implements a search algorithm to make this problem solved.
-//!
-//! The core of the solution is a Branch and Bound algorithm implemented over a
-//! Depth-First Search (DFS). This approach explores all possible
-//! combinations while aggressively pruning entire branches of the search space that
-//! are guaranteed to not contain the optimal solution.
+//! the query. This module implements a greedy algorithm to make this problem tractable.
 //!
 //! The key components are:
 //!
@@ -20,33 +15,23 @@
 //!     `Candidate` plan fragment. The goal is to pick exactly one `Candidate` from
 //!     each set of `Alternatives`.
 //!
-//! 2.  Before the main search, a fast Greedy Algorithm (`find_initial_plan`)
-//!     is run to find a "good enough" initial plan.
-//!     This provides a strong `best_cost` value, which is critical for making the
-//!     pruning in the main search much more effective.
+//! 2.  Singletons (fields with only one candidate) are merged eagerly before the main
+//!     search. This reduces the number of candidates to consider.
 //!
-//! 3.  The Bounding Function (`min_remaining_costs`) - this is the most important
-//!     optimization. We pre-compute a vector that contains an optimistic,
-//!     "best-case" cost for completing the plan from any given step to the end.
-//!     It never overestimates the true cost, which allows
-//!     for the pruning check: if a partial plan's cost plus the optimistic
-//!     remaining cost is already worse than our best-found solution, we can safely
-//!     abandon the entire branch.
+//! 3.  The main greedy search iterates over the remaining decision points and at each
+//!     step picks the candidate that adds the smallest cost to the current plan.
+//!     Cost computation uses `calculate_added_cost_of_merge` to avoid expensive
+//!     temporary tree clones.
 //!
-//! 4.  To find good solutions faster, we sort both the
-//!     decision points and the choices themselves:
-//!     -   Sets of `Alternatives` are sorted by size (fewest choices first) to reduce
-//!         the branching factor and find a complete plan sooner.
-//!     -   `Candidates` within each set are sorted by their individual cost to explore
-//!         the most promising options first.
+//! 4.  Sets of `Alternatives` are sorted by size (fewest choices first) to reduce
+//!     the branching factor and find a complete plan sooner.
 //!
-//! 5.  The `Candidate` struct uses `OnceCell` to ensure that the
-//!     potentially expensive work of building and costing a `QueryTree` is only ever
-//!     done if a candidate is actually evaluated, and never more
-//!     than once.
+//! 5.  The `Candidate` struct uses `LazyTransform` to ensure that the
+//!     potentially expensive work of building a `QueryTree` is only done
+//!     if a candidate is actually evaluated, and never more than once.
 
 use lazy_init::LazyTransform;
-use std::{cell::OnceCell, rc::Rc};
+use std::rc::Rc;
 
 use crate::{
     graph::{edge::Edge, error::GraphError, Graph},
@@ -77,19 +62,16 @@ const FIELD_COST: u64 = 1;
 struct Candidate<'graph> {
     /// The actual `QueryTree` for this candiate, computed only when first needed.
     tree: LazyQueryTree<'graph>,
-    /// The cached cost of this tree, computed only once.
-    cost: OnceCell<u64>,
 }
 
-/// Represents a set of alternative Candidates to satisfy a single leaf in the query.
-/// The final plan must choose exactly one fragment from each ChoiceGroup.
+/// A group of alternatives - all possible ways to resolve one field.
+/// The final plan must pick exactly one Candidate from each group.
 type Alternatives<'graph> = Vec<Candidate<'graph>>;
 
 impl<'graph> Candidate<'graph> {
     fn new(path: OperationPath<'graph>, mutation_pos: MutationFieldPosition) -> Self {
         Self {
             tree: LazyTransform::new((path, mutation_pos)),
-            cost: OnceCell::new(),
         }
     }
 
@@ -100,23 +82,13 @@ impl<'graph> Candidate<'graph> {
             .get_or_create(|(p, mp)| QueryTree::from_path(graph, &p, mp))
             .clone()?)
     }
-
-    #[inline]
-    fn get_cost(&self, graph: &Graph) -> Result<u64, QueryPlanError> {
-        if let Some(v) = self.cost.get() {
-            return Ok(*v);
-        }
-        let tree = self.get_tree(graph)?;
-        let cost = calculate_cost_of_tree(graph, &tree.root);
-        let _ = self.cost.set(cost);
-        Ok(cost)
-    }
 }
 
-/// Each `Alternatives` group represents a set of possible ways to satisfy one leaf of the query.
+/// Build the list of alternatives for each field in the query.
+/// Returns a list where each entry is all the ways to resolve one field.
 fn prepare_alternatives<'graph>(operation: ResolvedOperation<'graph>) -> Vec<Alternatives<'graph>> {
     let is_mutation = matches!(operation.operation_kind, OperationKind::Mutation);
-    let mut per_leaf_alternatives_asc: Vec<Alternatives<'graph>> = Vec::new();
+    let mut per_leaf_alternatives: Vec<Alternatives<'graph>> = Vec::new();
 
     for (index, root_field_options) in operation.root_field_groups.into_iter().enumerate() {
         let mutation_field_position: MutationFieldPosition = is_mutation.then_some(index);
@@ -131,53 +103,46 @@ fn prepare_alternatives<'graph>(operation: ResolvedOperation<'graph>) -> Vec<Alt
             })
             .collect();
 
-        per_leaf_alternatives_asc.extend(leaf_alternatives);
+        per_leaf_alternatives.extend(leaf_alternatives);
     }
 
     // Sort alternatives by length in ascending order.
-    per_leaf_alternatives_asc.sort_by_key(|alternatives| alternatives.len());
+    per_leaf_alternatives.sort_by_key(|alternatives| alternatives.len());
 
-    per_leaf_alternatives_asc
+    per_leaf_alternatives
 }
 
-fn calculate_min_remaining_costs(
+/// Merge fields that have only one possible resolution.
+///
+/// Returns:
+/// - The merged base tree, if any singletons were found.
+/// - The remaining alternatives, which still have more than one candidate.
+fn merge_singleton_alternatives<'graph>(
     graph: &Graph,
-    per_leaf_alternatives_asc: &[Alternatives],
-) -> Result<Vec<u64>, QueryPlanError> {
-    // Pre-compute a lower bound for pruning.
-    // Finds the absolute best-case cost for each set of alternatives.
-    let best_case_cost_per_leaf = per_leaf_alternatives_asc
-        .iter()
-        .map(|alternatives| {
-            alternatives
-                .iter()
-                .map(|candidate| candidate.get_cost(graph))
-                .try_fold(u64::MAX, |acc, cost_result| {
-                    Ok::<u64, QueryPlanError>(acc.min(cost_result?))
-                })
-        })
-        .collect::<Result<Vec<u64>, _>>()?;
+    per_leaf_alternatives: Vec<Alternatives<'graph>>,
+) -> Result<(Option<QueryTree>, Vec<Alternatives<'graph>>), QueryPlanError> {
+    // Split into singletons (1 candidate) and non-singletons (2+ candidates).
+    let (singletons, remaining): (Vec<_>, Vec<_>) = per_leaf_alternatives
+        .into_iter()
+        .partition(|a| a.len() == 1);
 
-    // Pre-compute a "suffix lower bound" (LB) to enable effective pruning.
-    // `min_remaining_costs[i]` stores an optimistic "best-case" cost for completing the
-    // plan from alternatives `i` to the end.
-    // In the `explore_plan_combinations`, we can then check:
-    // `cost_so_far + min_remaining_costs[depth] >= best_cost_so_far`.
-    // If this is true, we know the current path is a dead end and can be abandoned.
-    let mut min_remaining_costs = vec![0; per_leaf_alternatives_asc.len() + 1];
-    for i in (0..per_leaf_alternatives_asc.len()).rev() {
-        min_remaining_costs[i] = min_remaining_costs[i + 1] + best_case_cost_per_leaf[i];
+    // Merge all singletons into one base tree.
+    let mut base_tree: Option<QueryTree> = None;
+    for alternatives in singletons {
+        let candidate = alternatives
+            .into_iter()
+            .next()
+            .expect("singleton has one candidate");
+        let candidate_tree = candidate.get_tree(graph)?;
+        match base_tree.as_mut() {
+            // Merge into the existing base tree.
+            Some(tree) => Rc::make_mut(&mut tree.root).merge_nodes(&candidate_tree.root),
+            // This is the first singleton - it becomes the base tree.
+            None => base_tree = Some(candidate_tree),
+        }
     }
-    Ok(min_remaining_costs)
-}
 
-fn sort_candidates_by_cost(graph: &Graph, per_leaf_alternatives_asc: &mut [Alternatives]) {
-    // Within each set of alternatives, sort choices by their cost.
-    // Trying cheaper options first
-    // is more likely to lead to better solutions sooner.
-    for paths in per_leaf_alternatives_asc {
-        paths.sort_by_key(|c| c.get_cost(graph).unwrap_or(u64::MAX));
-    }
+    Ok((base_tree, remaining))
 }
 
 pub fn find_best_combination(
@@ -194,174 +159,128 @@ pub fn find_best_combination(
         return Err(QueryPlanError::EmptyPlan);
     }
 
-    let mut per_leaf_alternatives_asc = prepare_alternatives(operation);
-    if per_leaf_alternatives_asc.is_empty() {
+    let per_leaf_alternatives = prepare_alternatives(operation);
+    if per_leaf_alternatives.is_empty() {
         return Err(QueryPlanError::EmptyPlan);
     }
 
-    let min_remaining_costs = calculate_min_remaining_costs(graph, &per_leaf_alternatives_asc)?;
-    sort_candidates_by_cost(graph, &mut per_leaf_alternatives_asc);
+    // Merge fields with only one candidate
+    let (base_tree, per_leaf_alternatives) =
+        merge_singleton_alternatives(graph, per_leaf_alternatives)?;
 
-    let mut best_cost = u64::MAX;
-    let mut best_tree: Option<QueryTree> = None;
-
-    // Runs a fast, greedy search to find a good-enough initial solution.
-    // A strong initial `best_cost` is critical for effective pruning.
-    if let Some((cost, tree)) = find_initial_plan(graph, &per_leaf_alternatives_asc) {
-        if cost < best_cost {
-            best_cost = cost;
-            best_tree = Some(tree);
-        }
+    // If all fields were singletons, we are done.
+    if per_leaf_alternatives.is_empty() {
+        return base_tree.ok_or(QueryPlanError::EmptyPlan);
     }
 
-    let mut state = ExplorationState {
-        best_cost,
-        best_tree,
-    };
+    let mut current_tree = base_tree;
+    let mut current_cost = current_tree
+        .as_ref()
+        .map(|tree| calculate_cost_of_tree(graph, &tree.root))
+        .unwrap_or(0);
 
-    // Performs the search for the optimal solution
-    explore_plan_combinations(
-        graph,
-        &per_leaf_alternatives_asc,
-        0,
-        None,
-        0,
-        &min_remaining_costs,
-        cancellation_token,
-        &mut state,
-    )?;
+    // For each group, choose the candidate that adds the lowest cost.
+    //
+    // This is fast because we do not build a temporary merged tree for every
+    // candidate. That is too expensive for large queries.
+    // Instead, we compare the current tree with the candidate tree
+    // and calculate only the cost that is missing from the current tree.
+    for alternatives in &per_leaf_alternatives {
+        cancellation_token.bail_if_cancelled()?;
 
-    state.best_tree.ok_or(QueryPlanError::EmptyPlan)
-}
-
-/// A fast search that finds a good, but not best plan.
-/// It works by making the "locally best" choice at each step.
-fn find_initial_plan(
-    graph: &Graph,
-    alternatives_list: &[Alternatives],
-) -> Option<(u64, QueryTree)> {
-    let mut current_tree: Option<QueryTree> = None;
-    let mut current_cost: u64 = 0;
-
-    for alternatives in alternatives_list {
-        let mut best_delta = u64::MAX;
         let mut best_next: Option<(u64, QueryTree)> = None;
 
-        // At each step, pick the candidate that adds the smallest cost to the current plan
         for candidate in alternatives {
-            let cand_tree = match candidate.get_tree(graph) {
-                Ok(t) => t,
+            let candidate_tree = match candidate.get_tree(graph) {
+                Ok(tree) => tree,
                 Err(_) => continue,
             };
-            let next_tree = match current_tree.as_ref() {
-                Some(t) => {
-                    let mut merged = t.clone();
-                    Rc::make_mut(&mut merged.root).merge_nodes(&cand_tree.root);
-                    merged
+
+            let added_cost = match current_tree.as_ref() {
+                Some(tree) => {
+                    calculate_added_cost_of_merge(graph, &tree.root, &candidate_tree.root)
                 }
-                None => cand_tree.clone(),
+                None => calculate_cost_of_tree(graph, &candidate_tree.root),
             };
-            let next_cost = calculate_cost_of_tree(graph, &next_tree.root);
-            let delta = next_cost.saturating_sub(current_cost);
-            if delta < best_delta {
-                best_delta = delta;
-                best_next = Some((next_cost, next_tree));
+            let next_cost = current_cost + added_cost;
+
+            if best_next
+                .as_ref()
+                .is_none_or(|(best_cost, _)| next_cost < *best_cost)
+            {
+                best_next = Some((next_cost, candidate_tree));
             }
         }
 
-        if let Some((next_cost, next_tree)) = best_next {
-            current_cost = next_cost;
-            current_tree = Some(next_tree);
-        } else {
-            return None;
+        let (next_cost, next_tree) = best_next.ok_or(QueryPlanError::EmptyPlan)?;
+
+        // Merge only the selected candidate. Rejected candidates were only read.
+        match current_tree.as_mut() {
+            Some(tree) => Rc::make_mut(&mut tree.root).merge_nodes(&next_tree.root),
+            None => current_tree = Some(next_tree),
         }
+        current_cost = next_cost;
     }
 
-    current_tree.map(|t| (current_cost, t))
+    current_tree.ok_or(QueryPlanError::EmptyPlan)
 }
 
-struct ExplorationState {
-    best_cost: u64,
-    best_tree: Option<QueryTree>,
-}
-
-#[allow(clippy::too_many_arguments)]
-/// Performs branch-and-bound (to prune early) depth-first search to find the best combination
-fn explore_plan_combinations(
+/// Calculate how much cost `source` would add to `target`.
+///
+/// `target` is the query tree we already selected.
+/// `source` is a candidate tree we may select next.
+///
+/// We only count nodes that are missing from `target`. If a node already exists,
+/// we go deeper and check its children and requirements. This gives the same
+/// cost as a full merge followed by a full cost calculation, but it avoids the
+/// expensive temporary merge.
+fn calculate_added_cost_of_merge(
     graph: &Graph,
-    groups: &[Alternatives],
-    group_index: usize,
-    tree_so_far: Option<QueryTree>,
-    cost_so_far: u64,
-    min_remaining_costs: &[u64],
-    cancellation_token: &CancellationToken,
-    state: &mut ExplorationState,
-) -> Result<(), QueryPlanError> {
-    cancellation_token.bail_if_cancelled()?;
-
-    // This is the most critical optimization.
-    // If the current path's cost + the absolute best-case cost
-    // for all remaining choices is already worse than our
-    // best solution, we can abandon this entire search branch.
-    if cost_so_far + min_remaining_costs[group_index] >= state.best_cost {
-        return Ok(());
-    }
-
-    // If we've made a choice for every set of alternatives,
-    // we have a complete plan.
-    // If it's the best one we've seen, we save it.
-    if group_index == groups.len() {
-        if cost_so_far < state.best_cost {
-            state.best_cost = cost_so_far;
-            state.best_tree = tree_so_far;
-        }
-        return Ok(());
-    }
-
-    // Explore each possible candidate for the current set of alternatives.
-    for cand in groups[group_index].iter() {
-        let cand_tree = cand.get_tree(graph)?;
-        let next_tree = match tree_so_far.as_ref() {
-            Some(t) => {
-                let mut merged = t.clone();
-                Rc::make_mut(&mut merged.root).merge_nodes(&cand_tree.root);
-                merged
-            }
-            None => cand_tree.clone(),
-        };
-
-        let next_cost = calculate_cost_of_tree(graph, &next_tree.root);
-        // If the next step alone is too expensive, skip it.
-        if next_cost >= state.best_cost {
-            continue;
-        }
-
-        explore_plan_combinations(
+    target: &QueryTreeNode,
+    source: &QueryTreeNode,
+) -> u64 {
+    calculate_added_cost_for_node_list(graph, &target.children, &source.children, false)
+        + calculate_added_cost_for_node_list(
             graph,
-            groups,
-            group_index + 1,
-            Some(next_tree),
-            next_cost,
-            min_remaining_costs,
-            cancellation_token,
-            state,
-        )?;
-    }
-
-    Ok(())
+            &target.requirements,
+            &source.requirements,
+            true,
+        )
 }
 
+fn calculate_added_cost_for_node_list(
+    graph: &Graph,
+    target_list: &[Rc<QueryTreeNode>],
+    source_list: &[Rc<QueryTreeNode>],
+    is_requirement: bool,
+) -> u64 {
+    source_list
+        .iter()
+        .map(|source_node| {
+            // If the node already exists, only its missing nested parts add cost.
+            if let Some(target_node) = target_list
+                .iter()
+                .find(|target_node| target_node.as_ref() == source_node.as_ref())
+            {
+                calculate_added_cost_of_merge(graph, target_node, source_node)
+            } else if is_requirement {
+                CROSS_SUBGRAPH_COST + calculate_cost_of_tree(graph, source_node)
+            } else {
+                edge_cost(graph, source_node) + calculate_cost_of_tree(graph, source_node)
+            }
+        })
+        .sum()
+}
+
+/// Calculate the total cost of a query tree node and all its children.
 #[inline(always)]
 fn calculate_cost_of_tree(graph: &Graph, node: &QueryTreeNode) -> u64 {
     let mut current_cost = FIELD_COST;
 
+    // Add cost for each child node
     for child in &node.children {
-        if child.edge_from_parent.is_some_and(|edge_index| {
-            matches!(
-                graph.edge(edge_index).expect("edge should exist"),
-                Edge::SubgraphEntrypoint { .. }
-            )
-        }) {
+        if edge_cost(graph, child) > 0 {
+            // If this child crosses into a different subgraph
             current_cost += CROSS_SUBGRAPH_COST;
         }
 
@@ -374,4 +293,18 @@ fn calculate_cost_of_tree(graph: &Graph, node: &QueryTreeNode) -> u64 {
     }
 
     current_cost
+}
+
+#[inline(always)]
+fn edge_cost(graph: &Graph, node: &QueryTreeNode) -> u64 {
+    if node.edge_from_parent.is_some_and(|edge_index| {
+        matches!(
+            graph.edge(edge_index).expect("edge should exist"),
+            Edge::SubgraphEntrypoint { .. }
+        )
+    }) {
+        CROSS_SUBGRAPH_COST
+    } else {
+        0
+    }
 }

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1655,7 +1655,6 @@ fn find_satisfiable_key<'a>(
             &OperationPath {
                 root_node: query_node.node_index,
                 last_segment: None,
-                visited_edge_indices: Default::default(),
                 cost: 0,
                 union_context: None,
             },

--- a/lib/query-planner/src/planner/fetch/fetch_step_data.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_step_data.rs
@@ -48,7 +48,7 @@ pub struct FetchStepData<State> {
     pub internal_aliases_locations: Vec<(String, AliasesRecords)>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FetchStepKind {
     Entity,
     Root,

--- a/lib/query-planner/src/planner/fetch/optimize/batch_multi_type.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/batch_multi_type.rs
@@ -6,7 +6,7 @@ use tracing::{instrument, trace};
 
 use crate::ast::merge_path::Condition;
 use crate::planner::fetch::fetch_step_data::{
-    type_condition_types_from_response_path, FetchStepFlags,
+    type_condition_types_from_response_path, FetchStepFlags, FetchStepKind,
 };
 use crate::{
     ast::merge_path::{MergePath, Segment},
@@ -14,7 +14,40 @@ use crate::{
         error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
         optimize::utils::perform_fetch_step_merge, state::MultiTypeFetchStep,
     },
+    state::supergraph_state::SubgraphName,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BatchKey {
+    kind: FetchStepKind,
+    service_name: SubgraphName,
+    normalized_path_hash: u64,
+    response_path_len: usize,
+    type_condition_layout_hash: u64,
+    used_for_requires: bool,
+}
+
+impl BatchKey {
+    // Coarse grouping only; can_be_batched_with remains the correctness check.
+    fn from_step(
+        step: &FetchStepData<MultiTypeFetchStep>,
+        normalized_path_hash: u64,
+        type_condition_layout_hash: u64,
+    ) -> Option<Self> {
+        if !step.is_entity_call() {
+            return None;
+        }
+
+        Some(Self {
+            kind: step.kind.clone(),
+            service_name: step.service_name.clone(),
+            normalized_path_hash,
+            response_path_len: step.response_path.len(),
+            type_condition_layout_hash,
+            used_for_requires: step.flags.contains(FetchStepFlags::USED_FOR_REQUIRES),
+        })
+    }
+}
 
 impl FetchGraph<MultiTypeFetchStep> {
     /// Batches sibling entity fetches that only differ by type conditions.
@@ -39,131 +72,148 @@ impl FetchGraph<MultiTypeFetchStep> {
 
         while let Some(parent_index) = queue.pop_front() {
             // We only batch child steps that share the same parent.
-            let mut merges_to_perform = Vec::<(NodeIndex, NodeIndex)>::new();
-            let mut node_indexes: HashMap<NodeIndex, NodeIndex> = HashMap::new();
             let siblings_indices = self
                 .graph
                 .neighbors_directed(parent_index, Direction::Outgoing)
                 .collect::<Vec<NodeIndex>>();
+
+            for sibling_index in siblings_indices.iter() {
+                queue.push_back(*sibling_index);
+            }
+
+            let mut sibling_infos = Vec::<(NodeIndex, u64)>::new();
+            let mut sibling_groups = HashMap::<BatchKey, Vec<(NodeIndex, u64)>>::new();
+            for sibling_index in siblings_indices.iter() {
+                let current = self.get_step_data(*sibling_index)?;
+                let normalized_path_hash = normalized_path_hash(&current.response_path);
+                sibling_infos.push((*sibling_index, normalized_path_hash));
+
+                if let Some(batch_key) = BatchKey::from_step(
+                    current,
+                    normalized_path_hash,
+                    type_condition_layout_hash(&current.response_path),
+                ) {
+                    sibling_groups
+                        .entry(batch_key)
+                        .or_default()
+                        .push((*sibling_index, normalized_path_hash));
+                }
+            }
+
+            // If every group has one item, no merge is possible.
+            // In that case, skip the coverage map because it is only used when merging.
+            if !sibling_groups.values().any(|group| group.len() > 1) {
+                continue;
+            }
+
             // For each type-condition position on sibling paths, collect all requested concrete types.
             // Example: siblings request |[Book] and |[Magazine] at the same position,
             // so coverage for that position is {Book, Magazine}.
             let requested_type_condition_types_by_position =
-                self.requested_type_condition_types_by_position(&siblings_indices)?;
+                self.requested_type_condition_types_by_position(&sibling_infos)?;
 
-            for (i, sibling_index) in siblings_indices.iter().enumerate() {
-                queue.push_back(*sibling_index);
-                let current = self.get_step_data(*sibling_index)?;
+            for sibling_group in sibling_groups.values() {
+                if sibling_group.len() < 2 {
+                    continue;
+                }
 
-                for other_sibling_index in siblings_indices.iter().skip(i + 1) {
-                    trace!(
-                        "checking if [{}] and [{}] can be batched",
-                        sibling_index.index(),
-                        other_sibling_index.index()
-                    );
+                let mut targets = Vec::<(NodeIndex, u64)>::new();
+                for (source_index, source_normalized_path_hash) in sibling_group {
+                    if self.graph.node_weight(*source_index).is_none() {
+                        continue;
+                    }
 
-                    let other_sibling = self.get_step_data(*other_sibling_index)?;
+                    let mut merged = false;
+                    for (target_index, target_normalized_path_hash) in &targets {
+                        if self.graph.node_weight(*target_index).is_none() {
+                            continue;
+                        }
 
-                    if current.can_be_batched_with(other_sibling) {
+                        trace!(
+                            "checking if [{}] and [{}] can be batched",
+                            target_index.index(),
+                            source_index.index()
+                        );
+
+                        if self.is_ancestor_or_descendant(*target_index, *source_index) {
+                            continue;
+                        }
+
+                        // Revalidate because previous merges may change step compatibility.
+                        let can_still_batch = {
+                            let left = self.get_step_data(*target_index)?;
+                            let right = self.get_step_data(*source_index)?;
+                            left.can_be_batched_with(right)
+                        };
+
+                        if !can_still_batch {
+                            continue;
+                        }
+
                         trace!(
                             "Found multi-type batching optimization: [{}] <- [{}]",
-                            sibling_index.index(),
-                            other_sibling_index.index()
+                            target_index.index(),
+                            source_index.index()
                         );
-                        // Register their original indexes in the map.
-                        node_indexes.insert(*sibling_index, *sibling_index);
-                        node_indexes.insert(*other_sibling_index, *other_sibling_index);
 
-                        merges_to_perform.push((*sibling_index, *other_sibling_index));
-                    }
-                }
-            }
+                        let (me, other) =
+                            self.get_pair_of_steps_mut(*target_index, *source_index)?;
+                        let original_me_path = me.response_path.clone();
+                        let original_other_path = other.response_path.clone();
 
-            // First find all merge candidates. Then apply merges.
-            for (child_index, other_child_index) in merges_to_perform {
-                // Get the latest indexes for the nodes, accounting for previous merges.
-                let child_index_latest = node_indexes
-                    .get(&child_index)
-                    .ok_or(FetchGraphError::IndexMappingLost)?;
-                let other_child_index_latest = node_indexes
-                    .get(&other_child_index)
-                    .ok_or(FetchGraphError::IndexMappingLost)?;
-
-                if child_index_latest == other_child_index_latest {
-                    continue;
-                }
-
-                if self.is_ancestor_or_descendant(*child_index_latest, *other_child_index_latest) {
-                    continue;
-                }
-
-                // Revalidate because previous merges may change step compatibility
-                let can_still_batch = {
-                    let left = self.get_step_data(*child_index_latest)?;
-                    let right = self.get_step_data(*other_child_index_latest)?;
-                    left.can_be_batched_with(right)
-                };
-
-                if !can_still_batch {
-                    continue;
-                }
-
-                let (me, other) =
-                    self.get_pair_of_steps_mut(*child_index_latest, *other_child_index_latest)?;
-
-                let original_me_path = me.response_path.clone();
-                let original_other_path = other.response_path.clone();
-
-                // We "declare" the known type for the step, so later merging will be possible into that type instead of failing with an error.
-                for (input_type_name, _) in other.input.iter_selections() {
-                    me.input.declare_known_type(input_type_name);
-                }
-
-                // We "declare" the known type for the step, so later merging will be possible into that type instead of failing with an error.
-                for (output_type_name, _) in other.output.iter_selections() {
-                    me.output.declare_known_type(output_type_name);
-                }
-
-                perform_fetch_step_merge(
-                    *child_index_latest,
-                    *other_child_index_latest,
-                    self,
-                    true,
-                )?;
-
-                let merged = self.get_step_data_mut(*child_index_latest)?;
-                // After merge, update the path so Flatten(path) is correct.
-                // Example:
-                //   `me`     path: products.[Book].reviews
-                //   `other`  path: products.[User].reviews
-                //   `merged` path: products.[Book|User].reviews (or stripped if fully covered)
-                //
-                // Without recomputing this path, merged results can be flattened
-                // at the wrong location.
-                merged.response_path = merge_batched_response_paths(
-                    &original_me_path,
-                    &original_other_path,
-                    &requested_type_condition_types_by_position,
-                );
-                if merged.is_fetching_multiple_types() {
-                    if let Some(condition) = merged.condition.clone() {
-                        if let Some(conditioned_types) =
-                            type_condition_types_from_response_path(&merged.response_path)
-                        {
-                            // Multi-type merged step: keep condition on matching
-                            // type branches instead of gating the whole fetch step.
-                            merged
-                                .output
-                                .wrap_with_condition_for_types(condition, &conditioned_types);
-                            merged.condition = None;
+                        // We "declare" the known type for the step, so later merging will be possible into that type instead of failing with an error.
+                        for (input_type_name, _) in other.input.iter_selections() {
+                            me.input.declare_known_type(input_type_name);
                         }
+
+                        // We "declare" the known type for the step, so later merging will be possible into that type instead of failing with an error.
+                        for (output_type_name, _) in other.output.iter_selections() {
+                            me.output.declare_known_type(output_type_name);
+                        }
+
+                        perform_fetch_step_merge(*target_index, *source_index, self, true)?;
+
+                        let merged_step = self.get_step_data_mut(*target_index)?;
+                        // After merge, update the path so Flatten(path) is correct.
+                        // Example:
+                        //   `me`     path: products.[Book].reviews
+                        //   `other`  path: products.[User].reviews
+                        //   `merged` path: products.[Book|User].reviews (or stripped if fully covered)
+                        //
+                        // Without recomputing this path, merged results can be flattened
+                        // at the wrong location.
+                        merged_step.response_path = merge_batched_response_paths(
+                            &original_me_path,
+                            &original_other_path,
+                            *target_normalized_path_hash,
+                            &requested_type_condition_types_by_position,
+                        );
+                        if merged_step.is_fetching_multiple_types() {
+                            if let Some(condition) = merged_step.condition.clone() {
+                                if let Some(conditioned_types) =
+                                    type_condition_types_from_response_path(
+                                        &merged_step.response_path,
+                                    )
+                                {
+                                    // Multi-type merged step: keep condition on matching
+                                    // type branches instead of gating the whole fetch step.
+                                    merged_step.output.wrap_with_condition_for_types(
+                                        condition,
+                                        &conditioned_types,
+                                    );
+                                    merged_step.condition = None;
+                                }
+                            }
+                        }
+
+                        merged = true;
+                        break;
+                    }
+
+                    if !merged {
+                        targets.push((*source_index, *source_normalized_path_hash));
                     }
                 }
-
-                // Because `other_child` was merged into `child`,
-                // then everything that was pointing to `other_child`
-                // has to point to the `child`.
-                node_indexes.insert(*other_child_index_latest, *child_index_latest);
             }
         }
 
@@ -172,18 +222,16 @@ impl FetchGraph<MultiTypeFetchStep> {
 
     fn requested_type_condition_types_by_position(
         &self,
-        siblings_indices: &[NodeIndex],
+        sibling_infos: &[(NodeIndex, u64)],
     ) -> Result<HashMap<(u64, usize), BTreeSet<String>>, FetchGraphError> {
         // Key: (path hash without type conditions, type-condition position).
         // Value: all concrete types requested by siblings at that position.
         let mut result = HashMap::<(u64, usize), BTreeSet<String>>::new();
 
         // Iterate over all siblings (fetch steps)
-        for sibling_index in siblings_indices {
+        for (sibling_index, normalized_path_hash) in sibling_infos {
             let sibling = self.get_step_data(*sibling_index)?;
             let path = &sibling.response_path;
-            // Create a key for the `result` hashmap
-            let normalized_path_key = normalized_path_hash(path);
 
             // Index of the current non-type-condition segment.
             let mut non_type_condition_position = 0;
@@ -201,7 +249,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                         if !pending_type_condition_members.is_empty() {
                             // We reached a non-type segment, so save collected types for this slot
                             result
-                                .entry((normalized_path_key, non_type_condition_position))
+                                .entry((*normalized_path_hash, non_type_condition_position))
                                 .or_default()
                                 .extend(pending_type_condition_members.iter().cloned());
                             pending_type_condition_members.clear();
@@ -216,7 +264,7 @@ impl FetchGraph<MultiTypeFetchStep> {
             // If path ends with type conditions, save them for the last slot
             if !pending_type_condition_members.is_empty() {
                 result
-                    .entry((normalized_path_key, non_type_condition_position))
+                    .entry((*normalized_path_hash, non_type_condition_position))
                     .or_default()
                     .extend(pending_type_condition_members);
             }
@@ -229,6 +277,7 @@ impl FetchGraph<MultiTypeFetchStep> {
 fn merge_batched_response_paths(
     me: &MergePath,
     other: &MergePath,
+    normalized_path_key: u64,
     requested_type_condition_types_by_position: &HashMap<(u64, usize), BTreeSet<String>>,
 ) -> MergePath {
     // Merge rule at each slot (type-condition part only):
@@ -319,10 +368,9 @@ fn merge_batched_response_paths(
 
     // If non-type-condition parts differ, do not merge.
     // Example: a.@.b vs a.c.b.
-    if me.without_type_castings() != other.without_type_castings() {
+    if !same_path_without_type_conditions(me, other) {
         return me.clone();
     }
-    let normalized_path_key = normalized_path_hash(me);
 
     // Final merged path.
     let mut merged = Vec::<Segment>::new();
@@ -416,6 +464,29 @@ fn normalized_path_hash(path: &MergePath) -> u64 {
     hasher.finish()
 }
 
+fn type_condition_layout_hash(path: &MergePath) -> u64 {
+    let mut hasher = DefaultHasher::new();
+
+    for (position, segment) in path.inner.iter().enumerate() {
+        if let Segment::TypeCondition(_, condition) = segment {
+            position.hash(&mut hasher);
+            condition.hash(&mut hasher);
+        }
+    }
+
+    hasher.finish()
+}
+
+fn same_path_without_type_conditions(left: &MergePath, right: &MergePath) -> bool {
+    left.inner
+        .iter()
+        .filter(|segment| !matches!(segment, Segment::TypeCondition(_, _)))
+        .eq(right
+            .inner
+            .iter()
+            .filter(|segment| !matches!(segment, Segment::TypeCondition(_, _))))
+}
+
 impl FetchStepData<MultiTypeFetchStep> {
     pub fn can_be_batched_with(&self, other: &Self) -> bool {
         // Both steps must be the same fetch kind.
@@ -434,8 +505,7 @@ impl FetchStepData<MultiTypeFetchStep> {
         }
 
         // Paths must match after removing type conditions.
-        if self.response_path.without_type_castings() != other.response_path.without_type_castings()
-        {
+        if !same_path_without_type_conditions(&self.response_path, &other.response_path) {
             return false;
         }
 
@@ -530,8 +600,12 @@ mod tests {
             ]),
         )]);
 
-        let merged =
-            merge_batched_response_paths(&me, &other, &requested_type_condition_types_by_position);
+        let merged = merge_batched_response_paths(
+            &me,
+            &other,
+            normalized_path_key,
+            &requested_type_condition_types_by_position,
+        );
 
         assert_eq!(
             format!("{}", FlattenNodePath::from(merged)),
@@ -549,8 +623,12 @@ mod tests {
             BTreeSet::from_iter(["Book".to_string(), "User".to_string()]),
         )]);
 
-        let merged =
-            merge_batched_response_paths(&me, &other, &requested_type_condition_types_by_position);
+        let merged = merge_batched_response_paths(
+            &me,
+            &other,
+            normalized_path_key,
+            &requested_type_condition_types_by_position,
+        );
 
         assert_eq!(
             format!("{}", FlattenNodePath::from(merged)),

--- a/lib/query-planner/src/planner/fetch/optimize/merge_leafs.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/merge_leafs.rs
@@ -1,9 +1,22 @@
-use petgraph::graph::NodeIndex;
-use tracing::{instrument, trace};
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+};
 
-use crate::planner::fetch::{
-    error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
-    optimize::utils::perform_fetch_step_merge, state::MultiTypeFetchStep,
+use petgraph::graph::NodeIndex;
+use rustc_hash::FxHasher;
+use tracing::instrument;
+
+use crate::{
+    ast::merge_path::{Condition, Segment},
+    planner::{
+        fetch::{
+            error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
+            optimize::utils::perform_fetch_step_merge, state::MultiTypeFetchStep,
+        },
+        tree::query_tree_node::MutationFieldPosition,
+    },
+    state::supergraph_state::SubgraphName,
 };
 
 impl FetchStepData<MultiTypeFetchStep> {
@@ -39,8 +52,8 @@ impl FetchStepData<MultiTypeFetchStep> {
             return false;
         }
 
-        // `other` must be a leaf node (no children).
-        if fetch_graph.children_of(other_index).count() != 0 {
+        // `other` must still be a leaf node (no children).
+        if fetch_graph.children_of(other_index).next().is_some() {
             return false;
         }
 
@@ -61,6 +74,15 @@ impl FetchStepData<MultiTypeFetchStep> {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct GroupKey {
+    service_name: SubgraphName,
+    response_path_hash: u64,
+    input_types_hash: u64,
+    condition: Option<Condition>,
+    mutation_field_position: MutationFieldPosition,
+}
+
 impl FetchGraph<MultiTypeFetchStep> {
     #[instrument(level = "trace", skip_all)]
     /// This optimization is about merging leaf nodes in the fetch nodes with other nodes.
@@ -68,36 +90,96 @@ impl FetchGraph<MultiTypeFetchStep> {
     /// The query performance is not degraded, because the leaf node has no children,
     /// meaning the overall depth (amount of parallel layers) is not increased.
     pub(crate) fn merge_leafs(&mut self) -> Result<(), FetchGraphError> {
-        while let Some((target_idx, leaf_idx)) = self.find_merge_candidate()? {
-            perform_fetch_step_merge(target_idx, leaf_idx, self, false)?;
+        let mut groups: HashMap<GroupKey, Vec<(NodeIndex, bool)>> = HashMap::new();
+
+        for node_index in self.graph.node_indices() {
+            if self.root_index == Some(node_index) {
+                continue;
+            }
+
+            let step = self.get_step_data(node_index)?;
+
+            let is_leaf = self.children_of(node_index).next().is_none();
+            groups
+                .entry(GroupKey {
+                    service_name: step.service_name.clone(),
+                    response_path_hash: response_path_hash(step),
+                    input_types_hash: input_types_hash(step),
+                    condition: step.condition.clone(),
+                    mutation_field_position: step.mutation_field_position,
+                })
+                .or_default()
+                .push((node_index, is_leaf));
         }
 
-        Ok(())
-    }
+        for group in groups.into_values() {
+            // Every item in the group can be a target, but only leaf nodes can be
+            // merged into another step. Keep one list instead of separate target
+            // and leaf lists, so we allocate less.
+            //
+            // Keep the target-first order. It makes the output stable because
+            // merge order affects selection order in the final printed plan.
+            for (target_index, _) in &group {
+                if self.graph.node_weight(*target_index).is_none() {
+                    continue;
+                }
 
-    fn find_merge_candidate(&self) -> Result<Option<(NodeIndex, NodeIndex)>, FetchGraphError> {
-        let all_nodes: Vec<NodeIndex> = self
-            .graph
-            .node_indices()
-            .filter(|&idx| self.root_index != Some(idx))
-            .collect();
+                for (leaf_index, _) in group.iter().filter(|(_, is_leaf)| *is_leaf) {
+                    if target_index == leaf_index
+                        || self.graph.node_weight(*target_index).is_none()
+                        || self.graph.node_weight(*leaf_index).is_none()
+                    {
+                        continue;
+                    }
 
-        for &target_idx in &all_nodes {
-            for &leaf_idx in &all_nodes {
-                let target_data = self.get_step_data(target_idx)?;
-                let leaf_data = self.get_step_data(leaf_idx)?;
+                    let can_merge = {
+                        let target_step = self.get_step_data(*target_index)?;
+                        let leaf_step = self.get_step_data(*leaf_index)?;
+                        target_step.can_merge_leafs(*target_index, *leaf_index, leaf_step, self)
+                    };
 
-                if target_data.can_merge_leafs(target_idx, leaf_idx, leaf_data, self) {
-                    trace!(
-                        "optimization found: merge leaf [{}] with [{}]",
-                        leaf_idx.index(),
-                        target_idx.index(),
-                    );
-                    return Ok(Some((target_idx, leaf_idx)));
+                    if can_merge {
+                        perform_fetch_step_merge(*target_index, *leaf_index, self, false)?;
+                    }
                 }
             }
         }
 
-        Ok(None)
+        Ok(())
     }
+}
+
+fn input_types_hash(step: &FetchStepData<MultiTypeFetchStep>) -> u64 {
+    let mut hasher = FxHasher::default();
+
+    for (type_name, _) in step.input.iter_selections() {
+        type_name.hash(&mut hasher);
+    }
+
+    hasher.finish()
+}
+
+fn response_path_hash(step: &FetchStepData<MultiTypeFetchStep>) -> u64 {
+    let mut hasher = FxHasher::default();
+
+    for segment in step.response_path.inner.iter() {
+        match segment {
+            Segment::Field(fp, hash, cond) => {
+                0u8.hash(&mut hasher);
+                fp.hash(&mut hasher);
+                hash.hash(&mut hasher);
+                cond.hash(&mut hasher);
+            }
+            Segment::List => 1u8.hash(&mut hasher),
+            Segment::TypeCondition(types, cond) => {
+                2u8.hash(&mut hasher);
+                for t in types {
+                    t.hash(&mut hasher);
+                }
+                cond.hash(&mut hasher);
+            }
+        }
+    }
+
+    hasher.finish()
 }

--- a/lib/query-planner/src/planner/fetch/optimize/merge_siblings.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/merge_siblings.rs
@@ -1,12 +1,24 @@
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    hash::{Hash, Hasher},
+};
 
 use petgraph::{graph::NodeIndex, Direction};
-use tracing::{instrument, trace};
+use tracing::instrument;
 
-use crate::planner::fetch::{
-    error::FetchGraphError, fetch_graph::FetchGraph, fetch_step_data::FetchStepData,
-    optimize::utils::perform_fetch_step_merge, state::MultiTypeFetchStep,
+use crate::{
+    ast::merge_path::{Condition, Segment},
+    planner::fetch::{
+        error::FetchGraphError,
+        fetch_graph::FetchGraph,
+        fetch_step_data::{FetchStepData, FetchStepKind},
+        optimize::utils::perform_fetch_step_merge,
+        state::MultiTypeFetchStep,
+    },
+    state::supergraph_state::SubgraphName,
 };
+
+type SiblingGroupKey = (SubgraphName, u64, Option<Condition>, FetchStepKind);
 
 impl FetchGraph<MultiTypeFetchStep> {
     #[instrument(level = "trace", skip_all)]
@@ -18,15 +30,6 @@ impl FetchGraph<MultiTypeFetchStep> {
         let mut queue = VecDeque::from([root_index]);
 
         while let Some(parent_index) = queue.pop_front() {
-            // Store pairs of sibling nodes that can be merged.
-            // The additional Vec<usize> is an indicator for conflicting field indexes in the 2nd sibling.
-            // If the Vec is empty, it means there are no conflicts.
-            let mut merges_to_perform = Vec::<(NodeIndex, NodeIndex)>::new();
-
-            // HashMap to keep track of node index mappings, especially after merges.
-            // Key: original index, Value: potentially updated index after merges.
-            let mut node_indexes: HashMap<NodeIndex, NodeIndex> = HashMap::new();
-
             // Sort fetch steps by mutation's field position,
             // to execute mutations in correct order.
             let mut siblings_with_pos: Vec<(NodeIndex, Option<usize>)> = self
@@ -45,68 +48,92 @@ impl FetchGraph<MultiTypeFetchStep> {
             let siblings: Vec<NodeIndex> =
                 siblings_with_pos.into_iter().map(|(idx, _)| idx).collect();
 
-            for (i, sibling_index) in siblings.iter().enumerate() {
-                // Add the current node to the queue for further processing (BFS).
+            for sibling_index in &siblings {
                 queue.push_back(*sibling_index);
-                let current = self.get_step_data(*sibling_index)?;
+            }
 
-                // Iterate through the remaining children (siblings) to check for merge possibilities.
-                for other_sibling_index in siblings.iter().skip(i + 1) {
-                    let other_sibling = self.get_step_data(*other_sibling_index)?;
+            let mut groups: HashMap<SiblingGroupKey, Vec<NodeIndex>> = HashMap::new();
+            for sibling_index in siblings {
+                if self.graph.node_weight(sibling_index).is_none() {
+                    continue;
+                }
 
-                    trace!(
-                        "checking if [{}] and [{}] can be merged",
-                        sibling_index.index(),
-                        other_sibling_index.index()
-                    );
+                let step = self.get_step_data(sibling_index)?;
+                groups
+                    .entry((
+                        step.service_name.clone(),
+                        response_path_shape_hash(step),
+                        if matches!(step.kind, FetchStepKind::Entity) {
+                            step.condition.clone()
+                        } else {
+                            None
+                        },
+                        step.kind.clone(),
+                    ))
+                    .or_default()
+                    .push(sibling_index);
+            }
 
-                    if current.can_merge_siblings(
-                        *sibling_index,
-                        *other_sibling_index,
-                        other_sibling,
-                        self,
-                    ) {
-                        trace!(
-                            "Found siblings optimization: {} <- {}",
-                            sibling_index.index(),
-                            other_sibling_index.index()
-                        );
-                        // Register their original indexes in the map.
-                        node_indexes.insert(*sibling_index, *sibling_index);
-                        node_indexes.insert(*other_sibling_index, *other_sibling_index);
+            for group in groups.into_values() {
+                let mut targets: Vec<NodeIndex> = Vec::new();
 
-                        merges_to_perform.push((*sibling_index, *other_sibling_index));
+                for source_index in group {
+                    if self.graph.node_weight(source_index).is_none() {
+                        continue;
+                    }
 
-                        // Since a merge is possible, move to the next child to avoid redundant checks.
-                        break;
+                    let mut merged = false;
+                    for &target_index in &targets {
+                        if self.graph.node_weight(target_index).is_none() {
+                            continue;
+                        }
+
+                        let can_merge = {
+                            let target = self.get_step_data(target_index)?;
+                            let source = self.get_step_data(source_index)?;
+                            target.can_merge_siblings(target_index, source_index, source, self)
+                        };
+
+                        if can_merge {
+                            perform_fetch_step_merge(target_index, source_index, self, false)?;
+                            merged = true;
+                            break;
+                        }
+                    }
+
+                    if !merged {
+                        targets.push(source_index);
                     }
                 }
             }
-
-            for (child_index, other_child_index) in merges_to_perform {
-                // Get the latest indexes for the nodes, accounting for previous merges.
-                let child_index_latest = node_indexes
-                    .get(&child_index)
-                    .ok_or(FetchGraphError::IndexMappingLost)?;
-                let other_child_index_latest = node_indexes
-                    .get(&other_child_index)
-                    .ok_or(FetchGraphError::IndexMappingLost)?;
-
-                perform_fetch_step_merge(
-                    *child_index_latest,
-                    *other_child_index_latest,
-                    self,
-                    false,
-                )?;
-
-                // Because `other_child` was merged into `child`,
-                // then everything that was pointing to `other_child`
-                // has to point to the `child`.
-                node_indexes.insert(*other_child_index_latest, *child_index_latest);
-            }
         }
+
         Ok(())
     }
+}
+
+fn response_path_shape_hash(step: &FetchStepData<MultiTypeFetchStep>) -> u64 {
+    let mut hasher = rustc_hash::FxHasher::default();
+
+    for segment in step.response_path.inner.iter() {
+        match segment {
+            Segment::Field(fp, _, cond) => {
+                0u8.hash(&mut hasher);
+                fp.hash(&mut hasher);
+                cond.hash(&mut hasher);
+            }
+            Segment::List => 1u8.hash(&mut hasher),
+            Segment::TypeCondition(types, cond) => {
+                2u8.hash(&mut hasher);
+                for t in types {
+                    t.hash(&mut hasher);
+                }
+                cond.hash(&mut hasher);
+            }
+        }
+    }
+
+    hasher.finish()
 }
 
 impl FetchStepData<MultiTypeFetchStep> {

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -5,7 +5,10 @@ pub(crate) mod path;
 pub(crate) mod pathfinder;
 mod utils;
 
-use std::collections::VecDeque;
+use std::{
+    collections::{HashSet, VecDeque},
+    rc::Rc,
+};
 
 use crate::{
     ast::{
@@ -19,7 +22,9 @@ use crate::{
         node::Node,
         Graph,
     },
-    planner::walker::pathfinder::{find_self_referencing_direct_path, NavigationTarget},
+    planner::walker::pathfinder::{
+        find_direct_path, find_self_referencing_direct_path, NavigationTarget,
+    },
     state::supergraph_state::{OperationKind, SupergraphState},
     utils::cancellation::CancellationToken,
 };
@@ -42,7 +47,7 @@ pub type BestPathsPerLeaf<'graph> = Vec<Vec<OperationPath<'graph>>>;
 // TODO: Consider to use VecDeque(fixed_size) if we can predict it?
 // TODO: Consider to drop this IR layer and just go with QTP directly.
 
-type WorkItem<'graph, 'op> = (&'op SelectionItem, Vec<OperationPath<'graph>>);
+type WorkItem<'graph, 'op> = (&'op SelectionItem, Rc<Vec<OperationPath<'graph>>>);
 type ResolutionStack<'graph, 'op> = Vec<WorkItem<'graph, 'op>>;
 
 #[instrument(level = "trace", skip_all)]
@@ -61,10 +66,12 @@ pub fn walk_operation<'graph, 'op: 'graph>(
     trace!("operation is of type {:?}", op_type);
 
     let root_entrypoints = get_entrypoints(graph, op_type)?;
-    let initial_paths: Vec<OperationPath<'graph>> = root_entrypoints
-        .iter()
-        .map(|edge| OperationPath::new_entrypoint(edge))
-        .collect();
+    let initial_paths: Rc<Vec<OperationPath<'graph>>> = Rc::new(
+        root_entrypoints
+            .iter()
+            .map(|edge| OperationPath::new_entrypoint(edge))
+            .collect(),
+    );
 
     let mut paths_grouped_by_root_field: Vec<BestPathsPerLeaf> =
         Vec::with_capacity(operation.selection_set.items.len());
@@ -73,7 +80,7 @@ pub fn walk_operation<'graph, 'op: 'graph>(
     for selection_item in selection_set.items.iter() {
         let mut stack_to_resolve: VecDeque<WorkItem> = VecDeque::new();
 
-        stack_to_resolve.push_back((selection_item, initial_paths.to_vec()));
+        stack_to_resolve.push_back((selection_item, Rc::clone(&initial_paths)));
 
         let mut paths_per_leaf: Vec<Vec<OperationPath<'graph>>> = vec![];
 
@@ -319,7 +326,7 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
         );
         let _enter = path_span.enter();
 
-        let mut direct_paths = find_direct_paths(
+        let direct_path = find_direct_path(
             graph,
             supergraph,
             override_context,
@@ -328,10 +335,11 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
             cancellation_token,
         )?;
 
-        trace!("Direct paths found: {}", direct_paths.len());
-        if !direct_paths.is_empty() {
+        let found_direct_path = direct_path.is_some();
+        trace!("Direct path found: {}", found_direct_path);
+        if let Some(direct_path) = direct_path {
             trace!("advanced: {}", path.pretty_print(graph));
-            next_paths.push(direct_paths.remove(0));
+            next_paths.push(direct_path);
         }
 
         if fields_to_resolve_locally.is_empty() {
@@ -350,7 +358,7 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
                 next_paths.push(indirect_paths.remove(0));
             }
 
-            if indirect_paths.is_empty() && direct_paths.is_empty() {
+            if indirect_paths.is_empty() && !found_direct_path {
                 // Looks like a union member or an interface implementation is not resolvable.
                 // The fact the fragment for that object type passed GraphQL validations,
                 // means that it's a child of the abstract type,
@@ -379,7 +387,10 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
                 supergraph,
                 override_context,
                 path,
-                &NavigationTarget::Field(&FieldSelection::new_typename()),
+                &NavigationTarget::Field {
+                    field: &FieldSelection::new_typename(),
+                    target_subgraph_ids: None,
+                },
                 cancellation_token,
             )?;
 
@@ -521,7 +532,7 @@ fn process_field<'graph, 'op: 'graph>(
     override_context: &'graph PlannerOverrideContext,
     field: &'op FieldSelection,
     paths: &[OperationPath<'graph>],
-    fields_to_resolve_locally: &[String],
+    _fields_to_resolve_locally: &[String],
     cancellation_token: &'graph CancellationToken,
 ) -> Result<
     (
@@ -542,6 +553,8 @@ fn process_field<'graph, 'op: 'graph>(
 
     cancellation_token.bail_if_cancelled()?;
 
+    let mut target_subgraph_ids_cache = None;
+
     for path in paths {
         let path_span = span!(
             Level::TRACE,
@@ -558,7 +571,10 @@ fn process_field<'graph, 'op: 'graph>(
             supergraph,
             override_context,
             path,
-            &NavigationTarget::Field(field),
+            &NavigationTarget::Field {
+                field: field,
+                target_subgraph_ids: None,
+            },
             cancellation_token,
         )?;
         trace!("Direct paths found: {}", direct_paths.len());
@@ -572,13 +588,24 @@ fn process_field<'graph, 'op: 'graph>(
             }
         }
 
-        if !fields_to_resolve_locally.contains(&field.name) && !found_direct_paths_to_leaf {
+        if !found_direct_paths_to_leaf {
+            if target_subgraph_ids_cache.is_none() {
+                target_subgraph_ids_cache =
+                    Some(field_target_subgraph_ids(supergraph, field, paths, graph)?);
+            }
+            let target_subgraph_ids = target_subgraph_ids_cache
+                .as_ref()
+                .and_then(|ids| ids.as_ref());
+
             let indirect_paths = find_indirect_paths(
                 graph,
                 supergraph,
                 override_context,
                 path,
-                &NavigationTarget::Field(field),
+                &NavigationTarget::Field {
+                    field: field,
+                    target_subgraph_ids,
+                },
                 &excluded,
                 cancellation_token,
             )?;
@@ -590,6 +617,10 @@ fn process_field<'graph, 'op: 'graph>(
                     tracker.add(&indirect_path)?;
                 }
             }
+        }
+
+        if found_direct_paths_to_leaf {
+            trace!("Skipping indirect paths for leaf direct hit");
         }
 
         trace!(
@@ -731,10 +762,48 @@ fn process_field<'graph, 'op: 'graph>(
         paths_per_leaf.push(find_best_paths(next_paths));
     } else {
         trace!("Found {} paths", next_paths.len());
+        let next_paths = Rc::new(next_paths);
         for next_selection_items in &field.selections.items {
-            next_stack_to_resolve.push((next_selection_items, next_paths.clone()));
+            next_stack_to_resolve.push((next_selection_items, Rc::clone(&next_paths)));
         }
     }
 
     Ok((next_stack_to_resolve, paths_per_leaf))
+}
+
+fn field_target_subgraph_ids(
+    supergraph: &SupergraphState,
+    field: &FieldSelection,
+    paths: &[OperationPath<'_>],
+    graph: &Graph,
+) -> Result<Option<HashSet<String>>, WalkOperationError> {
+    let mut parent_type_names = HashSet::new();
+
+    for path in paths {
+        let parent_node = graph.node(path.tail())?;
+        parent_type_names.insert(parent_node.name_str());
+    }
+
+    let mut target_subgraph_ids = HashSet::new();
+
+    for parent_type_name in parent_type_names {
+        let Some(parent_def) = supergraph.definitions.get(parent_type_name) else {
+            continue;
+        };
+        let Some(field_def) = parent_def.fields().get(&field.name) else {
+            continue;
+        };
+
+        for graph_id in field_def.resolvable_in_graphs(parent_def) {
+            if let Ok(subgraph_id) = supergraph.resolve_graph_id(&graph_id) {
+                target_subgraph_ids.insert(subgraph_id.0);
+            }
+        }
+    }
+
+    if target_subgraph_ids.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(target_subgraph_ids))
+    }
 }

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -581,6 +581,31 @@ fn process_field<'graph, 'op: 'graph>(
         }
 
         if !found_direct_paths_to_leaf {
+            let has_indirect_candidates = graph.edges_from(path.tail()).any(|edge| {
+                matches!(
+                    edge.weight(),
+                    Edge::EntityMove(_) | Edge::InterfaceObjectTypeMove(_)
+                )
+            });
+
+            if !has_indirect_candidates {
+                trace!(
+                              "Skipping indirect lookup for '{}' at tail {} because there are no entity/interface-object outgoing edges",
+                              field.name,
+                              path.tail().index()
+                          );
+                trace!(
+                    "{}: {}",
+                    if advanced {
+                        "advanced"
+                    } else {
+                        "failed to advance"
+                    },
+                    path.pretty_print(graph)
+                );
+                continue;
+            }
+
             if target_subgraph_ids_cache.is_none() {
                 target_subgraph_ids_cache =
                     Some(field_target_subgraph_ids(supergraph, field, paths, graph)?);

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -22,8 +22,9 @@ use crate::{
         node::Node,
         Graph,
     },
-    planner::walker::pathfinder::{
-        find_direct_path, find_self_referencing_direct_path, NavigationTarget,
+    planner::walker::{
+        path::UnionContext,
+        pathfinder::{find_direct_path, find_self_referencing_direct_path, NavigationTarget},
     },
     state::supergraph_state::{OperationKind, SupergraphState},
     utils::cancellation::CancellationToken,
@@ -445,37 +446,27 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
         return;
     };
 
-    let all_same_field = paths.iter().all(|path| {
-        path.union_context
-            .as_ref()
-            .is_some_and(|ctx| ctx.eq_field(union_context))
-    });
-
-    if !all_same_field {
-        return;
-    }
-
     // Collect the union members that each subgraph can return.
     //
     // All paths through the same graph share the same `possible_members` because they originate
     // from the same `UnionMembersData` (one per graph). We only need to record each graph's member
     // set once — no accumulation is required.
-    type GraphId<'graph> = &'graph str;
-    type MembersPerGraph<'graph> = Vec<(GraphId<'graph>, Vec<&'graph str>)>;
-    let mut members_per_graph: MembersPerGraph<'graph> = Vec::new();
+    let mut members_per_graph: Vec<&UnionContext<'graph>> = Vec::new();
 
     for path in paths.iter() {
-        let context = path
-            .union_context
-            .as_ref()
-            // It's safe to unwrap as `all_same_field` checked that all paths have the same context
-            .expect("union member context should exist at this point");
+        let Some(context) = path.union_context.as_ref() else {
+            return;
+        };
+
+        if !context.eq_field(union_context) {
+            return;
+        }
 
         if !members_per_graph
             .iter()
-            .any(|(graph_id, _)| graph_id == &context.graph_id)
+            .any(|existing_context| existing_context.graph_id == context.graph_id)
         {
-            members_per_graph.push((context.graph_id, context.possible_members.clone()));
+            members_per_graph.push(context);
         }
     }
 
@@ -483,18 +474,18 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
         return;
     }
 
-    let (_, least_members_set) = members_per_graph
+    let least_members_context = members_per_graph
         .iter()
-        .min_by_key(|(_, members)| members.len())
+        .min_by_key(|context| context.possible_members_len())
         // It's safe as we checked that `members_per_graph` has at least two entries above
         .expect("members_per_graph has at least two entries");
 
     // Start from the smallest member list.
     // Then shrink it with each graph until only shared members remain.
-    let mut shared_members: Vec<&'graph str> = least_members_set.clone();
+    let mut shared_members = least_members_context.possible_members();
 
-    for (_, members) in &members_per_graph {
-        shared_members.retain(|member| members.contains(member));
+    for context in &members_per_graph {
+        shared_members.retain(|member| context.possible_members_contains(member));
 
         if shared_members.is_empty() {
             // No union member exists in every candidate subgraph.
@@ -516,8 +507,9 @@ fn narrow_partial_union_paths<'graph>(paths: &mut Vec<OperationPath<'graph>>) {
             return false;
         }
 
-        // Update the possible members to the shared members set.
-        context.possible_members = shared_members.clone();
+        // At this point, the path leads to only one possible member,
+        // not need to store the shared members set.
+        context.set_possible_member(context.member_name);
         true
     });
 }

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -163,14 +163,14 @@ impl<'graph> OperationPath<'graph> {
             cumulative_cost: new_cost,
             requirement_tree: requirement,
             selection_attributes: match target {
-                NavigationTarget::Field(f) => Some(SelectionAttributes {
-                    alias: f.alias.clone(),
-                    arguments: f.arguments.clone(),
+                NavigationTarget::Field { field, .. } => Some(SelectionAttributes {
+                    alias: field.alias.clone(),
+                    arguments: field.arguments.clone(),
                 }),
                 NavigationTarget::ConcreteType(_, _) => None,
             },
             condition: match target {
-                NavigationTarget::Field(f) => (*f).into(),
+                NavigationTarget::Field { field, .. } => (*field).into(),
                 NavigationTarget::ConcreteType(_, condition) => condition.clone(),
             },
         };

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::{cmp, collections::HashSet, fmt::Debug};
+use std::{cmp, fmt::Debug};
 
 use petgraph::{
     graph::{EdgeIndex, NodeIndex},
@@ -131,7 +131,6 @@ impl PathSegment {
 pub struct OperationPath<'graph> {
     pub root_node: NodeIndex,
     pub last_segment: Option<Rc<PathSegment>>,
-    pub visited_edge_indices: Rc<HashSet<EdgeIndex>>,
     pub cost: u64,
     // The union context for the current path, if any.
     // If we hit a field returning a union, this will be set to the union context.
@@ -162,18 +161,13 @@ impl Debug for OperationPath<'_> {
 }
 
 impl<'graph> OperationPath<'graph> {
-    pub fn new(
-        root_node_index: NodeIndex,
-        last_segment: Option<Rc<PathSegment>>,
-        visited_edge_indices: Rc<HashSet<EdgeIndex>>,
-    ) -> Self {
+    pub fn new(root_node_index: NodeIndex, last_segment: Option<Rc<PathSegment>>) -> Self {
         Self {
             root_node: root_node_index,
             cost: last_segment
                 .as_ref()
                 .map_or(0, |segment| segment.cumulative_cost),
             last_segment,
-            visited_edge_indices,
             union_context: None,
         }
     }
@@ -182,9 +176,8 @@ impl<'graph> OperationPath<'graph> {
         // The first "segment" conceptually starts after the first edge from root
         let path_segment = PathSegment::new_root(edge);
         let arc_path_segment = Rc::new(path_segment);
-        let visited_set: Rc<HashSet<EdgeIndex>> = Rc::new([edge.id()].into_iter().collect());
 
-        OperationPath::new(edge.source(), Some(arc_path_segment), visited_set)
+        OperationPath::new(edge.source(), Some(arc_path_segment))
     }
 
     pub fn advance(
@@ -197,8 +190,6 @@ impl<'graph> OperationPath<'graph> {
         let prev_cost = self.cost;
         let edge_cost = edge_ref.weight().cost();
         let new_cost = prev_cost + edge_cost;
-        let mut new_visited = self.visited_edge_indices.clone();
-        Rc::make_mut(&mut new_visited).insert(edge_ref.id());
 
         let new_segment_data = PathSegment {
             prev: self.last_segment.clone(),
@@ -249,7 +240,6 @@ impl<'graph> OperationPath<'graph> {
             root_node: self.root_node,
             cost: new_cost,
             last_segment: Some(new_segment),
-            visited_edge_indices: new_visited,
             union_context,
         }
     }
@@ -267,10 +257,6 @@ impl<'graph> OperationPath<'graph> {
         self.last_segment
             .as_ref()
             .map_or(self.root_node, |segment| segment.tail_node)
-    }
-
-    pub fn has_visited_edge(&self, edge_index: &EdgeIndex) -> bool {
-        self.visited_edge_indices.contains(edge_index)
     }
 
     pub fn get_segments(&self) -> Vec<Rc<PathSegment>> {
@@ -392,13 +378,9 @@ impl<'graph> OperationPath<'graph> {
             previous_new_segment = Some(Rc::new(new_segment_data));
         }
 
-        OperationPath::new(
-            new_root_node.unwrap(),
-            previous_new_segment,
-            self.visited_edge_indices.clone(),
-        )
-        // The requirement continuation reuses other's tail, so it also must reuse its union context
-        .with_union_context(other.union_context.clone())
+        OperationPath::new(new_root_node.unwrap(), previous_new_segment)
+            // The requirement continuation reuses other's tail, so it also must reuse its union context
+            .with_union_context(other.union_context.clone())
     }
 
     fn with_union_context(mut self, scope: Option<UnionContext<'graph>>) -> Self {

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -8,6 +8,7 @@ use petgraph::{
 };
 
 use crate::ast::merge_path::Condition;
+use crate::graph::node::UnionMembersData;
 use crate::planner::walker::pathfinder::NavigationTarget;
 use crate::{
     ast::arguments::ArgumentsMap,
@@ -41,30 +42,73 @@ pub struct PathSegment {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+enum PossibleUnionMembers<'graph> {
+    All(&'graph [String]),
+    One(&'graph str),
+}
+
+impl<'graph> PossibleUnionMembers<'graph> {
+    fn contains(&self, member_type_name: &str) -> bool {
+        match self {
+            Self::All(members) => members.iter().any(|member| member == member_type_name),
+            Self::One(member) => *member == member_type_name,
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::All(members) => members.len(),
+            Self::One(_) => 1,
+        }
+    }
+
+    fn as_vec(&self) -> Vec<&'graph str> {
+        match self {
+            Self::All(members) => members.iter().map(|member| member.as_str()).collect(),
+            Self::One(member) => vec![member],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnionContext<'graph> {
-    pub parent_type_name: &'graph str,
-    pub field_name: &'graph str,
+    data: &'graph UnionMembersData,
     pub graph_id: &'graph str,
     pub member_name: &'graph str,
-    pub possible_members: Vec<&'graph str>,
+    possible_members: PossibleUnionMembers<'graph>,
 }
 
 impl<'graph> UnionContext<'graph> {
     fn can_resolve_member(&self, member_type_name: &str) -> bool {
-        self.possible_members.contains(&member_type_name)
+        self.possible_members.contains(member_type_name)
+    }
+
+    pub fn possible_members_len(&self) -> usize {
+        self.possible_members.len()
+    }
+
+    pub fn possible_members_contains(&self, member_type_name: &str) -> bool {
+        self.possible_members.contains(member_type_name)
     }
 
     pub fn eq_field(&self, other: &Self) -> bool {
-        self.parent_type_name == other.parent_type_name && self.field_name == other.field_name
+        self.data.type_name == other.data.type_name && self.data.field_name == other.data.field_name
+    }
+
+    pub fn possible_members(&self) -> Vec<&'graph str> {
+        self.possible_members.as_vec()
+    }
+
+    pub fn set_possible_member(&mut self, possible_member: &'graph str) {
+        self.possible_members = PossibleUnionMembers::One(possible_member);
     }
 
     fn narrow_to_member(&self, member_type_name: &'graph str) -> Self {
         Self {
-            parent_type_name: self.parent_type_name,
-            field_name: self.field_name,
+            data: self.data,
             graph_id: self.graph_id,
             member_name: member_type_name,
-            possible_members: vec![member_type_name],
+            possible_members: PossibleUnionMembers::One(member_type_name),
         }
     }
 }
@@ -177,6 +221,7 @@ impl<'graph> OperationPath<'graph> {
         let new_segment = Rc::new(new_segment_data);
 
         let union_context = match edge_ref.weight() {
+            Edge::FieldMove(field_move) if field_move.is_leaf => None,
             Edge::FieldMove(_) => {
                 let tail = graph.node(edge_ref.target()).ok();
                 let union_data = tail.and_then(|tail| tail.union_members_data());
@@ -184,15 +229,10 @@ impl<'graph> OperationPath<'graph> {
 
                 match (union_data, graph_id) {
                     (Some(union_data), Some(graph_id)) => Some(UnionContext {
-                        parent_type_name: &union_data.type_name,
-                        field_name: &union_data.field_name,
+                        data: union_data,
                         graph_id,
-                        member_name: &union_data.object_type_name,
-                        possible_members: union_data
-                            .possible_members
-                            .iter()
-                            .map(|member| member.as_str())
-                            .collect(),
+                        member_name: union_data.object_type_name.as_str(),
+                        possible_members: PossibleUnionMembers::All(&union_data.possible_members),
                     }),
                     _ => None,
                 }

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -78,7 +78,10 @@ impl<'graph> IndirectPathsLookupQueue<'graph> {
 
 #[derive(Debug)]
 pub enum NavigationTarget<'op> {
-    Field(&'op FieldSelection),
+    Field {
+        field: &'op FieldSelection,
+        target_subgraph_ids: Option<&'op HashSet<String>>,
+    },
     ConcreteType(&'op str, Option<Condition>),
 }
 
@@ -91,7 +94,7 @@ enum NavigationTargetKey<'op> {
 impl<'op> From<&'op NavigationTarget<'op>> for NavigationTargetKey<'op> {
     fn from(target: &'op NavigationTarget<'op>) -> Self {
         match target {
-            NavigationTarget::Field(field) => NavigationTargetKey::Field(&field.name),
+            NavigationTarget::Field { field, .. } => NavigationTargetKey::Field(&field.name),
             NavigationTarget::ConcreteType(type_name, _) => {
                 NavigationTargetKey::ConcreteType(type_name)
             }
@@ -239,6 +242,17 @@ impl<'graph> PathSearch<'graph> {
 
                 let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
 
+                if let NavigationTarget::Field {
+                    target_subgraph_ids: Some(target_subgraph_names),
+                    ..
+                } = target
+                {
+                    if !target_subgraph_names.contains(edge_tail_graph_id) {
+                        trace!("Ignoring. Target field is not resolvable in this graph");
+                        continue;
+                    }
+                }
+
                 if visited_graphs.contains(edge_tail_graph_id) {
                     trace!(
                     "Ignoring, graph is excluded and already visited (current: {}, visited: {:?})",
@@ -248,7 +262,6 @@ impl<'graph> PathSearch<'graph> {
                     continue;
                 }
 
-                let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
                 let edge = edge_ref.weight();
 
                 if edge_tail_graph_id == source_graph_id
@@ -265,16 +278,16 @@ impl<'graph> PathSearch<'graph> {
                 // the edge cannot help us, we skip it.
                 // We allow other entity-move edge to be used instead,
                 // that will be used to collect the required fields.
-                if let NavigationTarget::Field(FieldSelection {
-                    name: target_field_name,
+                if let NavigationTarget::Field {
+                    field: target_field,
                     ..
-                }) = target
+                } = target
                 {
                     if let Some(requirements) = edge.requirements() {
                         if self.requirements_includes_field(
                             requirements,
                             tail_node.name_str(),
-                            target_field_name,
+                            target_field.name.as_str(),
                         ) {
                             continue;
                         }
@@ -493,7 +506,7 @@ impl<'graph> PathSearch<'graph> {
         }
 
         let edges_iter: Box<dyn Iterator<Item = _>> = match target {
-            NavigationTarget::Field(field) => {
+            NavigationTarget::Field { field, .. } => {
                 Box::new(graph.edges_from(path_tail_index).filter(
                     move |e| matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name),
                 ))
@@ -522,6 +535,63 @@ impl<'graph> PathSearch<'graph> {
 
         Ok(result)
     }
+
+    fn find_direct_path(
+        &mut self,
+        path: &OperationPath<'graph>,
+        target: &NavigationTarget<'_>,
+    ) -> Result<Option<OperationPath<'graph>>, WalkOperationError> {
+        let graph = self.graph;
+        let path_tail_index = path.tail();
+
+        // Respect the path's current union scope when targeting a concrete type.
+        if let NavigationTarget::ConcreteType(type_name, _) = target {
+            if !path.can_resolve_union_member(type_name) {
+                return Ok(None);
+            }
+        }
+
+        let edges_iter: Box<dyn Iterator<Item = _>> = match target {
+            NavigationTarget::Field { field, .. } => {
+                Box::new(graph.edges_from(path_tail_index).filter(
+                    move |e| matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name),
+                ))
+            }
+            NavigationTarget::ConcreteType(type_name, _condition) => Box::new(
+                graph
+                    .edges_from(path_tail_index)
+                    .filter(move |e| match e.weight() {
+                        Edge::AbstractMove(t) => t == type_name,
+                        Edge::InterfaceObjectTypeMove(t) => &t.object_type_name == type_name,
+                        _ => false,
+                    }),
+            ),
+        };
+
+        for edge_ref in edges_iter {
+            if let Some(new_path) = self.try_advance_direct_path(path, &edge_ref, target)? {
+                return Ok(Some(new_path));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[instrument(level = "trace", skip_all, fields(
+        path = path.pretty_print(graph),
+        current_cost = path.cost,
+    ))]
+pub fn find_direct_path<'graph>(
+    graph: &'graph Graph,
+    supergraph: &'graph SupergraphState,
+    override_context: &'graph PlannerOverrideContext,
+    path: &OperationPath<'graph>,
+    target: &NavigationTarget<'_>,
+    cancellation_token: &'graph CancellationToken,
+) -> Result<Option<OperationPath<'graph>>, WalkOperationError> {
+    PathSearch::new(graph, supergraph, override_context, cancellation_token)
+        .find_direct_path(path, target)
 }
 
 #[instrument(level = "trace", skip_all, fields(
@@ -581,17 +651,20 @@ impl<'graph> PathSearch<'graph> {
         use_only_direct_edges: bool,
     ) -> Result<Option<Vec<OperationPath<'graph>>>, WalkOperationError> {
         let graph = self.graph;
-        let override_context = self.override_context;
-        let cancellation_token = self.cancellation_token;
         let edge = edge_ref.weight();
 
         if let Edge::FieldMove(field_move) = edge {
-            // TODO: This should be passed from the executor,
-            //       I will work on it next.
-            if !field_move.satisfies_override_rules(override_context) {
+            if !field_move.satisfies_override_rules(self.override_context) {
                 return Ok(None);
             }
         }
+
+        if edge.requirements().is_none() {
+            return Ok(Some(vec![]));
+        }
+
+        let cancellation_token = self.cancellation_token;
+        let edge = edge_ref.weight();
 
         match edge.requirements() {
             None => Ok(Some(vec![])),
@@ -717,40 +790,31 @@ impl<'graph> PathSearch<'graph> {
         excluded: &ExcludedFromLookup<'graph>,
         use_only_direct_edges: bool,
     ) -> Result<FieldRequirementsResult<'graph>, WalkOperationError> {
-        let mut direct_path_results: Vec<Vec<OperationPath<'graph>>> =
-            Vec::with_capacity(move_requirement.paths.len());
-        let mut indirect_path_results: Vec<Vec<OperationPath<'graph>>> =
-            Vec::with_capacity(move_requirement.paths.len());
+        let mut next_paths: Vec<OperationPath<'graph>> = Vec::new();
 
         for path in move_requirement.paths.iter() {
-            let direct_paths = self.find_direct_paths(path, &NavigationTarget::Field(field))?;
+            let direct_paths = self.find_direct_paths(
+                path,
+                &NavigationTarget::Field {
+                    field,
+                    target_subgraph_ids: None,
+                },
+            )?;
             // Skip looking for indirect paths if we already found direct paths to a leaf
             let found_direct_paths_to_leaf = !direct_paths.is_empty() && field.is_leaf();
-            direct_path_results.push(direct_paths);
+            next_paths.extend(direct_paths);
 
             let needs_indirect = !use_only_direct_edges && !found_direct_paths_to_leaf;
-            let indirect_paths = if needs_indirect {
-                self.find_indirect_paths(path, &NavigationTarget::Field(field), excluded)?
-            } else {
-                Vec::new()
-            };
-
-            indirect_path_results.push(indirect_paths);
-        }
-
-        // sum of direct and indirect
-        let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
-            + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
-
-        let mut next_paths: Vec<OperationPath<'graph>> = Vec::with_capacity(total_capacity);
-
-        // These extend calls should not reallocate `next_paths`.
-        for paths_vec in direct_path_results {
-            next_paths.extend(paths_vec);
-        }
-        // No need to check use_only_direct_edges again, indirect_path_results_vecs will be empty if not used.
-        for paths_vec in indirect_path_results {
-            next_paths.extend(paths_vec);
+            if needs_indirect {
+                next_paths.extend(self.find_indirect_paths(
+                    path,
+                    &NavigationTarget::Field {
+                        field,
+                        target_subgraph_ids: None,
+                    },
+                    excluded,
+                )?);
+            }
         }
 
         if next_paths.is_empty() {
@@ -792,51 +856,30 @@ impl<'graph> PathSearch<'graph> {
         excluded: &ExcludedFromLookup<'graph>,
     ) -> Result<FragmentRequirementsResult<'graph>, WalkOperationError> {
         let type_name = &fragment_selection.type_condition;
-        // Collect all Vec<OperationPath<'graph>> results from find_direct_paths
-        let mut direct_path_results: Vec<Vec<OperationPath<'graph>>> =
-            Vec::with_capacity(requirement.paths.len());
+        let mut next_paths: Vec<OperationPath<'graph>> = Vec::new();
         for path in requirement.paths.iter() {
             let current_type_name = self.graph.node(path.tail())?.name_str();
             // If the current type already matches the fragment condition, we can keep
             // using the same path. For example, `Item` matches `... on Tagged` when
             // `Item implements Tagged`, so there is no need to find an edge to `Tagged`.
             if self.type_condition_matches(current_type_name, type_name) {
-                direct_path_results.push(vec![path.clone()]);
+                next_paths.extend(vec![path.clone()]);
             } else {
-                direct_path_results.push(self.find_direct_paths(
+                next_paths.extend(self.find_direct_paths(
                     path,
                     // @skip/@include can't be used in @requires and @provides,
                     // that's why we pass no condition
                     &NavigationTarget::ConcreteType(type_name, None),
                 )?);
             }
-        }
 
-        // Collect all Vec<OperationPath<'graph>> results from find_indirect_paths
-        let mut indirect_path_results: Vec<Vec<OperationPath<'graph>>> =
-            Vec::with_capacity(requirement.paths.len());
-        for path_from_rc in requirement.paths.iter() {
-            indirect_path_results.push(self.find_indirect_paths(
-                path_from_rc,
+            next_paths.extend(self.find_indirect_paths(
+                path,
                 // @skip/@include can't be used in @requires and @provides,
                 // that's why we pass no condition
                 &NavigationTarget::ConcreteType(type_name, None),
                 excluded,
             )?);
-        }
-
-        // sum of direct and indirect
-        let total_capacity: usize = direct_path_results.iter().map(|v| v.len()).sum::<usize>()
-            + indirect_path_results.iter().map(|v| v.len()).sum::<usize>();
-
-        let mut next_paths: Vec<OperationPath<'graph>> = Vec::with_capacity(total_capacity);
-
-        // These extend calls should not reallocate `next_paths`.
-        for paths_vec in direct_path_results {
-            next_paths.extend(paths_vec);
-        }
-        for paths_vec in indirect_path_results {
-            next_paths.extend(paths_vec);
         }
 
         if next_paths.is_empty() {


### PR DESCRIPTION
Replace branch-and-bound search with greedy query planning
> 50% faster query_plan_abstract_many_subgraphs

Refactor NavigationTarget to support subgraph filtering
> 17% faster query_plan_abstract_many_subgraphs
> 30% faster query_plan_grafbase_many_plans

Refactor union member tracking in query planner
> 2-4% faster benchmarks

Remove visited edge tracking from OperationPath
> 10% faster query_plan_grafbase_many_plans

Refactor multi-type fetch batching logic
> 4% fater query_plan_grafbase_many_plans
> 4-5% faster query_plan_abstract_many_subgraphs

Optimize leaf merging using a grouping strategy
> 94.651% faster query_plan_abstract_many_subgraphs

Optimize sibling merging logic in query planner
> 20% faster  query_plan_abstract_many_subgraphs
> 15% faster query_plan_heavy_query

Skip indirect lookup when no candidates are available
> 2% faster plans