### PR TITLE
fix(query-planner): use operation_kind to detect mutation, instead of output type

### DIFF
--- a/.changeset/better_detection_of_mutations_in_query_planner.md
+++ b/.changeset/better_detection_of_mutations_in_query_planner.md
@@ -11,6 +11,4 @@ When a mutation is encountered in an operation (e.g. `mutation { ... }`), the qu
 
 Previuosly, Hive Router was checking if `type Mutation` was used in the root step to determine if a mutation was present.
 
-This change uses the actual incoming operation type to determine if a mutation is present.
-
-This change is a prerequisite for supporting referencing root types as regular types.
+This change uses the actual incoming operation type (`mutation { ... }`) to determine if a mutation is present in a specific plan.

--- a/.changeset/better_detection_of_mutations_in_query_planner.md
+++ b/.changeset/better_detection_of_mutations_in_query_planner.md
@@ -1,0 +1,16 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Better detection of mutations in query-planner
+
+When a mutation is encountered in an operation (e.g. `mutation { ... }`), the query planner needs to use `Sequence` instead of `Parallel` to ensure the mutation is executed in the correct order.
+
+Previuosly, Hive Router was checking if `type Mutation` was used in the root step to determine if a mutation was present.
+
+This change uses the actual incoming operation type to determine if a mutation is present.
+
+This change is a prerequisite for supporting referencing root types as regular types.

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1858,7 +1858,7 @@ pub fn build_fetch_graph_from_query_tree(
     options: &QueryPlannerOptions,
     cancellation_token: &CancellationToken,
 ) -> Result<FetchGraph<MultiTypeFetchStep>, FetchGraphError> {
-    let mut fetch_graph = FetchGraph::new(operation_kind.clone());
+    let mut fetch_graph = FetchGraph::new(operation_kind);
 
     process_query_node(
         graph,
@@ -1894,7 +1894,7 @@ pub fn build_fetch_graph_from_query_tree(
     // fine to unwrap as we have already checked the length
     fetch_graph.root_index = Some(*root_indexes.first().unwrap());
     let mut fetch_graph = fetch_graph.to_multi_type();
-    fetch_graph.optimize(supergraph, options, &operation_kind, cancellation_token)?;
+    fetch_graph.optimize(supergraph, options, cancellation_token)?;
     fetch_graph.collect_variable_usages()?;
 
     trace!("fetch graph after optimizations:");

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1858,7 +1858,7 @@ pub fn build_fetch_graph_from_query_tree(
     options: &QueryPlannerOptions,
     cancellation_token: &CancellationToken,
 ) -> Result<FetchGraph<MultiTypeFetchStep>, FetchGraphError> {
-    let mut fetch_graph = FetchGraph::new(operation_kind);
+    let mut fetch_graph = FetchGraph::new(operation_kind.clone());
 
     process_query_node(
         graph,
@@ -1894,7 +1894,7 @@ pub fn build_fetch_graph_from_query_tree(
     // fine to unwrap as we have already checked the length
     fetch_graph.root_index = Some(*root_indexes.first().unwrap());
     let mut fetch_graph = fetch_graph.to_multi_type();
-    fetch_graph.optimize(supergraph, options, cancellation_token)?;
+    fetch_graph.optimize(supergraph, options, &operation_kind, cancellation_token)?;
     fetch_graph.collect_variable_usages()?;
 
     trace!("fetch graph after optimizations:");

--- a/lib/query-planner/src/planner/fetch/optimize/mod.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         fetch::{error::FetchGraphError, fetch_graph::FetchGraph, state::MultiTypeFetchStep},
         QueryPlannerOptions,
     },
-    state::supergraph_state::{OperationKind, SupergraphState},
+    state::supergraph_state::SupergraphState,
     utils::cancellation::CancellationToken,
 };
 
@@ -28,7 +28,6 @@ impl FetchGraph<MultiTypeFetchStep> {
         &mut self,
         supergraph_state: &SupergraphState,
         options: &QueryPlannerOptions,
-        operation_kind: &OperationKind,
         cancellation_token: &CancellationToken,
     ) -> Result<(), FetchGraphError> {
         // Run optimization passes repeatedly until the graph stabilizes, as one optimization can create
@@ -58,7 +57,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                 break;
             }
         }
-        self.turn_mutations_into_sequence(operation_kind)?;
+        self.turn_mutations_into_sequence()?;
         self.fix_conflicting_type_mismatches(supergraph_state)?;
 
         // We call this last, because it should be done after all other optimizations/merging are done

--- a/lib/query-planner/src/planner/fetch/optimize/mod.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/mod.rs
@@ -14,9 +14,11 @@ mod utils;
 use tracing::instrument;
 
 use crate::{
-    planner::fetch::{error::FetchGraphError, fetch_graph::FetchGraph, state::MultiTypeFetchStep},
-    planner::QueryPlannerOptions,
-    state::supergraph_state::SupergraphState,
+    planner::{
+        fetch::{error::FetchGraphError, fetch_graph::FetchGraph, state::MultiTypeFetchStep},
+        QueryPlannerOptions,
+    },
+    state::supergraph_state::{OperationKind, SupergraphState},
     utils::cancellation::CancellationToken,
 };
 
@@ -26,6 +28,7 @@ impl FetchGraph<MultiTypeFetchStep> {
         &mut self,
         supergraph_state: &SupergraphState,
         options: &QueryPlannerOptions,
+        operation_kind: &OperationKind,
         cancellation_token: &CancellationToken,
     ) -> Result<(), FetchGraphError> {
         // Run optimization passes repeatedly until the graph stabilizes, as one optimization can create
@@ -55,7 +58,7 @@ impl FetchGraph<MultiTypeFetchStep> {
                 break;
             }
         }
-        self.turn_mutations_into_sequence()?;
+        self.turn_mutations_into_sequence(operation_kind)?;
         self.fix_conflicting_type_mismatches(supergraph_state)?;
 
         // We call this last, because it should be done after all other optimizations/merging are done

--- a/lib/query-planner/src/planner/fetch/optimize/turn_mutations_into_sequence.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/turn_mutations_into_sequence.rs
@@ -11,15 +11,12 @@ use crate::{
 
 impl FetchGraph<MultiTypeFetchStep> {
     #[instrument(level = "trace", skip_all)]
-    pub(crate) fn turn_mutations_into_sequence(
-        &mut self,
-        operation_kind: &OperationKind,
-    ) -> Result<(), FetchGraphError> {
+    pub(crate) fn turn_mutations_into_sequence(&mut self) -> Result<(), FetchGraphError> {
         let root_index = self
             .root_index
             .ok_or(FetchGraphError::NonSingleRootStep(0))?;
 
-        if operation_kind != &OperationKind::Mutation {
+        if self.operation_kind != OperationKind::Mutation {
             return Ok(());
         }
 

--- a/lib/query-planner/src/planner/fetch/optimize/turn_mutations_into_sequence.rs
+++ b/lib/query-planner/src/planner/fetch/optimize/turn_mutations_into_sequence.rs
@@ -4,18 +4,22 @@ use petgraph::{
 };
 use tracing::instrument;
 
-use crate::planner::fetch::{
-    error::FetchGraphError, fetch_graph::FetchGraph, state::MultiTypeFetchStep,
+use crate::{
+    planner::fetch::{error::FetchGraphError, fetch_graph::FetchGraph, state::MultiTypeFetchStep},
+    state::supergraph_state::OperationKind,
 };
 
 impl FetchGraph<MultiTypeFetchStep> {
     #[instrument(level = "trace", skip_all)]
-    pub(crate) fn turn_mutations_into_sequence(&mut self) -> Result<(), FetchGraphError> {
+    pub(crate) fn turn_mutations_into_sequence(
+        &mut self,
+        operation_kind: &OperationKind,
+    ) -> Result<(), FetchGraphError> {
         let root_index = self
             .root_index
             .ok_or(FetchGraphError::NonSingleRootStep(0))?;
 
-        if !is_mutation_fetch_step(self, root_index)? {
+        if operation_kind != &OperationKind::Mutation {
             return Ok(());
         }
 
@@ -62,19 +66,4 @@ impl FetchGraph<MultiTypeFetchStep> {
 
         Ok(())
     }
-}
-
-fn is_mutation_fetch_step(
-    fetch_graph: &FetchGraph<MultiTypeFetchStep>,
-    fetch_step_index: NodeIndex,
-) -> Result<bool, FetchGraphError> {
-    for edge_ref in fetch_graph.children_of(fetch_step_index) {
-        let child = fetch_graph.get_step_data(edge_ref.target().id())?;
-
-        if !child.output.is_selecting_definition("Mutation") {
-            return Ok(false);
-        }
-    }
-
-    Ok(true)
 }


### PR DESCRIPTION
Based on https://github.com/graphql-hive/router/pull/1190#discussion_r3505013271 