### PR TITLE
fix(executor): subgraph network/HTTP errors propagation

### DIFF
--- a/.changeset/subgraph_networkhttp_errors_propagation.md
+++ b/.changeset/subgraph_networkhttp_errors_propagation.md
@@ -1,0 +1,19 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Subgraph network/HTTP errors propagation
+
+Improves how the router reacts to failed or malformed subgraph HTTP responses. Instead of silently ignoring the HTTP status and content-type, the router now emits a GraphQL error for the failing fetch. The affected field is set to `null` and partial results from other subgraphs are preserved.
+
+| Subgraph response | Router behavior |
+| --- | --- |
+| `2xx`, valid content-type, valid GraphQL body | passed through unchanged |
+| `2xx`, valid content-type, valid JSON but no `data`/`errors` | `SUBREQUEST_MALFORMED_RESPONSE` |
+| `2xx`, valid content-type, body is not valid JSON | `SUBREQUEST_MALFORMED_RESPONSE` |
+| `2xx`, missing or non-JSON content-type (e.g. `text/html`) | `SUBREQUEST_MALFORMED_RESPONSE` |
+| Non-2xx status | `SUBREQUEST_HTTP_ERROR` (with `extensions.http.status`) |
+| Transport/connection failure (no HTTP response) | `SUBREQUEST_HTTP_ERROR` |
+
+Fixes [#1229](https://github.com/graphql-hive/router/issues/1229)

--- a/e2e/src/circuit_breaker.rs
+++ b/e2e/src/circuit_breaker.rs
@@ -121,7 +121,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Request to subgraph timed out",
       "extensions": {
         "code": "SUBGRAPH_REQUEST_TIMEOUT",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -143,7 +143,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -284,7 +284,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Received empty response body from subgraph \"accounts\"",
       "extensions": {
         "code": "SUBGRAPH_RESPONSE_BODY_EMPTY",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -310,7 +310,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -375,7 +375,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -385,6 +385,7 @@ mod circuit_breaker_e2e_tests {
         let success_mock = accounts_server
             .mock("POST", "/accounts")
             .with_status(200)
+            .with_header("content-type", "application/json")
             .with_body(r#"{"data":{"users":[{"id":"1"}]}}"#)
             .expect_at_least(1)
             .create_async()
@@ -430,6 +431,7 @@ mod circuit_breaker_e2e_tests {
         let products_success_mock = products_server
             .mock("POST", "/products")
             .with_status(200)
+            .with_header("content-type", "application/json")
             .with_body(r#"{"data":{"topProducts":[{"upc":"1"}]}}"#)
             .expect_at_least(1)
             .create_async()
@@ -487,7 +489,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -578,7 +580,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Received empty response body from subgraph \"accounts\"",
       "extensions": {
         "code": "SUBGRAPH_RESPONSE_BODY_EMPTY",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -641,7 +643,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Received empty response body from subgraph \"accounts\"",
       "extensions": {
         "code": "SUBGRAPH_RESPONSE_BODY_EMPTY",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -714,7 +716,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -777,7 +779,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Request to subgraph timed out",
       "extensions": {
         "code": "SUBGRAPH_REQUEST_TIMEOUT",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -799,7 +801,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -1376,7 +1378,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -1452,7 +1454,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Received empty response body from subgraph \"accounts\"",
       "extensions": {
         "code": "SUBGRAPH_RESPONSE_BODY_EMPTY",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -1513,24 +1515,36 @@ mod circuit_breaker_e2e_tests {
         // error extensions with the originating subgraph name.
         insta::assert_snapshot!(
             res.json_body_string_pretty().await,
-            @r###"{
-  "data": {
-    "users": [
-      {
-        "id": "1"
-      }
-    ]
-  },
-  "errors": [
-    {
-      "message": "upstream is unhappy",
-      "extensions": {
-        "code": "UPSTREAM_FAILURE",
-        "serviceName": "accounts"
-      }
-    }
-  ]
-}"###
+            @r#"
+        {
+          "data": {
+            "users": [
+              {
+                "id": "1"
+              }
+            ]
+          },
+          "errors": [
+            {
+              "message": "upstream is unhappy",
+              "extensions": {
+                "code": "UPSTREAM_FAILURE",
+                "service": "accounts"
+              }
+            },
+            {
+              "message": "Subgraph 'accounts' responded with an invalid HTTP status code '503 Service Unavailable'",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "accounts",
+                "http": {
+                  "status": 503
+                }
+              }
+            }
+          ]
+        }
+        "#
         );
 
         error_mock.assert_async().await;
@@ -1600,20 +1614,32 @@ mod circuit_breaker_e2e_tests {
         }
         insta::assert_snapshot!(
             bodies[0],
-            @r###"{
-  "data": {
-    "users": null
-  },
-  "errors": [
-    {
-      "message": "upstream is unhappy",
-      "extensions": {
-        "code": "UPSTREAM_FAILURE",
-        "serviceName": "accounts"
-      }
-    }
-  ]
-}"###
+            @r#"
+        {
+          "data": {
+            "users": null
+          },
+          "errors": [
+            {
+              "message": "upstream is unhappy",
+              "extensions": {
+                "code": "UPSTREAM_FAILURE",
+                "service": "accounts"
+              }
+            },
+            {
+              "message": "Subgraph 'accounts' responded with an invalid HTTP status code '503 Service Unavailable'",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "accounts",
+                "http": {
+                  "status": 503
+                }
+              }
+            }
+          ]
+        }
+        "#
         );
 
         error_mock.assert_async().await;
@@ -1635,7 +1661,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -1768,7 +1794,7 @@ mod circuit_breaker_e2e_tests {
       "message": "Rejected by the circuit breaker",
       "extensions": {
         "code": "SUBGRAPH_CIRCUIT_BREAKER_REJECTED",
-        "serviceName": "accounts"
+        "service": "accounts"
       }
     }
   ]
@@ -2606,6 +2632,7 @@ mod circuit_breaker_e2e_tests {
         let success_mock = accounts_server
             .mock("POST", "/accounts")
             .with_status(200)
+            .with_header("content-type", "application/json")
             .with_body(r#"{"data":{"users":[{"id":"1"}]}}"#)
             .expect_at_least(4)
             .create_async()

--- a/e2e/src/demand_control/estimator.rs
+++ b/e2e/src/demand_control/estimator.rs
@@ -1001,7 +1001,7 @@ mod estimator_tests {
         let blocked_products = requires_json["errors"].as_array().map_or(false, |errors| {
             errors.iter().any(|e| {
                 e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
-                    && e["extensions"]["serviceName"].as_str() == Some("products")
+                    && e["extensions"]["service"].as_str() == Some("products")
             })
         });
         assert!(

--- a/e2e/src/demand_control/subgraph_budgets.rs
+++ b/e2e/src/demand_control/subgraph_budgets.rs
@@ -75,7 +75,7 @@ mod subgraph_budgets_tests {
             err["extensions"]["code"].as_str(),
             Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
         );
-        assert_eq!(err["extensions"]["serviceName"].as_str(), Some("reviews"));
+        assert_eq!(err["extensions"]["service"].as_str(), Some("reviews"));
         assert_eq!(err["extensions"]["affectedPath"].as_str(), Some("me"));
     }
 
@@ -186,7 +186,7 @@ mod subgraph_budgets_tests {
         let blocked_products = json["errors"].as_array().map_or(false, |errors| {
             errors.iter().any(|e| {
                 e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
-                    && e["extensions"]["serviceName"].as_str() == Some("products")
+                    && e["extensions"]["service"].as_str() == Some("products")
             })
         });
         assert!(
@@ -248,7 +248,7 @@ mod subgraph_budgets_tests {
         let blocked_products = json["errors"].as_array().map_or(false, |errors| {
             errors.iter().any(|e| {
                 e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
-                    && e["extensions"]["serviceName"].as_str() == Some("products")
+                    && e["extensions"]["service"].as_str() == Some("products")
             })
         });
         assert!(
@@ -312,7 +312,7 @@ mod subgraph_budgets_tests {
         let blocked_reviews = json["errors"].as_array().map_or(false, |errors| {
             errors.iter().any(|e| {
                 e["extensions"]["code"].as_str() == Some("SUBGRAPH_COST_ESTIMATED_TOO_EXPENSIVE")
-                    && e["extensions"]["serviceName"].as_str() == Some("reviews")
+                    && e["extensions"]["service"].as_str() == Some("reviews")
             })
         });
 

--- a/e2e/src/env_vars.rs
+++ b/e2e/src/env_vars.rs
@@ -70,8 +70,8 @@ mod env_vars_e2e_tests {
                 {
                   "message": "Failed to send request to subgraph: client error (Connect)",
                   "extensions": {
-                    "code": "SUBGRAPH_REQUEST_FAILURE",
-                    "serviceName": "accounts"
+                    "code": "SUBREQUEST_HTTP_ERROR",
+                    "service": "accounts"
                   }
                 }
               ]

--- a/e2e/src/error_handling.rs
+++ b/e2e/src/error_handling.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod error_handling_e2e_tests {
-    use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
+    use crate::testkit::{ClientResponseExt, ResponseLike, TestRouter, TestSubgraphs};
 
     #[ntex::test]
     async fn should_continue_execution_when_a_subgraph_is_down() {
@@ -66,8 +66,8 @@ mod error_handling_e2e_tests {
             {
               "message": "Failed to send request to subgraph: client error (Connect)",
               "extensions": {
-                "code": "SUBGRAPH_REQUEST_FAILURE",
-                "serviceName": "products",
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
                 "affectedPath": "me.reviews.@.product"
               }
             }
@@ -83,6 +83,566 @@ mod error_handling_e2e_tests {
                 .len(),
             1,
             "expected 1 request to accounts subgraph"
+        );
+    }
+
+    // Subgraph returns non-200, with a valid GraphQL body, and also a custom subgraph error in `errors`
+    #[ntex::test]
+    async fn should_report_error_when_subgraph_responds_with_non_200_and_custom_error() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path != "/products" {
+                    return None;
+                }
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    Some(
+                        r#"{"errors":[{"message":"Internal server error from products"}]}"#
+                            .to_string(),
+                    ),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                      reviews:
+                        url: "{subgraphs_url}/reviews"
+                      products:
+                        url: "{subgraphs_url}/products"
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // The subgraph's own error is propagated AND a `SUBREQUEST_HTTP_ERROR`
+        // carrying the HTTP status is injected, while partial data is kept.
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Internal server error from products",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            },
+            {
+              "message": "Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product",
+                "http": {
+                  "status": 500
+                }
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    // Subgraph returns non-200, with a valid GraphQL body, no custom errors
+    #[ntex::test]
+    async fn should_report_error_when_subgraph_responds_with_non_200_no_custom_error() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path != "/products" {
+                    return None;
+                }
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    Some(r#"{"data": null}"#.to_string()),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                      reviews:
+                        url: "{subgraphs_url}/reviews"
+                      products:
+                        url: "{subgraphs_url}/products"
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // The subgraph's own error is propagated AND a `SUBREQUEST_HTTP_ERROR`
+        // carrying the HTTP status is injected, while partial data is kept.
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Subgraph returned malformed response",
+              "extensions": {
+                "code": "SUBREQUEST_MALFORMED_RESPONSE",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    // Subgraph returns non-200, with an invalid GraphQL body
+    #[ntex::test]
+    async fn should_report_error_when_subgraph_responds_with_non_200_invalid_graphql_body() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path != "/products" {
+                    return None;
+                }
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    Some(r#"{"error": "oopsi boopsi"}"#.to_string()),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                      reviews:
+                        url: "{subgraphs_url}/reviews"
+                      products:
+                        url: "{subgraphs_url}/products"
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // The subgraph's own error is propagated AND a `SUBREQUEST_HTTP_ERROR`
+        // carrying the HTTP status is injected, while partial data is kept.
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Subgraph returned malformed response",
+              "extensions": {
+                "code": "SUBREQUEST_MALFORMED_RESPONSE",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    // Subgraph returns 200, with a invalid GraphQL body
+    #[ntex::test]
+    async fn should_report_error_when_subgraph_responds_with_200_invalid_graphql_body() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path != "/products" {
+                    return None;
+                }
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::OK,
+                    Some(r#"{"error": "oopsi boopsi"}"#.to_string()),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                      reviews:
+                        url: "{subgraphs_url}/reviews"
+                      products:
+                        url: "{subgraphs_url}/products"
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // The subgraph's own error is propagated AND a `SUBREQUEST_HTTP_ERROR`
+        // carrying the HTTP status is injected, while partial data is kept.
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Subgraph returned malformed response",
+              "extensions": {
+                "code": "SUBREQUEST_MALFORMED_RESPONSE",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    // Subgraph returns 200, with a GraphQL body, with invalid content type
+    #[ntex::test]
+    async fn should_report_error_when_subgraph_responds_with_200_invalid_content_type() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path != "/products" {
+                    return None;
+                }
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("text/html"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::OK,
+                    Some(r#"{"errors": [{"message": "test"}]}"#.to_string()),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                      reviews:
+                        url: "{subgraphs_url}/reviews"
+                      products:
+                        url: "{subgraphs_url}/products"
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // The subgraph's own error is propagated AND a `SUBREQUEST_HTTP_ERROR`
+        // carrying the HTTP status is injected, while partial data is kept.
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid content type returned from subgraph 'products': 'text/html'",
+              "extensions": {
+                "code": "SUBREQUEST_MALFORMED_RESPONSE",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    // Subgraph returns 200, with invalid JSON body
+    #[ntex::test]
+    async fn should_report_error_when_subgraph_responds_with_200_invalid_json_body() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path != "/products" {
+                    return None;
+                }
+                let mut headers = http::HeaderMap::new();
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Some(ResponseLike::new(
+                    axum::http::StatusCode::OK,
+                    Some(r#"bad json"#.to_string()),
+                    Some(headers),
+                ))
+            })
+            .build()
+            .start()
+            .await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      accounts:
+                        url: "{subgraphs_url}/accounts"
+                      reviews:
+                        url: "{subgraphs_url}/reviews"
+                      products:
+                        url: "{subgraphs_url}/products"
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        // The subgraph's own error is propagated AND a `SUBREQUEST_HTTP_ERROR`
+        // carrying the HTTP status is injected, while partial data is kept.
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Failed to deserialize subgraph response: Invalid JSON value at line 1 column 1\n\n\tbad json\n\t^.......\n",
+              "extensions": {
+                "code": "SUBREQUEST_MALFORMED_RESPONSE",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
         );
     }
 }

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -1323,7 +1323,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1348,7 +1348,7 @@ mod issues_e2e_tests {
               "message": "NullableNested.fieldThatErrors always fails",
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1378,7 +1378,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1408,7 +1408,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1496,7 +1496,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1521,7 +1521,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1550,7 +1550,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -1724,7 +1724,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "accounts"
+                "service": "accounts"
               }
             }
           ]
@@ -2862,7 +2862,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "a"
+                "service": "a"
               }
             }
           ]
@@ -2951,7 +2951,7 @@ mod issues_e2e_tests {
               ],
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "a"
+                "service": "a"
               }
             }
           ]

--- a/e2e/src/override_subgraph_urls.rs
+++ b/e2e/src/override_subgraph_urls.rs
@@ -117,8 +117,8 @@ mod override_subgraph_urls_e2e_tests {
             {
               "message": "Failed to send request to subgraph: client error (Connect)",
               "extensions": {
-                "code": "SUBGRAPH_REQUEST_FAILURE",
-                "serviceName": "accounts"
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "accounts"
               }
             }
           ]

--- a/e2e/src/subscriptions.rs
+++ b/e2e/src/subscriptions.rs
@@ -1155,16 +1155,16 @@ mod subscriptions_e2e_tests {
 
         assert_snapshot!(body_str, @r#"
         event: next
-        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","serviceName":"products","affectedPath":"reviewAddedForProduct.product"}}]}
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
 
         event: next
-        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","serviceName":"products","affectedPath":"reviewAddedForProduct.product"}}]}
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
 
         event: next
-        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","serviceName":"products","affectedPath":"reviewAddedForProduct.product"}}]}
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
 
         event: next
-        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","serviceName":"products","affectedPath":"reviewAddedForProduct.product"}}]}
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Something Went Wrong!","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
 
         event: complete
         "#);
@@ -1389,7 +1389,7 @@ mod subscriptions_e2e_tests {
         data: {"data":{"reviewAdded":{"id":"3"}}}
 
         event: next
-        data: {"errors":[{"message":"Error reading SSE subscription stream: Stream read error: error reading a body from connection","extensions":{"code":"SUBGRAPH_SUBSCRIPTION_SSE_STREAM_ERROR","serviceName":"reviews"}}]}
+        data: {"errors":[{"message":"Error reading SSE subscription stream: Stream read error: error reading a body from connection","extensions":{"code":"SUBGRAPH_SUBSCRIPTION_SSE_STREAM_ERROR","service":"reviews"}}]}
 
         event: complete
         "#);

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -1119,7 +1119,7 @@ async fn test_otlp_http_client_transport_failure_sets_graphql_status_and_error_t
             labels::GRAPHQL_RESPONSE_STATUS,
             values::GraphQLResponseStatus::Error.as_str(),
         ),
-        (labels::ERROR_TYPE, "SUBGRAPH_REQUEST_FAILURE"),
+        (labels::ERROR_TYPE, "SUBREQUEST_HTTP_ERROR"),
     ];
 
     assert_histogram_count(

--- a/e2e/src/timeout_per_subgraph.rs
+++ b/e2e/src/timeout_per_subgraph.rs
@@ -120,7 +120,7 @@ mod timeout_per_subgraph_e2e_tests {
                       "message": "Request to subgraph timed out",
                       "extensions": {
                         "code": "SUBGRAPH_REQUEST_TIMEOUT",
-                        "serviceName": "accounts"
+                        "service": "accounts"
                       }
                     }
                   ]

--- a/lib/executor/src/execution/error.rs
+++ b/lib/executor/src/execution/error.rs
@@ -104,9 +104,11 @@ impl From<&PlanExecutionError> for GraphQLError {
         if let Some(subgraph_name) = &val.context.subgraph_name {
             error = error.add_subgraph_name(subgraph_name);
         }
+
         if let Some(affected_path) = &val.context.affected_path {
             error = error.add_affected_path(affected_path);
         }
+
         error
     }
 }

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -1610,7 +1610,7 @@ impl<'exec> Executor<'exec> {
                 );
             }
 
-            let response = self
+            let mut response = self
                 .executors
                 .execute(
                     opts.subgraph_name,
@@ -1630,6 +1630,15 @@ impl<'exec> Executor<'exec> {
                     subgraph_operation_span.record_error_count(errors.len());
                     subgraph_operation_span
                         .record_errors(|| errors.iter().map(|e| e.into()).collect());
+                }
+            }
+
+            if let Some(status) = &response.status {
+                if !status.is_success() {
+                    response.append_error(GraphQLError::create_from_status_code(
+                        status,
+                        opts.subgraph_name,
+                    ));
                 }
             }
 

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -2031,6 +2031,8 @@ mod tests {
 
         let mock_a = subgraph_a
             .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
             .with_body(r#"{"data":{"from_a":"value_a"}}"#)
             .create();
 
@@ -2048,6 +2050,8 @@ mod tests {
 
         let mock_b = subgraph_b
             .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
             .with_chunked_body(move |writer| {
                 // We can add some delay here to make sure the parallel execution is actually working
                 std::thread::sleep(Duration::from_millis(1000));

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -33,7 +33,7 @@ pub enum SubgraphExecutorError {
     #[strum(serialize = "SUBGRAPH_REQUEST_BUILD_FAILURE")]
     RequestBuildFailure(#[from] http::Error),
     #[error("Failed to send request to subgraph: {0}")]
-    #[strum(serialize = "SUBGRAPH_REQUEST_FAILURE")]
+    #[strum(serialize = "SUBREQUEST_HTTP_ERROR")]
     RequestFailure(#[from] hyper_util::client::legacy::Error),
     #[error("Failed to receive response: {0}")]
     #[strum(serialize = "SUBGRAPH_RESPONSE_FAILURE")]
@@ -57,8 +57,14 @@ pub enum SubgraphExecutorError {
     #[strum(serialize = "SUBGRAPH_RESPONSE_BODY_EMPTY")]
     EmptyResponseBody(String, Arc<HeaderMap>),
     #[error("Failed to deserialize subgraph response: {0}")]
-    #[strum(serialize = "SUBGRAPH_RESPONSE_DESERIALIZATION_FAILURE")]
+    #[strum(serialize = "SUBREQUEST_MALFORMED_RESPONSE")]
     ResponseDeserializationFailure(sonic_rs::Error, Option<Arc<HeaderMap>>),
+    #[error("Subgraph returned malformed response")]
+    #[strum(serialize = "SUBREQUEST_MALFORMED_RESPONSE")]
+    MalformedResponse(Option<Arc<HeaderMap>>),
+    #[error("Invalid content type returned from subgraph '{0}': '{1}'")]
+    #[strum(serialize = "SUBREQUEST_MALFORMED_RESPONSE")]
+    InvalidContentType(String, String, Arc<HeaderMap>),
     #[error(transparent)]
     #[strum(serialize = "SUBGRAPH_HTTPS_CERTS_FAILURE")]
     TlsCertificatesError(#[from] TlsCertificatesError),
@@ -131,6 +137,8 @@ impl SubgraphExecutorError {
             Self::EmptyResponseBody(_, headers) => Some(headers.as_ref()),
             Self::ResponseBodyReadFailure(_, _, headers) => Some(headers.as_ref()),
             Self::ResponseDeserializationFailure(_, headers) => headers.as_deref(),
+            Self::MalformedResponse(headers) => headers.as_deref(),
+            Self::InvalidContentType(_, _, headers) => Some(headers.as_ref()),
             _ => None,
         }
     }

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -495,8 +495,20 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             response = end_payload.response;
         }
 
+        let (is_content_type_valid, content_type) =
+            validate_response_content_type(&response.headers);
+
+        if !is_content_type_valid {
+            return Err(SubgraphExecutorError::InvalidContentType(
+                self.subgraph_name.clone(),
+                content_type.unwrap_or("").to_string(),
+                response.headers,
+            ));
+        }
+
         let response_result =
             response.deserialize_http_response(execution_request.custom_scalar_paths);
+
         if let Some(mut http_request_capture) = http_request_capture {
             finish_capture_from_subgraph_result(
                 &mut http_request_capture.capture,
@@ -690,6 +702,39 @@ pub struct SubgraphHttpResponse {
     pub status: StatusCode,
     pub headers: Arc<HeaderMap>,
     pub body: Bytes,
+}
+
+const VALID_GRAPHQL_CONTENT_TYPES: [&str; 2] =
+    ["application/json", "application/graphql-response+json"];
+
+#[inline]
+fn is_valid_graphql_content_type(header_value: &str) -> bool {
+    // Split by `;` to remove any charset or boundary parameters
+    // and then take the first one.
+    // We can't rely on simple string comparison because of additianal attributes (like charset),
+    // and we can't rely on starts_with because there are valid values that start with `application/json` and can confuse our check.
+    let essence = header_value.split(';').next().unwrap_or("").trim();
+
+    VALID_GRAPHQL_CONTENT_TYPES
+        .iter()
+        .any(|valid| valid.eq_ignore_ascii_case(essence))
+}
+
+#[inline]
+fn validate_response_content_type(headers: &HeaderMap) -> (bool, Option<&str>) {
+    let content_type = headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok());
+
+    let Some(content_type) = content_type else {
+        return (false, None);
+    };
+
+    if !is_valid_graphql_content_type(content_type) {
+        return (false, Some(content_type));
+    }
+
+    (true, Some(content_type))
 }
 
 impl SubgraphHttpResponse {

--- a/lib/executor/src/response/graphql_error.rs
+++ b/lib/executor/src/response/graphql_error.rs
@@ -2,8 +2,9 @@ use core::fmt;
 use graphql_tools::parser::Pos;
 use graphql_tools::validation::utils::ValidationError;
 use hive_router_internal::graphql::{ObservedError, PathSegment};
+use http::StatusCode;
 use serde::{de, Deserialize, Deserializer, Serialize};
-use sonic_rs::Value;
+use sonic_rs::{json, Value};
 use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -67,6 +68,31 @@ impl From<&Pos> for GraphQLErrorLocation {
 impl GraphQLError {
     pub fn entity_index_and_path<'a>(&'a self) -> Option<EntityIndexAndPath<'a>> {
         self.path.as_ref().and_then(|p| p.entity_index_and_path())
+    }
+
+    pub fn append_extensions(&mut self, extensions: BTreeMap<String, Value>) {
+        self.extensions.extensions.extend(extensions);
+    }
+
+    pub fn create_from_status_code(status: &StatusCode, subgraph_name: &str) -> Self {
+        let mut extensions = GraphQLErrorExtensions::new_from_code_and_service_name(
+            "SUBREQUEST_HTTP_ERROR",
+            subgraph_name,
+        );
+
+        extensions
+            .extensions
+            .insert("http".into(), json!({ "status": status.as_u16() }));
+
+        Self {
+            message: format!(
+                "Subgraph '{0}' responded with an invalid HTTP status code '{1}'",
+                subgraph_name, status
+            ),
+            locations: None,
+            extensions,
+            path: None,
+        }
     }
 
     pub fn normalize_entity_error(
@@ -165,7 +191,7 @@ impl GraphQLError {
     /// assert_eq!(json!(error), json!({
     ///     "message": "An error occurred",
     ///     "extensions": {
-    ///         "serviceName": "users",
+    ///         "service": "users",
     ///         "code": "DOWNSTREAM_SERVICE_ERROR"
     ///     }
     /// }));
@@ -287,7 +313,7 @@ impl GraphQLErrorPath {
 pub struct GraphQLErrorExtensions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "service", skip_serializing_if = "Option::is_none")]
     pub service_name: Option<String>,
     /// Corresponds to a path of a Flatten(Fetch) node that caused the error.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -329,9 +355,9 @@ impl<'de> Deserialize<'de> for GraphQLErrorExtensions {
                             }
                             code = Some(map.next_value()?);
                         }
-                        "serviceName" => {
+                        "service" => {
                             if service_name.is_some() {
-                                return Err(de::Error::duplicate_field("serviceName"));
+                                return Err(de::Error::duplicate_field("service"));
                             }
                             service_name = Some(map.next_value()?);
                         }

--- a/lib/executor/src/response/subgraph_response.rs
+++ b/lib/executor/src/response/subgraph_response.rs
@@ -25,6 +25,16 @@ pub struct SubgraphResponse<'a> {
     pub status: Option<StatusCode>,
 }
 
+impl SubgraphResponse<'_> {
+    pub fn append_error(&mut self, error: GraphQLError) {
+        if let Some(errors) = &mut self.errors {
+            errors.push(error);
+        } else {
+            self.errors = Some(vec![error]);
+        }
+    }
+}
+
 impl<'de> de::Deserialize<'de> for SubgraphResponse<'de> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -272,6 +282,11 @@ impl<'a> SubgraphResponse<'a> {
                 .end()
                 .map_err(|e| SubgraphExecutorError::ResponseDeserializationFailure(e, None))?;
             resp.bytes = Some(bytes);
+
+            if resp.data.is_null() && resp.errors.is_none() {
+                return Err(SubgraphExecutorError::MalformedResponse(None));
+            }
+
             Ok(resp)
         })
     }


### PR DESCRIPTION
Related: https://github.com/graphql-hive/router/issues/1229 

This PR makes the router propagate proper GraphQL errors when a subgraph HTTP call fails or returns an unexpected response, instead of silently ignoring the HTTP status and `content-type`.

| Subgraph response | Router behavior |
| --- | --- |
| `2xx`, valid content-type, valid GraphQL body | passed through unchanged |
| `2xx`, valid content-type, valid JSON but no `data`/`errors` | `SUBREQUEST_MALFORMED_RESPONSE` |
| `2xx`, valid content-type, body is not valid JSON | `SUBREQUEST_MALFORMED_RESPONSE` |
| `2xx`, missing or non-JSON content-type (e.g. `text/html`) | `SUBREQUEST_MALFORMED_RESPONSE` |
| Non-2xx status | inject `SUBREQUEST_HTTP_ERROR` (with `extensions.http.status`) |
| Transport/connection failure (no HTTP response) | `SUBREQUEST_HTTP_ERROR` |

In addition, added a bunch for e2e tests for all the scenarios above, because our current error handling testing was lacking. 

Additional changes that worth mentioning:

- Some of the errors has been renamed 
- Changed `error.extensions.serviceName` to be just `error.extensions.service`
- `Content-type` header in subgraphs response is now strictly enforced 
- Adjusted some existing tests to send `Content-Type`
- Added a mechanism to extend `error.extensions` with custom data, based on what the `SubgraphExecutorError` knows (for example: to inject `http: { status: xxx }` when we get !200 