### PR TITLE
fix(executor): debug log message when subscription buffer consumer drops before producer stops

### DIFF
--- a/.changeset/debug_log_message_when_subscription_buffer_consumer_drops_before_producer_stops.md
+++ b/.changeset/debug_log_message_when_subscription_buffer_consumer_drops_before_producer_stops.md
@@ -1,0 +1,10 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Debug log message when subscription buffer consumer drops before producer stops
+
+"Consumer for subgraph {} at {} dropped the receiver" was logged at `error` level, but it fires on the normal teardown path: once all clients unsubscribe/disconnect from a subscription, the broadcast channel closes, the pump task stops draining, and the mpsc receiver drops. This is expected cleanup, not a failure, so users were seeing noisy error logs for routine subscribe/unsubscribe churn.
+
+Changed to `debug` level with a clearer message explaining it's expected shutdown of the upstream drain, not an actual error.

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -2,7 +2,7 @@ use futures::stream::{BoxStream, Stream};
 use futures_util::StreamExt;
 use ntex::rt;
 use tokio::sync::mpsc;
-use tracing::{error, warn};
+use tracing::{debug, warn};
 
 use crate::executors::error::SubgraphExecutorError;
 use crate::response::subgraph_response::SubgraphResponse;
@@ -36,8 +36,11 @@ pub async fn drain_into<S>(
                 );
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
-                error!(
-                    "Consumer for subgraph {} at {} dropped the receiver",
+                // expected teardown path: fires once all downstream clients have
+                // unsubscribed/disconnected and the buffer's receiver was dropped.
+                // not an error, just means there's nothing left to forward to.
+                debug!(
+                    "Subscription buffer for subgraph {} at {} has no more receivers, all consumers disconnected or unsubscribed; stopping upstream drain",
                     subgraph_name, endpoint
                 );
                 break;


### PR DESCRIPTION
Ref ROUTER-377

"Consumer for subgraph {} at {} dropped the receiver" was logged at error! level, but it fires on the normal teardown path: once all clients unsubscribe/disconnect from a subscription, the broadcast channel closes, the pump task stops draining, and the mpsc receiver drops. This is expected cleanup, not a failure, so users were seeing noisy error logs for routine subscribe/unsubscribe churn.

Changed to debug! with a clearer message explaining it's expected shutdown of the upstream drain, not an actual error.
