### PR TITLE
Restrict indirect path finding to valid subgraphs

### DIFF
--- a/.changeset/restrict_field_targets.md
+++ b/.changeset/restrict_field_targets.md
@@ -1,0 +1,14 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Restrict indirect path finding to valid subgraphs
+
+Fix an issue where query planning could appear stuck on some complex federated schemas due to excessive indirect path exploration.
+
+Indirect path exploration happens when the planner cannot resolve a field directly in the current subgraph and starts searching for a route through other subgraphs that could satisfy the field and its requirements.
+
+Indirect field lookup is now limited to subgraphs that can actually resolve the requested field, reducing unnecessary work and preventing planning stalls.

--- a/lib/query-planner/src/planner/walker/excluded.rs
+++ b/lib/query-planner/src/planner/walker/excluded.rs
@@ -6,7 +6,7 @@ use crate::ast::type_aware_selection::TypeAwareSelection;
 #[derive(Default)]
 pub struct ExcludedFromLookup<'graph> {
     pub graph_ids: HashSet<&'graph str>,
-    pub requirement: HashSet<TypeAwareSelection>,
+    pub requirement: HashSet<&'graph TypeAwareSelection>,
 }
 
 impl<'graph> ExcludedFromLookup<'graph> {

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -545,6 +545,13 @@ fn process_field<'graph, 'op: 'graph>(
 
     cancellation_token.bail_if_cancelled()?;
 
+    let target_subgraph_ids =
+        if !paths.is_empty() && !fields_to_resolve_locally.contains(&field.name) {
+            field_target_subgraph_ids(supergraph, field, paths, graph)?
+        } else {
+            None
+        };
+
     for path in paths {
         let path_span = span!(
             Level::TRACE,
@@ -579,8 +586,6 @@ fn process_field<'graph, 'op: 'graph>(
         }
 
         if !fields_to_resolve_locally.contains(&field.name) && !found_direct_paths_to_leaf {
-            let target_subgraph_ids = field_target_subgraph_ids(supergraph, field, paths, graph)?;
-
             let indirect_paths = find_indirect_paths(
                 graph,
                 supergraph,
@@ -750,23 +755,23 @@ fn process_field<'graph, 'op: 'graph>(
     Ok((next_stack_to_resolve, paths_per_leaf))
 }
 
-fn field_target_subgraph_ids(
+fn field_target_subgraph_ids<'graph>(
     supergraph: &SupergraphState,
     field: &FieldSelection,
-    paths: &[OperationPath<'_>],
-    graph: &Graph,
+    paths: &[OperationPath<'graph>],
+    graph: &'graph Graph,
 ) -> Result<Option<HashSet<String>>, WalkOperationError> {
     let mut parent_type_names = HashSet::new();
 
     for path in paths {
         let parent_node = graph.node(path.tail())?;
-        parent_type_names.insert(parent_node.name_str().to_string());
+        parent_type_names.insert(parent_node.name_str());
     }
 
     let mut target_subgraph_ids = HashSet::new();
 
     for parent_type_name in parent_type_names {
-        let Some(parent_def) = supergraph.definitions.get(parent_type_name.as_str()) else {
+        let Some(parent_def) = supergraph.definitions.get(parent_type_name) else {
             continue;
         };
         let Some(field_def) = parent_def.fields().get(&field.name) else {

--- a/lib/query-planner/src/planner/walker/mod.rs
+++ b/lib/query-planner/src/planner/walker/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod path;
 pub(crate) mod pathfinder;
 pub(crate) mod utils;
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 use crate::{
     ast::{
@@ -379,7 +379,10 @@ fn process_inline_fragment<'graph, 'op: 'graph>(
                 supergraph,
                 override_context,
                 path,
-                &NavigationTarget::Field(&FieldSelection::new_typename()),
+                &NavigationTarget::Field {
+                    field: &FieldSelection::new_typename(),
+                    target_subgraph_ids: None,
+                },
                 cancellation_token,
             )?;
 
@@ -558,7 +561,10 @@ fn process_field<'graph, 'op: 'graph>(
             supergraph,
             override_context,
             path,
-            &NavigationTarget::Field(field),
+            &NavigationTarget::Field {
+                field,
+                target_subgraph_ids: None,
+            },
             cancellation_token,
         )?;
         trace!("Direct paths found: {}", direct_paths.len());
@@ -573,12 +579,17 @@ fn process_field<'graph, 'op: 'graph>(
         }
 
         if !fields_to_resolve_locally.contains(&field.name) && !found_direct_paths_to_leaf {
+            let target_subgraph_ids = field_target_subgraph_ids(supergraph, field, paths, graph)?;
+
             let indirect_paths = find_indirect_paths(
                 graph,
                 supergraph,
                 override_context,
                 path,
-                &NavigationTarget::Field(field),
+                &NavigationTarget::Field {
+                    field,
+                    target_subgraph_ids: target_subgraph_ids.as_ref(),
+                },
                 &excluded,
                 cancellation_token,
             )?;
@@ -737,4 +748,41 @@ fn process_field<'graph, 'op: 'graph>(
     }
 
     Ok((next_stack_to_resolve, paths_per_leaf))
+}
+
+fn field_target_subgraph_ids(
+    supergraph: &SupergraphState,
+    field: &FieldSelection,
+    paths: &[OperationPath<'_>],
+    graph: &Graph,
+) -> Result<Option<HashSet<String>>, WalkOperationError> {
+    let mut parent_type_names = HashSet::new();
+
+    for path in paths {
+        let parent_node = graph.node(path.tail())?;
+        parent_type_names.insert(parent_node.name_str().to_string());
+    }
+
+    let mut target_subgraph_ids = HashSet::new();
+
+    for parent_type_name in parent_type_names {
+        let Some(parent_def) = supergraph.definitions.get(parent_type_name.as_str()) else {
+            continue;
+        };
+        let Some(field_def) = parent_def.fields().get(&field.name) else {
+            continue;
+        };
+
+        for graph_id in field_def.resolvable_in_graphs(parent_def) {
+            if let Ok(subgraph_id) = supergraph.resolve_graph_id(&graph_id) {
+                target_subgraph_ids.insert(subgraph_id.0.to_string());
+            }
+        }
+    }
+
+    if target_subgraph_ids.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(target_subgraph_ids))
+    }
 }

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -163,14 +163,14 @@ impl<'graph> OperationPath<'graph> {
             cumulative_cost: new_cost,
             requirement_tree: requirement,
             selection_attributes: match target {
-                NavigationTarget::Field(f) => Some(SelectionAttributes {
-                    alias: f.alias.clone(),
-                    arguments: f.arguments.clone(),
+                NavigationTarget::Field { field, .. } => Some(SelectionAttributes {
+                    alias: field.alias.clone(),
+                    arguments: field.arguments.clone(),
                 }),
                 NavigationTarget::ConcreteType(_, _) => None,
             },
             condition: match target {
-                NavigationTarget::Field(f) => (*f).into(),
+                NavigationTarget::Field { field, .. } => (*field).into(),
                 NavigationTarget::ConcreteType(_, condition) => condition.clone(),
             },
         };

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -242,15 +242,17 @@ impl<'graph> PathSearch<'graph> {
 
                 let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
 
-                if let NavigationTarget::Field {
-                    target_subgraph_ids: Some(target_subgraph_ids),
-                    ..
-                } = target
-                {
-                    if !target_subgraph_ids.contains(edge_tail_graph_id) {
-                        trace!("Ignoring. Target field is not resolvable in this graph");
-                        continue;
-                    }
+                let is_resolvable = match target {
+                    NavigationTarget::Field {
+                        target_subgraph_ids: Some(ids),
+                        ..
+                    } => ids.contains(edge_tail_graph_id),
+                    _ => true,
+                };
+
+                if !is_resolvable {
+                    trace!("Ignoring. Target field is not resolvable in this graph");
+                    continue;
                 }
 
                 if visited_graphs.contains(edge_tail_graph_id) {

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -33,7 +33,7 @@ type ActiveEdgeChecks = HashSet<(NodeIndex, EdgeIndex)>;
 struct IndirectPathsLookupQueue<'graph> {
     queue: Vec<(
         VisitedGraphs<'graph>,
-        HashSet<TypeAwareSelection>,
+        HashSet<&'graph TypeAwareSelection>,
         OperationPath<'graph>,
     )>,
 }
@@ -59,7 +59,7 @@ impl<'graph> IndirectPathsLookupQueue<'graph> {
     pub fn add(
         &mut self,
         visited_graphs: VisitedGraphs<'graph>,
-        selections: HashSet<TypeAwareSelection>,
+        selections: HashSet<&'graph TypeAwareSelection>,
         path: OperationPath<'graph>,
     ) {
         self.queue.push((visited_graphs, selections, path));
@@ -69,7 +69,7 @@ impl<'graph> IndirectPathsLookupQueue<'graph> {
         &mut self,
     ) -> Option<(
         VisitedGraphs<'graph>,
-        HashSet<TypeAwareSelection>,
+        HashSet<&'graph TypeAwareSelection>,
         OperationPath<'graph>,
     )> {
         self.queue.pop()
@@ -78,7 +78,10 @@ impl<'graph> IndirectPathsLookupQueue<'graph> {
 
 #[derive(Debug)]
 pub enum NavigationTarget<'op> {
-    Field(&'op FieldSelection),
+    Field {
+        field: &'op FieldSelection,
+        target_subgraph_ids: Option<&'op HashSet<String>>,
+    },
     ConcreteType(&'op str, Option<Condition>),
 }
 
@@ -91,7 +94,7 @@ enum NavigationTargetKey<'op> {
 impl<'op> From<&'op NavigationTarget<'op>> for NavigationTargetKey<'op> {
     fn from(target: &'op NavigationTarget<'op>) -> Self {
         match target {
-            NavigationTarget::Field(field) => NavigationTargetKey::Field(&field.name),
+            NavigationTarget::Field { field, .. } => NavigationTargetKey::Field(&field.name),
             NavigationTarget::ConcreteType(type_name, _) => {
                 NavigationTargetKey::ConcreteType(type_name)
             }
@@ -239,6 +242,17 @@ impl<'graph> PathSearch<'graph> {
 
                 let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
 
+                if let NavigationTarget::Field {
+                    target_subgraph_ids: Some(target_subgraph_ids),
+                    ..
+                } = target
+                {
+                    if !target_subgraph_ids.contains(edge_tail_graph_id) {
+                        trace!("Ignoring. Target field is not resolvable in this graph");
+                        continue;
+                    }
+                }
+
                 if visited_graphs.contains(edge_tail_graph_id) {
                     trace!(
                     "Ignoring, graph is excluded and already visited (current: {}, visited: {:?})",
@@ -248,7 +262,6 @@ impl<'graph> PathSearch<'graph> {
                     continue;
                 }
 
-                let edge_tail_graph_id = graph.node(edge_ref.target().id())?.graph_id().unwrap();
                 let edge = edge_ref.weight();
 
                 if edge_tail_graph_id == source_graph_id
@@ -265,16 +278,16 @@ impl<'graph> PathSearch<'graph> {
                 // the edge cannot help us, we skip it.
                 // We allow other entity-move edge to be used instead,
                 // that will be used to collect the required fields.
-                if let NavigationTarget::Field(FieldSelection {
-                    name: target_field_name,
+                if let NavigationTarget::Field {
+                    field: target_field,
                     ..
-                }) = target
+                } = target
                 {
                     if let Some(requirements) = edge.requirements() {
                         if self.requirements_includes_field(
                             requirements,
                             tail_node.name_str(),
-                            target_field_name,
+                            target_field.name.as_str(),
                         ) {
                             continue;
                         }
@@ -355,7 +368,7 @@ impl<'graph> PathSearch<'graph> {
                             let next_requirements = match edge.requirements() {
                                 Some(requirements) => {
                                     let mut new_visited_key_fields = visited_key_fields.clone();
-                                    new_visited_key_fields.insert(requirements.clone());
+                                    new_visited_key_fields.insert(requirements);
                                     new_visited_key_fields
                                 }
                                 None => visited_key_fields.clone(),
@@ -493,7 +506,7 @@ impl<'graph> PathSearch<'graph> {
         }
 
         let edges_iter: Box<dyn Iterator<Item = _>> = match target {
-            NavigationTarget::Field(field) => {
+            NavigationTarget::Field { field, .. } => {
                 Box::new(graph.edges_from(path_tail_index).filter(move |e| {
                     matches!(e.weight(), Edge::FieldMove(f) if f.name == field.name)
                         || matches!(e.weight(), Edge::ReentryMove(r) if r.name == field.name)
@@ -722,16 +735,35 @@ impl<'graph> PathSearch<'graph> {
             Vec::with_capacity(move_requirement.paths.len());
         let mut indirect_path_results: Vec<Vec<OperationPath<'graph>>> =
             Vec::with_capacity(move_requirement.paths.len());
+        let target_subgraph_ids = super::field_target_subgraph_ids(
+            self.supergraph,
+            field,
+            move_requirement.paths.as_ref(),
+            self.graph,
+        )?;
 
         for path in move_requirement.paths.iter() {
-            let direct_paths = self.find_direct_paths(path, &NavigationTarget::Field(field))?;
+            let direct_paths = self.find_direct_paths(
+                path,
+                &NavigationTarget::Field {
+                    field,
+                    target_subgraph_ids: None,
+                },
+            )?;
             // Skip looking for indirect paths if we already found direct paths to a leaf
             let found_direct_paths_to_leaf = !direct_paths.is_empty() && field.is_leaf();
             direct_path_results.push(direct_paths);
 
             let needs_indirect = !use_only_direct_edges && !found_direct_paths_to_leaf;
             let indirect_paths = if needs_indirect {
-                self.find_indirect_paths(path, &NavigationTarget::Field(field), excluded)?
+                self.find_indirect_paths(
+                    path,
+                    &NavigationTarget::Field {
+                        field,
+                        target_subgraph_ids: target_subgraph_ids.as_ref(),
+                    },
+                    excluded,
+                )?
             } else {
                 Vec::new()
             };


### PR DESCRIPTION
Fix an issue where query planning could appear stuck on some complex federated schemas due to excessive indirect path exploration.

Indirect path exploration happens when the planner cannot resolve a field directly in the current subgraph and starts searching for a route through other subgraphs that could satisfy the field and its requirements.

Indirect field lookup is now limited to subgraphs that can actually resolve the requested field, reducing unnecessary work and preventing planning stalls.

--

Not the cheapest, as we allocate String, but also not crazy perf expensive.