### PR TITLE
Allow to bypass persisted document ID requirement

### DIFF
--- a/.changeset/require_id_bypass.md
+++ b/.changeset/require_id_bypass.md
@@ -1,0 +1,10 @@
+---
+hive-router-plan-executor: minor
+hive-router: minor
+---
+
+# Allow to bypass persisted document ID requirement
+
+Add `hive::persisted_documents::skip_enforcement` request context flag. When set to `true`, the router skips the persisted document ID requirement. This allows requests with a full operation string to pass through even when `persisted_documents.require_id` is enabled.
+
+The flag is writable from `OnHttpRequest` and `OnGraphqlParams` plugin hooks, and from the `router.request` coprocessor stage.

--- a/.changeset/require_id_bypass.md
+++ b/.changeset/require_id_bypass.md
@@ -8,3 +8,14 @@ hive-router: minor
 Add `hive::persisted_documents::skip_enforcement` request context flag. When set to `true`, the router skips the persisted document ID requirement. This allows requests with a full operation string to pass through even when `persisted_documents.require_id` is enabled.
 
 The flag is writable from `OnHttpRequest` and `OnGraphqlParams` plugin hooks, and from the `router.request` coprocessor stage.
+
+`persisted_documents.require_id` now accepts an expression in addition to a static boolean. The expression is evaluated per-request and supports request context (`.request.headers`, `.request.method`, `.request.url`) and the `env()` function for environment variables. When the expression returns `true`, the document ID requirement is enforced, when `false`, it is skipped for that request.
+
+Example:
+
+```yaml
+persisted_documents:
+  require_id:
+    expression: |
+      is_null(env("BYPASS_SECRET")) || .request.headers."x-bypass-require-id" != env("BYPASS_SECRET")
+```

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, vec};
 use futures_util::stream;
 use graphql_tools::validation::utils::ValidationError;
 use hive_console_sdk::expressions::{
-    values::boolean::BooleanConversionError, ExpressionCompileError, ProgramResolutionError,
+    values::boolean::BooleanConversionError, ProgramResolutionError,
 };
 use hive_router_internal::http::ReadBodyStreamError;
 use hive_router_plan_executor::{
@@ -96,9 +96,6 @@ pub enum PipelineError {
     #[error("{0}")]
     #[strum(serialize = "PERSISTED_DOCUMENT_RESOLUTION_FAILED")]
     PersistedDocumentResolution(String),
-    #[error("Failed to compile persisted document require_id expression: {0}")]
-    #[strum(serialize = "PERSISTED_DOCUMENT_ID_EXPRESSION_FAILED")]
-    PersistedDocumentIdExpressionError(ExpressionCompileError),
     #[error("Failed to evaluate persisted document require_id expression: {0}")]
     #[strum(serialize = "PERSISTED_DOCUMENT_ID_EXPRESSION_EVALUATION_ERROR")]
     PersistedDocumentIdExpressionEvaluationError(ProgramResolutionError<BooleanConversionError>),
@@ -269,7 +266,6 @@ impl PipelineError {
             (Self::PersistedDocumentExtraction(_), false) => StatusCode::BAD_REQUEST,
             (Self::PersistedDocumentExtraction(_), true) => StatusCode::OK,
             (Self::PersistedDocumentResolution(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::PersistedDocumentIdExpressionError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
             (Self::PersistedDocumentIdExpressionEvaluationError(_), _) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -2,6 +2,9 @@ use std::{sync::Arc, vec};
 
 use futures_util::stream;
 use graphql_tools::validation::utils::ValidationError;
+use hive_console_sdk::expressions::{
+    values::boolean::BooleanConversionError, ExpressionCompileError, ProgramResolutionError,
+};
 use hive_router_internal::http::ReadBodyStreamError;
 use hive_router_plan_executor::{
     coprocessor::CoprocessorError,
@@ -93,6 +96,12 @@ pub enum PipelineError {
     #[error("{0}")]
     #[strum(serialize = "PERSISTED_DOCUMENT_RESOLUTION_FAILED")]
     PersistedDocumentResolution(String),
+    #[error("Failed to compile persisted document require_id expression: {0}")]
+    #[strum(serialize = "PERSISTED_DOCUMENT_ID_EXPRESSION_FAILED")]
+    PersistedDocumentIdExpressionError(ExpressionCompileError),
+    #[error("Failed to evaluate persisted document require_id expression: {0}")]
+    #[strum(serialize = "PERSISTED_DOCUMENT_ID_EXPRESSION_EVALUATION_ERROR")]
+    PersistedDocumentIdExpressionEvaluationError(ProgramResolutionError<BooleanConversionError>),
     #[error("Failed to minify parsed GraphQL operation: {0}")]
     #[strum(serialize = "GRAPHQL_PARSE_MINIFY_FAILED")]
     FailedToMinifyParsedOperation(String),
@@ -260,6 +269,10 @@ impl PipelineError {
             (Self::PersistedDocumentExtraction(_), false) => StatusCode::BAD_REQUEST,
             (Self::PersistedDocumentExtraction(_), true) => StatusCode::OK,
             (Self::PersistedDocumentResolution(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
+            (Self::PersistedDocumentIdExpressionError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
+            (Self::PersistedDocumentIdExpressionEvaluationError(_), _) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
             (Self::FailedToParseOperation(_), false) => StatusCode::BAD_REQUEST,
             (Self::FailedToParseOperation(_), true) => StatusCode::OK,
             (Self::FailedToMinifyParsedOperation(_), false) => StatusCode::BAD_REQUEST,

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -534,10 +534,22 @@ impl<'a> OperationPreparation<'a> {
         }
 
         if self.require_id {
-            // If require_id is set, clear the query to make the document ID-based resolution mandatory.
-            prepared_operation.graphql_params.query = None;
-            if prepared_operation.resolved_document_id.is_none() {
-                return Err(PipelineError::PersistedDocumentIdRequired);
+            let skip_enforcement = self
+                .plugin_req_state
+                .as_ref()
+                .and_then(|state| state.request_context.read_lock().ok())
+                .and_then(|ctx| ctx.persisted_documents.skip_enforcement)
+                // If the lock (read_lock()) fails to be acquired,
+                // treat it as skip_enforcement = false, to avoid failing the request.
+                // When skip_enforcement is None, treat it as `false`.
+                .unwrap_or(false);
+
+            if !skip_enforcement {
+                // If require_id is set, clear the query to make the document ID-based resolution mandatory.
+                prepared_operation.graphql_params.query = None;
+                if prepared_operation.resolved_document_id.is_none() {
+                    return Err(PipelineError::PersistedDocumentIdRequired);
+                }
             }
             return Ok(());
         }
@@ -595,6 +607,7 @@ mod tests {
     use hive_router_internal::telemetry::metrics::Metrics;
     use hive_router_plan_executor::hooks::on_graphql_params::GraphQLParams;
     use hive_router_plan_executor::plugin_context::PluginRequestState;
+    use hive_router_plan_executor::request_context::SharedRequestContext;
     use ntex::util::Bytes;
     use ntex::web::test::TestRequest;
     use ntex::web::HttpRequest;
@@ -832,5 +845,79 @@ mod tests {
 
         assert!(op.graphql_params.query.is_none());
         assert!(op.resolved_document_id.is_some());
+    }
+
+    #[test]
+    fn skip_enforcement_bypasses_require_id() {
+        let req = request();
+        let resolver = Arc::new(document_id_resolver());
+        let persisted_documents_runtime = PersistedDocumentsRuntime {
+            document_id_resolver: resolver,
+            persisted_document_resolver: None,
+        };
+        // Set skip_enforcement to true to bypass require_id enforcement.
+        let request_context = SharedRequestContext::default();
+        request_context
+            .update(|ctx| {
+                ctx.persisted_documents.skip_enforcement = Some(true);
+            })
+            .unwrap();
+        let plugin_req_state: Option<PluginRequestState<'_>> = None;
+        let prep = OperationPreparation {
+            req: &req,
+            persisted_documents_runtime: &persisted_documents_runtime,
+            plugin_req_state: &plugin_req_state,
+            body: Bytes::new(),
+            require_id: true,
+            persisted_documents_enabled: true,
+            log_missing_id_requests: false,
+            client_identity: ClientIdentity::default(),
+            metrics: Arc::new(Metrics::new(None)),
+        };
+        // No ID in the operation, should be blocked by require_id enforcement,
+        // but skip_enforcement should bypass it.
+        let mut op = operation(Some("query { me { id } }"), None);
+
+        assert!(
+            prep.enforce_require_id_policy(&mut op).is_ok(),
+            "skip_enforcement should bypass require_id"
+        );
+    }
+
+    #[test]
+    fn skip_enforcement_false_still_enforces_require_id() {
+        let req = request();
+        let resolver = Arc::new(document_id_resolver());
+        let persisted_documents_runtime = PersistedDocumentsRuntime {
+            document_id_resolver: resolver,
+            persisted_document_resolver: None,
+        };
+        let request_context = SharedRequestContext::default();
+        request_context
+            .update(|ctx| {
+                ctx.persisted_documents.skip_enforcement = Some(false);
+            })
+            .unwrap();
+        let plugin_req_state: Option<PluginRequestState<'_>> = None;
+        let prep = OperationPreparation {
+            req: &req,
+            persisted_documents_runtime: &persisted_documents_runtime,
+            plugin_req_state: &plugin_req_state,
+            body: Bytes::new(),
+            require_id: true,
+            persisted_documents_enabled: true,
+            log_missing_id_requests: false,
+            client_identity: ClientIdentity::default(),
+            metrics: Arc::new(Metrics::new(None)),
+        };
+        // No ID in the operation, should be blocked by require_id enforcement,
+        // and skip_enforcement=false should not bypass it.
+        let mut op = operation(Some("query { me { id } }"), None);
+
+        let err = prep
+            .enforce_require_id_policy(&mut op)
+            .expect_err("skip_enforcement=false should still enforce require_id");
+
+        assert!(matches!(err, PipelineError::PersistedDocumentIdRequired));
     }
 }

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -10,6 +10,7 @@ use hive_router_plan_executor::hooks::on_graphql_params::{
 use hive_router_plan_executor::plugin_context::PluginRequestState;
 use hive_router_plan_executor::plugin_trait::{EndControlFlow, StartControlFlow};
 use hive_router_plan_executor::plugins::hooks;
+use hive_router_plan_executor::request_context::RequestContextExt;
 use http::{header::CONTENT_TYPE, Method};
 use ntex::util::Bytes;
 use ntex::web::types::Query;
@@ -535,11 +536,15 @@ impl<'a> OperationPreparation<'a> {
 
         if self.require_id {
             let skip_enforcement = self
-                .plugin_req_state
-                .as_ref()
-                .and_then(|state| state.request_context.read_lock().ok())
-                .and_then(|ctx| ctx.persisted_documents.skip_enforcement)
-                // If the lock (read_lock()) fails to be acquired,
+                .req
+                .read_request_context()
+                .ok()
+                .and_then(|ctx| {
+                    ctx.read_lock()
+                        .ok()
+                        .and_then(|guard| guard.persisted_documents.skip_enforcement)
+                })
+                // If the read_lock() fails to be acquired,
                 // treat it as skip_enforcement = false, to avoid failing the request.
                 // When skip_enforcement is None, treat it as `false`.
                 .unwrap_or(false);
@@ -606,7 +611,7 @@ mod tests {
     use hive_router_config::persisted_documents::PersistedDocumentsConfig;
     use hive_router_internal::telemetry::metrics::Metrics;
     use hive_router_plan_executor::hooks::on_graphql_params::GraphQLParams;
-    use hive_router_plan_executor::plugin_context::PluginRequestState;
+    use hive_router_plan_executor::plugin_context::{PluginContext, PluginRequestState};
     use hive_router_plan_executor::request_context::SharedRequestContext;
     use ntex::util::Bytes;
     use ntex::web::test::TestRequest;
@@ -862,7 +867,12 @@ mod tests {
                 ctx.persisted_documents.skip_enforcement = Some(true);
             })
             .unwrap();
-        let plugin_req_state: Option<PluginRequestState<'_>> = None;
+        let plugin_req_state = Some(PluginRequestState {
+            plugins: Arc::new(Vec::new()),
+            router_http_request: (&req).into(),
+            context: Arc::new(PluginContext::default()),
+            request_context,
+        });
         let prep = OperationPreparation {
             req: &req,
             persisted_documents_runtime: &persisted_documents_runtime,

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -2,8 +2,12 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
+use hive_console_sdk::expressions::{CompileExpression, ProgramHints};
+use hive_router_config::primitives::value_or_expression::ValueOrExpression;
+use hive_router_internal::expressions::{ToVrlValue, ValueOrProgram};
 use hive_router_internal::json::MapAccessSerdeExt;
 use hive_router_internal::telemetry::metrics::Metrics;
+use hive_router_plan_executor::execution::client_request_details::ntex_header_map_to_vrl_value;
 use hive_router_plan_executor::hooks::on_graphql_params::{
     GraphQLParams, OnGraphQLParamsEndHookPayload, OnGraphQLParamsStartHookPayload,
 };
@@ -305,7 +309,7 @@ pub struct OperationPreparation<'a> {
     persisted_documents_runtime: &'a PersistedDocumentsRuntime,
     plugin_req_state: &'a Option<PluginRequestState<'a>>,
     body: Bytes,
-    require_id: bool,
+    require_id: ValueOrProgram<bool>,
     persisted_documents_enabled: bool,
     log_missing_id_requests: bool,
     client_identity: ClientIdentity<'a>,
@@ -327,7 +331,16 @@ impl<'a> OperationPreparation<'a> {
             persisted_documents_runtime: &shared_state.persisted_documents_runtime,
             plugin_req_state,
             body,
-            require_id: shared_state.router_config.persisted_documents.require_id,
+            require_id: match &shared_state.router_config.persisted_documents.require_id {
+                ValueOrExpression::Value(value) => ValueOrProgram::Value(value.clone()),
+                ValueOrExpression::Expression { expression } => {
+                    let program = expression
+                        .compile_expression(None)
+                        .map_err(|err| PipelineError::PersistedDocumentIdExpressionError(err))?;
+                    let hints = ProgramHints::from_program(&program);
+                    ValueOrProgram::Program(Box::new(program), hints)
+                }
+            },
             persisted_documents_enabled: shared_state.router_config.persisted_documents.enabled,
             log_missing_id_requests: shared_state
                 .router_config
@@ -391,7 +404,6 @@ impl<'a> OperationPreparation<'a> {
                 event = "persisted_documents.missing_id_request",
                 method = %self.req.method(),
                 path = %self.req.uri().path(),
-                require_id = self.require_id,
                 operation_name = operation.graphql_params.operation_name.as_deref().unwrap_or(""),
                 operation_body = operation.graphql_params.query.as_deref().unwrap_or(""),
                 client_name = self.client_identity.name.unwrap_or(""),
@@ -534,7 +546,22 @@ impl<'a> OperationPreparation<'a> {
             return Ok(());
         }
 
-        if self.require_id {
+        let require_id = self
+            .require_id
+            .resolve_with_hints(|hints| {
+                hints.context_builder(|root| {
+                    root.insert_object("request", |req| {
+                        req.insert_lazy("method", || self.req.method().as_str().into())
+                            .insert_lazy("headers", || {
+                                ntex_header_map_to_vrl_value(self.req.headers())
+                            })
+                            .insert_lazy("url", || self.req.uri().to_vrl_value());
+                    });
+                })
+            })
+            .map_err(|err| PipelineError::PersistedDocumentIdExpressionEvaluationError(err))?;
+
+        if require_id {
             let skip_enforcement = self
                 .req
                 .read_request_context()
@@ -609,6 +636,7 @@ mod tests {
 
     use async_trait::async_trait;
     use hive_router_config::persisted_documents::PersistedDocumentsConfig;
+    use hive_router_internal::expressions::ValueOrProgram;
     use hive_router_internal::telemetry::metrics::Metrics;
     use hive_router_plan_executor::hooks::on_graphql_params::GraphQLParams;
     use hive_router_plan_executor::plugin_context::{PluginContext, PluginRequestState};
@@ -681,7 +709,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: false,
+            require_id: ValueOrProgram::Value(false),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -721,7 +749,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: true,
+            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -750,7 +778,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: true,
+            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -779,7 +807,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: false,
+            require_id: ValueOrProgram::Value(false),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -808,7 +836,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: true,
+            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: false,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -837,7 +865,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: false,
+            require_id: ValueOrProgram::Value(false),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -878,7 +906,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: true,
+            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -914,7 +942,7 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: true,
+            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -547,16 +547,14 @@ impl<'a> OperationPreparation<'a> {
                 // When skip_enforcement is None, treat it as `false`.
                 .unwrap_or(false);
 
-            if skip_enforcement {
+            if !skip_enforcement {
+                // If require_id is set, clear the query to make the document ID-based resolution mandatory.
+                prepared_operation.graphql_params.query = None;
+                if prepared_operation.resolved_document_id.is_none() {
+                    return Err(PipelineError::PersistedDocumentIdRequired);
+                }
                 return Ok(());
             }
-
-            // If require_id is set, clear the query to make the document ID-based resolution mandatory.
-            prepared_operation.graphql_params.query = None;
-            if prepared_operation.resolved_document_id.is_none() {
-                return Err(PipelineError::PersistedDocumentIdRequired);
-            }
-            return Ok(());
         }
 
         if prepared_operation.graphql_params.query.is_some() {

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -611,7 +611,7 @@ mod tests {
     use hive_router_internal::telemetry::metrics::Metrics;
     use hive_router_plan_executor::hooks::on_graphql_params::GraphQLParams;
     use hive_router_plan_executor::plugin_context::{PluginContext, PluginRequestState};
-    use hive_router_plan_executor::request_context::SharedRequestContext;
+    use hive_router_plan_executor::request_context::{RequestContextExt, SharedRequestContext};
     use ntex::util::Bytes;
     use ntex::web::test::TestRequest;
     use ntex::web::HttpRequest;
@@ -853,7 +853,7 @@ mod tests {
 
     #[test]
     fn skip_enforcement_bypasses_require_id() {
-        let req = request();
+        let mut req = request();
         let resolver = Arc::new(document_id_resolver());
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
@@ -867,6 +867,7 @@ mod tests {
                 ctx.persisted_documents.skip_enforcement = Some(true);
             })
             .unwrap();
+        req.write_request_context(request_context.clone());
         let plugin_req_state = Some(PluginRequestState {
             plugins: Arc::new(Vec::new()),
             router_http_request: (&req).into(),
@@ -887,6 +888,8 @@ mod tests {
         // but skip_enforcement should bypass it.
         let mut op = operation(Some("query { me { id } }"), None);
 
+        println!("{:?}", prep.enforce_require_id_policy(&mut op));
+
         assert!(
             prep.enforce_require_id_policy(&mut op).is_ok(),
             "skip_enforcement should bypass require_id"
@@ -895,7 +898,7 @@ mod tests {
 
     #[test]
     fn skip_enforcement_false_still_enforces_require_id() {
-        let req = request();
+        let mut req = request();
         let resolver = Arc::new(document_id_resolver());
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
@@ -908,6 +911,7 @@ mod tests {
                 ctx.persisted_documents.skip_enforcement = Some(false);
             })
             .unwrap();
+        req.write_request_context(request_context.clone());
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
             req: &req,

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -2,12 +2,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
-use hive_console_sdk::expressions::{CompileExpression, ProgramHints};
-use hive_router_config::primitives::value_or_expression::ValueOrExpression;
-use hive_router_internal::expressions::{ToVrlValue, ValueOrProgram};
 use hive_router_internal::json::MapAccessSerdeExt;
 use hive_router_internal::telemetry::metrics::Metrics;
-use hive_router_plan_executor::execution::client_request_details::ntex_header_map_to_vrl_value;
 use hive_router_plan_executor::hooks::on_graphql_params::{
     GraphQLParams, OnGraphQLParamsEndHookPayload, OnGraphQLParamsStartHookPayload,
 };
@@ -309,7 +305,6 @@ pub struct OperationPreparation<'a> {
     persisted_documents_runtime: &'a PersistedDocumentsRuntime,
     plugin_req_state: &'a Option<PluginRequestState<'a>>,
     body: Bytes,
-    require_id: ValueOrProgram<bool>,
     persisted_documents_enabled: bool,
     log_missing_id_requests: bool,
     client_identity: ClientIdentity<'a>,
@@ -331,16 +326,6 @@ impl<'a> OperationPreparation<'a> {
             persisted_documents_runtime: &shared_state.persisted_documents_runtime,
             plugin_req_state,
             body,
-            require_id: match &shared_state.router_config.persisted_documents.require_id {
-                ValueOrExpression::Value(value) => ValueOrProgram::Value(value.clone()),
-                ValueOrExpression::Expression { expression } => {
-                    let program = expression
-                        .compile_expression(None)
-                        .map_err(|err| PipelineError::PersistedDocumentIdExpressionError(err))?;
-                    let hints = ProgramHints::from_program(&program);
-                    ValueOrProgram::Program(Box::new(program), hints)
-                }
-            },
             persisted_documents_enabled: shared_state.router_config.persisted_documents.enabled,
             log_missing_id_requests: shared_state
                 .router_config
@@ -546,21 +531,7 @@ impl<'a> OperationPreparation<'a> {
             return Ok(());
         }
 
-        let require_id = self
-            .require_id
-            .resolve_with_hints(|hints| {
-                hints.context_builder(|root| {
-                    root.insert_object("request", |req| {
-                        req.insert_lazy("method", || self.req.method().as_str().into())
-                            .insert_lazy("headers", || {
-                                ntex_header_map_to_vrl_value(self.req.headers())
-                            })
-                            .insert_lazy("url", || self.req.uri().to_vrl_value());
-                    });
-                })
-            })
-            .map_err(|err| PipelineError::PersistedDocumentIdExpressionEvaluationError(err))?;
-
+        let require_id = self.persisted_documents_runtime.require_id(self.req)?;
         if require_id {
             let skip_enforcement = self
                 .req
@@ -576,12 +547,14 @@ impl<'a> OperationPreparation<'a> {
                 // When skip_enforcement is None, treat it as `false`.
                 .unwrap_or(false);
 
-            if !skip_enforcement {
-                // If require_id is set, clear the query to make the document ID-based resolution mandatory.
-                prepared_operation.graphql_params.query = None;
-                if prepared_operation.resolved_document_id.is_none() {
-                    return Err(PipelineError::PersistedDocumentIdRequired);
-                }
+            if skip_enforcement {
+                return Ok(());
+            }
+
+            // If require_id is set, clear the query to make the document ID-based resolution mandatory.
+            prepared_operation.graphql_params.query = None;
+            if prepared_operation.resolved_document_id.is_none() {
+                return Err(PipelineError::PersistedDocumentIdRequired);
             }
             return Ok(());
         }
@@ -702,6 +675,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: Some(persisted_resolver.clone()),
+            require_id: ValueOrProgram::Value(false),
         };
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
@@ -709,7 +683,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(false),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -742,6 +715,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(true),
         };
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
@@ -749,7 +723,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -771,6 +744,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(true),
         };
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
@@ -778,7 +752,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -800,6 +773,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(false),
         };
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
@@ -807,7 +781,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(false),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -829,6 +802,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(true),
         };
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
@@ -836,7 +810,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: false,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -858,6 +831,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(false),
         };
         let plugin_req_state: Option<PluginRequestState<'_>> = None;
         let prep = OperationPreparation {
@@ -865,7 +839,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(false),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -887,6 +860,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(true),
         };
         // Set skip_enforcement to true to bypass require_id enforcement.
         let request_context = SharedRequestContext::default();
@@ -906,7 +880,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),
@@ -929,6 +902,7 @@ mod tests {
         let persisted_documents_runtime = PersistedDocumentsRuntime {
             document_id_resolver: resolver,
             persisted_document_resolver: None,
+            require_id: ValueOrProgram::Value(true),
         };
         let request_context = SharedRequestContext::default();
         request_context
@@ -942,7 +916,6 @@ mod tests {
             persisted_documents_runtime: &persisted_documents_runtime,
             plugin_req_state: &plugin_req_state,
             body: Bytes::new(),
-            require_id: ValueOrProgram::Value(true),
             persisted_documents_enabled: true,
             log_missing_id_requests: false,
             client_identity: ClientIdentity::default(),

--- a/bin/router/src/pipeline/persisted_documents/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/mod.rs
@@ -51,8 +51,7 @@ impl PersistedDocumentsRuntime {
             ValueOrExpression::Expression { expression } => {
                 let program = expression.compile_expression(None).map_err(|err| {
                     PersistedDocumentResolverError::Configuration(format!(
-                        "
-                      Failed to compile persisted document require_id expression: {err}"
+                        "Failed to compile persisted document require_id expression: {err}"
                     ))
                 })?;
                 let hints = ProgramHints::from_program(&program);

--- a/bin/router/src/pipeline/persisted_documents/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/mod.rs
@@ -1,10 +1,16 @@
 use std::sync::Arc;
 
+use hive_console_sdk::expressions::{CompileExpression, ProgramHints};
 use hive_router_config::persisted_documents::{
     PersistedDocumentsConfig, PersistedDocumentsStorageConfig,
 };
+use hive_router_config::primitives::value_or_expression::ValueOrExpression;
 use hive_router_internal::background_tasks::BackgroundTasksManager;
+use hive_router_internal::expressions::{ToVrlValue, ValueOrProgram};
+use hive_router_plan_executor::execution::client_request_details::ntex_header_map_to_vrl_value;
+use ntex::web::HttpRequest;
 
+use crate::pipeline::error::PipelineError;
 use crate::pipeline::persisted_documents::extract::DocumentIdResolver;
 use crate::pipeline::persisted_documents::resolve::storage::{
     StorageManifestReloadTask, StorageResolver,
@@ -22,6 +28,7 @@ pub mod types;
 pub struct PersistedDocumentsRuntime {
     pub document_id_resolver: Arc<DocumentIdResolver>,
     pub persisted_document_resolver: Option<Arc<dyn PersistedDocumentResolver>>,
+    pub(crate) require_id: ValueOrProgram<bool>,
 }
 
 impl PersistedDocumentsRuntime {
@@ -38,6 +45,20 @@ impl PersistedDocumentsRuntime {
                 ))
             })?,
         );
+
+        let require_id = match &config.require_id {
+            ValueOrExpression::Value(value) => ValueOrProgram::Value(*value),
+            ValueOrExpression::Expression { expression } => {
+                let program = expression.compile_expression(None).map_err(|err| {
+                    PersistedDocumentResolverError::Configuration(format!(
+                        "
+                      Failed to compile persisted document require_id expression: {err}"
+                    ))
+                })?;
+                let hints = ProgramHints::from_program(&program);
+                ValueOrProgram::Program(Box::new(program), hints)
+            }
+        };
 
         let persisted_document_resolver = if config.enabled {
             let storage = config
@@ -89,6 +110,7 @@ impl PersistedDocumentsRuntime {
         Ok(Self {
             document_id_resolver,
             persisted_document_resolver,
+            require_id,
         })
     }
 
@@ -106,5 +128,21 @@ impl PersistedDocumentsRuntime {
         // `/` can't be used as it would conflict with the path param extractor.
         // The `/:id` would match `/health` endpoint for example.
         !is_root_endpoint
+    }
+
+    pub fn require_id(&self, request: &HttpRequest) -> Result<bool, PipelineError> {
+        self.require_id
+            .resolve_with_hints(|hints| {
+                hints.context_builder(|root| {
+                    root.insert_object("request", |req| {
+                        req.insert_lazy("method", || request.method().as_str().into())
+                            .insert_lazy("headers", || {
+                                ntex_header_map_to_vrl_value(request.headers())
+                            })
+                            .insert_lazy("url", || request.uri().to_vrl_value());
+                    });
+                })
+            })
+            .map_err(PipelineError::PersistedDocumentIdExpressionEvaluationError)
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -2443,7 +2443,7 @@ Configuration for persisted documents extraction and resolution.
 |----|----|-----------|--------|
 |**enabled**|`boolean`|Default: `false`<br/>||
 |**log\_missing\_id**|`boolean`|Default: `false`<br/>||
-|**require\_id**|`boolean`|Default: `false`<br/>||
+|**require\_id**||Default: `false`<br/>||
 |[**selectors**](#persisted_documentsselectors)|`array`|||
 |**storage**||||
 

--- a/e2e/src/persisted_documents/mod.rs
+++ b/e2e/src/persisted_documents/mod.rs
@@ -8,6 +8,7 @@ mod extractor_url_query_param;
 mod method_get;
 mod policy;
 mod shared;
+mod skip_enforcement;
 mod storage_file;
 mod storage_hive;
 mod storage_s3;

--- a/e2e/src/persisted_documents/policy.rs
+++ b/e2e/src/persisted_documents/policy.rs
@@ -112,11 +112,9 @@ async fn require_id_expression_basic() {
     assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;
 
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
+        .send_graphql_request(
+            "{ topProducts { name } }",
+            None,
             some_header_map! {
                 http::header::HeaderName::from_static("x-require-id") => "false"
             },

--- a/e2e/src/persisted_documents/policy.rs
+++ b/e2e/src/persisted_documents/policy.rs
@@ -1,7 +1,7 @@
 use sonic_rs::json;
 
-use super::shared::{assert_resolves_successfully, write_manifest};
-use crate::testkit::{TestRouter, TestSubgraphs};
+use super::shared::{assert_error_code, assert_resolves_successfully, write_manifest};
+use crate::testkit::{some_header_map, EnvVarsGuard, TestRouter, TestSubgraphs};
 
 #[ntex::test]
 async fn query_wins_when_require_id_is_false() {
@@ -72,4 +72,134 @@ async fn disabled_mode_ignores_extracted_id() {
         .await;
 
     assert_resolves_successfully(response).await;
+}
+
+#[ntex::test]
+async fn require_id_expression_basic() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id:
+                    expression: .request.headers."x-require-id" == "true"
+                  storage:
+                    type: file
+                    path: "{}"
+                "#,
+            manifest.path().display(),
+        ))
+        .build()
+        .start()
+        .await;
+
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            some_header_map! {
+                http::header::HeaderName::from_static("x-require-id") => "true"
+            },
+        )
+        .await;
+
+    assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;
+
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            some_header_map! {
+                http::header::HeaderName::from_static("x-require-id") => "false"
+            },
+        )
+        .await;
+
+    assert_resolves_successfully(response).await;
+}
+
+#[ntex::test]
+async fn require_id_expression_with_env_secret() {
+    let _env_guard = EnvVarsGuard::new()
+        .set("BYPASS_SECRET", "bypass123")
+        .apply()
+        .await;
+
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id:
+                    expression: is_null(env("BYPASS_SECRET")) || .request.headers."x-bypass-require-id" != env("BYPASS_SECRET")
+                  storage:
+                    type: file
+                    path: "{}"
+                "#,
+            manifest.path().display(),
+        ))
+        .build()
+        .start()
+        .await;
+
+    // Header does not match the env secret.
+    // require_id is true
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            some_header_map! {
+                http::header::HeaderName::from_static("x-bypass-require-id") => "wrong-secret"
+            },
+        )
+        .await;
+    assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;
+
+    // Header matches the env secret.
+    // require_id is false
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            some_header_map! {
+                http::header::HeaderName::from_static("x-bypass-require-id") => "bypass123"
+            },
+        )
+        .await;
+
+    assert_resolves_successfully(response).await;
+
+    // Env var not set.
+    // is_null(env(...)) is true, so require_id is true
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            None,
+        )
+        .await;
+
+    assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;
 }

--- a/e2e/src/persisted_documents/policy.rs
+++ b/e2e/src/persisted_documents/policy.rs
@@ -100,11 +100,9 @@ async fn require_id_expression_basic() {
         .await;
 
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
+        .send_graphql_request(
+            "{ topProducts { name } }",
+            None,
             some_header_map! {
                 http::header::HeaderName::from_static("x-require-id") => "true"
             },
@@ -161,11 +159,9 @@ async fn require_id_expression_with_env_secret() {
     // Header does not match the env secret.
     // require_id is true
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
+        .send_graphql_request(
+            "{ topProducts { name } }",
+            None,
             some_header_map! {
                 http::header::HeaderName::from_static("x-bypass-require-id") => "wrong-secret"
             },
@@ -176,11 +172,9 @@ async fn require_id_expression_with_env_secret() {
     // Header matches the env secret.
     // require_id is false
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
+        .send_graphql_request(
+            "{ topProducts { name } }",
+            None,
             some_header_map! {
                 http::header::HeaderName::from_static("x-bypass-require-id") => "bypass123"
             },
@@ -192,13 +186,7 @@ async fn require_id_expression_with_env_secret() {
     // Env var not set.
     // is_null(env(...)) is true, so require_id is true
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
-            None,
-        )
+        .send_graphql_request("{ topProducts { name } }", None, None)
         .await;
 
     assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;

--- a/e2e/src/persisted_documents/skip_enforcement.rs
+++ b/e2e/src/persisted_documents/skip_enforcement.rs
@@ -12,19 +12,23 @@ use sonic_rs::json;
 use super::shared::{assert_error_code, assert_resolves_successfully, write_manifest};
 use crate::testkit::{coprocessor::TestCoprocessor, TestRouter, TestSubgraphs};
 
-#[derive(Default)]
-struct TestSkipEnforcementPlugin;
+struct TestSkipEnforcementPlugin {
+    skip_enforcement: bool,
+}
 
 #[async_trait]
 impl RouterPlugin for TestSkipEnforcementPlugin {
-    type Config = ();
+    type Config = bool;
 
     fn plugin_name() -> &'static str {
         "test_skip_enforcement"
     }
 
     fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
-        payload.initialize_plugin_with_defaults()
+        let config = payload.config()?;
+        payload.initialize_plugin(Self {
+            skip_enforcement: config,
+        })
     }
 
     fn on_http_request<'req>(
@@ -36,36 +40,7 @@ impl RouterPlugin for TestSkipEnforcementPlugin {
             .write()
             .unwrap()
             .persisted_documents()
-            .set_skip_enforcement(true);
-        payload.proceed()
-    }
-}
-
-#[derive(Default)]
-struct TestSkipEnforcementFalsePlugin;
-
-#[async_trait]
-impl RouterPlugin for TestSkipEnforcementFalsePlugin {
-    type Config = ();
-
-    fn plugin_name() -> &'static str {
-        "test_skip_enforcement_false"
-    }
-
-    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
-        payload.initialize_plugin_with_defaults()
-    }
-
-    fn on_http_request<'req>(
-        &self,
-        payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        payload
-            .request_context
-            .write()
-            .unwrap()
-            .persisted_documents()
-            .set_skip_enforcement(false);
+            .set_skip_enforcement(self.skip_enforcement);
         payload.proceed()
     }
 }
@@ -119,6 +94,7 @@ async fn plugin_bypass_via_on_http_request() {
                 plugins:
                   test_skip_enforcement:
                     enabled: true
+                    config: true
                 "#,
             manifest.path().display(),
         ))
@@ -157,6 +133,7 @@ async fn plugin_bypass_via_on_graphql_params() {
                 plugins:
                   test_skip_enforcement_on_graphql_params:
                     enabled: true
+                    config: true
                 "#,
             manifest.path().display(),
         ))
@@ -193,13 +170,14 @@ async fn skip_enforcement_false_still_enforces() {
                     type: file
                     path: "{}"
                 plugins:
-                  test_skip_enforcement_false:
+                  test_skip_enforcement:
                     enabled: true
+                    config: false
                 "#,
             manifest.path().display(),
         ))
-        // Plugin sets skip_enforcement to false via on_graphql_params
-        .register_plugin::<TestSkipEnforcementFalsePlugin>()
+        // Plugin sets skip_enforcement to false via on_http_request
+        .register_plugin::<TestSkipEnforcementPlugin>()
         .build()
         .start()
         .await;
@@ -233,6 +211,7 @@ async fn skip_enforcement_with_valid_document_id() {
                 plugins:
                   test_skip_enforcement:
                     enabled: true
+                    config: true
                 "#,
             manifest.path().display(),
         ))

--- a/e2e/src/persisted_documents/skip_enforcement.rs
+++ b/e2e/src/persisted_documents/skip_enforcement.rs
@@ -1,0 +1,479 @@
+use hive_router::{
+    async_trait,
+    plugins::hooks::on_graphql_params::{
+        OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult,
+    },
+    plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+    plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+    plugins::plugin_trait::{RouterPlugin, StartHookPayload},
+};
+use sonic_rs::json;
+
+use super::shared::{assert_error_code, assert_resolves_successfully, write_manifest};
+use crate::testkit::{coprocessor::TestCoprocessor, TestRouter, TestSubgraphs};
+
+#[derive(Default)]
+struct TestSkipEnforcementPlugin;
+
+#[async_trait]
+impl RouterPlugin for TestSkipEnforcementPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "test_skip_enforcement"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin_with_defaults()
+    }
+
+    fn on_http_request<'req>(
+        &self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
+        payload
+            .request_context
+            .write()
+            .unwrap()
+            .persisted_documents()
+            .set_skip_enforcement(true);
+        payload.proceed()
+    }
+}
+
+#[derive(Default)]
+struct TestSkipEnforcementFalsePlugin;
+
+#[async_trait]
+impl RouterPlugin for TestSkipEnforcementFalsePlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "test_skip_enforcement_false"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin_with_defaults()
+    }
+
+    fn on_http_request<'req>(
+        &self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
+        payload
+            .request_context
+            .write()
+            .unwrap()
+            .persisted_documents()
+            .set_skip_enforcement(false);
+        payload.proceed()
+    }
+}
+
+#[derive(Default)]
+struct TestSkipEnforcementOnGraphqlParamsPlugin;
+
+#[async_trait]
+impl RouterPlugin for TestSkipEnforcementOnGraphqlParamsPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "test_skip_enforcement_on_graphql_params"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin_with_defaults()
+    }
+
+    async fn on_graphql_params<'exec>(
+        &'exec self,
+        payload: OnGraphQLParamsStartHookPayload<'exec>,
+    ) -> OnGraphQLParamsStartHookResult<'exec> {
+        payload
+            .request_context
+            .write()
+            .unwrap()
+            .persisted_documents()
+            .set_skip_enforcement(true);
+        payload.proceed()
+    }
+}
+
+#[ntex::test]
+async fn plugin_bypass_via_on_http_request() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                plugins:
+                  test_skip_enforcement:
+                    enabled: true
+                "#,
+            manifest.path().display(),
+        ))
+        // Plugin sets skip_enforcement to true on HTTP request
+        .register_plugin::<TestSkipEnforcementPlugin>()
+        .build()
+        .start()
+        .await;
+
+    // We send no document id
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            None,
+        )
+        .await;
+
+    // But it should still resolve successfully, because skip_enforcement is true
+    assert_resolves_successfully(response).await;
+}
+
+#[ntex::test]
+async fn plugin_bypass_via_on_graphql_params() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                plugins:
+                  test_skip_enforcement_on_graphql_params:
+                    enabled: true
+                "#,
+            manifest.path().display(),
+        ))
+        // Plugin sets skip_enforcement to true via on_graphql_params
+        .register_plugin::<TestSkipEnforcementOnGraphqlParamsPlugin>()
+        .build()
+        .start()
+        .await;
+
+    // We send no document id
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            None,
+        )
+        .await;
+
+    // But it should still resolve successfully, because skip_enforcement is true
+    assert_resolves_successfully(response).await;
+}
+
+#[ntex::test]
+async fn skip_enforcement_false_still_enforces() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                plugins:
+                  test_skip_enforcement_false:
+                    enabled: true
+                "#,
+            manifest.path().display(),
+        ))
+        // Plugin sets skip_enforcement to false via on_graphql_params
+        .register_plugin::<TestSkipEnforcementFalsePlugin>()
+        .build()
+        .start()
+        .await;
+
+    // We send no document id
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            None,
+        )
+        .await;
+
+    // Request should fail as it lacks a document id
+    assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;
+}
+
+#[ntex::test]
+async fn skip_enforcement_with_valid_document_id() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                plugins:
+                  test_skip_enforcement:
+                    enabled: true
+                "#,
+            manifest.path().display(),
+        ))
+        // Plugin sets skip_enforcement to true
+        .register_plugin::<TestSkipEnforcementPlugin>()
+        .build()
+        .start()
+        .await;
+
+    // We send the ID
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "documentId": "sha256:abc123"
+            }),
+            None,
+        )
+        .await;
+
+    assert_resolves_successfully(response).await;
+}
+
+#[ntex::test]
+async fn coprocessor_skip_enforcement_via_router_request() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let mut coprocessor = TestCoprocessor::new().await;
+    let host = coprocessor.host_with_port();
+
+    // Coprocessor sets skip_enforcement to true
+    let router_request_mock = coprocessor
+        .mock_stage("router.request")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "version": 1,
+                "control": "continue",
+                "context": {
+                    "hive::persisted_documents::skip_enforcement": true
+                }
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                coprocessor:
+                  url: http://{host}/coprocessor
+                  protocol: http1
+                  stages:
+                    router:
+                      request:
+                        include:
+                          context: true
+                "#,
+            manifest.path().display(),
+        ))
+        .build()
+        .start()
+        .await;
+
+    // Request has no ID
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            None,
+        )
+        .await;
+
+    // Request should succeed, because we bypassed enforcement
+    assert_resolves_successfully(response).await;
+    router_request_mock.assert_async().await;
+}
+
+#[ntex::test]
+async fn coprocessor_skip_enforcement_false_still_enforces() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let mut coprocessor = TestCoprocessor::new().await;
+    let host = coprocessor.host_with_port();
+
+    // Coprocessor sets skip_enforcement to false
+    let router_request_mock = coprocessor
+        .mock_stage("router.request")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "version": 1,
+                "control": "continue",
+                "context": {
+                    "hive::persisted_documents::skip_enforcement": false
+                }
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                coprocessor:
+                  url: http://{host}/coprocessor
+                  protocol: http1
+                  stages:
+                    router:
+                      request:
+                        include:
+                          context: true
+                "#,
+            manifest.path().display(),
+        ))
+        .build()
+        .start()
+        .await;
+
+    // Request has no ID
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "query": "{ topProducts { name } }"
+            }),
+            None,
+        )
+        .await;
+
+    // Request should fail, because we did not bypass enforcement
+    assert_error_code(response, "PERSISTED_DOCUMENT_ID_REQUIRED").await;
+    router_request_mock.assert_async().await;
+}
+
+#[ntex::test]
+async fn coprocessor_skip_enforcement_with_valid_document_id() {
+    let manifest = write_manifest();
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+    let mut coprocessor = TestCoprocessor::new().await;
+    let host = coprocessor.host_with_port();
+
+    let router_request_mock = coprocessor
+        .mock_stage("router.request")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "version": 1,
+                "control": "continue",
+                "context": {
+                    "hive::persisted_documents::skip_enforcement": true
+                }
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                persisted_documents:
+                  enabled: true
+                  require_id: true
+                  storage:
+                    type: file
+                    path: "{}"
+                coprocessor:
+                  url: http://{host}/coprocessor
+                  protocol: http1
+                  stages:
+                    router:
+                      request:
+                        include:
+                          headers: true
+                "#,
+            manifest.path().display(),
+        ))
+        .build()
+        .start()
+        .await;
+
+    let response = router
+        .send_post_request(
+            "/graphql",
+            json!({
+                "documentId": "sha256:abc123"
+            }),
+            None,
+        )
+        .await;
+
+    assert_resolves_successfully(response).await;
+    router_request_mock.assert_async().await;
+}

--- a/e2e/src/persisted_documents/skip_enforcement.rs
+++ b/e2e/src/persisted_documents/skip_enforcement.rs
@@ -130,13 +130,7 @@ async fn plugin_bypass_via_on_http_request() {
 
     // We send no document id
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
-            None,
-        )
+        .send_graphql_request("{ topProducts { name } }", None, None)
         .await;
 
     // But it should still resolve successfully, because skip_enforcement is true
@@ -174,13 +168,7 @@ async fn plugin_bypass_via_on_graphql_params() {
 
     // We send no document id
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
-            None,
-        )
+        .send_graphql_request("{ topProducts { name } }", None, None)
         .await;
 
     // But it should still resolve successfully, because skip_enforcement is true
@@ -218,13 +206,7 @@ async fn skip_enforcement_false_still_enforces() {
 
     // We send no document id
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
-            None,
-        )
+        .send_graphql_request("{ topProducts { name } }", None, None)
         .await;
 
     // Request should fail as it lacks a document id
@@ -329,13 +311,7 @@ async fn coprocessor_skip_enforcement_via_router_request() {
 
     // Request has no ID
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
-            None,
-        )
+        .send_graphql_request("{ topProducts { name } }", None, None)
         .await;
 
     // Request should succeed, because we bypassed enforcement
@@ -398,13 +374,7 @@ async fn coprocessor_skip_enforcement_false_still_enforces() {
 
     // Request has no ID
     let response = router
-        .send_post_request(
-            "/graphql",
-            json!({
-                "query": "{ topProducts { name } }"
-            }),
-            None,
-        )
+        .send_graphql_request("{ topProducts { name } }", None, None)
         .await;
 
     // Request should fail, because we did not bypass enforcement

--- a/lib/executor/src/request_context/deser.rs
+++ b/lib/executor/src/request_context/deser.rs
@@ -11,6 +11,11 @@ pub trait RequestContextValueExt {
         key: &'static str,
         expected: &'static str,
     ) -> Result<&'a str, RequestContextError>;
+    fn expect_bool(
+        &self,
+        key: &'static str,
+        expected: &'static str,
+    ) -> Result<bool, RequestContextError>;
     fn expect_array<'a>(
         &'a self,
         key: &'static str,
@@ -29,6 +34,21 @@ impl RequestContextValueExt for Value {
             .ok_or_else(|| RequestContextError::ReservedKeyTypeMismatch {
                 key: key.to_string(),
                 expected: allowed_types,
+            })?;
+
+        Ok(value)
+    }
+
+    fn expect_bool(
+        &self,
+        key: &'static str,
+        expected: &'static str,
+    ) -> Result<bool, RequestContextError> {
+        let value = self
+            .as_bool()
+            .ok_or_else(|| RequestContextError::ReservedKeyTypeMismatch {
+                key: key.to_string(),
+                expected,
             })?;
 
         Ok(value)

--- a/lib/executor/src/request_context/domains/mod.rs
+++ b/lib/executor/src/request_context/domains/mod.rs
@@ -1,5 +1,6 @@
 use super::domains::authentication::AuthenticationContext;
 use super::domains::operation::OperationContext;
+use super::domains::persisted_documents::PersistedDocumentsContext;
 use super::domains::progressive_override::ProgressiveOverrideContext;
 use super::domains::telemetry::TelemetryContext;
 use super::RequestContextError;
@@ -13,6 +14,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 mod authentication;
 mod operation;
+pub(crate) mod persisted_documents;
 mod progressive_override;
 mod telemetry;
 
@@ -178,6 +180,7 @@ reserved_domains! {
     progressive_override: ProgressiveOverrideContext,
     authentication: AuthenticationContext,
     telemetry: TelemetryContext,
+    persisted_documents: PersistedDocumentsContext,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/lib/executor/src/request_context/domains/persisted_documents.rs
+++ b/lib/executor/src/request_context/domains/persisted_documents.rs
@@ -1,0 +1,84 @@
+use serde::ser::SerializeMap;
+use sonic_rs::{JsonValueTrait, Value};
+
+use super::super::api::plugin::{RequestContextPluginRead, RequestContextPluginWrite};
+use super::super::deser::RequestContextValueExt;
+use super::RequestContextDomain;
+use super::RequestContextError;
+use crate::hooks;
+
+pub trait CanWritePersistedDocuments {}
+impl CanWritePersistedDocuments for hooks::OnHttpRequest {}
+impl CanWritePersistedDocuments for hooks::OnGraphqlParams {}
+
+pub(crate) const SKIP_ENFORCEMENT_KEY: &str = "hive::persisted_documents::skip_enforcement";
+
+#[derive(Debug, Clone, Default)]
+pub struct PersistedDocumentsContext {
+    pub skip_enforcement: Option<bool>,
+}
+
+impl PersistedDocumentsContext {
+    fn set_skip_enforcement_value(&mut self, value: Value) -> Result<(), RequestContextError> {
+        if value.is_null() {
+            self.skip_enforcement = None;
+            return Ok(());
+        }
+
+        let flag = value.expect_bool(SKIP_ENFORCEMENT_KEY, "boolean or null")?;
+        self.skip_enforcement = Some(flag);
+        Ok(())
+    }
+}
+
+pub struct RequestContextPersistedDocumentsRead<'a> {
+    context: &'a PersistedDocumentsContext,
+}
+
+impl RequestContextPersistedDocumentsRead<'_> {
+    pub fn skip_enforcement(&self) -> Option<bool> {
+        self.context.skip_enforcement
+    }
+}
+
+pub struct RequestContextPersistedDocumentsWrite<'a> {
+    context: &'a mut PersistedDocumentsContext,
+}
+
+impl RequestContextPersistedDocumentsWrite<'_> {
+    pub fn set_skip_enforcement(&mut self, value: bool) -> &mut Self {
+        self.context.skip_enforcement = Some(value);
+        self
+    }
+}
+
+impl<Hook> RequestContextPluginRead<Hook> {
+    pub fn persisted_documents(&self) -> RequestContextPersistedDocumentsRead<'_> {
+        RequestContextPersistedDocumentsRead {
+            context: &self.snapshot.persisted_documents,
+        }
+    }
+}
+
+impl<Hook: CanWritePersistedDocuments> RequestContextPluginWrite<'_, Hook> {
+    pub fn persisted_documents(&mut self) -> RequestContextPersistedDocumentsWrite<'_> {
+        RequestContextPersistedDocumentsWrite {
+            context: &mut self.context.persisted_documents,
+        }
+    }
+}
+
+impl RequestContextDomain for PersistedDocumentsContext {
+    const DOMAIN_PREFIX: &'static str = "hive::persisted_documents::";
+
+    fn set_key_value(&mut self, key: &str, value: Value) -> Result<(), RequestContextError> {
+        match key {
+            SKIP_ENFORCEMENT_KEY => self.set_skip_enforcement_value(value),
+            _ => self.unknown_key(key),
+        }
+    }
+
+    super::impl_domain_serde!(
+        SKIP_ENFORCEMENT_KEY => skip_enforcement,
+    );
+}

--- a/lib/executor/src/request_context/mod.rs
+++ b/lib/executor/src/request_context/mod.rs
@@ -6,6 +6,9 @@ mod web;
 
 pub use api::coprocessor::RequestContextPatch;
 pub use api::plugin::RequestContextPluginApi;
+pub use domains::persisted_documents::{
+    RequestContextPersistedDocumentsRead, RequestContextPersistedDocumentsWrite,
+};
 pub use domains::{RequestContext, SelectedRequestContext, SharedRequestContext};
 pub use error::RequestContextError;
 pub use web::RequestContextExt;

--- a/lib/router-config/src/persisted_documents.rs
+++ b/lib/router-config/src/persisted_documents.rs
@@ -7,13 +7,14 @@ use crate::primitives::file_path::FilePath;
 use crate::primitives::retry_policy::RetryPolicyConfig;
 use crate::primitives::single_or_multiple::SingleOrMultiple;
 use crate::primitives::toggle::ToggleWith;
+use crate::primitives::value_or_expression::ValueOrExpression;
 
 #[derive(Debug, Serialize, JsonSchema, Clone, Default)]
 pub struct PersistedDocumentsConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
-    pub require_id: bool,
+    pub require_id: ValueOrExpression<bool>,
     #[serde(default)]
     pub log_missing_id: bool,
     #[serde(default)]
@@ -28,7 +29,7 @@ struct RawPersistedDocumentsConfig {
     #[serde(default)]
     enabled: bool,
     #[serde(default)]
-    require_id: bool,
+    require_id: ValueOrExpression<bool>,
     #[serde(default)]
     log_missing_id: bool,
     #[serde(default)]


### PR DESCRIPTION
This PR adds two new features to persisted documents.

Closes #1235

---

**1. New flag to skip persisted document id check**

A new flag `hive::persisted_documents::skip_enforcement` can skip the `require_id` check on per-request basis. When set to `true`, requests with a full query string are allowed even if `persisted_documents.require_id` is turned on.

Users can set this flag from:
- `OnHttpRequest` plugin hook
- `OnGraphqlParams` plugin hook
- `router.request` coprocessor stage

---

**2. `require_id` can now use an expression**

`persisted_documents.require_id` now accepts an expression (not just `true` or `false`). The expression is checked for each request and can use:
- `.request.headers`
- `.request.method`
- `.request.url`
- `env()` function for environment variables

When the expression returns `true`, the ID is required. When it returns `false`, the ID is not required.

```yaml
persisted_documents:
  require_id:
    expression: |
      is_null(env("BYPASS_SECRET")) 
      || 
      .request.headers."x-bypass-require-id" != env("BYPASS_SECRET")
```