### PR TITLE
fix(query-planner): fix stack overflow on cyclic fragment spreads with sibling fields or directives

### DIFF
--- a/.changeset/fix_stack_overflow_on_cyclic_fragment_spreads_with_sibling_fields_or_directives.md
+++ b/.changeset/fix_stack_overflow_on_cyclic_fragment_spreads_with_sibling_fields_or_directives.md
@@ -1,0 +1,10 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Fix stack overflow on cyclic fragment spreads with sibling fields or directives
+
+A self-referential fragment that also selects a sibling field (`fragment A on Query { x ...A }`) or puts a directive on the cycling spread (`...A @include(if: $c)`) caused unbounded recursion during fragment inlining in normalization, overflowing the stack and crashing the process.

--- a/lib/query-planner/src/ast/normalization/mod.rs
+++ b/lib/query-planner/src/ast/normalization/mod.rs
@@ -2821,4 +2821,76 @@ mod tests {
             "expected an error for a cyclic fragment, got Ok"
         );
     }
+
+    #[test]
+    fn cyclic_fragment_self_reference_with_sibling_field_returns_error() {
+        // fragment A on Query { x ...A } - self-cycle with a sibling field breaks the
+        // single-bare-spread fast path and must still be rejected, not overflow the stack.
+        let schema = parse_schema(
+            r#"
+            type Query {
+              x: String
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+        let parsed = parse_query::<String>(
+            r#"
+            query { ...A }
+            fragment A on Query { x ...A }
+            "#,
+        )
+        .expect("to parse")
+        .into_static();
+
+        // run in a thread with a deadline so a stack overflow / hang fails as a test failure
+        // instead of aborting the whole test process.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = normalize_operation(&supergraph, &parsed, None);
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("normalize_operation hung or crashed on a self-cycle with a sibling field");
+        assert!(
+            result.is_err(),
+            "expected an error for a cyclic fragment, got Ok"
+        );
+    }
+
+    #[test]
+    fn cyclic_fragment_self_reference_with_directive_returns_error() {
+        // fragment A on Query { ...A @include(if: $c) } - a directive on the cycling spread
+        // also breaks the single-bare-spread fast path and must still be rejected.
+        let schema = parse_schema(
+            r#"
+            type Query {
+              field: String
+            }
+            "#,
+        );
+        let supergraph = SupergraphState::new(&schema);
+        let parsed = parse_query::<String>(
+            r#"
+            query ($c: Boolean!) { ...A }
+            fragment A on Query { ...A @include(if: $c) }
+            "#,
+        )
+        .expect("to parse")
+        .into_static();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = normalize_operation(&supergraph, &parsed, None);
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("normalize_operation hung or crashed on a self-cycle with a directive");
+        assert!(
+            result.is_err(),
+            "expected an error for a cyclic fragment, got Ok"
+        );
+    }
 }

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use graphql_tools::parser::query::{
     Definition, FragmentDefinition, InlineFragment, Mutation, OperationDefinition, Query,
@@ -20,7 +20,7 @@ pub fn inline_fragment_spreads(ctx: &mut NormalizationContext) -> Result<(), Nor
         // fresh per top-level definition: tracks fragment names currently being expanded on
         // the active inline/wrap path, so any cyclic expansion - regardless of shape - is
         // caught before it recurses forever.
-        let mut active_fragments = HashSet::new();
+        let mut active_fragments = Vec::new();
         match definition {
             Definition::Operation(op_def) => match op_def {
                 OperationDefinition::SelectionSet(selection_set) => {
@@ -72,12 +72,12 @@ pub fn inline_fragment_spreads(ctx: &mut NormalizationContext) -> Result<(), Nor
 
 #[inline]
 // active_fragments borrows names out of fragment_map ('f) instead of cloning strings -
-// insert/remove per expansion is then just a hash of a &str.
+// push/pop per expansion is then just a pointer compare over a handful of entries.
 fn handle_selection_set<'a, 'f>(
     selection_set: &mut SelectionSet<'a, String>,
     fragment_map: &'f HashMap<String, FragmentDefinition<'a, String>>,
     parent_type_condition: Option<&TypeCondition<'a, String>>,
-    active_fragments: &mut HashSet<&'f str>,
+    active_fragments: &mut Vec<&'f str>,
 ) -> Result<(), NormalizationError> {
     let old_items = std::mem::take(&mut selection_set.items);
     let mut new_items = Vec::with_capacity(old_items.len());
@@ -153,11 +153,12 @@ fn handle_selection_set<'a, 'f>(
                 // guards every recursive expansion below (inline and wrap alike), not just the
                 // bare-spread fast path above - a sibling field or a directive on the cycling
                 // spread breaks out of that fast path, so this is the backstop that catches it.
-                if !active_fragments.insert(fragment_def.name.as_str()) {
+                if active_fragments.contains(&fragment_def.name.as_str()) {
                     return Err(NormalizationError::CyclicFragmentSpread {
                         fragment_name: spread.fragment_name.clone(),
                     });
                 }
+                active_fragments.push(fragment_def.name.as_str());
 
                 let result = if parent_type_condition == Some(&fragment_def.type_condition)
                     // `...Frag @include(...)` stores `@include` on the spread itself.
@@ -192,7 +193,7 @@ fn handle_selection_set<'a, 'f>(
                     .map(|_| new_items.push(Selection::InlineFragment(inline_fragment)))
                 };
 
-                active_fragments.remove(fragment_def.name.as_str());
+                active_fragments.pop();
                 result?;
             }
             Selection::InlineFragment(mut inline_fragment) => {

--- a/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/inline_fragment_spreads.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use graphql_tools::parser::query::{
     Definition, FragmentDefinition, InlineFragment, Mutation, OperationDefinition, Query,
@@ -17,19 +17,43 @@ pub fn inline_fragment_spreads(ctx: &mut NormalizationContext) -> Result<(), Nor
     }
 
     for definition in &mut ctx.document.definitions {
+        // fresh per top-level definition: tracks fragment names currently being expanded on
+        // the active inline/wrap path, so any cyclic expansion - regardless of shape - is
+        // caught before it recurses forever.
+        let mut active_fragments = HashSet::new();
         match definition {
             Definition::Operation(op_def) => match op_def {
                 OperationDefinition::SelectionSet(selection_set) => {
-                    handle_selection_set(selection_set, &fragment_map, None)?;
+                    handle_selection_set(
+                        selection_set,
+                        &fragment_map,
+                        None,
+                        &mut active_fragments,
+                    )?;
                 }
                 OperationDefinition::Query(Query { selection_set, .. }) => {
-                    handle_selection_set(selection_set, &fragment_map, None)?;
+                    handle_selection_set(
+                        selection_set,
+                        &fragment_map,
+                        None,
+                        &mut active_fragments,
+                    )?;
                 }
                 OperationDefinition::Mutation(Mutation { selection_set, .. }) => {
-                    handle_selection_set(selection_set, &fragment_map, None)?;
+                    handle_selection_set(
+                        selection_set,
+                        &fragment_map,
+                        None,
+                        &mut active_fragments,
+                    )?;
                 }
                 OperationDefinition::Subscription(Subscription { selection_set, .. }) => {
-                    handle_selection_set(selection_set, &fragment_map, None)?;
+                    handle_selection_set(
+                        selection_set,
+                        &fragment_map,
+                        None,
+                        &mut active_fragments,
+                    )?;
                 }
             },
             Definition::Fragment(frag_def) => {
@@ -37,6 +61,7 @@ pub fn inline_fragment_spreads(ctx: &mut NormalizationContext) -> Result<(), Nor
                     &mut frag_def.selection_set,
                     &fragment_map,
                     Some(&frag_def.type_condition),
+                    &mut active_fragments,
                 )?;
             }
         }
@@ -46,10 +71,13 @@ pub fn inline_fragment_spreads(ctx: &mut NormalizationContext) -> Result<(), Nor
 }
 
 #[inline]
-fn handle_selection_set<'a>(
+// active_fragments borrows names out of fragment_map ('f) instead of cloning strings -
+// insert/remove per expansion is then just a hash of a &str.
+fn handle_selection_set<'a, 'f>(
     selection_set: &mut SelectionSet<'a, String>,
-    fragment_map: &HashMap<String, FragmentDefinition<'a, String>>,
+    fragment_map: &'f HashMap<String, FragmentDefinition<'a, String>>,
     parent_type_condition: Option<&TypeCondition<'a, String>>,
+    active_fragments: &mut HashSet<&'f str>,
 ) -> Result<(), NormalizationError> {
     let old_items = std::mem::take(&mut selection_set.items);
     let mut new_items = Vec::with_capacity(old_items.len());
@@ -62,6 +90,7 @@ fn handle_selection_set<'a>(
                     fragment_map,
                     // Crossing a field boundary resets the type condition context
                     None,
+                    active_fragments,
                 )?;
                 new_items.push(Selection::Field(field));
             }
@@ -121,7 +150,16 @@ fn handle_selection_set<'a>(
                     break def;
                 };
 
-                if parent_type_condition == Some(&fragment_def.type_condition)
+                // guards every recursive expansion below (inline and wrap alike), not just the
+                // bare-spread fast path above - a sibling field or a directive on the cycling
+                // spread breaks out of that fast path, so this is the backstop that catches it.
+                if !active_fragments.insert(fragment_def.name.as_str()) {
+                    return Err(NormalizationError::CyclicFragmentSpread {
+                        fragment_name: spread.fragment_name.clone(),
+                    });
+                }
+
+                let result = if parent_type_condition == Some(&fragment_def.type_condition)
                     // `...Frag @include(...)` stores `@include` on the spread itself.
                     // In the code below, we inline the fragment's selections,
                     // so any directives would be lost.
@@ -130,8 +168,13 @@ fn handle_selection_set<'a>(
                     // If the fragment's type condition matches the top type condition,
                     // we can inline its selections directly.
                     let mut inlined = fragment_def.selection_set.clone();
-                    handle_selection_set(&mut inlined, fragment_map, parent_type_condition)?;
-                    new_items.extend(inlined.items);
+                    handle_selection_set(
+                        &mut inlined,
+                        fragment_map,
+                        parent_type_condition,
+                        active_fragments,
+                    )
+                    .map(|_| new_items.extend(inlined.items))
                 } else {
                     // type mismatch or has directives: wrap in an inline fragment.
                     let mut inline_fragment = InlineFragment {
@@ -144,15 +187,20 @@ fn handle_selection_set<'a>(
                         &mut inline_fragment.selection_set,
                         fragment_map,
                         inline_fragment.type_condition.as_ref(),
-                    )?;
-                    new_items.push(Selection::InlineFragment(inline_fragment));
-                }
+                        active_fragments,
+                    )
+                    .map(|_| new_items.push(Selection::InlineFragment(inline_fragment)))
+                };
+
+                active_fragments.remove(fragment_def.name.as_str());
+                result?;
             }
             Selection::InlineFragment(mut inline_fragment) => {
                 handle_selection_set(
                     &mut inline_fragment.selection_set,
                     fragment_map,
                     inline_fragment.type_condition.as_ref(),
+                    active_fragments,
                 )?;
                 new_items.push(Selection::InlineFragment(inline_fragment));
             }


### PR DESCRIPTION
Closes #1230

A self-referential fragment that also selects a sibling field (`fragment A on Query { x ...A }`) or puts a directive on the cycling spread (`...A @include(if: $c)`) caused unbounded recursion during fragment inlining in normalization, overflowing the stack and crashing the process.

We now thread a borrowed `Vec<&str>`        of fragment names currently being expanded through every recursive inlining path. Push before expanding a fragment's body, error with `CyclicFragmentSpread` on a repeat (linear scan via contains), pop on the way out. Names borrow from the fragment map, so no string cloning per expansion.
