### PR TITLE
Remove unused path visited state in Query Planner

### DIFF
--- a/.changeset/small_qp_improvements.md
+++ b/.changeset/small_qp_improvements.md
@@ -1,0 +1,10 @@
+---
+hive-router-query-planner: patch
+hive-router-plan-executor: patch
+hive-router: patch
+node-addon: patch
+---
+
+# Query Planning performance improvements
+
+Removed unused per-path edge tracking and switched to references instead of owned values - no cloning of selection items.

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -1775,7 +1775,6 @@ fn find_satisfiable_key<'a>(
             &OperationPath {
                 root_node: query_node.node_index,
                 last_segment: None,
-                visited_edge_indices: Default::default(),
                 cost: 0,
                 union_context: None,
             },

--- a/lib/query-planner/src/planner/walker/path.rs
+++ b/lib/query-planner/src/planner/walker/path.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::{cmp, collections::HashSet, fmt::Debug};
+use std::{cmp, fmt::Debug};
 
 use petgraph::{
     graph::{EdgeIndex, NodeIndex},
@@ -87,7 +87,6 @@ impl PathSegment {
 pub struct OperationPath<'graph> {
     pub root_node: NodeIndex,
     pub last_segment: Option<Rc<PathSegment>>,
-    pub visited_edge_indices: Rc<HashSet<EdgeIndex>>,
     pub cost: u64,
     // The union context for the current path, if any.
     // If we hit a field returning a union, this will be set to the union context.
@@ -118,18 +117,13 @@ impl Debug for OperationPath<'_> {
 }
 
 impl<'graph> OperationPath<'graph> {
-    pub fn new(
-        root_node_index: NodeIndex,
-        last_segment: Option<Rc<PathSegment>>,
-        visited_edge_indices: Rc<HashSet<EdgeIndex>>,
-    ) -> Self {
+    pub fn new(root_node_index: NodeIndex, last_segment: Option<Rc<PathSegment>>) -> Self {
         Self {
             root_node: root_node_index,
             cost: last_segment
                 .as_ref()
                 .map_or(0, |segment| segment.cumulative_cost),
             last_segment,
-            visited_edge_indices,
             union_context: None,
         }
     }
@@ -138,9 +132,8 @@ impl<'graph> OperationPath<'graph> {
         // The first "segment" conceptually starts after the first edge from root
         let path_segment = PathSegment::new_root(edge);
         let arc_path_segment = Rc::new(path_segment);
-        let visited_set: Rc<HashSet<EdgeIndex>> = Rc::new([edge.id()].into_iter().collect());
 
-        OperationPath::new(edge.source(), Some(arc_path_segment), visited_set)
+        OperationPath::new(edge.source(), Some(arc_path_segment))
     }
 
     pub fn advance(
@@ -153,8 +146,6 @@ impl<'graph> OperationPath<'graph> {
         let prev_cost = self.cost;
         let edge_cost = edge_ref.weight().cost();
         let new_cost = prev_cost + edge_cost;
-        let mut new_visited = self.visited_edge_indices.clone();
-        Rc::make_mut(&mut new_visited).insert(edge_ref.id());
 
         let new_segment_data = PathSegment {
             prev: self.last_segment.clone(),
@@ -209,7 +200,6 @@ impl<'graph> OperationPath<'graph> {
             root_node: self.root_node,
             cost: new_cost,
             last_segment: Some(new_segment),
-            visited_edge_indices: new_visited,
             union_context,
         }
     }
@@ -227,10 +217,6 @@ impl<'graph> OperationPath<'graph> {
         self.last_segment
             .as_ref()
             .map_or(self.root_node, |segment| segment.tail_node)
-    }
-
-    pub fn has_visited_edge(&self, edge_index: &EdgeIndex) -> bool {
-        self.visited_edge_indices.contains(edge_index)
     }
 
     pub fn get_segments(&self) -> Vec<Rc<PathSegment>> {
@@ -352,13 +338,9 @@ impl<'graph> OperationPath<'graph> {
             previous_new_segment = Some(Rc::new(new_segment_data));
         }
 
-        OperationPath::new(
-            new_root_node.unwrap(),
-            previous_new_segment,
-            self.visited_edge_indices.clone(),
-        )
-        // The requirement continuation reuses other's tail, so it also must reuse its union context
-        .with_union_context(other.union_context.clone())
+        OperationPath::new(new_root_node.unwrap(), previous_new_segment)
+            // The requirement continuation reuses other's tail, so it also must reuse its union context
+            .with_union_context(other.union_context.clone())
     }
 
     fn with_union_context(mut self, scope: Option<UnionContext<'graph>>) -> Self {

--- a/lib/query-planner/src/planner/walker/pathfinder.rs
+++ b/lib/query-planner/src/planner/walker/pathfinder.rs
@@ -595,7 +595,7 @@ impl<'graph> PathSearch<'graph> {
                 for selection in selections.selection_set.items.iter() {
                     requirements.push_front(MoveRequirement {
                         paths: Rc::new(vec![path.clone()]),
-                        selection: selection.clone(),
+                        selection,
                     });
                 }
 
@@ -687,7 +687,7 @@ impl<'graph> PathSearch<'graph> {
 #[derive(Debug)]
 pub struct MoveRequirement<'graph> {
     pub paths: Rc<Vec<OperationPath<'graph>>>,
-    pub selection: SelectionItem,
+    pub selection: &'graph SelectionItem,
 }
 
 type FieldRequirementsResult<'graph> =
@@ -780,7 +780,7 @@ impl<'graph> PathSearch<'graph> {
             .unwrap() // Safe due to the check above
             .iter()
             .map(|selection_item| MoveRequirement {
-                selection: selection_item.clone(),
+                selection: selection_item,
                 paths: Rc::clone(&shared_next_paths_for_subs),
             })
             .collect();
@@ -866,7 +866,7 @@ impl<'graph> PathSearch<'graph> {
             .unwrap() // Safe due to the check above
             .iter()
             .map(|selection_item| MoveRequirement {
-                selection: selection_item.clone(),
+                selection: selection_item,
                 paths: Rc::clone(&shared_next_paths_for_subs),
             })
             .collect();


### PR DESCRIPTION
There was this thing in QP where we tracked which edges were visited, but it's dead code, so I drop it.

I also moved to use references instead of owned values, so we clone `SelectionItem` less when dealing with requirements.

No changes in QP's behavior, it behaves well, good QP.