### PR TITLE
feat(router): subgraph error masking

### DIFF
--- a/.changeset/subgraph_error_masking.md
+++ b/.changeset/subgraph_error_masking.md
@@ -24,7 +24,7 @@ error_masking:
         - code
   subgraphs:
     products:
-      error_message: false
+      enabled: false
 ```
 
 - `error_message` toggles message redaction; `extensions` redacts extension keys via an `allow`/`deny` list.

--- a/.changeset/subgraph_error_masking.md
+++ b/.changeset/subgraph_error_masking.md
@@ -1,0 +1,36 @@
+---
+hive-router-config: patch
+hive-router: patch
+hive-router-plan-executor: patch
+hive-router-internal: patch
+---
+
+# Subgraph Error Masking
+
+Mask subgraph errors before they reach clients, preventing internal details from leaking.
+
+Masking is **enabled by default**: subgraph error messages are replaced with `"Unexpected error"`. It runs last in the pipeline, so metrics, tracing, and logging still see the original error.
+
+Configure it under `error_masking`:
+
+```yaml
+error_masking:
+  redacted_error_message: "Unexpected error"
+  all:
+    error_message: true
+    extensions:
+      mode: allow # allow | deny
+      keys:
+        - code
+  subgraphs:
+    products:
+      error_message: false
+```
+
+- `error_message` toggles message redaction; `extensions` redacts extension keys via an `allow`/`deny` list.
+- `subgraphs.<name>` overrides `all` per subgraph, inheriting any field it doesn't set.
+- Set `DISABLE_SUBGRAPH_ERROR_MASKING=true` to disable message masking without editing the config.
+
+[Documentation](http://the-guild.dev/graphql/hive/docs/router/security/error-masking)
+
+Fixes https://github.com/graphql-hive/router/issues/1194

--- a/.changeset/subgraph_error_masking.md
+++ b/.changeset/subgraph_error_masking.md
@@ -15,9 +15,10 @@ Configure it under `error_masking`:
 
 ```yaml
 error_masking:
+  enabled: true # enabled by default 
   redacted_error_message: "Unexpected error"
-  all:
-    error_message: true
+  all: # default config, unless you override it with subgraph-specific 
+    enabled: true
     extensions:
       mode: allow # allow | deny
       keys:

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -7,6 +7,7 @@ use hive_router_internal::telemetry::traces::spans::graphql::{
 };
 use hive_router_plan_executor::execution::client_request_details::ClientRequestDetails;
 use hive_router_plan_executor::execution::demand_control::DemandControlExecutionContext;
+use hive_router_plan_executor::execution::error_masking::ErrorMaskingRuntime;
 use hive_router_plan_executor::execution::jwt_forward::JwtAuthForwardingPlan;
 use hive_router_plan_executor::execution::operation_name::OperationNameFactory;
 use hive_router_plan_executor::execution::plan::{
@@ -119,6 +120,10 @@ pub async fn execute_plan<'exec>(
             None
         };
 
+        let error_masking_runtime = Arc::new(ErrorMaskingRuntime::compile_from_config(
+            &app_state.router_config.error_masking,
+        ));
+
         let operation_name = planned_request.client_request_details.operation.name;
         let result = execute_query_plan(QueryPlanExecutionOpts {
             query_plan: planned_request.query_plan_payload,
@@ -149,6 +154,7 @@ pub async fn execute_plan<'exec>(
                 operation_name,
             ),
             response_header_sink,
+            error_masking_runtime,
         })
         .await?;
 

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -7,7 +7,6 @@ use hive_router_internal::telemetry::traces::spans::graphql::{
 };
 use hive_router_plan_executor::execution::client_request_details::ClientRequestDetails;
 use hive_router_plan_executor::execution::demand_control::DemandControlExecutionContext;
-use hive_router_plan_executor::execution::error_masking::ErrorMaskingRuntime;
 use hive_router_plan_executor::execution::jwt_forward::JwtAuthForwardingPlan;
 use hive_router_plan_executor::execution::operation_name::OperationNameFactory;
 use hive_router_plan_executor::execution::plan::{
@@ -120,10 +119,6 @@ pub async fn execute_plan<'exec>(
             None
         };
 
-        let error_masking_runtime = Arc::new(ErrorMaskingRuntime::compile_from_config(
-            &app_state.router_config.error_masking,
-        ));
-
         let operation_name = planned_request.client_request_details.operation.name;
         let result = execute_query_plan(QueryPlanExecutionOpts {
             query_plan: planned_request.query_plan_payload,
@@ -154,7 +149,7 @@ pub async fn execute_plan<'exec>(
                 operation_name,
             ),
             response_header_sink,
-            error_masking_runtime,
+            error_masking_runtime: app_state.error_masking.clone(),
         })
         .await?;
 

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -12,6 +12,7 @@ use hive_router_internal::telemetry::metrics::subscription_metrics::Subscription
 use hive_router_internal::telemetry::metrics::Metrics;
 use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::coprocessor::{CoprocessorError, CoprocessorRuntime};
+use hive_router_plan_executor::execution::error_masking::ErrorMaskingRuntime;
 use hive_router_plan_executor::execution::plan::FailedExecutionResult;
 use hive_router_plan_executor::extensions::{
     compile::compile_extensions_plan, plan::ExtensionsPlan,
@@ -328,6 +329,8 @@ pub struct RouterSharedState {
     pub active_subscriptions: ActiveSubscriptions,
     /// The storage manager for the router.
     pub storage_manager: Arc<StorageManager>,
+    /// The error masking configuration for the router.
+    pub error_masking: Arc<ErrorMaskingRuntime>,
 }
 
 impl RouterSharedState {
@@ -356,6 +359,9 @@ impl RouterSharedState {
                 .map_err(Box::new)
             })
             .transpose()?;
+        let error_masking = Arc::new(ErrorMaskingRuntime::compile_from_config(
+            &router_config.error_masking,
+        ));
 
         Ok(Self {
             validation_plan: Arc::new(validation_plan),
@@ -392,6 +398,7 @@ impl RouterSharedState {
             long_lived_client_count: Arc::new(AtomicUsize::new(0)),
             active_subscriptions,
             storage_manager,
+            error_masking,
         })
     }
 }

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -330,7 +330,7 @@ pub struct RouterSharedState {
     /// The storage manager for the router.
     pub storage_manager: Arc<StorageManager>,
     /// The error masking configuration for the router.
-    pub error_masking: Arc<ErrorMaskingRuntime>,
+    pub error_masking: Arc<Option<ErrorMaskingRuntime>>,
 }
 
 impl RouterSharedState {

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 |[**cors**](#cors)|`object`|Configuration for CORS (Cross-Origin Resource Sharing).<br/>Default: `{"allow_any_origin":false,"allow_credentials":false,"enabled":false,"policies":[]}`<br/>|yes|
 |[**csrf**](#csrf)|`object`|Configuration for CSRF prevention.<br/>Default: `{"enabled":false,"required_headers":[]}`<br/>||
 |[**demand\_control**](#demand_control)|`object`, `null`||yes|
-|[**error\_masking**](#error_masking)|`object`|Configuration for error masking.<br/>Default: `{"all":{"error_message":true,"extensions":null},"redacted_error_message":"Unexpected error"}`<br/>||
+|[**error\_masking**](#error_masking)|`object`|Configuration for error masking.<br/>Default: `{"all":{"error_message":true},"redacted_error_message":"Unexpected error"}`<br/>||
 |[**headers**](#headers)|`object`|Configuration for the headers.<br/>Default: `{}`<br/>||
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"graphql_endpoint":"/graphql","host":"0.0.0.0","port":4000}`<br/>||
 |**introspection**||Configuration to enable or disable introspection queries.<br/>||
@@ -61,7 +61,6 @@ csrf:
 error_masking:
   all:
     error_message: true
-    extensions: null
   redacted_error_message: Unexpected error
 headers:
   all:
@@ -1050,9 +1049,9 @@ Configuration for error masking.
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**all**](#error_maskingall)|`object`|Default: `{"error_message":true,"extensions":null}`<br/>||
-|**redacted\_error\_message**|`string`|Default: `"Unexpected error"`<br/>||
-|[**subgraphs**](#error_maskingsubgraphs)|`object`, `null`|||
+|[**all**](#error_maskingall)|`object`|The default error masking configuration for all subgraphs.<br/>Default: `{"error_message":true}`<br/>||
+|**redacted\_error\_message**|`string`|The error message to redact in subgraph errors. The default is "Unexpected error".<br/>Default: `"Unexpected error"`<br/>||
+|[**subgraphs**](#error_maskingsubgraphs)|`object`, `null`|The error masking configuration for individual subgraphs.<br/>||
 
 **Additional Properties:** not allowed   
 **Example**
@@ -1060,7 +1059,6 @@ Configuration for error masking.
 ```yaml
 all:
   error_message: true
-  extensions: null
 redacted_error_message: Unexpected error
 
 ```
@@ -1069,24 +1067,31 @@ redacted_error_message: Unexpected error
 <a name="error_maskingall"></a>
 ### error\_masking\.all: object
 
+The default error masking configuration for all subgraphs.
+
+
 **Properties**
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**error\_message**|`boolean`, `null`|||
-|**extensions**||||
+|**error\_message**|`boolean`|Whether to redact the error message in subgraph errors. The default is `true`.<br/><br/>This field can be set to `false`, in order to disable error masking, by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.<br/>Default: `true`<br/>||
+|**extensions**||Whether to redact the `extensions` in errors.<br/><br/>You may pick the execution mode by setting `mode: allow` or `mode: deny`.<br/>Note: only root-level fields are supported.<br/>||
 
+**Additional Properties:** not allowed  
 **Example**
 
 ```yaml
 error_message: true
-extensions: null
 
 ```
 
    
 <a name="error_maskingsubgraphs"></a>
 ### error\_masking\.subgraphs: object,null
+
+The error masking configuration for individual subgraphs.
+Any configuration field that will be specified here, will override the configuration in `all`.
+
 
 **Additional Properties**
 
@@ -1102,9 +1107,10 @@ extensions: null
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**error\_message**|`boolean`, `null`|||
-|**extensions**||||
+|**error\_message**|`boolean`, `null`|Whether to redact the `error_message` in errors, for that specific subgraph.<br/><br/>Configuring this will override the global `all.error_message` setting.<br/>||
+|**extensions**||Whether to redact the `extensions` in errors, for that specific subgraph.<br/>Configuring this will override the global `all.extensions` setting.<br/><br/>You may pick the execution mode by setting `mode: allow` or `mode: deny`.<br/>Note: only root-level fields are supported.<br/>||
 
+**Additional Properties:** not allowed  
 **Example**
 
 ```yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 |[**cors**](#cors)|`object`|Configuration for CORS (Cross-Origin Resource Sharing).<br/>Default: `{"allow_any_origin":false,"allow_credentials":false,"enabled":false,"policies":[]}`<br/>|yes|
 |[**csrf**](#csrf)|`object`|Configuration for CSRF prevention.<br/>Default: `{"enabled":false,"required_headers":[]}`<br/>||
 |[**demand\_control**](#demand_control)|`object`, `null`||yes|
-|[**error\_masking**](#error_masking)|`object`|Configuration for error masking.<br/>Default: `{"all":{"error_message":true},"redacted_error_message":"Unexpected error"}`<br/>||
+|[**error\_masking**](#error_masking)|`object`|Configuration for error masking.<br/>Default: `{"all":{"enabled":true},"enabled":true,"redacted_error_message":"Unexpected error"}`<br/>||
 |[**headers**](#headers)|`object`|Configuration for the headers.<br/>Default: `{}`<br/>||
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"graphql_endpoint":"/graphql","host":"0.0.0.0","port":4000}`<br/>||
 |**introspection**||Configuration to enable or disable introspection queries.<br/>||
@@ -60,7 +60,8 @@ csrf:
     - x-csrf-token
 error_masking:
   all:
-    error_message: true
+    enabled: true
+  enabled: true
   redacted_error_message: Unexpected error
 headers:
   all:
@@ -1049,7 +1050,8 @@ Configuration for error masking.
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**all**](#error_maskingall)|`object`|The default error masking configuration for all subgraphs.<br/>Default: `{"error_message":true}`<br/>||
+|[**all**](#error_maskingall)|`object`|The default error masking configuration for all subgraphs.<br/>Default: `{"enabled":true}`<br/>||
+|**enabled**|`boolean`|A switch for enabling or disabling error masking feature completely.<br/><br/>Defaults to `true`.<br/><br/>You can also disable it by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.<br/>Default: `true`<br/>||
 |**redacted\_error\_message**|`string`|The error message to redact in subgraph errors. The default is "Unexpected error".<br/>Default: `"Unexpected error"`<br/>||
 |[**subgraphs**](#error_maskingsubgraphs)|`object`, `null`|The error masking configuration for individual subgraphs.<br/>||
 
@@ -1058,7 +1060,8 @@ Configuration for error masking.
 
 ```yaml
 all:
-  error_message: true
+  enabled: true
+enabled: true
 redacted_error_message: Unexpected error
 
 ```
@@ -1074,14 +1077,14 @@ The default error masking configuration for all subgraphs.
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**error\_message**|`boolean`|Whether to redact the error message in subgraph errors. The default is `true`.<br/><br/>This field can be set to `false`, in order to disable error masking, by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.<br/>Default: `true`<br/>||
+|**enabled**|`boolean`|Whether to redact the error message in subgraph errors. The default is `true`.<br/>Default: `true`<br/>||
 |**extensions**||Whether to redact the `extensions` in errors.<br/><br/>You may pick the execution mode by setting `mode: allow` or `mode: deny`.<br/>Note: only root-level fields are supported.<br/>||
 
-**Additional Properties:** not allowed  
+**Additional Properties:** not allowed   
 **Example**
 
 ```yaml
-error_message: true
+enabled: true
 
 ```
 
@@ -1107,18 +1110,10 @@ Any configuration field that will be specified here, will override the configura
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**error\_message**|`boolean`, `null`|Whether to redact the `error_message` in errors, for that specific subgraph.<br/><br/>Configuring this will override the global `all.error_message` setting.<br/>||
+|**enabled**|`boolean`, `null`|Whether to redact the `error_message` in errors, for that specific subgraph.<br/><br/>Configuring this will override the global `all.error_message` setting.<br/>||
 |**extensions**||Whether to redact the `extensions` in errors, for that specific subgraph.<br/>Configuring this will override the global `all.extensions` setting.<br/><br/>You may pick the execution mode by setting `mode: allow` or `mode: deny`.<br/>Note: only root-level fields are supported.<br/>||
 
-**Additional Properties:** not allowed  
-**Example**
-
-```yaml
-error_message: null
-extensions: null
-
-```
-
+**Additional Properties:** not allowed   
    
 <a name="headers"></a>
 ## headers: object

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 |[**cors**](#cors)|`object`|Configuration for CORS (Cross-Origin Resource Sharing).<br/>Default: `{"allow_any_origin":false,"allow_credentials":false,"enabled":false,"policies":[]}`<br/>|yes|
 |[**csrf**](#csrf)|`object`|Configuration for CSRF prevention.<br/>Default: `{"enabled":false,"required_headers":[]}`<br/>||
 |[**demand\_control**](#demand_control)|`object`, `null`||yes|
+|[**error\_masking**](#error_masking)|`object`|Configuration for error masking.<br/>Default: `{"all":{"error_message":true,"extensions":null},"redacted_error_message":"Unexpected error"}`<br/>||
 |[**headers**](#headers)|`object`|Configuration for the headers.<br/>Default: `{}`<br/>||
 |[**http**](#http)|`object`|Configuration for the HTTP server/listener.<br/>Default: `{"graphql_endpoint":"/graphql","host":"0.0.0.0","port":4000}`<br/>||
 |**introspection**||Configuration to enable or disable introspection queries.<br/>||
@@ -57,6 +58,11 @@ csrf:
   enabled: true
   required_headers:
     - x-csrf-token
+error_masking:
+  all:
+    error_message: true
+    extensions: null
+  redacted_error_message: Unexpected error
 headers:
   all:
     request:
@@ -1032,6 +1038,80 @@ Per-subgraph overrides. Keys are subgraph names.
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**Additional Properties**|`integer`|Format: `"uint"`<br/>Minimum: `0`<br/>||
+
+   
+<a name="error_masking"></a>
+## error\_masking: object
+
+Configuration for error masking.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|[**all**](#error_maskingall)|`object`|Default: `{"error_message":true,"extensions":null}`<br/>||
+|**redacted\_error\_message**|`string`|Default: `"Unexpected error"`<br/>||
+|[**subgraphs**](#error_maskingsubgraphs)|`object`, `null`|||
+
+**Additional Properties:** not allowed   
+**Example**
+
+```yaml
+all:
+  error_message: true
+  extensions: null
+redacted_error_message: Unexpected error
+
+```
+
+   
+<a name="error_maskingall"></a>
+### error\_masking\.all: object
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**error\_message**|`boolean`, `null`|||
+|**extensions**||||
+
+**Example**
+
+```yaml
+error_message: true
+extensions: null
+
+```
+
+   
+<a name="error_maskingsubgraphs"></a>
+### error\_masking\.subgraphs: object,null
+
+**Additional Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|[**Additional Properties**](#error_maskingsubgraphsadditionalproperties)|`object`|||
+
+   
+<a name="error_maskingsubgraphsadditionalproperties"></a>
+#### error\_masking\.subgraphs\.additionalProperties: object
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**error\_message**|`boolean`, `null`|||
+|**extensions**||||
+
+**Example**
+
+```yaml
+error_message: null
+extensions: null
+
+```
 
    
 <a name="headers"></a>

--- a/e2e/configs/env_vars.router.yaml
+++ b/e2e/configs/env_vars.router.yaml
@@ -15,4 +15,4 @@ headers:
           expression: env("ROUTER_ENV_HEADER", "default")
 error_masking:
   all:
-    error_message: false
+    enabled: false

--- a/e2e/configs/env_vars.router.yaml
+++ b/e2e/configs/env_vars.router.yaml
@@ -13,3 +13,6 @@ headers:
       - insert:
           name: "x-router-env"
           expression: env("ROUTER_ENV_HEADER", "default")
+error_masking:
+  all:
+    error_message: false

--- a/e2e/configs/timeout_per_subgraph_dynamic.router.yaml
+++ b/e2e/configs/timeout_per_subgraph_dynamic.router.yaml
@@ -16,3 +16,6 @@ traffic_shaping:
           } else {
             .default
           }
+error_masking:
+  all:
+    error_message: false

--- a/e2e/configs/timeout_per_subgraph_dynamic.router.yaml
+++ b/e2e/configs/timeout_per_subgraph_dynamic.router.yaml
@@ -18,4 +18,4 @@ traffic_shaping:
           }
 error_masking:
   all:
-    error_message: false
+    enabled: false

--- a/e2e/src/circuit_breaker.rs
+++ b/e2e/src/circuit_breaker.rs
@@ -86,6 +86,9 @@ mod circuit_breaker_e2e_tests {
         supergraph:
           source: file
           path: supergraph.graphql
+        error_masking:
+          all:
+            error_message: false
         traffic_shaping:
           all:
             request_timeout: 200ms
@@ -246,6 +249,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -336,6 +342,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -443,6 +452,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -540,6 +552,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -608,6 +623,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -671,6 +689,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -740,6 +761,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         request_timeout: 500ms
@@ -1332,6 +1356,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1408,6 +1435,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1490,6 +1520,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1579,6 +1612,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1755,6 +1791,9 @@ mod circuit_breaker_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: false
                 traffic_shaping:
                     all:
                         circuit_breaker:

--- a/e2e/src/circuit_breaker.rs
+++ b/e2e/src/circuit_breaker.rs
@@ -88,7 +88,7 @@ mod circuit_breaker_e2e_tests {
           path: supergraph.graphql
         error_masking:
           all:
-            error_message: false
+            enabled: false
         traffic_shaping:
           all:
             request_timeout: 200ms
@@ -251,7 +251,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -344,7 +344,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -454,7 +454,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -554,7 +554,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -625,7 +625,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -691,7 +691,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -763,7 +763,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         request_timeout: 500ms
@@ -1358,7 +1358,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1437,7 +1437,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1522,7 +1522,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1614,7 +1614,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:
@@ -1793,7 +1793,7 @@ mod circuit_breaker_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: false
+                    enabled: false
                 traffic_shaping:
                     all:
                         circuit_breaker:

--- a/e2e/src/demand_control/subgraph_budgets.rs
+++ b/e2e/src/demand_control/subgraph_budgets.rs
@@ -12,6 +12,9 @@ mod subgraph_budgets_tests {
         supergraph:
             source: file
             path: supergraph.graphql
+        error_masking:
+          all:
+            error_message: false
         demand_control:
             enabled: true
             operation_cost:

--- a/e2e/src/demand_control/subgraph_budgets.rs
+++ b/e2e/src/demand_control/subgraph_budgets.rs
@@ -14,7 +14,7 @@ mod subgraph_budgets_tests {
             path: supergraph.graphql
         error_masking:
           all:
-            error_message: false
+            enabled: false
         demand_control:
             enabled: true
             operation_cost:

--- a/e2e/src/error_handling.rs
+++ b/e2e/src/error_handling.rs
@@ -16,6 +16,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -119,6 +122,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -221,6 +227,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -312,6 +321,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -403,6 +415,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -494,6 +509,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -585,6 +603,9 @@ mod error_handling_e2e_tests {
                   supergraph:
                     source: file
                     path: supergraph.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:

--- a/e2e/src/error_handling.rs
+++ b/e2e/src/error_handling.rs
@@ -18,7 +18,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -124,7 +124,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -229,7 +229,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -323,7 +323,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -417,7 +417,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -511,7 +511,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -605,7 +605,7 @@ mod error_handling_e2e_tests {
                     path: supergraph.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:

--- a/e2e/src/error_masking.rs
+++ b/e2e/src/error_masking.rs
@@ -55,7 +55,7 @@ mod error_masking_e2e_tests {
                   path: supergraph.graphql
                 error_masking:
                   all:
-                    error_message: true
+                    enabled: true
                 override_subgraph_urls:
                   subgraphs:
                     accounts:
@@ -242,7 +242,7 @@ mod error_masking_e2e_tests {
                 &subgraphs.url(),
                 r#"error_masking:
                 all:
-                  error_message: false
+                  enabled: false
             "#,
             ))
             .build()
@@ -321,7 +321,7 @@ mod error_masking_e2e_tests {
                 &subgraphs.url(),
                 r#"error_masking:
                 all:
-                  error_message: true # enabled here, but disabled via env var
+                  enabled: true # enabled here, but disabled via env var
             "#,
             ))
             .build()
@@ -468,7 +468,7 @@ mod error_masking_e2e_tests {
                 &subgraphs.url(),
                 r#"error_masking:
                 all:
-                  error_message: true
+                  enabled: true
                   extensions:
                     mode: allow
                     keys:
@@ -551,7 +551,7 @@ mod error_masking_e2e_tests {
                     url: "http://0.0.0.0:1000/products"
               error_masking:
                 all:
-                  error_message: true
+                  enabled: true
                   extensions:
                     mode: deny
                     keys:
@@ -629,7 +629,7 @@ mod error_masking_e2e_tests {
                     url: "http://0.0.0.0:1000/products"
               error_masking:
                 all:
-                  error_message: true
+                  enabled: true
                   extensions:
                     mode: deny
                     keys:
@@ -714,10 +714,10 @@ mod error_masking_e2e_tests {
                     url: "http://0.0.0.0:1000/products"
               error_masking:
                 all:
-                  error_message: true
+                  enabled: true
                 subgraphs:
                   products:
-                    error_message: false
+                    enabled: false
             "#,
             ))
             .build()
@@ -782,14 +782,14 @@ mod error_masking_e2e_tests {
                 &subgraphs.url(),
                 r#"error_masking:
                 all:
-                  error_message: true
+                  enabled: true
                   extensions:
                     mode: allow
                     keys:
                       - code
                 subgraphs:
                   products:
-                    error_message: false
+                    enabled: false
             "#,
             ))
             .build()
@@ -868,13 +868,13 @@ mod error_masking_e2e_tests {
                     url: "http://0.0.0.0:1000/products"
               error_masking:
                 all:
-                  error_message: true
+                  enabled: true
                   extensions:
                     mode: allow
                     keys: [] # allow none!
                 subgraphs:
                   products:
-                    error_message: false
+                    enabled: false
                     extensions:
                       mode: deny
                       keys: [] # dont deny anything!

--- a/e2e/src/error_masking.rs
+++ b/e2e/src/error_masking.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod error_masking_e2e_tests {
-    use crate::testkit::{ClientResponseExt, RequestLike, ResponseLike, TestRouter, TestSubgraphs};
+    use crate::testkit::{
+        ClientResponseExt, EnvVarsGuard, RequestLike, ResponseLike, TestRouter, TestSubgraphs,
+    };
 
     fn failing_products_subgraph(req: RequestLike) -> Option<ResponseLike> {
         if req.path != "/products" {
@@ -39,6 +41,55 @@ mod error_masking_e2e_tests {
     }
 
     static QUERY: &str = "{ me { reviews { id product { upc name } } } }";
+
+    #[ntex::test]
+    async fn should_not_mask_non_subgraph_errors() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                error_masking:
+                  all:
+                    error_message: true
+                override_subgraph_urls:
+                  subgraphs:
+                    accounts:
+                      url: "{subgraphs_url}/accounts"
+                    reviews:
+                      url: "{subgraphs_url}/reviews"
+                    products:
+                      url: "http://0.0.0.0:1000/products"
+              "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ i bad query", None, None)
+            .await;
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "errors": [
+            {
+              "message": "Failed to parse GraphQL operation: Parse error at 1:14\nUnexpected end of input\nExpected }\n",
+              "extensions": {
+                "code": "GRAPHQL_PARSE_FAILED"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
 
     #[ntex::test]
     async fn should_mask_network_error_by_default() {
@@ -99,8 +150,8 @@ mod error_masking_e2e_tests {
             {
               "message": "Unexpected error",
               "extensions": {
-                "code": "SUBGRAPH_REQUEST_FAILURE",
-                "serviceName": "products",
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
                 "affectedPath": "me.reviews.@.product"
               }
             }
@@ -157,8 +208,19 @@ mod error_masking_e2e_tests {
               "message": "Unexpected error",
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "products",
+                "service": "products",
                 "affectedPath": "me.reviews.@.product"
+              }
+            },
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product",
+                "http": {
+                  "status": 500
+                }
               }
             }
           ]
@@ -220,8 +282,98 @@ mod error_masking_e2e_tests {
               "message": "Internal server error from products",
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "products",
+                "service": "products",
                 "affectedPath": "me.reviews.@.product"
+              }
+            },
+            {
+              "message": "Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product",
+                "http": {
+                  "status": 500
+                }
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn should_allow_to_disable_all_masking_via_env_var() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let _env_var_guard = EnvVarsGuard::new()
+            .set("DISABLE_SUBGRAPH_ERROR_MASKING", "true")
+            .apply()
+            .await;
+
+        let router = TestRouter::builder()
+            .inline_config(config_boilerplate(
+                &subgraphs.url(),
+                r#"error_masking:
+                all:
+                  error_message: true # enabled here, but disabled via env var
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Internal server error from products",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            },
+            {
+              "message": "Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product",
+                "http": {
+                  "status": 500
+                }
               }
             }
           ]
@@ -282,8 +434,19 @@ mod error_masking_e2e_tests {
               "message": "shit happens",
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR",
-                "serviceName": "products",
+                "service": "products",
                 "affectedPath": "me.reviews.@.product"
+              }
+            },
+            {
+              "message": "shit happens",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product",
+                "http": {
+                  "status": 500
+                }
               }
             }
           ]
@@ -291,9 +454,6 @@ mod error_masking_e2e_tests {
         "#
         );
     }
-
-    #[ntex::test]
-    async fn override_for_one_subgraph() {}
 
     #[ntex::test]
     async fn extensions_allow_list() {
@@ -353,6 +513,12 @@ mod error_masking_e2e_tests {
               "extensions": {
                 "code": "DOWNSTREAM_SERVICE_ERROR"
               }
+            },
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR"
+              }
             }
           ]
         }
@@ -390,7 +556,7 @@ mod error_masking_e2e_tests {
                     mode: deny
                     keys:
                       - code
-                      - serviceName
+                      - service
             "#,
             ))
             .build()
@@ -429,6 +595,329 @@ mod error_masking_e2e_tests {
             {
               "message": "Unexpected error",
               "extensions": {
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn per_subgraph_extensions_config_override() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let subgraphs_url = subgraphs.url();
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+              supergraph:
+                source: file
+                path: supergraph.graphql
+              override_subgraph_urls:
+                subgraphs:
+                  accounts:
+                    url: "{subgraphs_url}/accounts"
+                  reviews:
+                    url: "{subgraphs_url}/reviews"
+                  products:
+                    url: "http://0.0.0.0:1000/products"
+              error_masking:
+                all:
+                  error_message: true
+                  extensions:
+                    mode: deny
+                    keys:
+                      - code
+                      - service
+                subgraphs:
+                  products:
+                    extensions:
+                      mode: deny
+                      keys:
+                      - code
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn per_subgraph_message_config_override() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let subgraphs_url = subgraphs.url();
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+              supergraph:
+                source: file
+                path: supergraph.graphql
+              override_subgraph_urls:
+                subgraphs:
+                  accounts:
+                    url: "{subgraphs_url}/accounts"
+                  reviews:
+                    url: "{subgraphs_url}/reviews"
+                  products:
+                    url: "http://0.0.0.0:1000/products"
+              error_masking:
+                all:
+                  error_message: true
+                subgraphs:
+                  products:
+                    error_message: false
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Failed to send request to subgraph: client error (Connect)",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn per_subgraph_without_extensions_inherits_all_extensions() {
+        // A subgraph listed under `subgraphs` that sets only `error_message` still inherits
+        // `all.extensions`; only the fields it explicitly sets override `all`.
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .inline_config(config_boilerplate(
+                &subgraphs.url(),
+                r#"error_masking:
+                all:
+                  error_message: true
+                  extensions:
+                    mode: allow
+                    keys:
+                      - code
+                subgraphs:
+                  products:
+                    error_message: false
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Internal server error from products",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR"
+              }
+            },
+            {
+              "message": "Subgraph 'products' responded with an invalid HTTP status code '500 Internal Server Error'",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn full_config_override_per_subgraph() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let subgraphs_url = subgraphs.url();
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+              supergraph:
+                source: file
+                path: supergraph.graphql
+              override_subgraph_urls:
+                subgraphs:
+                  accounts:
+                    url: "{subgraphs_url}/accounts"
+                  reviews:
+                    url: "{subgraphs_url}/reviews"
+                  products:
+                    url: "http://0.0.0.0:1000/products"
+              error_masking:
+                all:
+                  error_message: true
+                  extensions:
+                    mode: allow
+                    keys: [] # allow none!
+                subgraphs:
+                  products:
+                    error_message: false
+                    extensions:
+                      mode: deny
+                      keys: [] # dont deny anything!
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Failed to send request to subgraph: client error (Connect)",
+              "extensions": {
+                "code": "SUBREQUEST_HTTP_ERROR",
+                "service": "products",
                 "affectedPath": "me.reviews.@.product"
               }
             }

--- a/e2e/src/error_masking.rs
+++ b/e2e/src/error_masking.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod error_masking_e2e_tests {
     use crate::testkit::{
-        ClientResponseExt, EnvVarsGuard, RequestLike, ResponseLike, TestRouter, TestSubgraphs,
+        some_header_map, ClientResponseExt, EnvVarsGuard, RequestLike, ResponseLike, TestRouter,
+        TestSubgraphs,
     };
 
     fn failing_products_subgraph(req: RequestLike) -> Option<ResponseLike> {
@@ -925,5 +926,181 @@ mod error_masking_e2e_tests {
         }
         "#
         );
+    }
+
+    // Break the source subgraph stream after 3 events (via `x-break-after` header),
+    // so the failure happens mid-stream and hits the masking-eligible streaming error branch.
+    fn subscription_config(error_masking: &str) -> String {
+        format!(
+            r#"
+            supergraph:
+                source: file
+                path: supergraph.graphql
+            subscriptions:
+                enabled: true
+            headers:
+                all:
+                    request:
+                        - propagate:
+                            named: x-break-after
+            {error_masking}
+            "#
+        )
+    }
+
+    static SUBSCRIPTION_QUERY: &str = "subscription { reviewAdded(intervalInMs: 100) { id } }";
+
+    fn subscription_request_headers() -> Option<http::HeaderMap> {
+        some_header_map! {
+            http::header::ACCEPT => "text/event-stream",
+            http::header::HeaderName::from_static("x-break-after") => "3"
+        }
+    }
+
+    #[ntex::test]
+    async fn subscription_stream_error_masked_by_default() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(subscription_config(""))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(SUBSCRIPTION_QUERY, None, subscription_request_headers())
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+
+        insta::assert_snapshot!(res.string_body().await, @r#"
+        event: next
+        data: {"data":{"reviewAdded":{"id":"1"}}}
+
+        event: next
+        data: {"data":{"reviewAdded":{"id":"2"}}}
+
+        event: next
+        data: {"data":{"reviewAdded":{"id":"3"}}}
+
+        event: next
+        data: {"errors":[{"message":"Unexpected error","extensions":{"code":"SUBGRAPH_SUBSCRIPTION_SSE_STREAM_ERROR","service":"reviews"}}]}
+
+        event: complete
+        "#);
+    }
+
+    #[ntex::test]
+    async fn subscription_stream_error_masking_disabled() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(subscription_config(
+                r#"error_masking:
+                enabled: false"#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(SUBSCRIPTION_QUERY, None, subscription_request_headers())
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+
+        insta::assert_snapshot!(res.string_body().await, @r#"
+        event: next
+        data: {"data":{"reviewAdded":{"id":"1"}}}
+
+        event: next
+        data: {"data":{"reviewAdded":{"id":"2"}}}
+
+        event: next
+        data: {"data":{"reviewAdded":{"id":"3"}}}
+
+        event: next
+        data: {"errors":[{"message":"Error reading SSE subscription stream: Stream read error: error reading a body from connection","extensions":{"code":"SUBGRAPH_SUBSCRIPTION_SSE_STREAM_ERROR","service":"reviews"}}]}
+
+        event: complete
+        "#);
+    }
+
+    // Subgraph-originated errors surface inside each streamed event (via entity resolution),
+    // and must be masked just like in the query/mutation path.
+    #[ntex::test]
+    async fn subscription_subgraph_error_masked_by_default() {
+        use sonic_rs::json;
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(|req| {
+                if req.path.contains("products") {
+                    Some(ResponseLike::new(
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        Some(r#"{"errors":[{"message":"Something Went Wrong!"}]}"#.to_string()),
+                        some_header_map! {
+                            http::header::CONTENT_TYPE => "application/json"
+                        },
+                    ))
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription ($upc: String!) {
+                    reviewAddedForProduct(productUpc: $upc, intervalInMs: 0) {
+                        product {
+                            name
+                        }
+                    }
+                }
+                "#,
+                Some(json!({ "upc": "2" })),
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert_eq!(res.status(), 200, "Expected 200 OK");
+
+        insta::assert_snapshot!(res.string_body().await, @r#"
+        event: next
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Unexpected error","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Unexpected error","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
+
+        event: next
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Unexpected error","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Unexpected error","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
+
+        event: next
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Unexpected error","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Unexpected error","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
+
+        event: next
+        data: {"data":{"reviewAddedForProduct":{"product":{"name":null}}},"errors":[{"message":"Unexpected error","extensions":{"code":"DOWNSTREAM_SERVICE_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product"}},{"message":"Unexpected error","extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","affectedPath":"reviewAddedForProduct.product","http":{"status":500}}}]}
+
+        event: complete
+        "#);
     }
 }

--- a/e2e/src/error_masking.rs
+++ b/e2e/src/error_masking.rs
@@ -1,0 +1,440 @@
+#[cfg(test)]
+mod error_masking_e2e_tests {
+    use crate::testkit::{ClientResponseExt, RequestLike, ResponseLike, TestRouter, TestSubgraphs};
+
+    fn failing_products_subgraph(req: RequestLike) -> Option<ResponseLike> {
+        if req.path != "/products" {
+            return None;
+        }
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        Some(ResponseLike::new(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Some(r#"{"errors":[{"message":"Internal server error from products"}]}"#.to_string()),
+            Some(headers),
+        ))
+    }
+
+    fn config_boilerplate(subgraphs_url: &str, error_masking: &str) -> String {
+        format!(
+            r#"
+          supergraph:
+            source: file
+            path: supergraph.graphql
+          override_subgraph_urls:
+            subgraphs:
+              accounts:
+                url: "{subgraphs_url}/accounts"
+              reviews:
+                url: "{subgraphs_url}/reviews"
+              products:
+                url: "{subgraphs_url}/products"
+          {}
+          "#,
+            error_masking
+        )
+    }
+
+    static QUERY: &str = "{ me { reviews { id product { upc name } } } }";
+
+    #[ntex::test]
+    async fn should_mask_network_error_by_default() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let subgraphs_url = subgraphs.url();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                  source: file
+                  path: supergraph.graphql
+                override_subgraph_urls:
+                  subgraphs:
+                    accounts:
+                      url: "{subgraphs_url}/accounts"
+                    reviews:
+                      url: "{subgraphs_url}/reviews"
+                    products:
+                      url: "http://0.0.0.0:1000/products"
+              "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ me { reviews { id product { upc name } } } }", None, None)
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_FAILURE",
+                "serviceName": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn should_mask_downstream_service_error_by_default() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .inline_config(config_boilerplate(&subgraphs.url(), ""))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn should_allow_to_disable_all_masking() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .inline_config(config_boilerplate(
+                &subgraphs.url(),
+                r#"error_masking:
+                all:
+                  error_message: false
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Internal server error from products",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn should_allow_to_customize_masking_message() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .inline_config(config_boilerplate(
+                &subgraphs.url(),
+                r#"error_masking:
+                redacted_error_message: "shit happens"
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "shit happens",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR",
+                "serviceName": "products",
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn override_for_one_subgraph() {}
+
+    #[ntex::test]
+    async fn extensions_allow_list() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .inline_config(config_boilerplate(
+                &subgraphs.url(),
+                r#"error_masking:
+                all:
+                  error_message: true
+                  extensions:
+                    mode: allow
+                    keys:
+                      - code
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "code": "DOWNSTREAM_SERVICE_ERROR"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn extensions_deny_list() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(failing_products_subgraph)
+            .build()
+            .start()
+            .await;
+
+        let subgraphs_url = subgraphs.url();
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+              supergraph:
+                source: file
+                path: supergraph.graphql
+              override_subgraph_urls:
+                subgraphs:
+                  accounts:
+                    url: "{subgraphs_url}/accounts"
+                  reviews:
+                    url: "{subgraphs_url}/reviews"
+                  products:
+                    url: "http://0.0.0.0:1000/products"
+              error_masking:
+                all:
+                  error_message: true
+                  extensions:
+                    mode: deny
+                    keys:
+                      - code
+                      - serviceName
+            "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request(QUERY, None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(
+          res.json_body_string_pretty().await,
+          @r#"
+        {
+          "data": {
+            "me": {
+              "reviews": [
+                {
+                  "id": "1",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                },
+                {
+                  "id": "2",
+                  "product": {
+                    "upc": "1",
+                    "name": null
+                  }
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Unexpected error",
+              "extensions": {
+                "affectedPath": "me.reviews.@.product"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+}

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -1290,7 +1290,7 @@ mod issues_e2e_tests {
                     path: src/issues/supergraph.non-null-root-field.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -1434,7 +1434,7 @@ mod issues_e2e_tests {
                     path: src/issues/supergraph.error-and-null-propagation.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -1696,7 +1696,7 @@ mod issues_e2e_tests {
                     path: src/issues/supergraph.error-and-null-propagation.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -2809,7 +2809,7 @@ mod issues_e2e_tests {
                     path: src/issues/supergraph.interface-shared-field.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       a:
@@ -2898,7 +2898,7 @@ mod issues_e2e_tests {
                     path: src/issues/supergraph.union-shared-field.graphql
                   error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                   override_subgraph_urls:
                     subgraphs:
                       a:

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -1288,6 +1288,9 @@ mod issues_e2e_tests {
                   supergraph:
                     source: file
                     path: src/issues/supergraph.non-null-root-field.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -1429,6 +1432,9 @@ mod issues_e2e_tests {
                   supergraph:
                     source: file
                     path: src/issues/supergraph.error-and-null-propagation.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -1688,6 +1694,9 @@ mod issues_e2e_tests {
                   supergraph:
                     source: file
                     path: src/issues/supergraph.error-and-null-propagation.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       accounts:
@@ -2798,6 +2807,9 @@ mod issues_e2e_tests {
                   supergraph:
                     source: file
                     path: src/issues/supergraph.interface-shared-field.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       a:
@@ -2884,6 +2896,9 @@ mod issues_e2e_tests {
                   supergraph:
                     source: file
                     path: src/issues/supergraph.union-shared-field.graphql
+                  error_masking:
+                    all:
+                      error_message: false
                   override_subgraph_urls:
                     subgraphs:
                       a:

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -25,6 +25,8 @@ mod env_vars;
 #[cfg(test)]
 mod error_handling;
 #[cfg(test)]
+mod error_masking;
+#[cfg(test)]
 mod extensions_propagation;
 #[cfg(test)]
 mod file_supergraph;

--- a/e2e/src/override_subgraph_urls.rs
+++ b/e2e/src/override_subgraph_urls.rs
@@ -66,7 +66,7 @@ mod override_subgraph_urls_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                 override_subgraph_urls:
                     subgraphs:
                         accounts:

--- a/e2e/src/override_subgraph_urls.rs
+++ b/e2e/src/override_subgraph_urls.rs
@@ -64,6 +64,9 @@ mod override_subgraph_urls_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                    all:
+                      error_message: false
                 override_subgraph_urls:
                     subgraphs:
                         accounts:

--- a/e2e/src/subscriptions.rs
+++ b/e2e/src/subscriptions.rs
@@ -1124,7 +1124,7 @@ mod subscriptions_e2e_tests {
                     path: supergraph.graphql
                 error_masking:
                     all:
-                      error_message: false
+                      enabled: false
                 subscriptions:
                     enabled: true
                 "#,
@@ -1349,6 +1349,8 @@ mod subscriptions_e2e_tests {
                     path: supergraph.graphql
                 subscriptions:
                     enabled: true
+                error_masking:
+                    enabled: false
                 headers:
                     all:
                         request:

--- a/e2e/src/subscriptions.rs
+++ b/e2e/src/subscriptions.rs
@@ -1122,6 +1122,9 @@ mod subscriptions_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                error_masking:
+                    all:
+                      error_message: false
                 subscriptions:
                     enabled: true
                 "#,

--- a/lib/executor/src/execution/error_masking.rs
+++ b/lib/executor/src/execution/error_masking.rs
@@ -1,29 +1,40 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::response::graphql_error::{GraphQLError, GraphQLErrorExtensions};
-use hive_router_config::error_masking::{
-    ErrorMaskingConfig, ExtensionsMaskingConfig, SubgraphErrorMaskingConfig,
-};
+use hive_router_config::error_masking::{ErrorMaskingConfig, ExtensionsMaskingConfig};
 
 pub struct ErrorMaskingRuntime {
-    default_redacted_error_message: String,
-    per_subgraph_config: HashMap<String, ErrorMaskingCompiledConfig>,
-    default_config: ErrorMaskingCompiledConfig,
+    redacted_error_message: String,
+
+    // Error masking for the error message, split by "all" and subgraph-specific
+    default_error_masking: bool,
+    per_subgraph_error_masking: HashMap<String, bool>,
+
+    // Error masking for the error extensions, split by "all" and subgraph-specific
+    default_extensions_masking: Option<RedactExtensionsPlan>,
+    per_subgraph_extensions_masking: HashMap<String, Option<RedactExtensionsPlan>>,
 }
 
 impl ErrorMaskingRuntime {
     pub fn apply(&self, err: &mut GraphQLError) {
         if let Some(service_name) = &err.extensions.service_name {
-            let effective_config = self
-                .per_subgraph_config
+            let should_mask_message = self
+                .per_subgraph_error_masking
                 .get(service_name)
-                .unwrap_or(&self.default_config);
+                .copied()
+                .unwrap_or(self.default_error_masking);
 
-            if effective_config.redact_error_message {
-                err.message = self.default_redacted_error_message.clone();
+            if should_mask_message {
+                err.message = self.redacted_error_message.clone();
             }
 
-            if let Some(plan) = &effective_config.extensions_plan {
+            let extensions_masking_config = self
+                .per_subgraph_extensions_masking
+                .get(service_name)
+                .and_then(|plan| plan.as_ref())
+                .or(self.default_extensions_masking.as_ref());
+
+            if let Some(plan) = extensions_masking_config {
                 plan.apply(&mut err.extensions);
             }
         }
@@ -31,39 +42,56 @@ impl ErrorMaskingRuntime {
 
     pub fn compile_from_config(config: &ErrorMaskingConfig) -> Self {
         Self {
-            default_redacted_error_message: config.redacted_error_message.clone(),
-            per_subgraph_config: config
+            redacted_error_message: config.redacted_error_message.clone(),
+            default_error_masking: config.all.error_message,
+            per_subgraph_error_masking: config
                 .subgraphs
                 .as_ref()
                 .map(|subgraphs| {
                     subgraphs
                         .iter()
-                        .map(|(name, cfg)| (name.clone(), Self::compile_config(cfg)))
+                        .map(|(name, cfg)| {
+                            (
+                                name.clone(),
+                                cfg.error_message.unwrap_or(config.all.error_message),
+                            )
+                        })
                         .collect()
                 })
                 .unwrap_or_default(),
-            default_config: Self::compile_config(&config.all),
+            default_extensions_masking: config
+                .all
+                .extensions
+                .as_ref()
+                .map(Self::compile_extensions_config),
+            per_subgraph_extensions_masking: config
+                .subgraphs
+                .as_ref()
+                .map(|subgraphs| {
+                    subgraphs
+                        .iter()
+                        .map(|(name, cfg)| {
+                            (
+                                name.clone(),
+                                cfg.extensions.as_ref().map(Self::compile_extensions_config),
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
         }
     }
 
-    fn compile_config(config: &SubgraphErrorMaskingConfig) -> ErrorMaskingCompiledConfig {
-        let extensions_plan = config.extensions.as_ref().map(|cfg| match cfg {
+    fn compile_extensions_config(
+        extensions_config: &ExtensionsMaskingConfig,
+    ) -> RedactExtensionsPlan {
+        match extensions_config {
             ExtensionsMaskingConfig::AllowList { keys } => {
                 RedactExtensionsPlan::Allow(keys.clone())
             }
             ExtensionsMaskingConfig::DenyList { keys } => RedactExtensionsPlan::Deny(keys.clone()),
-        });
-
-        ErrorMaskingCompiledConfig {
-            redact_error_message: config.error_message.unwrap_or(true),
-            extensions_plan,
         }
     }
-}
-
-struct ErrorMaskingCompiledConfig {
-    redact_error_message: bool,
-    extensions_plan: Option<RedactExtensionsPlan>,
 }
 
 enum RedactExtensionsPlan {
@@ -85,7 +113,7 @@ impl RedactExtensionsPlan {
 
     fn apply_deny_list(extensions: &mut GraphQLErrorExtensions, list: &[String]) {
         for removal_path in list {
-            Self::remove_field(extensions, &removal_path);
+            Self::remove_field(extensions, removal_path);
         }
     }
 
@@ -98,7 +126,7 @@ impl RedactExtensionsPlan {
         for key in list {
             match key.as_str() {
                 "code" => allow_code = true,
-                "serviceName" => allow_service_name = true,
+                "service" => allow_service_name = true,
                 "affectedPath" => allow_affected_path = true,
                 other => {
                     allowed_keys.insert(other);
@@ -127,15 +155,12 @@ impl RedactExtensionsPlan {
         match key {
             "code" => {
                 extensions.code = None;
-                return;
             }
-            "serviceName" => {
+            "service" => {
                 extensions.service_name = None;
-                return;
             }
             "affectedPath" => {
                 extensions.affected_path = None;
-                return;
             }
             _ => {
                 extensions.extensions.remove(key);

--- a/lib/executor/src/execution/error_masking.rs
+++ b/lib/executor/src/execution/error_masking.rs
@@ -1,0 +1,145 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::response::graphql_error::{GraphQLError, GraphQLErrorExtensions};
+use hive_router_config::error_masking::{
+    ErrorMaskingConfig, ExtensionsMaskingConfig, SubgraphErrorMaskingConfig,
+};
+
+pub struct ErrorMaskingRuntime {
+    default_redacted_error_message: String,
+    per_subgraph_config: HashMap<String, ErrorMaskingCompiledConfig>,
+    default_config: ErrorMaskingCompiledConfig,
+}
+
+impl ErrorMaskingRuntime {
+    pub fn apply(&self, err: &mut GraphQLError) {
+        if let Some(service_name) = &err.extensions.service_name {
+            let effective_config = self
+                .per_subgraph_config
+                .get(service_name)
+                .unwrap_or(&self.default_config);
+
+            if effective_config.redact_error_message {
+                err.message = self.default_redacted_error_message.clone();
+            }
+
+            if let Some(plan) = &effective_config.extensions_plan {
+                plan.apply(&mut err.extensions);
+            }
+        }
+    }
+
+    pub fn compile_from_config(config: &ErrorMaskingConfig) -> Self {
+        Self {
+            default_redacted_error_message: config.redacted_error_message.clone(),
+            per_subgraph_config: config
+                .subgraphs
+                .as_ref()
+                .map(|subgraphs| {
+                    subgraphs
+                        .iter()
+                        .map(|(name, cfg)| (name.clone(), Self::compile_config(cfg)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            default_config: Self::compile_config(&config.all),
+        }
+    }
+
+    fn compile_config(config: &SubgraphErrorMaskingConfig) -> ErrorMaskingCompiledConfig {
+        let extensions_plan = config.extensions.as_ref().map(|cfg| match cfg {
+            ExtensionsMaskingConfig::AllowList { keys } => {
+                RedactExtensionsPlan::Allow(keys.clone())
+            }
+            ExtensionsMaskingConfig::DenyList { keys } => RedactExtensionsPlan::Deny(keys.clone()),
+        });
+
+        ErrorMaskingCompiledConfig {
+            redact_error_message: config.error_message.unwrap_or(true),
+            extensions_plan,
+        }
+    }
+}
+
+struct ErrorMaskingCompiledConfig {
+    redact_error_message: bool,
+    extensions_plan: Option<RedactExtensionsPlan>,
+}
+
+enum RedactExtensionsPlan {
+    Allow(Vec<String>),
+    Deny(Vec<String>),
+}
+
+impl RedactExtensionsPlan {
+    pub fn apply(&self, extensions: &mut GraphQLErrorExtensions) {
+        match self {
+            RedactExtensionsPlan::Allow(list) => {
+                Self::apply_allow_list(extensions, list);
+            }
+            RedactExtensionsPlan::Deny(list) => {
+                Self::apply_deny_list(extensions, list);
+            }
+        }
+    }
+
+    fn apply_deny_list(extensions: &mut GraphQLErrorExtensions, list: &[String]) {
+        for removal_path in list {
+            Self::remove_field(extensions, &removal_path);
+        }
+    }
+
+    fn apply_allow_list(extensions: &mut GraphQLErrorExtensions, list: &[String]) {
+        let mut allow_code = false;
+        let mut allow_service_name = false;
+        let mut allow_affected_path = false;
+        let mut allowed_keys = HashSet::new();
+
+        for key in list {
+            match key.as_str() {
+                "code" => allow_code = true,
+                "serviceName" => allow_service_name = true,
+                "affectedPath" => allow_affected_path = true,
+                other => {
+                    allowed_keys.insert(other);
+                }
+            }
+        }
+
+        if !allow_code {
+            extensions.code = None;
+        }
+
+        if !allow_service_name {
+            extensions.service_name = None;
+        }
+
+        if !allow_affected_path {
+            extensions.affected_path = None;
+        }
+
+        extensions
+            .extensions
+            .retain(|key, _| allowed_keys.contains(key.as_str()));
+    }
+
+    fn remove_field(extensions: &mut GraphQLErrorExtensions, key: &str) {
+        match key {
+            "code" => {
+                extensions.code = None;
+                return;
+            }
+            "serviceName" => {
+                extensions.service_name = None;
+                return;
+            }
+            "affectedPath" => {
+                extensions.affected_path = None;
+                return;
+            }
+            _ => {
+                extensions.extensions.remove(key);
+            }
+        }
+    }
+}

--- a/lib/executor/src/execution/error_masking.rs
+++ b/lib/executor/src/execution/error_masking.rs
@@ -43,7 +43,7 @@ impl ErrorMaskingRuntime {
     pub fn compile_from_config(config: &ErrorMaskingConfig) -> Self {
         Self {
             redacted_error_message: config.redacted_error_message.clone(),
-            default_error_masking: config.all.error_message,
+            default_error_masking: config.all.enabled,
             per_subgraph_error_masking: config
                 .subgraphs
                 .as_ref()
@@ -51,10 +51,7 @@ impl ErrorMaskingRuntime {
                     subgraphs
                         .iter()
                         .map(|(name, cfg)| {
-                            (
-                                name.clone(),
-                                cfg.error_message.unwrap_or(config.all.error_message),
-                            )
+                            (name.clone(), cfg.enabled.unwrap_or(config.all.enabled))
                         })
                         .collect()
                 })

--- a/lib/executor/src/execution/error_masking.rs
+++ b/lib/executor/src/execution/error_masking.rs
@@ -25,7 +25,7 @@ impl ErrorMaskingRuntime {
                 .unwrap_or(self.default_error_masking);
 
             if should_mask_message {
-                err.message = self.redacted_error_message.clone();
+                err.message.clone_from(&self.redacted_error_message);
             }
 
             let extensions_masking_config = self

--- a/lib/executor/src/execution/error_masking.rs
+++ b/lib/executor/src/execution/error_masking.rs
@@ -59,11 +59,7 @@ impl ErrorMaskingRuntime {
                         .collect()
                 })
                 .unwrap_or_default(),
-            default_extensions_masking: config
-                .all
-                .extensions
-                .as_ref()
-                .map(Self::compile_extensions_config),
+            default_extensions_masking: config.all.extensions.as_ref().map(|v| v.into()),
             per_subgraph_extensions_masking: config
                 .subgraphs
                 .as_ref()
@@ -71,25 +67,11 @@ impl ErrorMaskingRuntime {
                     subgraphs
                         .iter()
                         .map(|(name, cfg)| {
-                            (
-                                name.clone(),
-                                cfg.extensions.as_ref().map(Self::compile_extensions_config),
-                            )
+                            (name.clone(), cfg.extensions.as_ref().map(|v| v.into()))
                         })
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
-    }
-
-    fn compile_extensions_config(
-        extensions_config: &ExtensionsMaskingConfig,
-    ) -> RedactExtensionsPlan {
-        match extensions_config {
-            ExtensionsMaskingConfig::AllowList { keys } => {
-                RedactExtensionsPlan::Allow(keys.clone())
-            }
-            ExtensionsMaskingConfig::DenyList { keys } => RedactExtensionsPlan::Deny(keys.clone()),
         }
     }
 }
@@ -97,6 +79,15 @@ impl ErrorMaskingRuntime {
 enum RedactExtensionsPlan {
     Allow(Vec<String>),
     Deny(Vec<String>),
+}
+
+impl From<&ExtensionsMaskingConfig> for RedactExtensionsPlan {
+    fn from(config: &ExtensionsMaskingConfig) -> Self {
+        match config {
+            ExtensionsMaskingConfig::AllowList { keys } => Self::Allow(keys.clone()),
+            ExtensionsMaskingConfig::DenyList { keys } => Self::Deny(keys.clone()),
+        }
+    }
 }
 
 impl RedactExtensionsPlan {

--- a/lib/executor/src/execution/error_masking.rs
+++ b/lib/executor/src/execution/error_masking.rs
@@ -40,8 +40,12 @@ impl ErrorMaskingRuntime {
         }
     }
 
-    pub fn compile_from_config(config: &ErrorMaskingConfig) -> Self {
-        Self {
+    pub fn compile_from_config(config: &ErrorMaskingConfig) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+
+        Some(Self {
             redacted_error_message: config.redacted_error_message.clone(),
             default_error_masking: config.all.enabled,
             per_subgraph_error_masking: config
@@ -69,7 +73,7 @@ impl ErrorMaskingRuntime {
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 

--- a/lib/executor/src/execution/mod.rs
+++ b/lib/executor/src/execution/mod.rs
@@ -1,6 +1,7 @@
 pub mod client_request_details;
 pub mod demand_control;
 pub mod error;
+pub mod error_masking;
 pub mod jwt_forward;
 pub mod operation_name;
 pub mod plan;

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -135,7 +135,7 @@ pub struct QueryPlanExecutionOpts<'exec> {
     pub plugin_req_state: Option<PluginRequestState<'exec>>,
     pub operation_name_factory: OperationNameFactory,
     pub response_header_sink: ResponseHeaderSink,
-    pub error_masking_runtime: Arc<ErrorMaskingRuntime>,
+    pub error_masking_runtime: Arc<Option<ErrorMaskingRuntime>>,
 }
 
 pub struct PlanSubscriptionOutput {
@@ -642,8 +642,10 @@ async fn execute_query_plan_with_data<'exec>(
         }
     }
 
-    for error in &mut errors {
-        opts.error_masking_runtime.apply(error);
+    if let Some(error_masking_runtime) = opts.error_masking_runtime.as_ref() {
+        for error in &mut errors {
+            error_masking_runtime.apply(error);
+        }
     }
 
     let body = project_by_operation(

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -176,6 +176,20 @@ impl FailedExecutionResult {
     }
 }
 
+#[inline]
+fn serialize_masked_failure(
+    mut error: GraphQLError,
+    error_masking_runtime: &Option<ErrorMaskingRuntime>,
+) -> Vec<u8> {
+    if let Some(runtime) = error_masking_runtime {
+        runtime.apply(&mut error);
+    }
+    FailedExecutionResult {
+        errors: vec![error],
+    }
+    .serialize()
+}
+
 fn early_http_response_into_execution_output(
     response: EarlyHTTPResponse,
     response_header_sink: &ResponseHeaderSink,
@@ -328,6 +342,7 @@ pub async fn execute_query_plan<'exec>(
         let client_jwt = opts.client_request.jwt.clone();
         let client_path_params = opts.client_request.path_params.into_owned();
         let response_header_sink = opts.response_header_sink.clone();
+        let error_masking_runtime = opts.error_masking_runtime.clone();
 
         let operation_name_factory = opts.operation_name_factory.clone();
 
@@ -352,9 +367,7 @@ pub async fn execute_query_plan<'exec>(
                         // we cannot guarantee that the subgraph will recover and clients might
                         // simply ignore errors wasting the router's resources
                         log_plan_execution_error(err);
-                        yield FailedExecutionResult {
-                            errors: vec![err.into()],
-                        }.serialize();
+                        yield serialize_masked_failure(err.into(), error_masking_runtime.as_ref());
                         return;
                     }
                 };
@@ -402,9 +415,7 @@ pub async fn execute_query_plan<'exec>(
                     Err(ref err) => {
                         // fatal error, stream it and stop
                         log_plan_execution_error(err);
-                        yield FailedExecutionResult {
-                            errors: vec![err.into()],
-                        }.serialize();
+                        yield serialize_masked_failure(err.into(), error_masking_runtime.as_ref());
                         return;
                     }
                 }

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -34,6 +34,7 @@ use tracing::Instrument;
 
 use crate::execution::client_request_details::OperationDetails;
 use crate::execution::demand_control::DemandControlExecutionContext;
+use crate::execution::error_masking::ErrorMaskingRuntime;
 use crate::execution::operation_name::OperationNameFactory;
 use crate::headers::cache_control;
 use crate::{
@@ -134,6 +135,7 @@ pub struct QueryPlanExecutionOpts<'exec> {
     pub plugin_req_state: Option<PluginRequestState<'exec>>,
     pub operation_name_factory: OperationNameFactory,
     pub response_header_sink: ResponseHeaderSink,
+    pub error_masking_runtime: Arc<ErrorMaskingRuntime>,
 }
 
 pub struct PlanSubscriptionOutput {
@@ -393,6 +395,7 @@ pub async fn execute_query_plan<'exec>(
                     operation_name_factory: operation_name_factory.clone(),
                     demand_control_context: opts.demand_control_context.clone(),
                     response_header_sink: response_header_sink.clone(),
+                    error_masking_runtime: opts.error_masking_runtime.clone(),
                 };
                 match execute_query_plan_with_data(response.data, opts).await {
                     Ok(result) => yield result.body,
@@ -637,6 +640,10 @@ async fn execute_query_plan_with_data<'exec>(
             errors = new_errors;
             status_code = new_status_code;
         }
+    }
+
+    for error in &mut errors {
+        opts.error_masking_runtime.apply(error);
     }
 
     let body = project_by_operation(

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -202,10 +202,8 @@ impl EnvVarOverrides {
                 disable_subgraph_error_masking
             );
 
-            config = config.set_override(
-                "error_masking.all.error_message",
-                !disable_subgraph_error_masking,
-            )?;
+            config =
+                config.set_override("error_masking.enabled", !disable_subgraph_error_masking)?;
         }
 
         Ok(config)

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -59,6 +59,10 @@ pub struct EnvVarOverrides {
     // Query planner overrides
     #[envconfig(from = "QUERY_PLANNER_EXPERIMENTAL_ABSTRACT_TYPE_FOLDING")]
     pub query_planner_experimental_abstract_type_folding: Option<bool>,
+
+    // Error masking
+    #[envconfig(from = "DISABLE_SUBGRAPH_ERROR_MASKING")]
+    pub disable_subgraph_error_masking: Option<bool>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -189,6 +193,18 @@ impl EnvVarOverrides {
             config = config.set_override(
                 "query_planner.experimental_abstract_type_folding",
                 experimental_abstract_type_folding,
+            )?;
+        }
+
+        if let Some(disable_subgraph_error_masking) = self.disable_subgraph_error_masking.take() {
+            debug!(
+                "[config-override] 'disable_subgraph_error_masking' = {}",
+                disable_subgraph_error_masking
+            );
+
+            config = config.set_override(
+                "error_masking.all.error_message",
+                !disable_subgraph_error_masking,
             )?;
         }
 

--- a/lib/router-config/src/error_masking.rs
+++ b/lib/router-config/src/error_masking.rs
@@ -1,0 +1,58 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorMaskingConfig {
+    #[serde(default = "default_redacted_error_message")]
+    pub redacted_error_message: String,
+    #[serde(default)]
+    pub all: SubgraphErrorMaskingConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subgraphs: Option<HashMap<String, SubgraphErrorMaskingConfig>>,
+}
+
+fn default_redacted_error_message() -> String {
+    "Unexpected error".to_string()
+}
+
+impl Default for ErrorMaskingConfig {
+    fn default() -> Self {
+        Self {
+            redacted_error_message: default_redacted_error_message(),
+            all: SubgraphErrorMaskingConfig::default(),
+            subgraphs: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+pub struct SubgraphErrorMaskingConfig {
+    #[serde(default = "default_redact_error_message")]
+    pub error_message: Option<bool>,
+    #[serde(default)]
+    pub extensions: Option<ExtensionsMaskingConfig>,
+}
+
+fn default_redact_error_message() -> Option<bool> {
+    None
+}
+
+impl Default for SubgraphErrorMaskingConfig {
+    fn default() -> Self {
+        Self {
+            error_message: Some(true),
+            extensions: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields, tag = "mode")]
+pub enum ExtensionsMaskingConfig {
+    #[serde(rename = "allow")]
+    AllowList { keys: Vec<String> },
+    #[serde(rename = "deny")]
+    DenyList { keys: Vec<String> },
+}

--- a/lib/router-config/src/error_masking.rs
+++ b/lib/router-config/src/error_masking.rs
@@ -66,7 +66,7 @@ pub struct SubgraphErrorMaskingConfig {
     /// Whether to redact the `error_message` in errors, for that specific subgraph.
     ///
     /// Configuring this will override the global `all.error_message` setting.
-    #[serde(default = "default_subgraph_redact_error_message")]
+    #[serde(default)]
     pub error_message: Option<bool>,
     /// Whether to redact the `extensions` in errors, for that specific subgraph.
     /// Configuring this will override the global `all.extensions` setting.
@@ -75,19 +75,6 @@ pub struct SubgraphErrorMaskingConfig {
     /// Note: only root-level fields are supported.
     #[serde(default)]
     pub extensions: Option<ExtensionsMaskingConfig>,
-}
-
-fn default_subgraph_redact_error_message() -> Option<bool> {
-    None
-}
-
-impl Default for SubgraphErrorMaskingConfig {
-    fn default() -> Self {
-        Self {
-            error_message: default_subgraph_redact_error_message(),
-            extensions: None,
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/router-config/src/error_masking.rs
+++ b/lib/router-config/src/error_masking.rs
@@ -5,6 +5,13 @@ use std::collections::HashMap;
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ErrorMaskingConfig {
+    /// A switch for enabling or disabling error masking feature completely.
+    ///
+    /// Defaults to `true`.
+    ///
+    /// You can also disable it by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.
+    #[serde(default = "default_feature_enabled")]
+    pub enabled: bool,
     /// The error message to redact in subgraph errors. The default is "Unexpected error".
     #[serde(default = "default_redacted_error_message")]
     pub redacted_error_message: String,
@@ -17,6 +24,10 @@ pub struct ErrorMaskingConfig {
     pub subgraphs: Option<HashMap<String, SubgraphErrorMaskingConfig>>,
 }
 
+fn default_feature_enabled() -> bool {
+    true
+}
+
 fn default_redacted_error_message() -> String {
     "Unexpected error".to_string()
 }
@@ -27,6 +38,7 @@ impl Default for ErrorMaskingConfig {
             redacted_error_message: default_redacted_error_message(),
             all: AllErrorMaskingConfig::default(),
             subgraphs: None,
+            enabled: default_feature_enabled(),
         }
     }
 }
@@ -35,8 +47,6 @@ impl Default for ErrorMaskingConfig {
 #[serde(deny_unknown_fields)]
 pub struct AllErrorMaskingConfig {
     /// Whether to redact the error message in subgraph errors. The default is `true`.
-    ///
-    /// This field can be set to `false`, in order to disable error masking, by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.
     #[serde(default = "default_redact_error_message")]
     pub enabled: bool,
     /// Whether to redact the `extensions` in errors.

--- a/lib/router-config/src/error_masking.rs
+++ b/lib/router-config/src/error_masking.rs
@@ -5,10 +5,14 @@ use std::collections::HashMap;
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ErrorMaskingConfig {
+    /// The error message to redact in subgraph errors. The default is "Unexpected error".
     #[serde(default = "default_redacted_error_message")]
     pub redacted_error_message: String,
+    /// The default error masking configuration for all subgraphs.
     #[serde(default)]
-    pub all: SubgraphErrorMaskingConfig,
+    pub all: AllErrorMaskingConfig,
+    /// The error masking configuration for individual subgraphs.
+    /// Any configuration field that will be specified here, will override the configuration in `all`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subgraphs: Option<HashMap<String, SubgraphErrorMaskingConfig>>,
 }
@@ -21,28 +25,66 @@ impl Default for ErrorMaskingConfig {
     fn default() -> Self {
         Self {
             redacted_error_message: default_redacted_error_message(),
-            all: SubgraphErrorMaskingConfig::default(),
+            all: AllErrorMaskingConfig::default(),
             subgraphs: None,
         }
     }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-pub struct SubgraphErrorMaskingConfig {
+#[serde(deny_unknown_fields)]
+pub struct AllErrorMaskingConfig {
+    /// Whether to redact the error message in subgraph errors. The default is `true`.
+    ///
+    /// This field can be set to `false`, in order to disable error masking, by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.
     #[serde(default = "default_redact_error_message")]
+    pub error_message: bool,
+    /// Whether to redact the `extensions` in errors.
+    ///
+    /// You may pick the execution mode by setting `mode: allow` or `mode: deny`.
+    /// Note: only root-level fields are supported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<ExtensionsMaskingConfig>,
+}
+
+fn default_redact_error_message() -> bool {
+    true
+}
+
+impl Default for AllErrorMaskingConfig {
+    fn default() -> Self {
+        Self {
+            error_message: true,
+            extensions: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct SubgraphErrorMaskingConfig {
+    /// Whether to redact the `error_message` in errors, for that specific subgraph.
+    ///
+    /// Configuring this will override the global `all.error_message` setting.
+    #[serde(default = "default_subgraph_redact_error_message")]
     pub error_message: Option<bool>,
+    /// Whether to redact the `extensions` in errors, for that specific subgraph.
+    /// Configuring this will override the global `all.extensions` setting.
+    ///
+    /// You may pick the execution mode by setting `mode: allow` or `mode: deny`.
+    /// Note: only root-level fields are supported.
     #[serde(default)]
     pub extensions: Option<ExtensionsMaskingConfig>,
 }
 
-fn default_redact_error_message() -> Option<bool> {
+fn default_subgraph_redact_error_message() -> Option<bool> {
     None
 }
 
 impl Default for SubgraphErrorMaskingConfig {
     fn default() -> Self {
         Self {
-            error_message: Some(true),
+            error_message: default_subgraph_redact_error_message(),
             extensions: None,
         }
     }
@@ -51,8 +93,10 @@ impl Default for SubgraphErrorMaskingConfig {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, tag = "mode")]
 pub enum ExtensionsMaskingConfig {
+    /// Redact extensions based on the allowlist.
     #[serde(rename = "allow")]
     AllowList { keys: Vec<String> },
+    /// Redact extensions based on the denylist.
     #[serde(rename = "deny")]
     DenyList { keys: Vec<String> },
 }

--- a/lib/router-config/src/error_masking.rs
+++ b/lib/router-config/src/error_masking.rs
@@ -66,14 +66,14 @@ pub struct SubgraphErrorMaskingConfig {
     /// Whether to redact the `error_message` in errors, for that specific subgraph.
     ///
     /// Configuring this will override the global `all.error_message` setting.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// Whether to redact the `extensions` in errors, for that specific subgraph.
     /// Configuring this will override the global `all.extensions` setting.
     ///
     /// You may pick the execution mode by setting `mode: allow` or `mode: deny`.
     /// Note: only root-level fields are supported.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<ExtensionsMaskingConfig>,
 }
 

--- a/lib/router-config/src/error_masking.rs
+++ b/lib/router-config/src/error_masking.rs
@@ -38,7 +38,7 @@ pub struct AllErrorMaskingConfig {
     ///
     /// This field can be set to `false`, in order to disable error masking, by setting the `DISABLE_SUBGRAPH_ERROR_MASKING=true` environment variable.
     #[serde(default = "default_redact_error_message")]
-    pub error_message: bool,
+    pub enabled: bool,
     /// Whether to redact the `extensions` in errors.
     ///
     /// You may pick the execution mode by setting `mode: allow` or `mode: deny`.
@@ -54,7 +54,7 @@ fn default_redact_error_message() -> bool {
 impl Default for AllErrorMaskingConfig {
     fn default() -> Self {
         Self {
-            error_message: true,
+            enabled: true,
             extensions: None,
         }
     }
@@ -67,7 +67,7 @@ pub struct SubgraphErrorMaskingConfig {
     ///
     /// Configuring this will override the global `all.error_message` setting.
     #[serde(default)]
-    pub error_message: Option<bool>,
+    pub enabled: Option<bool>,
     /// Whether to redact the `extensions` in errors, for that specific subgraph.
     /// Configuring this will override the global `all.extensions` setting.
     ///

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -300,8 +300,10 @@ pub fn load_config(
 }
 
 pub fn parse_yaml_config(config_raw: String) -> Result<HiveRouterConfig, RouterConfigError> {
+    let env_overrides = EnvVarOverrides::init_from_env()?;
     let config_root_path = get_current_dir()?;
-    let config = Config::builder();
+    let mut config = Config::builder();
+    config = env_overrides.apply_overrides(config)?;
 
     with_start_path(&config_root_path, || {
         config

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cors;
 pub mod csrf;
 pub mod demand_control;
 mod env_overrides;
+pub mod error_masking;
 pub mod headers;
 pub mod http_server;
 pub mod introspection_policy;
@@ -33,6 +34,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{collections::HashMap, convert::Infallible};
 
+use crate::error_masking::ErrorMaskingConfig;
 use crate::storage::StorageConfigMap;
 use crate::{
     env_overrides::{EnvVarOverrides, EnvVarOverridesError},
@@ -163,6 +165,10 @@ pub struct HiveRouterConfig {
     /// ```
     #[serde(default, skip_serializing_if = "StorageConfigMap::is_empty")]
     pub storages: StorageConfigMap,
+
+    /// Configuration for error masking.
+    #[serde(default)]
+    pub error_masking: ErrorMaskingConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
       "name": "docs-md-generator",
       "license": "MIT",
       "dependencies": {
-        "jsonschema2mk": "^2.2.1"
+        "jsonschema2mk": "2.2.1"
       }
     },
     "lib/node-addon": {
@@ -1048,6 +1048,7 @@
       "version": "7.0.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1217,6 +1218,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/1194 
Docs PR:  https://github.com/graphql-hive/docs/pull/143

## Background 

This PR introduces error masking for subgraph errors. Subgraphs are considered internal, and not front-facing, so developers can safely assume that a subgraph service does not need to perform masking on that layer, and trust the router to perform masking for the error produced by the subgraph. 

By default, error masking is enabled, in order to prevent any leakage of internal/sensitive details from the errors. 

## How subgraph errors are detected? 

Any error that has `extensions.service` field, either constructed by the upstream service, or if it was syntethically created by the Router (in case of subgraph network errors).  

## When do we perform error masking? 

Error masking is performed last, after all metrics/tracing/logging took place. It's only impacting the final, user-facing response. 

## Configuration

* Developers can customize the error message used (default: `Unexpected error`) 
* Can enable/disable masking via config, or via env var (`DISABLE_SUBGRAPH_ERROR_MASKING=true`)
* Can mask `error.extesions` via deny/allow list 
* Can configure either `all` or per-subgraph configuration (overrides `all`)

Example: 

```yaml
              error_masking:
                all:
                  enabled: true
                  extensions:
                    mode: allow
                    keys: [] # allow none!
                subgraphs:
                  products:
                    enabled: false
                    extensions:
                      mode: deny
                      keys: [] # dont deny anything!
``` 

## More stuff in this PR 

* Since now error masking is enabled by default, some e2e needed to configure it as disabled, in order to pass the snapshot testing 
* I fixed a small issue in the way inline config in e2e tests are loaded, becase it was not using env overrides at all 

## TODO 

- [x] initial impl 
- [x] initial e2e
- [x] config is now "all or nothing" - we need to make each part of `all` and `subgraphs` and `Option` so user can override only part of the config (`all: { error_message: false, extension: { ... } }` + `subgraphs: { named: { error_message: true }}` should use the `error_message: true` AND the `exntesions` from `all`. 
- [x] some sanity testing
- [x] more e2es? 
- [x] does the detection of subgraph-specific errors is correct? should we have a branded error to detect it? 
- [x] rebase after https://github.com/graphql-hive/router/pull/1233 and confirm that it works correctly with the new errors added there
- [x] env var to disable masking  
- [x] docs
- [x] changeset