### PR TITLE
feat(router): subscriptions metrics

### DIFF
--- a/.changeset/drop_message_instead_of_complete_subscription_in_http_callback_transport.md
+++ b/.changeset/drop_message_instead_of_complete_subscription_in_http_callback_transport.md
@@ -1,0 +1,7 @@
+---
+hive-router: patch
+---
+
+# Drop messages instead of completing subscriptions in the HTTP callback transport
+
+When an HTTP callback subscription's internal buffer is full, acknowledge the callback and drop only that message instead of returning a 503 response and terminating the subscription. This aligns HTTP callback behavior with the other streaming transports and lets slow consumers recover without reconnecting.

--- a/.changeset/relax_logs_relating_to_laggingdropping_subscription_messages_from_warn_to_debug.md
+++ b/.changeset/relax_logs_relating_to_laggingdropping_subscription_messages_from_warn_to_debug.md
@@ -1,0 +1,8 @@
+---
+hive-router: patch
+hive-router-plan-executor: patch
+---
+
+# Log lagged and dropped subscription messages at `debug` level
+
+Reduce expected slow-consumer noise by changing logs for lagged client messages and messages dropped from full subscription buffers from `warn` to `debug`. These events no longer imply subscription termination and can be monitored through the subscription metrics.

--- a/.changeset/subscriptions_metrics.md
+++ b/.changeset/subscriptions_metrics.md
@@ -1,0 +1,44 @@
+---
+hive-router-plan-executor: minor
+hive-router: minor
+---
+
+# Add OpenTelemetry metrics for GraphQL subscriptions
+
+Add end-to-end observability into subscription activity between clients, the router, and subgraphs.
+
+## Live state
+
+| Metric                                            | Labels                                    | Unit             | Description                                                 |
+| ------------------------------------------------- | ----------------------------------------- | ---------------- | ----------------------------------------------------------- |
+| `hive.router.subscriptions.clients.active`        | `subscription.transport`                  | `{subscription}` | Active subscription operations from clients to the router   |
+| `hive.router.subscriptions.clients.connections`   | `subscription.transport`                  | `{connection}`   | Active client transport connections carrying subscriptions  |
+| `hive.router.subscriptions.subgraphs.active`      | `subgraph.name`                           | `{subscription}` | Active subscription operations from the router to subgraphs |
+| `hive.router.subscriptions.subgraphs.connections` | `subgraph.name`, `subscription.transport` | `{connection}`   | Active transport connections from the router to subgraphs   |
+
+Operations and connections are measured separately because one connection can carry multiple operations, while subscription deduplication can fan one subgraph operation out to multiple clients.
+
+## Lifecycle
+
+| Metric                                              | Labels                                              | Unit             | Description                    |
+| --------------------------------------------------- | --------------------------------------------------- | ---------------- | ------------------------------ |
+| `hive.router.subscriptions.clients.started_total`   | `subscription.transport`                            | `{subscription}` | Client subscriptions started   |
+| `hive.router.subscriptions.clients.ended_total`     | `subscription.transport`, `subscription.end_reason` | `{subscription}` | Client subscriptions ended     |
+| `hive.router.subscriptions.subgraphs.started_total` | `subgraph.name`                                     | `{subscription}` | Subgraph subscriptions started |
+| `hive.router.subscriptions.subgraphs.ended_total`   | `subgraph.name`                                     | `{subscription}` | Subgraph subscriptions ended   |
+
+Every recorded start has exactly one matching end. Client end reasons are `completed` when the source finishes normally, `error` when an error is delivered to the client, and `client_disconnected` when the client disconnects, unsubscribes, or the router otherwise drops the stream.
+
+The counters expose subscription churn and remain meaningful across router restarts. Comparing start and end rates can reveal mass disconnects or reconnect loops even when the active subscription count appears stable.
+
+## Message delivery
+
+| Metric                                                       | Labels                   | Unit        | Description                                                                |
+| ------------------------------------------------------------ | ------------------------ | ----------- | -------------------------------------------------------------------------- |
+| `hive.router.subscriptions.clients.sent_messages_total`      | `subscription.transport` | `{message}` | Messages successfully sent to client subscribers                           |
+| `hive.router.subscriptions.clients.lagged_messages_total`    | `subscription.transport` | `{message}` | Messages skipped for lagging clients on broadcast fan-out                  |
+| `hive.router.subscriptions.subgraphs.dropped_messages_total` | `subscription.transport` | `{message}` | Subgraph messages dropped because an internal subscription buffer was full |
+
+Lagged and dropped counters increase by the number of messages skipped without terminating the subscription. `sent_messages_total / (sent_messages_total + lagged_messages_total)` provides the client delivery ratio for each transport.
+
+`subscription.transport` can be `websocket`, `http_multipart`, `http_sse`, or `http_callback`. Units such as `{subscription}`, `{connection}`, and `{message}` are UCUM annotations that identify what each instrument counts.

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -292,11 +292,14 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             let cb_path = path.to_string();
             let cb_addr = listen.to_string();
             let cb_subs = callback_subscriptions_for_handler.clone();
+            let cb_telemetry_context = telemetry.context.clone();
             let mut cb_server_builder = web::HttpServer::new(async move || {
                 let cb_subs = cb_subs.clone();
                 let cb_path = cb_path.clone();
+                let telemetry_context = cb_telemetry_context.clone();
                 web::App::new()
                     .state(cb_subs)
+                    .state(telemetry_context)
                     .configure(move |m| add_callback_handler(m, &cb_path))
             });
             if let Some(workers) = workers {
@@ -340,6 +343,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             ))
             .state(shared_state.clone())
             .state(schema_state.clone())
+            .state(shared_state.telemetry_context.clone())
             .configure(|m| configure_ntex_app(m, &paths, prometheus))
             .configure(|m| {
                 if let Some(ref callback) = paths.callback {

--- a/bin/router/src/pipeline/http_callback.rs
+++ b/bin/router/src/pipeline/http_callback.rs
@@ -4,6 +4,8 @@ use hive_router_plan_executor::executors::http_callback::{
     CallbackMessage, CallbackSubscription, CallbackSubscriptionsMap, CALLBACK_PROTOCOL_VERSION,
     SUBSCRIPTION_PROTOCOL_HEADER,
 };
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
+use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::response::graphql_error::GraphQLError;
 use http::StatusCode;
 use ntex::util::Bytes;
@@ -152,6 +154,7 @@ fn handle_next(
     payload: &CallbackPayload<'_>,
     subscription: Ref<'_, String, CallbackSubscription>,
     callback_subscriptions: &CallbackSubscriptionsMap,
+    telemetry_context: &TelemetryContext,
 ) -> Result<(), CallbackError> {
     trace!(subscription_id = %subscription_id, "Received next message");
 
@@ -173,6 +176,10 @@ fn handle_next(
             // if the channel is full it means the consuming client is too slow and unable to keep
             // up. we terminate the subscription without an error message because it anyways cant go through
             warn!(subscription_id = %subscription_id, "Subscription client is too slow");
+            telemetry_context
+                .metrics
+                .subscriptions
+                .record_subgraph_termination(&subscription.subgraph_name, SubscriptionTransport::HttpCallback);
             drop(subscription);
             callback_subscriptions.remove(subscription_id);
             Err(CallbackError::ClientTooSlow {
@@ -211,6 +218,7 @@ pub async fn handler(
     path: Path<String>,
     body: Bytes,
     callback_subscriptions: web::types::State<CallbackSubscriptionsMap>,
+    telemetry_context: web::types::State<std::sync::Arc<TelemetryContext>>,
 ) -> Result<HttpResponse, CallbackError> {
     let subscription_id_from_path = path.into_inner();
 
@@ -238,7 +246,13 @@ pub async fn handler(
     match payload.action {
         CallbackAction::Check => handle_check(&payload.id, &subscription),
         CallbackAction::Next => {
-            handle_next(&payload.id, &payload, subscription, &callback_subscriptions)?;
+            handle_next(
+                &payload.id,
+                &payload,
+                subscription,
+                &callback_subscriptions,
+                &telemetry_context,
+            )?;
         }
         CallbackAction::Complete => {
             handle_complete(&payload.id, &payload, subscription, &callback_subscriptions)

--- a/bin/router/src/pipeline/http_callback.rs
+++ b/bin/router/src/pipeline/http_callback.rs
@@ -1,11 +1,12 @@
 use bytes::Bytes as BytesLib;
 use dashmap::mapref::one::Ref;
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
+use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::executors::http_callback::{
     CallbackMessage, CallbackSubscription, CallbackSubscriptionsMap, CALLBACK_PROTOCOL_VERSION,
     SUBSCRIPTION_PROTOCOL_HEADER,
 };
-use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
-use hive_router_internal::telemetry::TelemetryContext;
+use hive_router_plan_executor::executors::subscription_buffer::{try_send_or_drop, SendOutcome};
 use hive_router_plan_executor::response::graphql_error::GraphQLError;
 use http::StatusCode;
 use ntex::util::Bytes;
@@ -13,7 +14,6 @@ use ntex::web::WebResponseError;
 use ntex::web::{self, types::Path, HttpRequest, HttpResponse};
 use serde::Deserialize;
 use strum::EnumString;
-use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
 #[derive(Debug, Deserialize, EnumString)]
@@ -68,11 +68,6 @@ pub enum CallbackError {
     InvalidVerifier { subscription_id: String },
     #[error("Subscription receiver dropped for subscription ID '{subscription_id}'")]
     SubscriptionDropped { subscription_id: String },
-    // NOTE: intentionally a different variant from SubscriptionDropped
-    #[error(
-        "Client consuming too slowly. Event buffer full for subscription ID '{subscription_id}'"
-    )]
-    ClientTooSlow { subscription_id: String },
 }
 
 impl CallbackError {
@@ -85,7 +80,6 @@ impl CallbackError {
             CallbackError::SubscriptionNotFound { .. } => warn!("{}", self),
             CallbackError::InvalidVerifier { .. } => warn!("{}", self),
             CallbackError::SubscriptionDropped { .. } => debug!("{}", self),
-            CallbackError::ClientTooSlow { .. } => warn!("{}", self),
         }
     }
 }
@@ -100,9 +94,6 @@ impl WebResponseError for CallbackError {
             CallbackError::SubscriptionNotFound { .. }
             | CallbackError::SubscriptionDropped { .. }
             | CallbackError::SubscriptionIdMismatch { .. } => StatusCode::NOT_FOUND,
-            // 503 signals the subgraph that the router is temporarily unable to accept events,
-            // the subgraph can decide to retry or close the subscription on its end
-            CallbackError::ClientTooSlow { .. } => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
     fn error_response(&self, _: &HttpRequest) -> HttpResponse {
@@ -167,26 +158,19 @@ fn handle_next(
         }
     };
 
-    match subscription
-        .sender
-        .try_send(CallbackMessage::Next { payload: data })
-    {
-        Ok(()) => Ok(()),
-        Err(mpsc::error::TrySendError::Full(_)) => {
-            // if the channel is full it means the consuming client is too slow and unable to keep
-            // up. we terminate the subscription without an error message because it anyways cant go through
-            warn!(subscription_id = %subscription_id, "Subscription client is too slow");
-            telemetry_context
-                .metrics
-                .subscriptions
-                .record_subgraph_termination(&subscription.subgraph_name, SubscriptionTransport::HttpCallback);
-            drop(subscription);
-            callback_subscriptions.remove(subscription_id);
-            Err(CallbackError::ClientTooSlow {
-                subscription_id: subscription_id.to_string(),
-            })
-        }
-        Err(mpsc::error::TrySendError::Closed(_)) => {
+    let subgraph_name = subscription.subgraph_name.clone();
+    match try_send_or_drop(
+        &subscription.sender,
+        CallbackMessage::Next { payload: data },
+        telemetry_context,
+        SubscriptionTransport::HttpCallback,
+        &subgraph_name,
+        subscription_id,
+    ) {
+        // sent or dropped (consumer too slow): keep the subscription alive either way, same
+        // as the websocket/http drainers, the dropped-message metric already covers this.
+        SendOutcome::Sent | SendOutcome::Dropped => Ok(()),
+        SendOutcome::Closed => {
             debug!(subscription_id = %subscription_id, "Subscription receiver dropped");
             drop(subscription);
             callback_subscriptions.remove(subscription_id);

--- a/bin/router/src/pipeline/http_callback.rs
+++ b/bin/router/src/pipeline/http_callback.rs
@@ -158,13 +158,12 @@ fn handle_next(
         }
     };
 
-    let subgraph_name = subscription.subgraph_name.clone();
     match try_send_or_drop(
         &subscription.sender,
         CallbackMessage::Next { payload: data },
         telemetry_context,
         SubscriptionTransport::HttpCallback,
-        &subgraph_name,
+        &subscription.subgraph_name,
         subscription_id,
     ) {
         // sent or dropped (consumer too slow): keep the subscription alive either way, same

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -54,7 +54,7 @@ use crate::{
         error::PipelineError,
         execution::{execute_plan, PlannedRequest},
         execution_request::{GetQueryStr, OperationPreparation, OperationPreparationResult},
-        header::{RequestAccepts, ResponseMode, StreamContentType, TEXT_HTML_MIME},
+        header::{RequestAccepts, ResponseMode, TEXT_HTML_MIME},
         introspection_policy::handle_introspection_policy,
         normalize::{normalize_request_with_cache, GraphQLNormalizationPayload},
         parser::{parse_operation_with_cache, ParseResult},
@@ -74,7 +74,6 @@ use crate::{
 };
 
 use hive_router_internal::telemetry::metrics::catalog::values::GraphQLResponseStatus;
-use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
 
 pub mod active_subscriptions;
 pub mod authorization;
@@ -431,7 +430,7 @@ pub async fn graphql_request_handler(
             },
         );
 
-        shared_response.into_response(response_mode)
+        shared_response.into_response(response_mode, &shared_state.telemetry_context.metrics)
     }
     .instrument(span_clone)
     .await
@@ -543,26 +542,11 @@ pub async fn execute_planned_request<'exec>(
                 &response_header_sink,
             );
 
-            let sub_transport = match stream_content_type {
-                StreamContentType::IncrementalDelivery | StreamContentType::ApolloMultipartHTTP => {
-                    SubscriptionTransport::HttpMultipart
-                }
-                StreamContentType::SSE => SubscriptionTransport::HttpSse,
-            };
-            let subscription_metrics = {
-                let m = &shared_state.telemetry_context.metrics.subscriptions;
-                Some((
-                    m.active_client_operation(sub_transport),
-                    m.active_client_connection(sub_transport),
-                ))
-            };
-
             Ok(SharedRouterResponse::Stream(SharedRouterStreamResponse {
                 body: sender,
                 headers,
                 error_count: result.error_count,
                 receiver: Some(receiver),
-                subscription_metrics,
             }))
         }
         QueryPlanExecutionResult::Single(result) => {

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -54,7 +54,7 @@ use crate::{
         error::PipelineError,
         execution::{execute_plan, PlannedRequest},
         execution_request::{GetQueryStr, OperationPreparation, OperationPreparationResult},
-        header::{RequestAccepts, ResponseMode, TEXT_HTML_MIME},
+        header::{RequestAccepts, ResponseMode, StreamContentType, TEXT_HTML_MIME},
         introspection_policy::handle_introspection_policy,
         normalize::{normalize_request_with_cache, GraphQLNormalizationPayload},
         parser::{parse_operation_with_cache, ParseResult},
@@ -74,6 +74,7 @@ use crate::{
 };
 
 use hive_router_internal::telemetry::metrics::catalog::values::GraphQLResponseStatus;
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
 
 pub mod active_subscriptions;
 pub mod authorization;
@@ -542,11 +543,26 @@ pub async fn execute_planned_request<'exec>(
                 &response_header_sink,
             );
 
+            let sub_transport = match stream_content_type {
+                StreamContentType::IncrementalDelivery | StreamContentType::ApolloMultipartHTTP => {
+                    SubscriptionTransport::HttpMultipart
+                }
+                StreamContentType::SSE => SubscriptionTransport::HttpSse,
+            };
+            let subscription_metrics = {
+                let m = &shared_state.telemetry_context.metrics.subscriptions;
+                Some((
+                    m.active_client_operation(sub_transport),
+                    m.active_client_connection(sub_transport),
+                ))
+            };
+
             Ok(SharedRouterResponse::Stream(SharedRouterStreamResponse {
                 body: sender,
                 headers,
                 error_count: result.error_count,
                 receiver: Some(receiver),
+                subscription_metrics,
             }))
         }
         QueryPlanExecutionResult::Single(result) => {

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn, Instrument};
 
+use hive_router_internal::telemetry::metrics::catalog::values::SubscriptionEndReason;
 use hive_router_internal::telemetry::metrics::subscription_metrics::{
     ActiveClientConnectionGuard, SubscriptionTransport,
 };
@@ -602,7 +603,7 @@ async fn handle_text_frame(
                         // making cancellation impossible
                         rt::spawn(async move {
                             let _guard = guard;
-                            let _client_op_guard = client_op_guard;
+                            let mut client_op_guard = client_op_guard;
                             let mut cancelled = false;
 
                             loop {
@@ -614,6 +615,7 @@ async fn handle_text_frame(
                                                 metrics.subscriptions.record_client_sent(SubscriptionTransport::WebSocket);
                                             }
                                             Ok(SubscriptionEvent::Error(errors)) => {
+                                                client_op_guard.set_end_reason(SubscriptionEndReason::Error);
                                                 let _ = sink.send(ServerMessage::error(&id_for_loop, &errors)).await;
                                                 break;
                                             }
@@ -626,6 +628,7 @@ async fn handle_text_frame(
                                                 continue;
                                             }
                                             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                                client_op_guard.set_end_reason(SubscriptionEndReason::Completed);
                                                 break;
                                             }
                                         }

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -17,6 +17,9 @@ use std::time::Instant;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn, Instrument};
 
+use hive_router_internal::telemetry::metrics::subscription_metrics::{
+    ActiveClientConnectionGuard, SubscriptionTransport,
+};
 use hive_router_internal::telemetry::traces::spans::graphql::GraphQLOperationSpan;
 use hive_router_plan_executor::executors::graphql_transport_ws::{
     ClientMessage, CloseCode, ConnectionInitPayload, ServerMessage, WS_SUBPROTOCOL,
@@ -108,6 +111,18 @@ async fn ws_service(
         debug!("WebSocket connection accepted");
     }
 
+    let conn_guard: Option<ActiveClientConnectionGuard> = if has_accepted_subprotocol {
+        Some(
+            shared_state
+                .telemetry_context
+                .metrics
+                .subscriptions
+                .active_client_connection(SubscriptionTransport::WebSocket),
+        )
+    } else {
+        None
+    };
+
     let ws_uri: Rc<http::Uri> = Rc::new(
         shared_state
             .router_config
@@ -175,6 +190,8 @@ async fn ws_service(
         // in turn cancel all active subscription streams and perform
         // the cleanup in there
         state.borrow_mut().subscriptions.clear();
+        // drop conn_guard here to decrement the connection counter
+        drop(conn_guard);
     });
 
     Ok(chain(service).and_then(on_shutdown))
@@ -573,6 +590,8 @@ async fn handle_text_frame(
                             .receiver
                             .unwrap_or_else(|| response.body.subscribe());
 
+                        let client_op_guard = shared_state.telemetry_context.metrics.subscriptions.active_client_operation(SubscriptionTransport::WebSocket);
+
                         trace!(id = %id, "Subscription started");
 
                         let sink = sink.clone();
@@ -582,6 +601,7 @@ async fn handle_text_frame(
                         // making cancellation impossible
                         rt::spawn(async move {
                             let _guard = guard;
+                            let _client_op_guard = client_op_guard;
                             let mut cancelled = false;
 
                             loop {

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -617,7 +617,10 @@ async fn handle_text_frame(
                                                 break;
                                             }
                                             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                                                warn!(id = %id_for_loop, lagged = n, "Broadcast receiver lagged, dropping message");
+                                                // NOTE: not warn to avoid log spam when receiver starts
+                                                // lagging. users should rely on the lagged_messages
+                                                // metric to detect slow consumers and tune accordingly
+                                                debug!(id = %id_for_loop, lagged = n, "Broadcast receiver lagged, dropping message");
                                                 metrics.subscriptions.record_client_lag(SubscriptionTransport::WebSocket, n);
                                                 continue;
                                             }

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -591,6 +591,7 @@ async fn handle_text_frame(
                             .unwrap_or_else(|| response.body.subscribe());
 
                         let client_op_guard = shared_state.telemetry_context.metrics.subscriptions.active_client_operation(SubscriptionTransport::WebSocket);
+                        let metrics = shared_state.telemetry_context.metrics.clone();
 
                         trace!(id = %id, "Subscription started");
 
@@ -617,6 +618,7 @@ async fn handle_text_frame(
                                             }
                                             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                                                 warn!(id = %id_for_loop, lagged = n, "Broadcast receiver lagged, dropping message");
+                                                metrics.subscriptions.record_client_lag(SubscriptionTransport::WebSocket, n);
                                                 continue;
                                             }
                                             Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -383,7 +383,7 @@ async fn handle_text_frame(
                 let parser_result =
                     match parse_operation_with_cache(shared_state, &payload, &plugin_req_state).await {
                         Ok(result) => result,
-                        Err(err) => return Some(err.into_server_message(&id)),
+                        Err(err) => return Some(err.into_server_message(&id, shared_state)),
                     };
 
                 let parser_payload = match parser_result {
@@ -426,7 +426,7 @@ async fn handle_text_frame(
                         ));
                     }
                     Ok(None) => {}
-                    Err(err) => return Some(err.into_server_message(&id)),
+                    Err(err) => return Some(err.into_server_message(&id, shared_state)),
                 }
 
                 let normalize_payload = match normalize_request_with_cache(
@@ -438,7 +438,7 @@ async fn handle_text_frame(
                 .await
                 {
                     Ok(payload) => payload,
-                    Err(err) => return Some(err.into_server_message(&id)),
+                    Err(err) => return Some(err.into_server_message(&id, shared_state)),
                 };
 
                 let is_subscription = matches!(
@@ -447,7 +447,7 @@ async fn handle_text_frame(
                 );
 
                 if is_subscription && !shared_state.router_config.subscriptions.enabled {
-                    return Some(PipelineError::SubscriptionsNotSupported.into_server_message(&id));
+                    return Some(PipelineError::SubscriptionsNotSupported.into_server_message(&id, shared_state));
                 }
 
                 let request_dedupe_enabled =
@@ -520,24 +520,24 @@ async fn handle_text_frame(
                     let (shared_response, _role) = match result {
                         Ok(result) => result,
                         Err(PipelineError::JwtError(err)) => {
-                            let _ = sink.send(err.clone().into_server_message(&id)).await;
+                            let _ = sink.send(err.clone().into_server_message(&id, shared_state)).await;
                             // we report error as graphql error, but we also close the
                             // connection since we're dealing with auth so let's be safe
                             return Some(err.into_close_message());
                         },
-                        Err(err) => return Some(err.into_server_message(&id)),
+                        Err(err) => return Some(err.into_server_message(&id, shared_state)),
                     };
                     Arc::unwrap_or_clone(shared_response)
                 } else {
                     match exec(None).await {
                         Ok(result) => result,
                         Err(PipelineError::JwtError(err)) => {
-                            let _ = sink.send(err.clone().into_server_message(&id)).await;
+                            let _ = sink.send(err.clone().into_server_message(&id, shared_state)).await;
                             // we report error as graphql error, but we also close the
                             // connection since we're dealing with auth so let's be safe
                             return Some(err.into_close_message());
                         },
-                        Err(err) => return Some(err.into_server_message(&id)),
+                        Err(err) => return Some(err.into_server_message(&id, shared_state)),
                     }
                 };
 
@@ -747,9 +747,15 @@ fn parse_headers_from_extensions(extensions: Option<&HashMap<String, Value>>) ->
 
 // NOTE: no `From` trait because it can into ws message and ws closecode but both are ws::Message
 impl PipelineError {
-    fn into_server_message(self, id: &str) -> ws::Message {
+    fn into_server_message(self, id: &str, shared_state: &RouterSharedState) -> ws::Message {
         let code = self.graphql_error_code();
         let message = self.graphql_error_message();
+
+        shared_state
+            .telemetry_context
+            .metrics
+            .graphql
+            .record_error(code);
 
         let graphql_error = GraphQLError::from_message_and_extensions(
             message,
@@ -762,13 +768,18 @@ impl PipelineError {
 
 // NOTE: no `From` trait because it can into ws message and ws closecode but both are ws::Message
 impl JwtError {
-    fn into_server_message(self, id: &str) -> ws::Message {
+    fn into_server_message(self, id: &str, shared_state: &RouterSharedState) -> ws::Message {
+        let code = self.error_code();
+
+        shared_state
+            .telemetry_context
+            .metrics
+            .graphql
+            .record_error(code);
+
         ServerMessage::error(
             id,
-            &[GraphQLError::from_message_and_code(
-                self.to_string(),
-                self.error_code(),
-            )],
+            &[GraphQLError::from_message_and_code(self.to_string(), code)],
         )
     }
     fn into_close_message(self) -> ws::Message {

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -611,6 +611,7 @@ async fn handle_text_frame(
                                         match maybe_item {
                                             Ok(SubscriptionEvent::Raw(data)) => {
                                                 let _ = sink.send(ServerMessage::next(&id_for_loop, &data)).await;
+                                                metrics.subscriptions.record_client_sent(SubscriptionTransport::WebSocket);
                                             }
                                             Ok(SubscriptionEvent::Error(errors)) => {
                                                 let _ = sink.send(ServerMessage::error(&id_for_loop, &errors)).await;

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -7,6 +7,7 @@ use hive_router_config::traffic_shaping::{
 use hive_router_config::HiveRouterConfig;
 use hive_router_internal::expressions::{BooleanOrProgram, ExpressionCompileError};
 use hive_router_internal::inflight::{InFlightCleanupGuard, InFlightMap};
+use hive_router_internal::telemetry::metrics::catalog::values::SubscriptionEndReason;
 use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
 use hive_router_internal::telemetry::metrics::Metrics;
 use hive_router_internal::telemetry::TelemetryContext;
@@ -186,12 +187,11 @@ impl SharedRouterStreamResponse {
         };
         // each consumer (leader or joiner) gets its own guards, created here so dedup joiners
         // are counted too - dropped when the client stream below ends
-        let client_op_guard = metrics.subscriptions.active_client_operation(transport);
+        let mut client_op_guard = metrics.subscriptions.active_client_operation(transport);
         let client_conn_guard = metrics.subscriptions.active_client_connection(transport);
         let metrics = metrics.clone();
 
         let stream = Box::pin(async_stream::stream! {
-            let _client_op_guard = client_op_guard;
             let _client_conn_guard = client_conn_guard;
             loop {
                 match receiver.recv().await {
@@ -200,6 +200,7 @@ impl SharedRouterStreamResponse {
                         metrics.subscriptions.record_client_sent(transport);
                     }
                     Ok(SubscriptionEvent::Error(errors)) => {
+                        client_op_guard.set_end_reason(SubscriptionEndReason::Error);
                         yield FailedExecutionResult { errors }.serialize();
                         break;
                     }
@@ -212,10 +213,12 @@ impl SharedRouterStreamResponse {
                         continue;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        client_op_guard.set_end_reason(SubscriptionEndReason::Completed);
                         break;
                     }
                 }
             }
+            let _client_op_guard = client_op_guard;
         });
 
         let content_type_header = match stream_content_type {

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -7,6 +7,9 @@ use hive_router_config::traffic_shaping::{
 use hive_router_config::HiveRouterConfig;
 use hive_router_internal::expressions::{BooleanOrProgram, ExpressionCompileError};
 use hive_router_internal::inflight::{InFlightCleanupGuard, InFlightMap};
+use hive_router_internal::telemetry::metrics::subscription_metrics::{
+    ActiveClientConnectionGuard, ActiveClientOperationGuard,
+};
 use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::coprocessor::{CoprocessorError, CoprocessorRuntime};
 use hive_router_plan_executor::execution::plan::FailedExecutionResult;
@@ -152,6 +155,8 @@ pub struct SharedRouterStreamResponse {
     // there is no window where the channel has zero receivers and events can be lost.
     // joiners get None and subscribe via body.subscribe() when consumed.
     pub receiver: Option<tokio::sync::broadcast::Receiver<SubscriptionEvent>>,
+    // set for subscription responses, None for non-subscription streams
+    pub subscription_metrics: Option<(ActiveClientOperationGuard, ActiveClientConnectionGuard)>,
 }
 
 impl Clone for SharedRouterStreamResponse {
@@ -161,6 +166,8 @@ impl Clone for SharedRouterStreamResponse {
             headers: self.headers.clone(),
             error_count: self.error_count,
             receiver: None,
+            // guards are not cloned - each clone gets its own via into_response
+            subscription_metrics: None,
         }
     }
 }
@@ -170,8 +177,10 @@ impl SharedRouterStreamResponse {
         // leader already has a pre-subscribed receiver to avoid missing
         // any potential events emitted. joiners, on the other hand, subscribe
         let mut receiver = self.receiver.unwrap_or_else(|| self.body.subscribe());
+        let subscription_metrics = self.subscription_metrics;
 
         let stream = Box::pin(async_stream::stream! {
+            let _subscription_metrics = subscription_metrics;
             loop {
                 match receiver.recv().await {
                     Ok(SubscriptionEvent::Raw(data)) => {

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -27,7 +27,7 @@ use ntex::{http::HeaderMap, util::Bytes};
 use std::sync::atomic::AtomicUsize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{collections::HashSet, sync::Arc};
-use tracing::warn;
+use tracing::debug;
 
 use crate::cache_state::CacheState;
 use crate::jwt::context::JwtTokenPayload;
@@ -203,7 +203,10 @@ impl SharedRouterStreamResponse {
                         break;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        warn!(lagged = n, "Broadcast receiver lagged, dropping message");
+                        // NOTE: not warn to avoid log spam when receiver starts lagging.
+                        // users should rely on the lagged_messages metric to detect slow
+                        // consumers and tune accordingly
+                        debug!(lagged = n, "Broadcast receiver lagged, dropping message");
                         metrics.subscriptions.record_client_lag(transport, n);
                         continue;
                     }

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -197,6 +197,7 @@ impl SharedRouterStreamResponse {
                 match receiver.recv().await {
                     Ok(SubscriptionEvent::Raw(data)) => {
                         yield data.to_vec();
+                        metrics.subscriptions.record_client_sent(transport);
                     }
                     Ok(SubscriptionEvent::Error(errors)) => {
                         yield FailedExecutionResult { errors }.serialize();

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -7,9 +7,8 @@ use hive_router_config::traffic_shaping::{
 use hive_router_config::HiveRouterConfig;
 use hive_router_internal::expressions::{BooleanOrProgram, ExpressionCompileError};
 use hive_router_internal::inflight::{InFlightCleanupGuard, InFlightMap};
-use hive_router_internal::telemetry::metrics::subscription_metrics::{
-    ActiveClientConnectionGuard, ActiveClientOperationGuard,
-};
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
+use hive_router_internal::telemetry::metrics::Metrics;
 use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::coprocessor::{CoprocessorError, CoprocessorRuntime};
 use hive_router_plan_executor::execution::plan::FailedExecutionResult;
@@ -112,6 +111,7 @@ impl SharedRouterResponse {
     pub fn into_response(
         self,
         response_mode: &ResponseMode,
+        metrics: &Arc<Metrics>,
     ) -> Result<web::HttpResponse, PipelineError> {
         match self {
             SharedRouterResponse::Single(single) => Ok(single.into()),
@@ -119,7 +119,7 @@ impl SharedRouterResponse {
                 let stream_content_type = response_mode
                     .stream_content_type()
                     .ok_or(PipelineError::SubscriptionsTransportNotSupported)?;
-                Ok(stream.into_response(stream_content_type))
+                Ok(stream.into_response(stream_content_type, metrics))
             }
         }
     }
@@ -155,8 +155,6 @@ pub struct SharedRouterStreamResponse {
     // there is no window where the channel has zero receivers and events can be lost.
     // joiners get None and subscribe via body.subscribe() when consumed.
     pub receiver: Option<tokio::sync::broadcast::Receiver<SubscriptionEvent>>,
-    // set for subscription responses, None for non-subscription streams
-    pub subscription_metrics: Option<(ActiveClientOperationGuard, ActiveClientConnectionGuard)>,
 }
 
 impl Clone for SharedRouterStreamResponse {
@@ -166,21 +164,35 @@ impl Clone for SharedRouterStreamResponse {
             headers: self.headers.clone(),
             error_count: self.error_count,
             receiver: None,
-            // guards are not cloned - each clone gets its own via into_response
-            subscription_metrics: None,
         }
     }
 }
 
 impl SharedRouterStreamResponse {
-    pub fn into_response(self, stream_content_type: &StreamContentType) -> web::HttpResponse {
+    pub fn into_response(
+        self,
+        stream_content_type: &StreamContentType,
+        metrics: &Arc<Metrics>,
+    ) -> web::HttpResponse {
         // leader already has a pre-subscribed receiver to avoid missing
         // any potential events emitted. joiners, on the other hand, subscribe
         let mut receiver = self.receiver.unwrap_or_else(|| self.body.subscribe());
-        let subscription_metrics = self.subscription_metrics;
+
+        let transport = match stream_content_type {
+            StreamContentType::IncrementalDelivery | StreamContentType::ApolloMultipartHTTP => {
+                SubscriptionTransport::HttpMultipart
+            }
+            StreamContentType::SSE => SubscriptionTransport::HttpSse,
+        };
+        // each consumer (leader or joiner) gets its own guards, created here so dedup joiners
+        // are counted too - dropped when the client stream below ends
+        let client_op_guard = metrics.subscriptions.active_client_operation(transport);
+        let client_conn_guard = metrics.subscriptions.active_client_connection(transport);
+        let metrics = metrics.clone();
 
         let stream = Box::pin(async_stream::stream! {
-            let _subscription_metrics = subscription_metrics;
+            let _client_op_guard = client_op_guard;
+            let _client_conn_guard = client_conn_guard;
             loop {
                 match receiver.recv().await {
                     Ok(SubscriptionEvent::Raw(data)) => {
@@ -192,6 +204,7 @@ impl SharedRouterStreamResponse {
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         warn!(lagged = n, "Broadcast receiver lagged, dropping message");
+                        metrics.subscriptions.record_client_lag(transport, n);
                         continue;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/e2e/src/telemetry/mod.rs
+++ b/e2e/src/telemetry/mod.rs
@@ -1,3 +1,4 @@
 mod metrics;
+mod subscription_metrics;
 mod tracing;
 mod usage_reporting;

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -21,6 +21,8 @@ mod subscription_metrics_e2e_tests {
     const CLIENTS_ENDED_TOTAL: &str = "hive.router.subscriptions.clients.ended_total";
     const CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.lagged_messages_total";
+    const CLIENTS_SENT_MESSAGES_TOTAL: &str =
+        "hive.router.subscriptions.clients.sent_messages_total";
     const SUBGRAPHS_ACTIVE: &str = "hive.router.subscriptions.subgraphs.active";
     const SUBGRAPHS_CONNECTIONS: &str = "hive.router.subscriptions.subgraphs.connections";
     const SUBGRAPHS_STARTED_TOTAL: &str = "hive.router.subscriptions.subgraphs.started_total";
@@ -155,6 +157,13 @@ mod subscription_metrics_e2e_tests {
             0.0,
             "lag counter must not fire on normal completion"
         );
+
+        // reviewAddedLooping keeps emitting in the background regardless of how many
+        // chunks the client actually read, so only assert delivery happened at all
+        assert!(
+            metrics.latest_counter(CLIENTS_SENT_MESSAGES_TOTAL, &transport_attrs) >= 1.0,
+            "expected at least one message sent to the client"
+        );
     }
 
     #[ntex::test]
@@ -221,6 +230,12 @@ mod subscription_metrics_e2e_tests {
             "expected websocket client active gauge to return to 0"
         );
 
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_SENT_MESSAGES_TOTAL, &ws_attrs),
+            received as f64,
+            "expected the sent counter to match the number of events received over the finite WS stream"
+        );
+
         for phantom_transport in ["http_sse", "http_multipart", "http_callback"] {
             let attrs = [(labels::SUBSCRIPTION_TRANSPORT, phantom_transport)];
             assert!(
@@ -230,6 +245,10 @@ mod subscription_metrics_e2e_tests {
             assert!(
                 !metrics.has_counter(CLIENTS_CONNECTIONS, &attrs),
                 "did not expect a {phantom_transport}-labeled client connection series from a WS subscription"
+            );
+            assert!(
+                !metrics.has_counter(CLIENTS_SENT_MESSAGES_TOTAL, &attrs),
+                "did not expect a {phantom_transport}-labeled client sent series from a WS subscription"
             );
         }
     }
@@ -306,6 +325,23 @@ mod subscription_metrics_e2e_tests {
             ),
             1.0,
             "expected the multipart joiner to be counted active, not just the first subscriber"
+        );
+
+        // reviewAdded keeps emitting in the background regardless of how many chunks each
+        // client actually read, so only assert both joiners independently received deliveries
+        assert!(
+            metrics.latest_counter(
+                CLIENTS_SENT_MESSAGES_TOTAL,
+                &[(labels::SUBSCRIPTION_TRANSPORT, "http_sse")]
+            ) >= 1.0,
+            "expected at least one message sent to the SSE joiner"
+        );
+        assert!(
+            metrics.latest_counter(
+                CLIENTS_SENT_MESSAGES_TOTAL,
+                &[(labels::SUBSCRIPTION_TRANSPORT, "http_multipart")]
+            ) >= 1.0,
+            "expected at least one message sent to the multipart joiner, deduplication must not merge per-client delivery counts"
         );
 
         // only one subgraph operation was created, even though two clients joined

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -21,6 +21,7 @@ mod subscription_metrics_e2e_tests {
     const CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.lagged_messages_total";
     const SUBGRAPHS_ACTIVE: &str = "hive.router.subscriptions.subgraphs.active";
+    const SUBGRAPHS_CONNECTIONS: &str = "hive.router.subscriptions.subgraphs.connections";
     const SUBGRAPHS_OPERATIONS_TOTAL: &str = "hive.router.subscriptions.subgraphs.operations_total";
     const SUBGRAPHS_DROPPED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.subgraphs.dropped_messages_total";
@@ -338,6 +339,125 @@ mod subscription_metrics_e2e_tests {
                 .len(),
             1,
             "requests to reviews subgraph should be deduplicated"
+        );
+    }
+
+    #[ntex::test]
+    async fn http_callback_subgraph_transport_metrics() {
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let router_port = router_listener.local_addr().unwrap().port();
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .with_listener(router_listener)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    callback:
+                        public_url: http://0.0.0.0:{router_port}/callback
+                        subgraphs:
+                            - reviews
+                {}
+                "#,
+                otlp_metrics_config(&otlp_collector.http_metrics_endpoint())
+            ))
+            .build()
+            .start()
+            .await;
+
+        // reviewAddedLooping never completes on its own, so the subscription stays active
+        // until we drop the response stream below
+        let mut res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAddedLooping(intervalInMs: 200) {
+                        id
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+        let _ = res.next().await.expect("expected at least one chunk");
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        let subgraph_connection_attrs = [
+            (labels::SUBGRAPH_NAME, "reviews"),
+            (labels::SUBSCRIPTION_TRANSPORT, "http_callback"),
+        ];
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_CONNECTIONS, &subgraph_connection_attrs),
+            1.0,
+            "expected the http_callback-transported subgraph connection to be counted active"
+        );
+
+        let subgraph_attrs = [(labels::SUBGRAPH_NAME, "reviews")];
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_ACTIVE, &subgraph_attrs),
+            1.0,
+            "expected the subgraph subscription to be counted active"
+        );
+
+        let subgraph_subscribe_attrs = [
+            (labels::SUBGRAPH_NAME, "reviews"),
+            (labels::SUBSCRIPTION_OPERATION, "subscribe"),
+        ];
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_subscribe_attrs),
+            1.0,
+            "expected exactly one subgraph subscribe event"
+        );
+
+        // the client itself talks SSE to the router, the callback transport is only used
+        // between the router and the subgraph
+        let client_attrs = [(labels::SUBSCRIPTION_TRANSPORT, "http_sse")];
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_ACTIVE, &client_attrs),
+            1.0,
+            "client active gauge must be 1 while the subscription is live"
+        );
+
+        drop(res);
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_ACTIVE, &subgraph_attrs),
+            0.0,
+            "subgraph active gauge must return to 0 after the subscription ends"
+        );
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_CONNECTIONS, &subgraph_connection_attrs),
+            0.0,
+            "http_callback subgraph connection gauge must return to 0 after the subscription ends"
+        );
+
+        let subgraph_unsubscribe_attrs = [
+            (labels::SUBGRAPH_NAME, "reviews"),
+            (labels::SUBSCRIPTION_OPERATION, "unsubscribe"),
+        ];
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_unsubscribe_attrs),
+            1.0,
+            "expected exactly one http_callback subgraph unsubscribe event, matching the subscribe"
         );
     }
 

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -132,6 +132,17 @@ mod subscription_metrics_e2e_tests {
             1.0,
             "expected exactly one client subscription ended event, matching the start"
         );
+        assert_eq!(
+            metrics.latest_counter(
+                CLIENTS_ENDED_TOTAL,
+                &[
+                    (labels::SUBSCRIPTION_TRANSPORT, "http_sse"),
+                    (labels::SUBSCRIPTION_END_REASON, "client_disconnected"),
+                ]
+            ),
+            1.0,
+            "dropping the response stream should be attributed to client_disconnected"
+        );
 
         let subgraph_attrs = [(labels::SUBGRAPH_NAME, "reviews")];
         assert_eq!(
@@ -234,6 +245,17 @@ mod subscription_metrics_e2e_tests {
             metrics.latest_counter(CLIENTS_SENT_MESSAGES_TOTAL, &ws_attrs),
             received as f64,
             "expected the sent counter to match the number of events received over the finite WS stream"
+        );
+        assert_eq!(
+            metrics.latest_counter(
+                CLIENTS_ENDED_TOTAL,
+                &[
+                    (labels::SUBSCRIPTION_TRANSPORT, "websocket"),
+                    (labels::SUBSCRIPTION_END_REASON, "completed"),
+                ]
+            ),
+            1.0,
+            "a finite WS subscription that drains naturally should end with reason completed"
         );
 
         for phantom_transport in ["http_sse", "http_multipart", "http_callback"] {

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -9,9 +9,7 @@ mod subscription_metrics_e2e_tests {
     };
     use ntex::http;
 
-    use crate::testkit::{
-        otel::OtlpCollector, some_header_map, ClientResponseExt, TestRouter, TestSubgraphs,
-    };
+    use crate::testkit::{otel::OtlpCollector, some_header_map, TestRouter, TestSubgraphs};
 
     async fn wait_for_metrics_export() {
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -64,11 +62,15 @@ mod subscription_metrics_e2e_tests {
             .start()
             .await;
 
-        let res = router
+        // reviewAddedLooping never completes on its own, so we control the lifecycle by
+        // reading one event (to prove the gauges went up) and then dropping the response
+        // stream (to prove the gauges come back down). intervalInMs is high to avoid spamming
+        // events while we hold the subscription open.
+        let mut res = router
             .send_graphql_request(
                 r#"
                 subscription {
-                    reviewAdded(intervalInMs: 0) {
+                    reviewAddedLooping(intervalInMs: 200) {
                         id
                     }
                 }
@@ -81,10 +83,7 @@ mod subscription_metrics_e2e_tests {
             .await;
 
         assert!(res.status().is_success(), "Expected 200 OK");
-        // this query is a finite stream, so draining the body waits for completion
-        // and drops the subscription's RAII guards before we assert on the metrics.
-        let body = res.string_body().await;
-        assert!(body.contains("event: complete"));
+        let _ = res.next().await.expect("expected at least one chunk");
 
         wait_for_metrics_export().await;
         let metrics = otlp_collector.metrics_view().await;
@@ -92,13 +91,30 @@ mod subscription_metrics_e2e_tests {
         let transport_attrs = [(labels::SUBSCRIPTION_TRANSPORT, "http_sse")];
         assert_eq!(
             metrics.latest_counter(CLIENTS_ACTIVE, &transport_attrs),
+            1.0,
+            "client active gauge must be 1 while the subscription is live"
+        );
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_CONNECTIONS, &transport_attrs),
+            1.0,
+            "client connections gauge must be 1 while the subscription is live"
+        );
+
+        // dropping the response stream tears down the client's RAII guards
+        drop(res);
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_ACTIVE, &transport_attrs),
             0.0,
-            "client active gauge must return to 0 after the subscription completes"
+            "client active gauge must return to 0 after the subscription ends"
         );
         assert_eq!(
             metrics.latest_counter(CLIENTS_CONNECTIONS, &transport_attrs),
             0.0,
-            "client connections gauge must return to 0 after the subscription completes"
+            "client connections gauge must return to 0 after the subscription ends"
         );
 
         let subscribe_attrs = [

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -1,0 +1,400 @@
+#[cfg(test)]
+mod subscription_metrics_e2e_tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use hive_router_internal::telemetry::metrics::catalog::labels;
+    use hive_router_plan_executor::executors::{
+        graphql_transport_ws::SubscribePayload, websocket_client::WsClient,
+    };
+    use ntex::http;
+
+    use crate::testkit::{
+        otel::OtlpCollector, some_header_map, ClientResponseExt, TestRouter, TestSubgraphs,
+    };
+
+    async fn wait_for_metrics_export() {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    const CLIENTS_ACTIVE: &str = "hive.router.subscriptions.clients.active";
+    const CLIENTS_CONNECTIONS: &str = "hive.router.subscriptions.clients.connections";
+    const CLIENTS_OPERATIONS_TOTAL: &str = "hive.router.subscriptions.clients.operations_total";
+    const CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
+        "hive.router.subscriptions.clients.lagged_messages_total";
+    const SUBGRAPHS_ACTIVE: &str = "hive.router.subscriptions.subgraphs.active";
+    const SUBGRAPHS_OPERATIONS_TOTAL: &str = "hive.router.subscriptions.subgraphs.operations_total";
+    const SUBGRAPHS_DROPPED_MESSAGES_TOTAL: &str =
+        "hive.router.subscriptions.subgraphs.dropped_messages_total";
+
+    fn otlp_metrics_config(otlp_endpoint: &str) -> String {
+        format!(
+            r#"telemetry:
+                    metrics:
+                        exporters:
+                            - kind: otlp
+                              endpoint: {otlp_endpoint}
+                              protocol: http
+                              interval: 30ms
+                              max_export_timeout: 2s"#
+        )
+    }
+
+    #[ntex::test]
+    async fn sse_subscription_lifecycle_metrics_return_to_zero() {
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                {}
+                "#,
+                otlp_metrics_config(&otlp_collector.http_metrics_endpoint())
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAdded(intervalInMs: 0) {
+                        id
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+        // this query is a finite stream, so draining the body waits for completion
+        // and drops the subscription's RAII guards before we assert on the metrics.
+        let body = res.string_body().await;
+        assert!(body.contains("event: complete"));
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        let transport_attrs = [(labels::SUBSCRIPTION_TRANSPORT, "http_sse")];
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_ACTIVE, &transport_attrs),
+            0.0,
+            "client active gauge must return to 0 after the subscription completes"
+        );
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_CONNECTIONS, &transport_attrs),
+            0.0,
+            "client connections gauge must return to 0 after the subscription completes"
+        );
+
+        let subscribe_attrs = [
+            (labels::SUBSCRIPTION_TRANSPORT, "http_sse"),
+            (labels::SUBSCRIPTION_OPERATION, "subscribe"),
+        ];
+        let unsubscribe_attrs = [
+            (labels::SUBSCRIPTION_TRANSPORT, "http_sse"),
+            (labels::SUBSCRIPTION_OPERATION, "unsubscribe"),
+        ];
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_OPERATIONS_TOTAL, &subscribe_attrs),
+            1.0,
+            "expected exactly one client subscribe event"
+        );
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_OPERATIONS_TOTAL, &unsubscribe_attrs),
+            1.0,
+            "expected exactly one client unsubscribe event, matching the subscribe"
+        );
+
+        let subgraph_attrs = [(labels::SUBGRAPH_NAME, "reviews")];
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_ACTIVE, &subgraph_attrs),
+            0.0,
+            "subgraph active gauge must return to 0 after the subscription completes"
+        );
+
+        let subgraph_subscribe_attrs = [
+            (labels::SUBGRAPH_NAME, "reviews"),
+            (labels::SUBSCRIPTION_OPERATION, "subscribe"),
+        ];
+        let subgraph_unsubscribe_attrs = [
+            (labels::SUBGRAPH_NAME, "reviews"),
+            (labels::SUBSCRIPTION_OPERATION, "unsubscribe"),
+        ];
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_subscribe_attrs),
+            1.0,
+            "expected exactly one subgraph subscribe event"
+        );
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_unsubscribe_attrs),
+            1.0,
+            "expected exactly one subgraph unsubscribe event, matching the subscribe"
+        );
+
+        // no lag or drop counters should ever fire on this happy path
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_LAGGED_MESSAGES_TOTAL, &transport_attrs),
+            0.0,
+            "lag counter must not fire on normal completion"
+        );
+    }
+
+    #[ntex::test]
+    async fn websocket_subscription_only_produces_websocket_labeled_series() {
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                websocket:
+                    enabled: true
+                {}
+                "#,
+                otlp_metrics_config(&otlp_collector.http_metrics_endpoint())
+            ))
+            .build()
+            .start()
+            .await;
+
+        let query = r#"
+            subscription {
+                reviewAdded(intervalInMs: 0) {
+                    id
+                }
+            }
+        "#;
+
+        let wsconn = router.ws().await;
+        let mut ws_client = WsClient::init(wsconn, None)
+            .await
+            .expect("Failed to init WsClient");
+        let ws_payload = SubscribePayload {
+            query: query.into(),
+            ..Default::default()
+        };
+        let mut ws_stream = ws_client.subscribe(ws_payload, None).await;
+
+        // drain the finite stream so subscribe/unsubscribe both happen while the router runs
+        let mut received = 0;
+        while let Some(response) = ws_stream.next().await {
+            assert!(response.errors.is_none());
+            received += 1;
+        }
+        assert!(received > 0, "expected at least one event over the WS");
+        drop(ws_stream);
+        drop(ws_client);
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        let ws_attrs = [(labels::SUBSCRIPTION_TRANSPORT, "websocket")];
+        assert_eq!(
+            metrics.latest_counter(CLIENTS_ACTIVE, &ws_attrs),
+            0.0,
+            "expected websocket client active gauge to return to 0"
+        );
+
+        for phantom_transport in ["http_sse", "http_multipart", "http_callback"] {
+            let attrs = [(labels::SUBSCRIPTION_TRANSPORT, phantom_transport)];
+            assert!(
+                !metrics.has_counter(CLIENTS_ACTIVE, &attrs),
+                "did not expect a {phantom_transport}-labeled client series from a WS subscription"
+            );
+            assert!(
+                !metrics.has_counter(CLIENTS_CONNECTIONS, &attrs),
+                "did not expect a {phantom_transport}-labeled client connection series from a WS subscription"
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn deduplicated_clients_are_all_counted_active() {
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                traffic_shaping:
+                    router:
+                        dedupe:
+                            enabled: true
+                            headers: none
+                {}
+                "#,
+                otlp_metrics_config(&otlp_collector.http_metrics_endpoint())
+            ))
+            .build()
+            .start()
+            .await;
+
+        let query = r#"
+            subscription {
+                reviewAdded(intervalInMs: 100) {
+                    id
+                }
+            }
+        "#;
+
+        let sse_headers = some_header_map! {
+            http::header::ACCEPT => "text/event-stream"
+        };
+        let multipart_headers = some_header_map! {
+            http::header::ACCEPT => "multipart/mixed;subscriptionSpec=1.0"
+        };
+
+        let mut sub1 = router.send_graphql_request(query, None, sse_headers).await;
+        assert!(sub1.status().is_success());
+        let _ = sub1.next().await;
+
+        let mut sub2 = router
+            .send_graphql_request(query, None, multipart_headers)
+            .await;
+        assert!(sub2.status().is_success());
+        let _ = sub2.next().await;
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        assert_eq!(
+            metrics.latest_counter(
+                CLIENTS_ACTIVE,
+                &[(labels::SUBSCRIPTION_TRANSPORT, "http_sse")]
+            ),
+            1.0,
+            "expected the SSE joiner to be counted active"
+        );
+        assert_eq!(
+            metrics.latest_counter(
+                CLIENTS_ACTIVE,
+                &[(labels::SUBSCRIPTION_TRANSPORT, "http_multipart")]
+            ),
+            1.0,
+            "expected the multipart joiner to be counted active, not just the first subscriber"
+        );
+
+        // only one subgraph operation was created, even though two clients joined
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_ACTIVE, &[(labels::SUBGRAPH_NAME, "reviews")]),
+            1.0,
+            "expected exactly one deduplicated subgraph operation"
+        );
+
+        drop(sub1);
+        drop(sub2);
+
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "requests to reviews subgraph should be deduplicated"
+        );
+    }
+
+    #[ntex::test]
+    async fn backpressure_drops_message_and_keeps_subscription_alive() {
+        let otlp_collector = OtlpCollector::start()
+            .await
+            .expect("Failed to start OTLP collector");
+
+        let subgraphs = TestSubgraphs::builder()
+            // delay slows down entity resolution so the subgraph buffer fills up while the
+            // subgraph keeps emitting every 10ms
+            .with_delay(Duration::from_millis(30))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    subgraph_buffer_capacity: 1
+                {}
+                "#,
+                otlp_metrics_config(&otlp_collector.http_metrics_endpoint())
+            ))
+            .build()
+            .start()
+            .await;
+
+        let mut res = router
+            .send_graphql_request(
+                r#"subscription { reviewAddedLooping(intervalInMs: 10) { id product { name } } }"#,
+                None,
+                some_header_map! { http::header::ACCEPT => "text/event-stream" },
+            )
+            .await;
+        assert!(res.status().is_success());
+
+        // read one event to confirm the subgraph subscription is established
+        let _ = res.next().await.expect("expected at least one chunk");
+
+        // let the buffer fill and trigger backpressure handling
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        assert_eq!(
+            subgraphs.active_subscriptions(),
+            1,
+            "subscription must survive a full buffer instead of being terminated"
+        );
+
+        wait_for_metrics_export().await;
+        let metrics = otlp_collector.metrics_view().await;
+
+        // don't pin the transport label here: the test subgraph negotiates multipart vs SSE
+        // on its own, we only care that a drop was recorded on whichever HTTP transport was used
+        let dropped = metrics.latest_counter(SUBGRAPHS_DROPPED_MESSAGES_TOTAL, &[]);
+        assert!(
+            dropped > 0.0,
+            "expected at least one dropped message to be recorded, got {dropped}"
+        );
+
+        // the subgraph operation must still be active, the drop must not have torn it down
+        assert_eq!(
+            metrics.latest_counter(SUBGRAPHS_ACTIVE, &[(labels::SUBGRAPH_NAME, "reviews")]),
+            1.0,
+            "subgraph active gauge must still show the subscription as alive"
+        );
+
+        drop(res);
+    }
+}

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -17,12 +17,14 @@ mod subscription_metrics_e2e_tests {
 
     const CLIENTS_ACTIVE: &str = "hive.router.subscriptions.clients.active";
     const CLIENTS_CONNECTIONS: &str = "hive.router.subscriptions.clients.connections";
-    const CLIENTS_OPERATIONS_TOTAL: &str = "hive.router.subscriptions.clients.operations_total";
+    const CLIENTS_STARTED_TOTAL: &str = "hive.router.subscriptions.clients.started_total";
+    const CLIENTS_ENDED_TOTAL: &str = "hive.router.subscriptions.clients.ended_total";
     const CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.lagged_messages_total";
     const SUBGRAPHS_ACTIVE: &str = "hive.router.subscriptions.subgraphs.active";
     const SUBGRAPHS_CONNECTIONS: &str = "hive.router.subscriptions.subgraphs.connections";
-    const SUBGRAPHS_OPERATIONS_TOTAL: &str = "hive.router.subscriptions.subgraphs.operations_total";
+    const SUBGRAPHS_STARTED_TOTAL: &str = "hive.router.subscriptions.subgraphs.started_total";
+    const SUBGRAPHS_ENDED_TOTAL: &str = "hive.router.subscriptions.subgraphs.ended_total";
     const SUBGRAPHS_DROPPED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.subgraphs.dropped_messages_total";
 
@@ -118,23 +120,15 @@ mod subscription_metrics_e2e_tests {
             "client connections gauge must return to 0 after the subscription ends"
         );
 
-        let subscribe_attrs = [
-            (labels::SUBSCRIPTION_TRANSPORT, "http_sse"),
-            (labels::SUBSCRIPTION_OPERATION, "subscribe"),
-        ];
-        let unsubscribe_attrs = [
-            (labels::SUBSCRIPTION_TRANSPORT, "http_sse"),
-            (labels::SUBSCRIPTION_OPERATION, "unsubscribe"),
-        ];
         assert_eq!(
-            metrics.latest_counter(CLIENTS_OPERATIONS_TOTAL, &subscribe_attrs),
+            metrics.latest_counter(CLIENTS_STARTED_TOTAL, &transport_attrs),
             1.0,
-            "expected exactly one client subscribe event"
+            "expected exactly one client subscription started event"
         );
         assert_eq!(
-            metrics.latest_counter(CLIENTS_OPERATIONS_TOTAL, &unsubscribe_attrs),
+            metrics.latest_counter(CLIENTS_ENDED_TOTAL, &transport_attrs),
             1.0,
-            "expected exactly one client unsubscribe event, matching the subscribe"
+            "expected exactly one client subscription ended event, matching the start"
         );
 
         let subgraph_attrs = [(labels::SUBGRAPH_NAME, "reviews")];
@@ -144,23 +138,15 @@ mod subscription_metrics_e2e_tests {
             "subgraph active gauge must return to 0 after the subscription completes"
         );
 
-        let subgraph_subscribe_attrs = [
-            (labels::SUBGRAPH_NAME, "reviews"),
-            (labels::SUBSCRIPTION_OPERATION, "subscribe"),
-        ];
-        let subgraph_unsubscribe_attrs = [
-            (labels::SUBGRAPH_NAME, "reviews"),
-            (labels::SUBSCRIPTION_OPERATION, "unsubscribe"),
-        ];
         assert_eq!(
-            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_subscribe_attrs),
+            metrics.latest_counter(SUBGRAPHS_STARTED_TOTAL, &subgraph_attrs),
             1.0,
-            "expected exactly one subgraph subscribe event"
+            "expected exactly one subgraph subscription started event"
         );
         assert_eq!(
-            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_unsubscribe_attrs),
+            metrics.latest_counter(SUBGRAPHS_ENDED_TOTAL, &subgraph_attrs),
             1.0,
-            "expected exactly one subgraph unsubscribe event, matching the subscribe"
+            "expected exactly one subgraph subscription ended event, matching the start"
         );
 
         // no lag or drop counters should ever fire on this happy path
@@ -415,14 +401,10 @@ mod subscription_metrics_e2e_tests {
             "expected the subgraph subscription to be counted active"
         );
 
-        let subgraph_subscribe_attrs = [
-            (labels::SUBGRAPH_NAME, "reviews"),
-            (labels::SUBSCRIPTION_OPERATION, "subscribe"),
-        ];
         assert_eq!(
-            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_subscribe_attrs),
+            metrics.latest_counter(SUBGRAPHS_STARTED_TOTAL, &subgraph_attrs),
             1.0,
-            "expected exactly one subgraph subscribe event"
+            "expected exactly one subgraph subscription started event"
         );
 
         // the client itself talks SSE to the router, the callback transport is only used
@@ -450,14 +432,10 @@ mod subscription_metrics_e2e_tests {
             "http_callback subgraph connection gauge must return to 0 after the subscription ends"
         );
 
-        let subgraph_unsubscribe_attrs = [
-            (labels::SUBGRAPH_NAME, "reviews"),
-            (labels::SUBSCRIPTION_OPERATION, "unsubscribe"),
-        ];
         assert_eq!(
-            metrics.latest_counter(SUBGRAPHS_OPERATIONS_TOTAL, &subgraph_unsubscribe_attrs),
+            metrics.latest_counter(SUBGRAPHS_ENDED_TOTAL, &subgraph_attrs),
             1.0,
-            "expected exactly one http_callback subgraph unsubscribe event, matching the subscribe"
+            "expected exactly one http_callback subgraph subscription ended event, matching the start"
         );
     }
 

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -827,12 +827,15 @@ impl TestRouter<Built> {
                 let cb_path = path.to_string();
                 let cb_addr = listen.to_string();
                 let cb_subs = schema_state.callback_subscriptions.clone();
+                let cb_telemetry_context = shared_state.telemetry_context.clone();
 
                 let server = web::HttpServer::new(async move || {
                     let cb_subs = cb_subs.clone();
                     let cb_path = cb_path.clone();
+                    let telemetry_context = cb_telemetry_context.clone();
                     web::App::new()
                         .state(cb_subs)
+                        .state(telemetry_context)
                         .configure(move |m| add_callback_handler(m, &cb_path))
                 })
                 .bind(&cb_addr)
@@ -918,9 +921,10 @@ impl TestRouter<Built> {
                         paths.clone(),
                         prometheus.as_ref().map(|p| p.endpoint.clone()),
                     ))
-                    .state(shared_state)
+                    .state(shared_state.clone())
                     .state(schema_state)
                     .state(callback_subs)
+                    .state(shared_state.telemetry_context.clone())
                     .configure(|m| configure_ntex_app(m, &paths, prometheus))
                     .configure(|m| {
                         if let Some(ref callback) = serv_callback_path {

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -19,6 +19,7 @@ use hive_router_config::HiveRouterConfig;
 use hive_router_internal::inflight::InFlightRole;
 use hive_router_internal::telemetry::metrics::catalog::values::GraphQLResponseStatus;
 use hive_router_internal::telemetry::metrics::http_client_metrics::HttpClientRequestStateCapture;
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
 use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 
@@ -610,7 +611,24 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
                 custom_scalar_paths.clone(),
             );
 
+            let op_guard = self
+                .telemetry_context
+                .metrics
+                .subscriptions
+                .active_subgraph_operation(&self.subgraph_name);
+            let conn_guard = self
+                .telemetry_context
+                .metrics
+                .subscriptions
+                .active_subgraph_connection(
+                    &self.subgraph_name,
+                    SubscriptionTransport::HttpMultipart,
+                );
+
             let mapped = Box::pin(async_stream::stream! {
+                let _op_guard = op_guard;
+                let _conn_guard = conn_guard;
+
                 trace!("multipart subscription stream started");
                 for await result in stream {
                     match result {
@@ -643,7 +661,21 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
 
             let stream = sse::parse_to_stream(body_stream, custom_scalar_paths.clone());
 
+            let op_guard = self
+                .telemetry_context
+                .metrics
+                .subscriptions
+                .active_subgraph_operation(&self.subgraph_name);
+            let conn_guard = self
+                .telemetry_context
+                .metrics
+                .subscriptions
+                .active_subgraph_connection(&self.subgraph_name, SubscriptionTransport::HttpSse);
+
             let mapped = Box::pin(async_stream::stream! {
+                let _op_guard = op_guard;
+                let _conn_guard = conn_guard;
+
                 trace!("SSE subscription stream started");
                 for await result in stream {
                     match result {

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -649,6 +649,8 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             Ok(subscription_buffer::buffered(
                 mapped,
                 buffer_capacity,
+                self.telemetry_context.clone(),
+                SubscriptionTransport::HttpMultipart,
                 self.subgraph_name.clone(),
                 self.endpoint.to_string(),
             ))
@@ -696,6 +698,8 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
             Ok(subscription_buffer::buffered(
                 mapped,
                 buffer_capacity,
+                self.telemetry_context.clone(),
+                SubscriptionTransport::HttpSse,
                 self.subgraph_name.clone(),
                 self.endpoint.to_string(),
             ))

--- a/lib/executor/src/executors/http_callback.rs
+++ b/lib/executor/src/executors/http_callback.rs
@@ -14,6 +14,9 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, trace};
 use ulid::Ulid;
 
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
+use hive_router_internal::telemetry::TelemetryContext;
+
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
 use crate::executors::http::{build_request_body, HttpClient};
@@ -72,6 +75,7 @@ pub struct HttpCallbackSubgraphExecutor {
     pub callback_base_url: String,
     pub heartbeat_interval_ms: u64,
     pub active_subscriptions: CallbackSubscriptionsMap,
+    pub telemetry_context: Arc<TelemetryContext>,
 }
 
 impl HttpCallbackSubgraphExecutor {
@@ -82,6 +86,7 @@ impl HttpCallbackSubgraphExecutor {
         callback_base_url: String,
         heartbeat_interval_ms: u64,
         active_subscriptions: CallbackSubscriptionsMap,
+        telemetry_context: Arc<TelemetryContext>,
     ) -> Self {
         let mut header_map = HeaderMap::new();
         header_map.insert(
@@ -105,6 +110,7 @@ impl HttpCallbackSubgraphExecutor {
             callback_base_url,
             heartbeat_interval_ms,
             active_subscriptions,
+            telemetry_context,
         }
     }
 
@@ -242,9 +248,22 @@ impl SubgraphExecutor for HttpCallbackSubgraphExecutor {
             return Err(SubgraphExecutorError::HttpCallbackStatusCodeNotOk(status));
         }
 
+        let op_guard = self
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_operation(&self.subgraph_name);
+        let conn_guard = self
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_connection(&self.subgraph_name, SubscriptionTransport::HttpCallback);
+
         Ok(Box::pin(async_stream::stream! {
             // `guard` is held here; dropping the stream drops `guard`, removing the map entry.
             let _guard = guard;
+            let _op_guard = op_guard;
+            let _conn_guard = conn_guard;
 
             trace!(subscription_id = %subscription_id, "HTTP callback subscription stream started");
 

--- a/lib/executor/src/executors/http_callback.rs
+++ b/lib/executor/src/executors/http_callback.rs
@@ -29,6 +29,7 @@ pub const SUBSCRIPTION_PROTOCOL_HEADER: &str = "subscription-protocol";
 
 #[derive(Clone)]
 pub struct CallbackSubscription {
+    pub subgraph_name: String,
     pub verifier: String,
     pub sender: mpsc::Sender<CallbackMessage>,
     // the subgraph sends an initial check before responding to the subscription POST, but under
@@ -180,6 +181,7 @@ impl SubgraphExecutor for HttpCallbackSubgraphExecutor {
         self.active_subscriptions.insert(
             subscription_id.clone(),
             CallbackSubscription {
+                subgraph_name: self.subgraph_name.clone(),
                 verifier,
                 sender: tx,
                 created_at: Instant::now(),

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -737,6 +737,7 @@ impl SubgraphExecutorMap {
                     ws_endpoint_uri,
                     ws_tls_config,
                     self.config.subscriptions.subgraph_buffer_capacity,
+                    self.telemetry_context.clone(),
                 )
                 .to_boxed_arc();
 
@@ -769,6 +770,7 @@ impl SubgraphExecutorMap {
                     public_url.to_string(),
                     heartbeat_interval_ms,
                     self.callback_subscriptions.clone(),
+                    self.telemetry_context.clone(),
                 )
                 .to_boxed_arc();
 

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -2,7 +2,7 @@ use futures::stream::{BoxStream, Stream};
 use futures_util::StreamExt;
 use ntex::rt;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
 use hive_router_internal::telemetry::TelemetryContext;
@@ -36,7 +36,9 @@ pub fn try_send_or_drop<T>(
         Ok(()) => SendOutcome::Sent,
         Err(mpsc::error::TrySendError::Full(_)) => {
             // drop the message but keep the subscription alive, same as broadcast::Lagged
-            warn!(
+            // NOTE: not warn to avoid log spam with an active slow consumer. users should rely
+            // on the dropped_messages metric to detect slow consumers and tune accordingly
+            debug!(
                 subgraph_name = %subgraph_name, endpoint = %endpoint,
                 "Consumer for subgraph is too slow, dropping message",
             );

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -50,7 +50,7 @@ pub fn try_send_or_drop<T>(
             // expected teardown path: fires once all downstream clients have
             // unsubscribed/disconnected and the receiver was dropped.
             // not an error, just means there's nothing left to forward to.
-            // TODO: since this is expected, is the debug log even encessary?
+            // TODO: since this is expected, is the debug log even necessary?
             debug!(
                 subgraph_name = %subgraph_name, endpoint = %endpoint,
                 "Subscription buffer for subgraph has no more receivers, all consumers disconnected or unsubscribed; stopping upstream drain",

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -94,17 +94,6 @@ pub async fn drain_into<S>(
     }
 }
 
-/// Wrap a receiver into a stream the consumer reads from.
-pub fn receiver_stream(
-    mut rx: mpsc::Receiver<SubscriptionItem>,
-) -> BoxStream<'static, SubscriptionItem> {
-    Box::pin(async_stream::stream! {
-        while let Some(item) = rx.recv().await {
-            yield item;
-        }
-    })
-}
-
 /// Decouple a Send subscription source from its slow consumer so the emitting subgraph is never
 /// throttled by downstream latency. Spawns a drainer that forwards `source` into a bounded
 /// channel with drop-on-full semantics (see `drain_into`) and returns the consumer-side stream.
@@ -122,7 +111,7 @@ pub fn buffered<S>(
 where
     S: Stream<Item = SubscriptionItem> + Unpin + 'static,
 {
-    let (tx, rx) = mpsc::channel::<SubscriptionItem>(buffer_size);
+    let (tx, mut rx) = mpsc::channel::<SubscriptionItem>(buffer_size);
 
     // ntex::rt::spawn keeps the drainer on the local ntex runtime, matching the rest of the
     // subscription pipeline.
@@ -138,5 +127,9 @@ where
         .await;
     }));
 
-    receiver_stream(rx)
+    Box::pin(async_stream::stream! {
+        while let Some(item) = rx.recv().await {
+            yield item;
+        }
+    })
 }

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -4,15 +4,65 @@ use ntex::rt;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
+use hive_router_internal::telemetry::TelemetryContext;
+
 use crate::executors::error::SubgraphExecutorError;
 use crate::response::subgraph_response::SubgraphResponse;
 
 type SubscriptionItem = Result<SubgraphResponse<'static>, SubgraphExecutorError>;
 
+/// Outcome of `try_send_or_drop`, so callers can decide what to do about a closed receiver
+/// (the full/dropped case needs no follow-up, it's already been recorded).
+pub enum SendOutcome {
+    Sent,
+    Dropped,
+    Closed,
+}
+
+/// Central place to handle a full or closed bounded channel when forwarding a single
+/// subscription message. On `Full`, the message is dropped (consumer too slow) and recorded
+/// via `record_message_dropped`, but the channel/subscription stays alive, mirroring
+/// broadcast::Lagged semantics. On `Closed`, the caller is told so it can tear down its side.
+pub fn try_send_or_drop<T>(
+    tx: &mpsc::Sender<T>,
+    item: T,
+    telemetry_context: &TelemetryContext,
+    transport: SubscriptionTransport,
+    subgraph_name: &str,
+    endpoint: &str,
+) -> SendOutcome {
+    match tx.try_send(item) {
+        Ok(()) => SendOutcome::Sent,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            // drop the message but keep the subscription alive, same as broadcast::Lagged
+            warn!(
+                subgraph_name = %subgraph_name, endpoint = %endpoint,
+                "Consumer for subgraph is too slow, dropping message",
+            );
+            telemetry_context
+                .metrics
+                .subscriptions
+                .record_message_dropped(transport);
+            SendOutcome::Dropped
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            // expected teardown path: fires once all downstream clients have
+            // unsubscribed/disconnected and the receiver was dropped.
+            // not an error, just means there's nothing left to forward to.
+            // TODO: since this is expected, is the debug log even encessary?
+            debug!(
+                subgraph_name = %subgraph_name, endpoint = %endpoint,
+                "Subscription buffer for subgraph has no more receivers, all consumers disconnected or unsubscribed; stopping upstream drain",
+            );
+            SendOutcome::Closed
+        }
+    }
+}
+
 /// Forward every item from `source` into `tx`, dropping messages when the channel is full so
 /// the emitting subgraph is never throttled by a slow consumer (entity resolution, slow client,
-/// broadcaster lag). Dropping mirrors the broadcaster's drop-on-lag behavior and keeps the
-/// subscription alive. Returns when the source ends or the consumer drops the receiver.
+/// broadcaster lag). Returns when the source ends or the consumer drops the receiver.
 ///
 /// Use this directly when the source is non-Send (e.g. a websocket client holding Rc/RefCell)
 /// and must be driven on the caller's local runtime task. For Send sources prefer `buffered`,
@@ -20,31 +70,26 @@ type SubscriptionItem = Result<SubgraphResponse<'static>, SubgraphExecutorError>
 pub async fn drain_into<S>(
     mut source: S,
     tx: mpsc::Sender<SubscriptionItem>,
+    telemetry_context: &TelemetryContext,
+    transport: SubscriptionTransport,
     subgraph_name: &str,
     endpoint: &str,
 ) where
     S: Stream<Item = SubscriptionItem> + Unpin,
 {
     while let Some(item) = source.next().await {
-        match tx.try_send(item) {
-            Ok(()) => (),
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                // drop the message but keep the subscription alive, same as broadcast::Lagged
-                warn!(
-                    "Consumer for subgraph {} at {} is too slow, dropping message",
-                    subgraph_name, endpoint
-                );
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                // expected teardown path: fires once all downstream clients have
-                // unsubscribed/disconnected and the buffer's receiver was dropped.
-                // not an error, just means there's nothing left to forward to.
-                debug!(
-                    "Subscription buffer for subgraph {} at {} has no more receivers, all consumers disconnected or unsubscribed; stopping upstream drain",
-                    subgraph_name, endpoint
-                );
-                break;
-            }
+        if matches!(
+            try_send_or_drop(
+                &tx,
+                item,
+                telemetry_context,
+                transport,
+                subgraph_name,
+                endpoint
+            ),
+            SendOutcome::Closed
+        ) {
+            break;
         }
     }
 }
@@ -69,6 +114,8 @@ pub fn receiver_stream(
 pub fn buffered<S>(
     source: S,
     buffer_size: usize,
+    telemetry_context: std::sync::Arc<TelemetryContext>,
+    transport: SubscriptionTransport,
     subgraph_name: String,
     endpoint: String,
 ) -> BoxStream<'static, SubscriptionItem>
@@ -80,7 +127,15 @@ where
     // ntex::rt::spawn keeps the drainer on the local ntex runtime, matching the rest of the
     // subscription pipeline.
     drop(rt::spawn(async move {
-        drain_into(source, tx, &subgraph_name, &endpoint).await;
+        drain_into(
+            source,
+            tx,
+            &telemetry_context,
+            transport,
+            &subgraph_name,
+            &endpoint,
+        )
+        .await;
     }));
 
     receiver_stream(rx)

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -153,12 +153,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let subgraph_name_for_metrics = self.subgraph_name.clone();
         let telemetry_context = self.telemetry_context.clone();
 
-        // TODO: op_guard needs to be moved into the receiver stream
-        let op_guard = telemetry_context
-            .metrics
-            .subscriptions
-            .active_subgraph_operation(&self.subgraph_name);
-
         // no await intentionally. the task runs the subscription in the background
         // and sends responses through the channel. The spawned future itself stays local
         // to ntex runtime, so it can hold non-Send websocket client state.
@@ -206,18 +200,31 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 .await
                 .map(Ok);
 
-            // TODO:
-            // telemetry_context
-            //             .metrics
-            //             .subscriptions
-            //             .record_subgraph_termination(
-            //                 &subgraph_name,
-            //                 SubscriptionTransport::WebSocket,
-            //             );
-
-            drain_into(stream, tx, &subgraph_name, &endpoint.to_string()).await;
+            drain_into(
+                stream,
+                tx,
+                &telemetry_context,
+                SubscriptionTransport::WebSocket,
+                &subgraph_name,
+                &endpoint.to_string(),
+            )
+            .await;
         }));
 
-        Ok(receiver_stream(rx))
+        // op_guard lives with the receiver stream, so the active-operation metric stays up for
+        // as long as a consumer is actually pulling from it, and drops the moment the stream
+        // itself is dropped (subscription unsubscribed/disconnected)
+        let op_guard = self
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_operation(&self.subgraph_name);
+        let mut rx_stream = receiver_stream(rx);
+        Ok(Box::pin(async_stream::stream! {
+            let _op_guard = op_guard;
+            while let Some(item) = rx_stream.next().await {
+                yield item;
+            }
+        }))
     }
 }

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -206,6 +206,15 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 .await
                 .map(Ok);
 
+            // TODO:
+            // telemetry_context
+            //             .metrics
+            //             .subscriptions
+            //             .record_subgraph_termination(
+            //                 &subgraph_name,
+            //                 SubscriptionTransport::WebSocket,
+            //             );
+
             drain_into(stream, tx, &subgraph_name, &endpoint.to_string()).await;
         }));
 

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -15,7 +15,7 @@ use hive_router_internal::telemetry::TelemetryContext;
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
 use crate::executors::graphql_transport_ws::build_subscribe_payload;
-use crate::executors::subscription_buffer::{drain_into, receiver_stream};
+use crate::executors::subscription_buffer::drain_into;
 use crate::executors::websocket_client::{connect, WsClient};
 use crate::response::subgraph_response::SubgraphResponse;
 
@@ -134,7 +134,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     > {
         // buffer decouples the emitting subgraph from slow downstream consumers, dropping
         // messages under backpressure instead of throttling the subgraph
-        let (tx, rx) = mpsc::channel::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>(
+        let (tx, mut rx) = mpsc::channel::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>(
             self.buffer_capacity,
         );
 
@@ -219,10 +219,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             .metrics
             .subscriptions
             .active_subgraph_operation(&self.subgraph_name);
-        let mut rx_stream = receiver_stream(rx);
         Ok(Box::pin(async_stream::stream! {
             let _op_guard = op_guard;
-            while let Some(item) = rx_stream.next().await {
+            while let Some(item) = rx.recv().await {
                 yield item;
             }
         }))

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -9,6 +9,9 @@ use ntex::rt;
 use tokio::sync::mpsc;
 use tracing::debug;
 
+use hive_router_internal::telemetry::metrics::subscription_metrics::SubscriptionTransport;
+use hive_router_internal::telemetry::TelemetryContext;
+
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
 use crate::executors::graphql_transport_ws::build_subscribe_payload;
@@ -21,6 +24,7 @@ pub struct WsSubgraphExecutor {
     endpoint: http::Uri,
     tls_config: Option<Arc<rustls::ClientConfig>>,
     buffer_capacity: usize,
+    telemetry_context: Arc<TelemetryContext>,
 }
 
 impl WsSubgraphExecutor {
@@ -29,12 +33,14 @@ impl WsSubgraphExecutor {
         endpoint: http::Uri,
         tls_config: Option<Arc<rustls::ClientConfig>>,
         buffer_capacity: usize,
+        telemetry_context: Arc<TelemetryContext>,
     ) -> Self {
         Self {
             subgraph_name,
             endpoint,
             tls_config,
             buffer_capacity,
+            telemetry_context,
         }
     }
 }
@@ -144,6 +150,15 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             self.subgraph_name, self.endpoint
         );
 
+        let subgraph_name_for_metrics = self.subgraph_name.clone();
+        let telemetry_context = self.telemetry_context.clone();
+
+        // TODO: op_guard needs to be moved into the receiver stream
+        let op_guard = telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_operation(&self.subgraph_name);
+
         // no await intentionally. the task runs the subscription in the background
         // and sends responses through the channel. The spawned future itself stays local
         // to ntex runtime, so it can hold non-Send websocket client state.
@@ -177,6 +192,14 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                 "WebSocket subscription connection to subgraph {} at {} established",
                 subgraph_name, endpoint
             );
+
+            let _conn_guard = telemetry_context
+                .metrics
+                .subscriptions
+                .active_subgraph_connection(
+                    &subgraph_name_for_metrics,
+                    SubscriptionTransport::WebSocket,
+                );
 
             let stream = client
                 .subscribe(subscribe_payload, custom_scalar_paths)

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -187,8 +187,6 @@ pub mod names {
         "hive.router.subscriptions.subgraphs.dropped_messages_total";
     pub const SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.lagged_messages_total";
-    pub const SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL: &str =
-        "hive.router.subscriptions.subgraphs.terminated_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
@@ -226,14 +224,6 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     (
         names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL,
         &[labels::SUBSCRIPTION_TRANSPORT],
-    ),
-    (
-        names::SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL,
-        &[
-            labels::SUBGRAPH_NAME,
-            labels::SUBSCRIPTION_TRANSPORT,
-            labels::ERROR_TYPE,
-        ],
     ),
     (names::GRAPHQL_ERRORS_TOTAL, &[labels::CODE]),
     (

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -104,7 +104,6 @@ pub mod labels {
     pub const ERROR_TYPE: &str = "error.type";
     pub const SUBGRAPH_NAME: &str = "subgraph.name";
     pub const SUBSCRIPTION_TRANSPORT: &str = "subscription.transport";
-    pub const SUBSCRIPTION_OPERATION: &str = "subscription.operation";
     pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
     pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
     pub const HTTP_ROUTE: &str = "http.route";
@@ -128,7 +127,6 @@ pub mod units {
     pub const SECONDS: &str = "s";
     pub const SUBSCRIPTIONS: &str = "{subscription}";
     pub const CONNECTIONS: &str = "{connection}";
-    pub const OPERATIONS: &str = "{operation}";
     pub const MESSAGES: &str = "{message}";
 }
 
@@ -179,10 +177,14 @@ pub mod names {
     pub const SUBSCRIPTIONS_CLIENTS_ACTIVE: &str = "hive.router.subscriptions.clients.active";
     pub const SUBSCRIPTIONS_CLIENTS_CONNECTIONS: &str =
         "hive.router.subscriptions.clients.connections";
-    pub const SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL: &str =
-        "hive.router.subscriptions.clients.operations_total";
-    pub const SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL: &str =
-        "hive.router.subscriptions.subgraphs.operations_total";
+    pub const SUBSCRIPTIONS_CLIENTS_STARTED_TOTAL: &str =
+        "hive.router.subscriptions.clients.started_total";
+    pub const SUBSCRIPTIONS_CLIENTS_ENDED_TOTAL: &str =
+        "hive.router.subscriptions.clients.ended_total";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_STARTED_TOTAL: &str =
+        "hive.router.subscriptions.subgraphs.started_total";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_ENDED_TOTAL: &str =
+        "hive.router.subscriptions.subgraphs.ended_total";
     pub const SUBSCRIPTIONS_SUBGRAPHS_DROPPED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.subgraphs.dropped_messages_total";
     pub const SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
@@ -207,15 +209,20 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
         &[labels::SUBSCRIPTION_TRANSPORT],
     ),
     (
-        names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL,
-        &[
-            labels::SUBSCRIPTION_TRANSPORT,
-            labels::SUBSCRIPTION_OPERATION,
-        ],
+        names::SUBSCRIPTIONS_CLIENTS_STARTED_TOTAL,
+        &[labels::SUBSCRIPTION_TRANSPORT],
     ),
     (
-        names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL,
-        &[labels::SUBGRAPH_NAME, labels::SUBSCRIPTION_OPERATION],
+        names::SUBSCRIPTIONS_CLIENTS_ENDED_TOTAL,
+        &[labels::SUBSCRIPTION_TRANSPORT],
+    ),
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_STARTED_TOTAL,
+        &[labels::SUBGRAPH_NAME],
+    ),
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_ENDED_TOTAL,
+        &[labels::SUBGRAPH_NAME],
     ),
     (
         names::SUBSCRIPTIONS_SUBGRAPHS_DROPPED_MESSAGES_TOTAL,

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -104,6 +104,7 @@ pub mod labels {
     pub const ERROR_TYPE: &str = "error.type";
     pub const SUBGRAPH_NAME: &str = "subgraph.name";
     pub const SUBSCRIPTION_TRANSPORT: &str = "subscription.transport";
+    pub const SUBSCRIPTION_OPERATION: &str = "subscription.operation";
     pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
     pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
     pub const HTTP_ROUTE: &str = "http.route";
@@ -125,6 +126,10 @@ pub mod units {
     pub const DEMAND_CONTROL_COST_UNIT: &str = "{cost}";
     pub const BYTES: &str = "By";
     pub const SECONDS: &str = "s";
+    pub const SUBSCRIPTIONS: &str = "{subscription}";
+    pub const CONNECTIONS: &str = "{connection}";
+    pub const OPERATIONS: &str = "{operation}";
+    pub const MESSAGES: &str = "{message}";
 }
 
 pub mod names {
@@ -174,6 +179,14 @@ pub mod names {
     pub const SUBSCRIPTIONS_CLIENTS_ACTIVE: &str = "hive.router.subscriptions.clients.active";
     pub const SUBSCRIPTIONS_CLIENTS_CONNECTIONS: &str =
         "hive.router.subscriptions.clients.connections";
+    pub const SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL: &str =
+        "hive.router.subscriptions.clients.operations_total";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL: &str =
+        "hive.router.subscriptions.subgraphs.operations_total";
+    pub const SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
+        "hive.router.subscriptions.clients.lagged_messages_total";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL: &str =
+        "hive.router.subscriptions.subgraphs.terminated_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
@@ -192,6 +205,26 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     (
         names::SUBSCRIPTIONS_CLIENTS_CONNECTIONS,
         &[labels::SUBSCRIPTION_TRANSPORT],
+    ),
+    (
+        names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL,
+        &[labels::SUBSCRIPTION_TRANSPORT, labels::SUBSCRIPTION_OPERATION],
+    ),
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL,
+        &[labels::SUBGRAPH_NAME, labels::SUBSCRIPTION_OPERATION],
+    ),
+    (
+        names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL,
+        &[labels::SUBSCRIPTION_TRANSPORT],
+    ),
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL,
+        &[
+            labels::SUBGRAPH_NAME,
+            labels::SUBSCRIPTION_TRANSPORT,
+            labels::ERROR_TYPE,
+        ],
     ),
     (names::GRAPHQL_ERRORS_TOTAL, &[labels::CODE]),
     (

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -62,6 +62,27 @@ pub mod values {
         }
     }
 
+    /// Why a client subscription ended, recorded on the `ended_total` counter.
+    ///
+    /// Defaults to `ClientDisconnected` when a guard drops without an explicit
+    /// reason being set (e.g. the client closed the connection or the stream
+    /// was dropped), so every guard drop is still attributed to a reason.
+    #[derive(Clone, Copy, Debug, strum::IntoStaticStr)]
+    pub enum SubscriptionEndReason {
+        #[strum(serialize = "completed")]
+        Completed,
+        #[strum(serialize = "error")]
+        Error,
+        #[strum(serialize = "client_disconnected")]
+        ClientDisconnected,
+    }
+
+    impl SubscriptionEndReason {
+        pub fn as_str(self) -> &'static str {
+            self.into()
+        }
+    }
+
     /// Circuit breaker state exposed via metrics.
     ///
     /// The internal recloser state has three values (Closed, HalfOpen, Open),
@@ -104,6 +125,7 @@ pub mod labels {
     pub const ERROR_TYPE: &str = "error.type";
     pub const SUBGRAPH_NAME: &str = "subgraph.name";
     pub const SUBSCRIPTION_TRANSPORT: &str = "subscription.transport";
+    pub const SUBSCRIPTION_END_REASON: &str = "subscription.end_reason";
     pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
     pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
     pub const HTTP_ROUTE: &str = "http.route";
@@ -216,7 +238,10 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     ),
     (
         names::SUBSCRIPTIONS_CLIENTS_ENDED_TOTAL,
-        &[labels::SUBSCRIPTION_TRANSPORT],
+        &[
+            labels::SUBSCRIPTION_TRANSPORT,
+            labels::SUBSCRIPTION_END_REASON,
+        ],
     ),
     (
         names::SUBSCRIPTIONS_SUBGRAPHS_STARTED_TOTAL,

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -103,6 +103,7 @@ pub mod labels {
     pub const STATUS: &str = "status";
     pub const ERROR_TYPE: &str = "error.type";
     pub const SUBGRAPH_NAME: &str = "subgraph.name";
+    pub const SUBSCRIPTION_TRANSPORT: &str = "subscription.transport";
     pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
     pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
     pub const HTTP_ROUTE: &str = "http.route";
@@ -167,9 +168,31 @@ pub mod names {
     pub const COPROCESSOR_REQUESTS_TOTAL: &str = "hive.router.coprocessor.requests_total";
     pub const COPROCESSOR_DURATION: &str = "hive.router.coprocessor.duration";
     pub const COPROCESSOR_ERRORS_TOTAL: &str = "hive.router.coprocessor.errors_total";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_ACTIVE: &str = "hive.router.subscriptions.subgraphs.active";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_CONNECTIONS: &str =
+        "hive.router.subscriptions.subgraphs.connections";
+    pub const SUBSCRIPTIONS_CLIENTS_ACTIVE: &str = "hive.router.subscriptions.clients.active";
+    pub const SUBSCRIPTIONS_CLIENTS_CONNECTIONS: &str =
+        "hive.router.subscriptions.clients.connections";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_ACTIVE,
+        &[labels::SUBGRAPH_NAME],
+    ),
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_CONNECTIONS,
+        &[labels::SUBGRAPH_NAME, labels::SUBSCRIPTION_TRANSPORT],
+    ),
+    (
+        names::SUBSCRIPTIONS_CLIENTS_ACTIVE,
+        &[labels::SUBSCRIPTION_TRANSPORT],
+    ),
+    (
+        names::SUBSCRIPTIONS_CLIENTS_CONNECTIONS,
+        &[labels::SUBSCRIPTION_TRANSPORT],
+    ),
     (names::GRAPHQL_ERRORS_TOTAL, &[labels::CODE]),
     (
         names::COST_ESTIMATED,

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -183,6 +183,8 @@ pub mod names {
         "hive.router.subscriptions.clients.operations_total";
     pub const SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL: &str =
         "hive.router.subscriptions.subgraphs.operations_total";
+    pub const SUBSCRIPTIONS_SUBGRAPHS_DROPPED_MESSAGES_TOTAL: &str =
+        "hive.router.subscriptions.subgraphs.dropped_messages_total";
     pub const SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.lagged_messages_total";
     pub const SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL: &str =
@@ -208,11 +210,18 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     ),
     (
         names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL,
-        &[labels::SUBSCRIPTION_TRANSPORT, labels::SUBSCRIPTION_OPERATION],
+        &[
+            labels::SUBSCRIPTION_TRANSPORT,
+            labels::SUBSCRIPTION_OPERATION,
+        ],
     ),
     (
         names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL,
         &[labels::SUBGRAPH_NAME, labels::SUBSCRIPTION_OPERATION],
+    ),
+    (
+        names::SUBSCRIPTIONS_SUBGRAPHS_DROPPED_MESSAGES_TOTAL,
+        &[labels::SUBSCRIPTION_TRANSPORT],
     ),
     (
         names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL,

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -189,6 +189,8 @@ pub mod names {
         "hive.router.subscriptions.subgraphs.dropped_messages_total";
     pub const SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.lagged_messages_total";
+    pub const SUBSCRIPTIONS_CLIENTS_SENT_MESSAGES_TOTAL: &str =
+        "hive.router.subscriptions.clients.sent_messages_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
@@ -230,6 +232,10 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     ),
     (
         names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL,
+        &[labels::SUBSCRIPTION_TRANSPORT],
+    ),
+    (
+        names::SUBSCRIPTIONS_CLIENTS_SENT_MESSAGES_TOTAL,
         &[labels::SUBSCRIPTION_TRANSPORT],
     ),
     (names::GRAPHQL_ERRORS_TOTAL, &[labels::CODE]),

--- a/lib/internal/src/telemetry/metrics/mod.rs
+++ b/lib/internal/src/telemetry/metrics/mod.rs
@@ -9,6 +9,7 @@ pub mod http_client_metrics;
 pub mod http_server_metrics;
 pub mod persisted_documents_metrics;
 pub mod setup;
+pub mod subscription_metrics;
 pub mod supergraph_metrics;
 pub use opentelemetry::metrics::ObservableGauge;
 pub use setup::{build_meter_provider_from_config, MetricsSetup, PrometheusRuntimeConfig};
@@ -23,6 +24,7 @@ use crate::telemetry::metrics::graphql_metrics::GraphQLMetrics;
 use crate::telemetry::metrics::http_client_metrics::HttpClientMetrics;
 use crate::telemetry::metrics::http_server_metrics::HttpServerMetrics;
 use crate::telemetry::metrics::persisted_documents_metrics::PersistedDocumentsMetrics;
+use crate::telemetry::metrics::subscription_metrics::SubscriptionMetrics;
 use crate::telemetry::metrics::supergraph_metrics::SupergraphMetrics;
 
 pub struct Metrics {
@@ -35,6 +37,7 @@ pub struct Metrics {
     pub circuit_breaker: CircuitBreakerMetrics,
     pub persisted_documents: PersistedDocumentsMetrics,
     pub coprocessor: CoprocessorMetrics,
+    pub subscriptions: SubscriptionMetrics,
 }
 
 impl Metrics {
@@ -49,6 +52,7 @@ impl Metrics {
             circuit_breaker: CircuitBreakerMetrics::new(meter),
             persisted_documents: PersistedDocumentsMetrics::new(meter),
             coprocessor: CoprocessorMetrics::new(meter),
+            subscriptions: SubscriptionMetrics::new(meter),
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -1,9 +1,9 @@
 use opentelemetry::{
-    metrics::{Meter, UpDownCounter},
+    metrics::{Counter, Meter, UpDownCounter},
     KeyValue,
 };
 
-use crate::telemetry::metrics::catalog::{labels, names};
+use crate::telemetry::metrics::catalog::{labels, names, units};
 
 #[cfg(debug_assertions)]
 use crate::telemetry::metrics::catalog::debug_assert_attrs;
@@ -26,11 +26,29 @@ impl SubscriptionTransport {
     }
 }
 
+#[derive(Clone, Copy, Debug, strum::IntoStaticStr)]
+pub enum SubscriptionOperation {
+    #[strum(serialize = "subscribe")]
+    Subscribe,
+    #[strum(serialize = "unsubscribe")]
+    Unsubscribe,
+}
+
+impl SubscriptionOperation {
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+
 pub struct SubscriptionMetrics {
     subgraphs_active: Option<UpDownCounter<i64>>,
     subgraphs_connections: Option<UpDownCounter<i64>>,
+    subgraphs_operations_total: Option<Counter<u64>>,
+    subgraphs_terminated_total: Option<Counter<u64>>,
     clients_active: Option<UpDownCounter<i64>>,
     clients_connections: Option<UpDownCounter<i64>>,
+    clients_operations_total: Option<Counter<u64>>,
+    clients_lagged_messages_total: Option<Counter<u64>>,
 }
 
 impl SubscriptionMetrics {
@@ -38,28 +56,60 @@ impl SubscriptionMetrics {
         let subgraphs_active = meter.map(|m| {
             m.i64_up_down_counter(names::SUBSCRIPTIONS_SUBGRAPHS_ACTIVE)
                 .with_description("Active subscribed operations on a subgraph.")
+                .with_unit(units::SUBSCRIPTIONS)
                 .build()
         });
         let subgraphs_connections = meter.map(|m| {
             m.i64_up_down_counter(names::SUBSCRIPTIONS_SUBGRAPHS_CONNECTIONS)
                 .with_description("Active transport connections from router to subgraphs.")
+                .with_unit(units::CONNECTIONS)
+                .build()
+        });
+        let subgraphs_operations_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL)
+                .with_description("Total subscribe/unsubscribe operations on a subgraph.")
+                .with_unit(units::OPERATIONS)
+                .build()
+        });
+        let subgraphs_terminated_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL)
+                .with_description("Subgraph subscriptions force-terminated by the router.")
+                .with_unit(units::SUBSCRIPTIONS)
                 .build()
         });
         let clients_active = meter.map(|m| {
             m.i64_up_down_counter(names::SUBSCRIPTIONS_CLIENTS_ACTIVE)
                 .with_description("Active subscribed operations from clients to the router.")
+                .with_unit(units::SUBSCRIPTIONS)
                 .build()
         });
         let clients_connections = meter.map(|m| {
             m.i64_up_down_counter(names::SUBSCRIPTIONS_CLIENTS_CONNECTIONS)
                 .with_description("Active transport connections from clients to router.")
+                .with_unit(units::CONNECTIONS)
+                .build()
+        });
+        let clients_operations_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL)
+                .with_description("Total subscribe/unsubscribe operations from clients to the router.")
+                .with_unit(units::OPERATIONS)
+                .build()
+        });
+        let clients_lagged_messages_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL)
+                .with_description("Messages skipped by slow client subscribers due to broadcast lag.")
+                .with_unit(units::MESSAGES)
                 .build()
         });
         Self {
             subgraphs_active,
             subgraphs_connections,
+            subgraphs_operations_total,
+            subgraphs_terminated_total,
             clients_active,
             clients_connections,
+            clients_operations_total,
+            clients_lagged_messages_total,
         }
     }
 
@@ -73,8 +123,21 @@ impl SubscriptionMetrics {
         if let Some(c) = &self.subgraphs_active {
             c.add(1, &attrs);
         }
+        if let Some(c) = &self.subgraphs_operations_total {
+            let attrs = [
+                KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+                KeyValue::new(
+                    labels::SUBSCRIPTION_OPERATION,
+                    SubscriptionOperation::Subscribe.as_str(),
+                ),
+            ];
+            #[cfg(debug_assertions)]
+            debug_assert_attrs(names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL, &attrs);
+            c.add(1, &attrs);
+        }
         ActiveSubgraphOperationGuard {
             counter: self.subgraphs_active.clone(),
+            operations_total: self.subgraphs_operations_total.clone(),
             subgraph_name: subgraph_name.to_string(),
         }
     }
@@ -113,8 +176,21 @@ impl SubscriptionMetrics {
         if let Some(c) = &self.clients_active {
             c.add(1, &attrs);
         }
+        if let Some(c) = &self.clients_operations_total {
+            let attrs = [
+                KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, transport.as_str()),
+                KeyValue::new(
+                    labels::SUBSCRIPTION_OPERATION,
+                    SubscriptionOperation::Subscribe.as_str(),
+                ),
+            ];
+            #[cfg(debug_assertions)]
+            debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL, &attrs);
+            c.add(1, &attrs);
+        }
         ActiveClientOperationGuard {
             counter: self.clients_active.clone(),
+            operations_total: self.clients_operations_total.clone(),
             transport,
         }
     }
@@ -137,10 +213,42 @@ impl SubscriptionMetrics {
             transport,
         }
     }
+
+    /// Records `n` messages skipped by a slow client subscriber due to broadcast lag.
+    pub fn record_client_lag(&self, transport: SubscriptionTransport, n: u64) {
+        let attrs = [KeyValue::new(
+            labels::SUBSCRIPTION_TRANSPORT,
+            transport.as_str(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL, &attrs);
+        if let Some(c) = &self.clients_lagged_messages_total {
+            c.add(n, &attrs);
+        }
+    }
+
+    /// Records a subgraph subscription force-terminated by the router due to a slow consumer.
+    pub fn record_subgraph_termination(
+        &self,
+        subgraph_name: &str,
+        transport: SubscriptionTransport,
+    ) {
+        let attrs = [
+            KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+            KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, transport.as_str()),
+            KeyValue::new(labels::ERROR_TYPE, "slow_consumer"),
+        ];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL, &attrs);
+        if let Some(c) = &self.subgraphs_terminated_total {
+            c.add(1, &attrs);
+        }
+    }
 }
 
 pub struct ActiveSubgraphOperationGuard {
     counter: Option<UpDownCounter<i64>>,
+    operations_total: Option<Counter<u64>>,
     subgraph_name: String,
 }
 
@@ -153,6 +261,18 @@ impl Drop for ActiveSubgraphOperationGuard {
                     labels::SUBGRAPH_NAME,
                     self.subgraph_name.clone(),
                 )],
+            );
+        }
+        if let Some(c) = &self.operations_total {
+            c.add(
+                1,
+                &[
+                    KeyValue::new(labels::SUBGRAPH_NAME, self.subgraph_name.clone()),
+                    KeyValue::new(
+                        labels::SUBSCRIPTION_OPERATION,
+                        SubscriptionOperation::Unsubscribe.as_str(),
+                    ),
+                ],
             );
         }
     }
@@ -180,6 +300,7 @@ impl Drop for ActiveSubgraphConnectionGuard {
 
 pub struct ActiveClientOperationGuard {
     counter: Option<UpDownCounter<i64>>,
+    operations_total: Option<Counter<u64>>,
     transport: SubscriptionTransport,
 }
 
@@ -192,6 +313,18 @@ impl Drop for ActiveClientOperationGuard {
                     labels::SUBSCRIPTION_TRANSPORT,
                     self.transport.as_str(),
                 )],
+            );
+        }
+        if let Some(c) = &self.operations_total {
+            c.add(
+                1,
+                &[
+                    KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, self.transport.as_str()),
+                    KeyValue::new(
+                        labels::SUBSCRIPTION_OPERATION,
+                        SubscriptionOperation::Unsubscribe.as_str(),
+                    ),
+                ],
             );
         }
     }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -1,0 +1,217 @@
+use opentelemetry::{
+    metrics::{Meter, UpDownCounter},
+    KeyValue,
+};
+
+use crate::telemetry::metrics::catalog::{labels, names};
+
+#[cfg(debug_assertions)]
+use crate::telemetry::metrics::catalog::debug_assert_attrs;
+
+#[derive(Clone, Copy, Debug, strum::IntoStaticStr)]
+pub enum SubscriptionTransport {
+    #[strum(serialize = "websocket")]
+    WebSocket,
+    #[strum(serialize = "http_multipart")]
+    HttpMultipart,
+    #[strum(serialize = "http_sse")]
+    HttpSse,
+    #[strum(serialize = "http_callback")]
+    HttpCallback,
+}
+
+impl SubscriptionTransport {
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+
+pub struct SubscriptionMetrics {
+    subgraphs_active: Option<UpDownCounter<i64>>,
+    subgraphs_connections: Option<UpDownCounter<i64>>,
+    clients_active: Option<UpDownCounter<i64>>,
+    clients_connections: Option<UpDownCounter<i64>>,
+}
+
+impl SubscriptionMetrics {
+    pub fn new(meter: Option<&Meter>) -> Self {
+        let subgraphs_active = meter.map(|m| {
+            m.i64_up_down_counter(names::SUBSCRIPTIONS_SUBGRAPHS_ACTIVE)
+                .with_description("Active subscribed operations on a subgraph.")
+                .build()
+        });
+        let subgraphs_connections = meter.map(|m| {
+            m.i64_up_down_counter(names::SUBSCRIPTIONS_SUBGRAPHS_CONNECTIONS)
+                .with_description("Active transport connections from router to subgraphs.")
+                .build()
+        });
+        let clients_active = meter.map(|m| {
+            m.i64_up_down_counter(names::SUBSCRIPTIONS_CLIENTS_ACTIVE)
+                .with_description("Active subscribed operations from clients to the router.")
+                .build()
+        });
+        let clients_connections = meter.map(|m| {
+            m.i64_up_down_counter(names::SUBSCRIPTIONS_CLIENTS_CONNECTIONS)
+                .with_description("Active transport connections from clients to router.")
+                .build()
+        });
+        Self {
+            subgraphs_active,
+            subgraphs_connections,
+            clients_active,
+            clients_connections,
+        }
+    }
+
+    pub fn active_subgraph_operation(&self, subgraph_name: &str) -> ActiveSubgraphOperationGuard {
+        let attrs = [KeyValue::new(
+            labels::SUBGRAPH_NAME,
+            subgraph_name.to_string(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_SUBGRAPHS_ACTIVE, &attrs);
+        if let Some(c) = &self.subgraphs_active {
+            c.add(1, &attrs);
+        }
+        ActiveSubgraphOperationGuard {
+            counter: self.subgraphs_active.clone(),
+            subgraph_name: subgraph_name.to_string(),
+        }
+    }
+
+    pub fn active_subgraph_connection(
+        &self,
+        subgraph_name: &str,
+        transport: SubscriptionTransport,
+    ) -> ActiveSubgraphConnectionGuard {
+        let attrs = [
+            KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+            KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, transport.as_str()),
+        ];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_SUBGRAPHS_CONNECTIONS, &attrs);
+        if let Some(c) = &self.subgraphs_connections {
+            c.add(1, &attrs);
+        }
+        ActiveSubgraphConnectionGuard {
+            counter: self.subgraphs_connections.clone(),
+            subgraph_name: subgraph_name.to_string(),
+            transport,
+        }
+    }
+
+    pub fn active_client_operation(
+        &self,
+        transport: SubscriptionTransport,
+    ) -> ActiveClientOperationGuard {
+        let attrs = [KeyValue::new(
+            labels::SUBSCRIPTION_TRANSPORT,
+            transport.as_str(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_ACTIVE, &attrs);
+        if let Some(c) = &self.clients_active {
+            c.add(1, &attrs);
+        }
+        ActiveClientOperationGuard {
+            counter: self.clients_active.clone(),
+            transport,
+        }
+    }
+
+    pub fn active_client_connection(
+        &self,
+        transport: SubscriptionTransport,
+    ) -> ActiveClientConnectionGuard {
+        let attrs = [KeyValue::new(
+            labels::SUBSCRIPTION_TRANSPORT,
+            transport.as_str(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_CONNECTIONS, &attrs);
+        if let Some(c) = &self.clients_connections {
+            c.add(1, &attrs);
+        }
+        ActiveClientConnectionGuard {
+            counter: self.clients_connections.clone(),
+            transport,
+        }
+    }
+}
+
+pub struct ActiveSubgraphOperationGuard {
+    counter: Option<UpDownCounter<i64>>,
+    subgraph_name: String,
+}
+
+impl Drop for ActiveSubgraphOperationGuard {
+    fn drop(&mut self) {
+        if let Some(c) = &self.counter {
+            c.add(
+                -1,
+                &[KeyValue::new(
+                    labels::SUBGRAPH_NAME,
+                    self.subgraph_name.clone(),
+                )],
+            );
+        }
+    }
+}
+
+pub struct ActiveSubgraphConnectionGuard {
+    counter: Option<UpDownCounter<i64>>,
+    subgraph_name: String,
+    transport: SubscriptionTransport,
+}
+
+impl Drop for ActiveSubgraphConnectionGuard {
+    fn drop(&mut self) {
+        if let Some(c) = &self.counter {
+            c.add(
+                -1,
+                &[
+                    KeyValue::new(labels::SUBGRAPH_NAME, self.subgraph_name.clone()),
+                    KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, self.transport.as_str()),
+                ],
+            );
+        }
+    }
+}
+
+pub struct ActiveClientOperationGuard {
+    counter: Option<UpDownCounter<i64>>,
+    transport: SubscriptionTransport,
+}
+
+impl Drop for ActiveClientOperationGuard {
+    fn drop(&mut self) {
+        if let Some(c) = &self.counter {
+            c.add(
+                -1,
+                &[KeyValue::new(
+                    labels::SUBSCRIPTION_TRANSPORT,
+                    self.transport.as_str(),
+                )],
+            );
+        }
+    }
+}
+
+pub struct ActiveClientConnectionGuard {
+    counter: Option<UpDownCounter<i64>>,
+    transport: SubscriptionTransport,
+}
+
+impl Drop for ActiveClientConnectionGuard {
+    fn drop(&mut self) {
+        if let Some(c) = &self.counter {
+            c.add(
+                -1,
+                &[KeyValue::new(
+                    labels::SUBSCRIPTION_TRANSPORT,
+                    self.transport.as_str(),
+                )],
+            );
+        }
+    }
+}

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -37,6 +37,7 @@ pub struct SubscriptionMetrics {
     clients_started_total: Option<Counter<u64>>,
     clients_ended_total: Option<Counter<u64>>,
     clients_lagged_messages_total: Option<Counter<u64>>,
+    clients_sent_messages_total: Option<Counter<u64>>,
 }
 
 impl SubscriptionMetrics {
@@ -105,6 +106,12 @@ impl SubscriptionMetrics {
                 .with_unit(units::MESSAGES)
                 .build()
         });
+        let clients_sent_messages_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_SENT_MESSAGES_TOTAL)
+                .with_description("Total messages sent to client subscribers.")
+                .with_unit(units::MESSAGES)
+                .build()
+        });
         Self {
             subgraphs_active,
             subgraphs_connections,
@@ -116,6 +123,7 @@ impl SubscriptionMetrics {
             clients_started_total,
             clients_ended_total,
             clients_lagged_messages_total,
+            clients_sent_messages_total,
         }
     }
 
@@ -228,6 +236,19 @@ impl SubscriptionMetrics {
         debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL, &attrs);
         if let Some(c) = &self.clients_lagged_messages_total {
             c.add(n, &attrs);
+        }
+    }
+
+    /// Records a single message sent to a client subscriber.
+    pub fn record_client_sent(&self, transport: SubscriptionTransport) {
+        let attrs = [KeyValue::new(
+            labels::SUBSCRIPTION_TRANSPORT,
+            transport.as_str(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_SENT_MESSAGES_TOTAL, &attrs);
+        if let Some(c) = &self.clients_sent_messages_total {
+            c.add(1, &attrs);
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -26,28 +26,16 @@ impl SubscriptionTransport {
     }
 }
 
-#[derive(Clone, Copy, Debug, strum::IntoStaticStr)]
-pub enum SubscriptionOperation {
-    #[strum(serialize = "subscribe")]
-    Subscribe,
-    #[strum(serialize = "unsubscribe")]
-    Unsubscribe,
-}
-
-impl SubscriptionOperation {
-    pub fn as_str(self) -> &'static str {
-        self.into()
-    }
-}
-
 pub struct SubscriptionMetrics {
     subgraphs_active: Option<UpDownCounter<i64>>,
     subgraphs_connections: Option<UpDownCounter<i64>>,
-    subgraphs_operations_total: Option<Counter<u64>>,
+    subgraphs_started_total: Option<Counter<u64>>,
+    subgraphs_ended_total: Option<Counter<u64>>,
     subgraphs_dropped_messages_total: Option<Counter<u64>>,
     clients_active: Option<UpDownCounter<i64>>,
     clients_connections: Option<UpDownCounter<i64>>,
-    clients_operations_total: Option<Counter<u64>>,
+    clients_started_total: Option<Counter<u64>>,
+    clients_ended_total: Option<Counter<u64>>,
     clients_lagged_messages_total: Option<Counter<u64>>,
 }
 
@@ -65,10 +53,16 @@ impl SubscriptionMetrics {
                 .with_unit(units::CONNECTIONS)
                 .build()
         });
-        let subgraphs_operations_total = meter.map(|m| {
-            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL)
-                .with_description("Total subscribe/unsubscribe operations on a subgraph.")
-                .with_unit(units::OPERATIONS)
+        let subgraphs_started_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_STARTED_TOTAL)
+                .with_description("Total subscriptions started on a subgraph.")
+                .with_unit(units::SUBSCRIPTIONS)
+                .build()
+        });
+        let subgraphs_ended_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_ENDED_TOTAL)
+                .with_description("Total subscriptions ended on a subgraph.")
+                .with_unit(units::SUBSCRIPTIONS)
                 .build()
         });
         let subgraphs_dropped_messages_total = meter.map(|m| {
@@ -91,12 +85,16 @@ impl SubscriptionMetrics {
                 .with_unit(units::CONNECTIONS)
                 .build()
         });
-        let clients_operations_total = meter.map(|m| {
-            m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL)
-                .with_description(
-                    "Total subscribe/unsubscribe operations from clients to the router.",
-                )
-                .with_unit(units::OPERATIONS)
+        let clients_started_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_STARTED_TOTAL)
+                .with_description("Total subscriptions started from clients to the router.")
+                .with_unit(units::SUBSCRIPTIONS)
+                .build()
+        });
+        let clients_ended_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_ENDED_TOTAL)
+                .with_description("Total subscriptions ended from clients to the router.")
+                .with_unit(units::SUBSCRIPTIONS)
                 .build()
         });
         let clients_lagged_messages_total = meter.map(|m| {
@@ -110,11 +108,13 @@ impl SubscriptionMetrics {
         Self {
             subgraphs_active,
             subgraphs_connections,
-            subgraphs_operations_total,
+            subgraphs_started_total,
+            subgraphs_ended_total,
             subgraphs_dropped_messages_total,
             clients_active,
             clients_connections,
-            clients_operations_total,
+            clients_started_total,
+            clients_ended_total,
             clients_lagged_messages_total,
         }
     }
@@ -129,21 +129,12 @@ impl SubscriptionMetrics {
         if let Some(c) = &self.subgraphs_active {
             c.add(1, &attrs);
         }
-        if let Some(c) = &self.subgraphs_operations_total {
-            let attrs = [
-                KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
-                KeyValue::new(
-                    labels::SUBSCRIPTION_OPERATION,
-                    SubscriptionOperation::Subscribe.as_str(),
-                ),
-            ];
-            #[cfg(debug_assertions)]
-            debug_assert_attrs(names::SUBSCRIPTIONS_SUBGRAPHS_OPERATIONS_TOTAL, &attrs);
+        if let Some(c) = &self.subgraphs_started_total {
             c.add(1, &attrs);
         }
         ActiveSubgraphOperationGuard {
             counter: self.subgraphs_active.clone(),
-            operations_total: self.subgraphs_operations_total.clone(),
+            ended_total: self.subgraphs_ended_total.clone(),
             subgraph_name: subgraph_name.to_string(),
         }
     }
@@ -182,21 +173,12 @@ impl SubscriptionMetrics {
         if let Some(c) = &self.clients_active {
             c.add(1, &attrs);
         }
-        if let Some(c) = &self.clients_operations_total {
-            let attrs = [
-                KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, transport.as_str()),
-                KeyValue::new(
-                    labels::SUBSCRIPTION_OPERATION,
-                    SubscriptionOperation::Subscribe.as_str(),
-                ),
-            ];
-            #[cfg(debug_assertions)]
-            debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL, &attrs);
+        if let Some(c) = &self.clients_started_total {
             c.add(1, &attrs);
         }
         ActiveClientOperationGuard {
             counter: self.clients_active.clone(),
-            operations_total: self.clients_operations_total.clone(),
+            ended_total: self.clients_ended_total.clone(),
             transport,
         }
     }
@@ -252,32 +234,21 @@ impl SubscriptionMetrics {
 
 pub struct ActiveSubgraphOperationGuard {
     counter: Option<UpDownCounter<i64>>,
-    operations_total: Option<Counter<u64>>,
+    ended_total: Option<Counter<u64>>,
     subgraph_name: String,
 }
 
 impl Drop for ActiveSubgraphOperationGuard {
     fn drop(&mut self) {
+        let attrs = [KeyValue::new(
+            labels::SUBGRAPH_NAME,
+            self.subgraph_name.clone(),
+        )];
         if let Some(c) = &self.counter {
-            c.add(
-                -1,
-                &[KeyValue::new(
-                    labels::SUBGRAPH_NAME,
-                    self.subgraph_name.clone(),
-                )],
-            );
+            c.add(-1, &attrs);
         }
-        if let Some(c) = &self.operations_total {
-            c.add(
-                1,
-                &[
-                    KeyValue::new(labels::SUBGRAPH_NAME, self.subgraph_name.clone()),
-                    KeyValue::new(
-                        labels::SUBSCRIPTION_OPERATION,
-                        SubscriptionOperation::Unsubscribe.as_str(),
-                    ),
-                ],
-            );
+        if let Some(c) = &self.ended_total {
+            c.add(1, &attrs);
         }
     }
 }
@@ -304,32 +275,21 @@ impl Drop for ActiveSubgraphConnectionGuard {
 
 pub struct ActiveClientOperationGuard {
     counter: Option<UpDownCounter<i64>>,
-    operations_total: Option<Counter<u64>>,
+    ended_total: Option<Counter<u64>>,
     transport: SubscriptionTransport,
 }
 
 impl Drop for ActiveClientOperationGuard {
     fn drop(&mut self) {
+        let attrs = [KeyValue::new(
+            labels::SUBSCRIPTION_TRANSPORT,
+            self.transport.as_str(),
+        )];
         if let Some(c) = &self.counter {
-            c.add(
-                -1,
-                &[KeyValue::new(
-                    labels::SUBSCRIPTION_TRANSPORT,
-                    self.transport.as_str(),
-                )],
-            );
+            c.add(-1, &attrs);
         }
-        if let Some(c) = &self.operations_total {
-            c.add(
-                1,
-                &[
-                    KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, self.transport.as_str()),
-                    KeyValue::new(
-                        labels::SUBSCRIPTION_OPERATION,
-                        SubscriptionOperation::Unsubscribe.as_str(),
-                    ),
-                ],
-            );
+        if let Some(c) = &self.ended_total {
+            c.add(1, &attrs);
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     KeyValue,
 };
 
-use crate::telemetry::metrics::catalog::{labels, names, units};
+use crate::telemetry::metrics::catalog::{labels, names, units, values::SubscriptionEndReason};
 
 #[cfg(debug_assertions)]
 use crate::telemetry::metrics::catalog::debug_assert_attrs;
@@ -188,6 +188,7 @@ impl SubscriptionMetrics {
             counter: self.clients_active.clone(),
             ended_total: self.clients_ended_total.clone(),
             transport,
+            end_reason: SubscriptionEndReason::ClientDisconnected,
         }
     }
 
@@ -298,19 +299,32 @@ pub struct ActiveClientOperationGuard {
     counter: Option<UpDownCounter<i64>>,
     ended_total: Option<Counter<u64>>,
     transport: SubscriptionTransport,
+    end_reason: SubscriptionEndReason,
+}
+
+impl ActiveClientOperationGuard {
+    /// Records why the subscription ended. Call this before the guard drops;
+    /// if never called, the drop is attributed to `ClientDisconnected`.
+    pub fn set_end_reason(&mut self, reason: SubscriptionEndReason) {
+        self.end_reason = reason;
+    }
 }
 
 impl Drop for ActiveClientOperationGuard {
     fn drop(&mut self) {
-        let attrs = [KeyValue::new(
+        let active_attrs = [KeyValue::new(
             labels::SUBSCRIPTION_TRANSPORT,
             self.transport.as_str(),
         )];
         if let Some(c) = &self.counter {
-            c.add(-1, &attrs);
+            c.add(-1, &active_attrs);
         }
         if let Some(c) = &self.ended_total {
-            c.add(1, &attrs);
+            let ended_attrs = [
+                KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, self.transport.as_str()),
+                KeyValue::new(labels::SUBSCRIPTION_END_REASON, self.end_reason.as_str()),
+            ];
+            c.add(1, &ended_attrs);
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -44,7 +44,7 @@ pub struct SubscriptionMetrics {
     subgraphs_active: Option<UpDownCounter<i64>>,
     subgraphs_connections: Option<UpDownCounter<i64>>,
     subgraphs_operations_total: Option<Counter<u64>>,
-    subgraphs_terminated_total: Option<Counter<u64>>,
+    subgraphs_dropped_messages_total: Option<Counter<u64>>,
     clients_active: Option<UpDownCounter<i64>>,
     clients_connections: Option<UpDownCounter<i64>>,
     clients_operations_total: Option<Counter<u64>>,
@@ -71,10 +71,12 @@ impl SubscriptionMetrics {
                 .with_unit(units::OPERATIONS)
                 .build()
         });
-        let subgraphs_terminated_total = meter.map(|m| {
-            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL)
-                .with_description("Subgraph subscriptions force-terminated by the router.")
-                .with_unit(units::SUBSCRIPTIONS)
+        let subgraphs_dropped_messages_total = meter.map(|m| {
+            m.u64_counter(names::SUBSCRIPTIONS_SUBGRAPHS_DROPPED_MESSAGES_TOTAL)
+                .with_description(
+                    "Subgraph messages dropped because consumers were too slow to keep up.",
+                )
+                .with_unit(units::MESSAGES)
                 .build()
         });
         let clients_active = meter.map(|m| {
@@ -91,13 +93,17 @@ impl SubscriptionMetrics {
         });
         let clients_operations_total = meter.map(|m| {
             m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_OPERATIONS_TOTAL)
-                .with_description("Total subscribe/unsubscribe operations from clients to the router.")
+                .with_description(
+                    "Total subscribe/unsubscribe operations from clients to the router.",
+                )
                 .with_unit(units::OPERATIONS)
                 .build()
         });
         let clients_lagged_messages_total = meter.map(|m| {
             m.u64_counter(names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL)
-                .with_description("Messages skipped by slow client subscribers due to broadcast lag.")
+                .with_description(
+                    "Messages skipped by slow client subscribers due to broadcast lag.",
+                )
                 .with_unit(units::MESSAGES)
                 .build()
         });
@@ -105,7 +111,7 @@ impl SubscriptionMetrics {
             subgraphs_active,
             subgraphs_connections,
             subgraphs_operations_total,
-            subgraphs_terminated_total,
+            subgraphs_dropped_messages_total,
             clients_active,
             clients_connections,
             clients_operations_total,
@@ -214,6 +220,22 @@ impl SubscriptionMetrics {
         }
     }
 
+    /// Records a single subgraph message dropped because of a slow consumer.
+    pub fn record_message_dropped(&self, transport: SubscriptionTransport) {
+        let attrs = [KeyValue::new(
+            labels::SUBSCRIPTION_TRANSPORT,
+            transport.as_str(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(
+            names::SUBSCRIPTIONS_SUBGRAPHS_DROPPED_MESSAGES_TOTAL,
+            &attrs,
+        );
+        if let Some(c) = &self.subgraphs_dropped_messages_total {
+            c.add(1, &attrs);
+        }
+    }
+
     /// Records `n` messages skipped by a slow client subscriber due to broadcast lag.
     pub fn record_client_lag(&self, transport: SubscriptionTransport, n: u64) {
         let attrs = [KeyValue::new(
@@ -224,24 +246,6 @@ impl SubscriptionMetrics {
         debug_assert_attrs(names::SUBSCRIPTIONS_CLIENTS_LAGGED_MESSAGES_TOTAL, &attrs);
         if let Some(c) = &self.clients_lagged_messages_total {
             c.add(n, &attrs);
-        }
-    }
-
-    /// Records a subgraph subscription force-terminated by the router due to a slow consumer.
-    pub fn record_subgraph_termination(
-        &self,
-        subgraph_name: &str,
-        transport: SubscriptionTransport,
-    ) {
-        let attrs = [
-            KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
-            KeyValue::new(labels::SUBSCRIPTION_TRANSPORT, transport.as_str()),
-            KeyValue::new(labels::ERROR_TYPE, "slow_consumer"),
-        ];
-        #[cfg(debug_assertions)]
-        debug_assert_attrs(names::SUBSCRIPTIONS_SUBGRAPHS_TERMINATED_TOTAL, &attrs);
-        if let Some(c) = &self.subgraphs_terminated_total {
-            c.add(1, &attrs);
         }
     }
 }


### PR DESCRIPTION
Somewhat inspired by and therefore closes #1208, closes #921

Full observability into GraphQL subscription activity - both between clients and the router, and between the router and subgraphs - via OTEL metrics, so one can answer "how many subscriptions are live right now", "what is the subscription churn rate", and "are we dropping or losing subscription events" per transport and per subgraph.

### Live-state gauges

| Metric                                            | Labels                                    | Unit             | Meaning                                                     |
| ------------------------------------------------- | ----------------------------------------- | ---------------- | ----------------------------------------------------------- |
| `hive.router.subscriptions.clients.active`        | `subscription.transport`                  | `{subscription}` | Active subscription operations from clients to the router   |
| `hive.router.subscriptions.clients.connections`   | `subscription.transport`                  | `{connection}`   | Active transport connections carrying client subscriptions  |
| `hive.router.subscriptions.subgraphs.active`      | `subgraph.name`                           | `{subscription}` | Active subscription operations from the router to subgraphs |
| `hive.router.subscriptions.subgraphs.connections` | `subgraph.name`, `subscription.transport` | `{connection}`   | Active transport connections from the router to subgraphs   |

Operations and connections are separate because one connection can (will be able) multiplex multiple operations (WebSocket) or subscription deduplication can fan one subgraph operation out to many clients.

### Lifecycle counters

| Metric                                              | Labels                                              | Unit             | Meaning                                                      |
| --------------------------------------------------- | --------------------------------------------------- | ---------------- | ------------------------------------------------------------ |
| `hive.router.subscriptions.clients.started_total`   | `subscription.transport`                            | `{subscription}` | Client subscriptions started (churn/rate, survives restarts) |
| `hive.router.subscriptions.clients.ended_total`     | `subscription.transport`, `subscription.end_reason` | `{subscription}` | Client subscriptions ended                                   |
| `hive.router.subscriptions.subgraphs.started_total` | `subgraph.name`                                     | `{subscription}` | Subgraph subscriptions started                               |
| `hive.router.subscriptions.subgraphs.ended_total`   | `subgraph.name`                                     | `{subscription}` | Subgraph subscriptions ended                                 |

Every start is matched by exactly one end, regardless of how the subscription ends (explicit unsubscribe, connection drop, stream completion, error).

`hive.router.subscriptions.clients.ended_total` additionally carries `subscription.end_reason`, one of:

- `completed` - the upstream/broadcast source finished normally (subscription ran to completion).
- `error` - the subscription ended because an error event was delivered to the client.
- `client_disconnected` - the client closed the connection, unsubscribed, or the stream was otherwise dropped from the router's side. This is also the default recorded if a guard drops without an explicit reason set, so no end is ever left unattributed.

### Saturation/error counters

| Metric                                                       | Labels                   | Unit        | Meaning                                                                                                                      |
| ------------------------------------------------------------ | ------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
| `hive.router.subscriptions.clients.sent_messages_total`      | `subscription.transport` | `{message}` | Messages successfully sent to a client subscriber                                                                            |
| `hive.router.subscriptions.clients.lagged_messages_total`    | `subscription.transport` | `{message}` | Messages skipped for slow clients on the broadcast fan-out (incremented by the actual number skipped); subscription survives |
| `hive.router.subscriptions.subgraphs.dropped_messages_total` | `subscription.transport` | `{message}` | Subgraph messages dropped because the internal subscription buffer was full (consumer too slow); subscription survives       |

`sent_messages_total` and `lagged_messages_total` together give the % of messages a client actually received vs skipped (`sent / (sent + lagged)`), per transport.

No subscription is ever terminated because of a slow consumer. All buffer-full situations (subgraph WebSocket, HTTP multipart/SSE, HTTP callback) now drop the single message, record it, and keep the subscription alive - mirroring the broadcast lag semantics on the client side.

This includes a behavior change on the HTTP callback endpoint: a full buffer no longer terminates the subscription and returns 503; it responds OK and drops the message.

### Label semantics

`subscription.transport` values: `websocket`, `http_multipart`, `http_sse`, `http_callback` - covering all client-facing transports (WebSocket, incremental delivery / Apollo multipart HTTP, SSE) and all subgraph executors (WebSocket, HTTP multipart/SSE, HTTP callback).

`subscription.end_reason` values (client-side `ended_total` only): `completed`, `error`, `client_disconnected`.

### Why custom units?

The convention for what goes in units comes from the OTEL metrics spec, which says units should be UCUM (Unified Code for Units of Measure) case-sensitive codes.

Two kinds of values:

1. Real physical units - UCUM codes like s, ms, By (bytes), %. E.g. `http.server.request.duration` is defined with unit s in the semantic conventions.
2. Counts of things - UCUM has "annotations": a label in curly braces, like `{subscription}`, `{connection}`, `{request}`, `{message}`.
   Semantically it means "dimensionless count of X"; the braces are UCUM syntax for "this is a human hint, not a real unit". OTEL semantic conventions use this everywhere, e.g. `http.server.active_requests` has unit `{request}`, JVM thread count `{thread}`. Also per convention, when the unit is an annotation like this, the metric name should NOT repeat it (no `.subscriptions_count` suffix) - the unit field carries it

What it actually buys us:

- Exporters use it. The Prometheus exporter appends real units to the metric name (`_seconds`, `_bytes`) and uses it for the `# UNIT/# HELP` metadata; brace annotations are stripped from the name but still land in metadata.
- Backends/UIs use it. Grafana, Datadog etc. pick axis formatting and legends from it.
- It's documentation at the instrument - `{connection}` on `clients.connections` tells the reader the gauge counts connections, not bytes or operations.

### Why started and ended counters?

Why not derive ends from the `active` gauge (`ends = starts - active`)? Because the derivation is only correct between restarts. Backends (like Prometheus and alike) have special handling for counters: when a counter drops (100 -> 0), `rate()`/`increase()` recognize it as a reset and keep computing correctly across it. Gauges have no reset semantics - when the router restarts, `active` drops hard to 0 and any expression involving `delta(active)` sees that as a mass unsubscribe - producing nonsense. A real `ended_total` counter is correct across restarts.

What the start/end rates answer that `active` alone can't:

- Mass disconnects. End-rate spike with flat start rate = something killed a batch of subscriptions (deploy, LB idle timeout, subgraph WS outage). `active` alone shows only a dip you can't attribute.
- Flapping/churn. Start and end rates both high while `active` is flat = clients constantly reconnecting (broken keepalive, client retry loop). Invisible in the gauge.
- Average subscription lifetime = `active / rate(ended_total)`. A median lifetime of 3 seconds means a client is probably subscribing per-request instead of holding the stream.
- Invariant checking. `started_total - ended_total` should equal `active`; drift between them indicates a leaked lifecycle guard.

### Removed `CallbackError::ClientTooSlow`?

Slow consumer should not hold up or drop the subscription, messages should simply be dropped. This is in line with all other streaming executors.

### WebSocket server records GraphQL errors

Previously, GraphQL errors (like jwt, validation, parsing, etc.) were not recorded in the WebSocket server. [Now they are.](https://github.com/graphql-hive/router/pull/1261/commits/566e11cbcfd0d0ed98989050448cf5671698850d)

### TODO

- [x] docs https://github.com/graphql-hive/docs/pull/141
- [x] changeset
  - dropped client too slow http callback stop error, instead we drop the message like with other transports
  - relaxed logs relating to lagging/dropping messages from warn to debug
  - subscriptions metrics
