### PR TITLE
[SUPERSEDED] feat(router,executor): allow plugins to override the supergraph from on_http_request

### DIFF
--- a/.changeset/drop_with_schema_from_on_graphql_validation_plugin_hook.md
+++ b/.changeset/drop_with_schema_from_on_graphql_validation_plugin_hook.md
@@ -1,0 +1,24 @@
+---
+hive-router-plan-executor: major
+hive-router: patch
+---
+
+# Drop `with_schema` from the `on_graphql_validation` plugin hook
+
+Remove `OnGraphQLValidationStartHookPayload::with_schema`. Method was broken by design, it replaced the schema only for validation while parsing, introspection, normalization, planning, and execution continued using the request's original schema state. This could make a field disappear during validation while remaining visible through introspection, and it could leave schema-derived caches and planning state inconsistent with the schema used to validate the operation.
+
+Plugins that need a request-specific schema should now build and retain a stable `Arc<Document>` for each schema variant and select it in `on_http_request`:
+
+```rust
+fn on_http_request<'req>(
+    &'req self,
+    payload: OnHttpRequestHookPayload<'req>,
+) -> OnHttpRequestHookResult<'req> {
+    payload.set_schema_document(self.document_for_request(&payload).clone());
+    payload.proceed()
+}
+```
+
+The router resolves the selected supergraph document into an internally owned `SchemaState` and reuses it for later requests that provide the same `Arc<Document>`. The selected schema then applies consistently to the entire request pipeline, including validation, introspection, normalization, planning, and execution.
+
+Documents should be created when the plugin initializes or when the supergraph reloads, not per request. Creating a new `Arc<Document>` for every request defeats the router's schema-state cache and forces the schema state and query planner to be rebuilt.

--- a/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
+++ b/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
@@ -1,0 +1,6 @@
+---
+hive-router-plan-executor: minor
+hive-router: patch
+---
+
+# Replace the schema state in the on_http_request plugin hook

--- a/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
+++ b/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
@@ -24,3 +24,9 @@ fn on_http_request<'req>(
 ```
 
 See the new [plugin_examples/replace_schema](https://github.com/graphql-hive/router/tree/main/plugin_examples/replace_schema) example for a full walkthrough.
+
+Plugin author caveats:
+
+- `from_supergraph_sdl` is expensive (full planner build). Construct once per schema variant in the plugin lifecycle (e.g. `on_plugin_init` or the plugin's own reload loop), never per request.
+- Router-side supergraph reload does not touch plugin-owned states: no cache invalidation, no forced subscription close, no callback heartbeat enforcer background task. Their state, their lifecycle.
+- `on_http_request` is a **sync** hook. The feature lookup against their external service cannot be awaited there. They must resolve project -> enabled features asynchronously in their own lifecycle (background refresh, cache) and only do a synchronous map lookup (project_key -> Arc<SchemaState>) in the hook. If a blocking per-request lookup ever becomes a hard requirement, making `on_http_request` async (or adding an async early hook) is a separate change.

--- a/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
+++ b/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
@@ -3,30 +3,34 @@ hive-router-plan-executor: minor
 hive-router: patch
 ---
 
-# Replace the schema state in the on_http_request plugin hook
+# Select a schema document in the on_http_request plugin hook
 
-Add `OnHttpRequestHookPayload::set_schema_state`, letting a plugin override the schema used for a request as early as `on_http_request`, and have it hold for the entire pipeline: parsing, validation, normalization, planning, execution, and introspection.
+Add `OnHttpRequestHookPayload::set_schema_document`, allowing a plugin to select a supergraph `Arc<Document>` during `on_http_request`. The selected schema applies to validation, normalization, planning, execution, and introspection for both HTTP and WebSocket requests.
 
-Previously, a plugin could only swap the schema at the validation stage (`on_graphql_validation` via `payload.with_schema(...)`), which left introspection (`__schema`/`__type`) unaffected, since it reads from the schema resolved earlier in the pipeline. Fields hidden from validation would still show up in introspection.
+The router resolves each document into an internally owned `SchemaState` with isolated schema-derived caches. Resolved states are kept in a strict FIFO cache with a maximum of 10 entries. The first request builds the state, later requests reuse it, and inserting an eleventh document evicts the oldest entry.
 
-Plugins build and own their `Arc<SchemaState>` instances (e.g. via `SchemaState::from_supergraph_sdl` / `SchemaState::from_supergraph_document`, new public constructors on `hive_router::SchemaState`), each with its own fresh caches, so plan/validate/ normalize cache entries never leak across schema variants. The router does not manage the lifecycle of plugin-owned states: no background reload, no cache invalidation, no subscription force-close. Building a `SchemaState` is expensive (it builds a full query planner), so plugins should build one per schema variant up front, not per request.
+Plugins must retain and reuse the same `Arc<Document>` for each variant because cache keys use `Arc` allocation identity. Creating a new document or `Arc` per request causes a cache miss and an expensive planner rebuild.
 
-Example:
+If a selected document cannot be converted into a schema state, the router returns HTTP 500 rather than falling back to the default schema.
+
+### Caveats for plugin authors
+
+- Building a `SchemaState` includes a full query planner build. The first request for each document therefore has additional latency.
+- Router-side supergraph reloads do not mutate or invalidate cached plugin-selected states and do not force-close subscriptions using them.
+- `on_http_request` is synchronous. External feature or project lookups must be refreshed asynchronously in the plugin lifecycle so the hook only performs a synchronous lookup from request data to a stable `Arc<Document>`.
+
+### Example
 
 ```rust
 fn on_http_request<'req>(
     &'req self,
     payload: OnHttpRequestHookPayload<'req>,
 ) -> OnHttpRequestHookResult<'req> {
-    payload.set_schema_state(self.schema_state_for_request(&payload).clone());
+    if let Some(document) = self.schema_document_for_request(&payload) {
+        payload.set_schema_document(document.clone());
+    }
     payload.proceed()
 }
 ```
 
-See the new [plugin_examples/replace_schema](https://github.com/graphql-hive/router/tree/main/plugin_examples/replace_schema) example for a full walkthrough.
-
-Plugin author caveats:
-
-- `from_supergraph_sdl` is expensive (full planner build). Construct once per schema variant in the plugin lifecycle (e.g. `on_plugin_init` or the plugin's own reload loop), never per request.
-- Router-side supergraph reload does not touch plugin-owned states: no cache invalidation, no forced subscription close, no callback heartbeat enforcer background task. Their state, their lifecycle.
-- `on_http_request` is a **sync** hook. The feature lookup against their external service cannot be awaited there. They must resolve project -> enabled features asynchronously in their own lifecycle (background refresh, cache) and only do a synchronous map lookup (project_key -> Arc<SchemaState>) in the hook. If a blocking per-request lookup ever becomes a hard requirement, making `on_http_request` async (or adding an async early hook) is a separate change.
+See [`plugin_examples/replace_schema`](https://github.com/graphql-hive/router/tree/main/plugin_examples/replace_schema) for a complete example.

--- a/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
+++ b/.changeset/replace_the_schema_state_in_the_on_http_request_plugin_hook.md
@@ -4,3 +4,23 @@ hive-router: patch
 ---
 
 # Replace the schema state in the on_http_request plugin hook
+
+Add `OnHttpRequestHookPayload::set_schema_state`, letting a plugin override the schema used for a request as early as `on_http_request`, and have it hold for the entire pipeline: parsing, validation, normalization, planning, execution, and introspection.
+
+Previously, a plugin could only swap the schema at the validation stage (`on_graphql_validation` via `payload.with_schema(...)`), which left introspection (`__schema`/`__type`) unaffected, since it reads from the schema resolved earlier in the pipeline. Fields hidden from validation would still show up in introspection.
+
+Plugins build and own their `Arc<SchemaState>` instances (e.g. via `SchemaState::from_supergraph_sdl` / `SchemaState::from_supergraph_document`, new public constructors on `hive_router::SchemaState`), each with its own fresh caches, so plan/validate/ normalize cache entries never leak across schema variants. The router does not manage the lifecycle of plugin-owned states: no background reload, no cache invalidation, no subscription force-close. Building a `SchemaState` is expensive (it builds a full query planner), so plugins should build one per schema variant up front, not per request.
+
+Example:
+
+```rust
+fn on_http_request<'req>(
+    &'req self,
+    payload: OnHttpRequestHookPayload<'req>,
+) -> OnHttpRequestHookResult<'req> {
+    payload.set_schema_state(self.schema_state_for_request(&payload).clone());
+    payload.proceed()
+}
+```
+
+See the new [plugin_examples/replace_schema](https://github.com/graphql-hive/router/tree/main/plugin_examples/replace_schema) example for a full walkthrough.

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -58,12 +58,14 @@ pub use dashmap::DashMap;
 pub use graphql_tools;
 use graphql_tools::validation::rules::default_rules_validation_plan;
 pub use hive_router_config::humantime_serde;
-use hive_router_config::{load_config, subscriptions::CallbackConfig, HiveRouterConfig};
+pub use hive_router_config::HiveRouterConfig;
+use hive_router_config::{load_config, subscriptions::CallbackConfig};
 pub use hive_router_internal::background_tasks;
 use hive_router_internal::background_tasks::{BackgroundTask, CancellationToken};
+pub use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_internal::telemetry::{
     otel::tracing_opentelemetry::OpenTelemetrySpanExt,
-    traces::spans::http_request::HttpServerRequestSpan, TelemetryContext,
+    traces::spans::http_request::HttpServerRequestSpan,
 };
 pub use hive_router_internal::BoxError;
 use hive_router_internal::{
@@ -132,8 +134,17 @@ async fn graphql_endpoint_handler(
         .http_server
         .capture_request(&request);
 
+    // A plugin may have overridden the schema state for this request in `on_http_request`
+    // (see `OnHttpRequestHookPayload::set_schema_state`); otherwise fall back to the router's own.
+    let schema_state = request
+        .extensions()
+        .get::<Arc<SchemaState>>()
+        .cloned()
+        .unwrap_or_else(|| schema_state.get_ref().clone());
+
     let response =
-        graphql_endpoint_dispatch(&mut request, body_stream, schema_state, app_state.clone()).await;
+        graphql_endpoint_dispatch(&mut request, body_stream, &schema_state, app_state.clone())
+            .await;
 
     let graphql_operation = read_graphql_operation_metric_identity(&request);
     let graphql_operation_name = graphql_operation
@@ -159,7 +170,7 @@ async fn graphql_endpoint_handler(
 async fn graphql_endpoint_dispatch(
     request: &mut HttpRequest,
     body_stream: web::types::Payload,
-    schema_state: web::types::State<Arc<SchemaState>>,
+    schema_state: &Arc<SchemaState>,
     app_state: web::types::State<Arc<RouterSharedState>>,
 ) -> web::HttpResponse {
     let parent_ctx = app_state
@@ -188,7 +199,7 @@ async fn graphql_endpoint_dispatch(
             request,
             body_stream,
             app_state.get_ref(),
-            schema_state.get_ref(),
+            schema_state,
             &root_http_request_span,
             &mut response_mode,
             response_header_sink.clone(),

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -51,7 +51,10 @@ use crate::{
 
 use crate::cache_state::{register_cache_size_observers, CacheState};
 pub use crate::plugins::registry::PluginRegistry;
-pub use crate::{schema_state::SchemaState, shared_state::RouterSharedState};
+pub use crate::{
+    schema_state::{SchemaState, SupergraphManagerError},
+    shared_state::RouterSharedState,
+};
 pub use arc_swap::ArcSwap;
 pub use async_trait::async_trait;
 pub use dashmap::DashMap;

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -51,24 +51,19 @@ use crate::{
 
 use crate::cache_state::{register_cache_size_observers, CacheState};
 pub use crate::plugins::registry::PluginRegistry;
-pub use crate::{
-    schema_state::{SchemaState, SupergraphManagerError},
-    shared_state::RouterSharedState,
-};
+pub use crate::{schema_state::SchemaState, shared_state::RouterSharedState};
 pub use arc_swap::ArcSwap;
 pub use async_trait::async_trait;
 pub use dashmap::DashMap;
 pub use graphql_tools;
 use graphql_tools::validation::rules::default_rules_validation_plan;
 pub use hive_router_config::humantime_serde;
-pub use hive_router_config::HiveRouterConfig;
-use hive_router_config::{load_config, subscriptions::CallbackConfig};
+use hive_router_config::{load_config, subscriptions::CallbackConfig, HiveRouterConfig};
 pub use hive_router_internal::background_tasks;
 use hive_router_internal::background_tasks::{BackgroundTask, CancellationToken};
-pub use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_internal::telemetry::{
     otel::tracing_opentelemetry::OpenTelemetrySpanExt,
-    traces::spans::http_request::HttpServerRequestSpan,
+    traces::spans::http_request::HttpServerRequestSpan, TelemetryContext,
 };
 pub use hive_router_internal::BoxError;
 use hive_router_internal::{
@@ -137,8 +132,10 @@ async fn graphql_endpoint_handler(
         .http_server
         .capture_request(&request);
 
-    // A plugin may have overridden the schema state for this request in `on_http_request`
-    // (see `OnHttpRequestHookPayload::set_schema_state`); otherwise fall back to the router's own.
+    // A plugin may have overridden the schema document for this request in `on_http_request`
+    // (see `OnHttpRequestHookPayload::set_schema_document`); the plugin middleware resolves it
+    // into an `Arc<SchemaState>` and stores it in request extensions. Otherwise fall back to the
+    // router's own.
     let schema_state = request
         .extensions()
         .get::<Arc<SchemaState>>()

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -56,7 +56,13 @@ pub async fn ws_index(
     schema_state: web::types::State<Arc<SchemaState>>,
     shared_state: web::types::State<Arc<RouterSharedState>>,
 ) -> Result<HttpResponse, Error> {
-    let schema_state = schema_state.get_ref().clone();
+    // A plugin may have overridden the schema state for this request in `on_http_request`
+    // (see `OnHttpRequestHookPayload::set_schema_state`); otherwise fall back to the router's own.
+    let schema_state = req
+        .extensions()
+        .get::<Arc<SchemaState>>()
+        .cloned()
+        .unwrap_or_else(|| schema_state.get_ref().clone());
     let shared_state = shared_state.get_ref().clone();
 
     let accepted_subprotocol = ws::subprotocols(&req)

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -56,8 +56,10 @@ pub async fn ws_index(
     schema_state: web::types::State<Arc<SchemaState>>,
     shared_state: web::types::State<Arc<RouterSharedState>>,
 ) -> Result<HttpResponse, Error> {
-    // A plugin may have overridden the schema state for this request in `on_http_request`
-    // (see `OnHttpRequestHookPayload::set_schema_state`); otherwise fall back to the router's own.
+    // A plugin may have overridden the schema document for this request in `on_http_request`
+    // (see `OnHttpRequestHookPayload::set_schema_document`); the plugin middleware resolves it
+    // into an `Arc<SchemaState>` and stores it in request extensions. Otherwise fall back to the
+    // router's own.
     let schema_state = req
         .extensions()
         .get::<Arc<SchemaState>>()

--- a/bin/router/src/plugins/plugins_service.rs
+++ b/bin/router/src/plugins/plugins_service.rs
@@ -1,5 +1,6 @@
 use std::{ops::ControlFlow, sync::Arc};
 
+use graphql_tools::static_graphql::schema::Document;
 use hive_router_plan_executor::{
     hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpResponseHookPayload},
     plugin_context::PluginContext,
@@ -8,10 +9,12 @@ use hive_router_plan_executor::{
     request_context::{RequestContextExt, SharedRequestContext},
 };
 use ntex::{
+    http::StatusCode,
     service::{Service, ServiceCtx},
     web::{self, DefaultError},
     Middleware, SharedCfg,
 };
+use tracing::error;
 
 use crate::{RouterPaths, RouterSharedState};
 
@@ -128,6 +131,36 @@ where
 
             // Give the ownership back to variables
             req = start_payload.router_http_request;
+
+            // A plugin may have selected a schema document via `set_schema_document`. Resolve it
+            // through the router-owned schema-state cache here, once, so both HTTP and WebSocket
+            // entry points can just read the resulting `Arc<SchemaState>` from request extensions.
+            let selected_document = req.extensions().get::<Arc<Document>>().cloned();
+            if let Some(document) = selected_document {
+                let shared_state = shared_state
+                    .as_ref()
+                    .expect("router shared state must be present when plugins are configured");
+                match shared_state.schema_state_cache.resolve(
+                    document,
+                    shared_state.router_config.clone(),
+                    shared_state.telemetry_context.clone(),
+                ) {
+                    Ok(schema_state) => {
+                        req.extensions_mut().insert(schema_state);
+                    }
+                    Err(err) => {
+                        // if schema-state build fails, we intentionally return an internal error.
+                        // falling back to the default schema could expose fields the plugin intended
+                        // to remove or change - posing a security threat
+                        error!(error = %err, "failed to build schema state for plugin-selected document");
+                        let error_response = web::HttpResponse::build(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        )
+                        .body("Failed to build schema state for the selected schema document");
+                        return Ok(req.into_response(error_response));
+                    }
+                }
+            }
 
             let mut response = ctx.call(&self.service, req).await?;
 

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -77,6 +77,9 @@ pub enum SupergraphManagerError {
 
     #[error("Error from plugin: {0}")]
     PluginError(String),
+
+    #[error("Failed to parse supergraph SDL: {0}")]
+    ParseSupergraphError(#[from] graphql_tools::parser::schema::ParseError),
 }
 
 impl SchemaState {
@@ -86,6 +89,52 @@ impl SchemaState {
 
     pub fn is_ready(&self) -> bool {
         self.current_supergraph().is_some()
+    }
+
+    /// Builds a standalone `SchemaState` from a supergraph SDL string, with its own fresh
+    /// caches, demand-control runtime and callback subscriptions map. There is no background
+    /// loader and no reload channel: the caller (a plugin) owns the lifecycle and is expected
+    /// to build a new `SchemaState` whenever the schema variant changes.
+    ///
+    /// This is expensive (full planner build): construct once per schema variant, never per
+    /// request.
+    pub fn from_supergraph_sdl(
+        sdl: &str,
+        router_config: Arc<HiveRouterConfig>,
+        telemetry_context: Arc<TelemetryContext>,
+    ) -> Result<Self, SupergraphManagerError> {
+        let document = safe_parse_schema(sdl)?;
+        Self::from_supergraph_document(document, router_config, telemetry_context)
+    }
+
+    /// Same as [`Self::from_supergraph_sdl`], but takes an already-parsed supergraph document.
+    pub fn from_supergraph_document(
+        document: Document,
+        router_config: Arc<HiveRouterConfig>,
+        telemetry_context: Arc<TelemetryContext>,
+    ) -> Result<Self, SupergraphManagerError> {
+        let callback_subscriptions: CallbackSubscriptionsMap = Arc::new(DashMap::new());
+        let demand_control_runtime = DemandControlRuntime::from_config(
+            router_config.demand_control.as_ref(),
+            telemetry_context.metrics.clone(),
+        );
+
+        let supergraph_data = Self::build_data(
+            router_config,
+            telemetry_context.clone(),
+            document,
+            callback_subscriptions.clone(),
+        )?;
+
+        Ok(Self {
+            current_swapable: Arc::new(ArcSwap::from(Arc::new(Some(supergraph_data)))),
+            plan_cache: Cache::new(1000),
+            validate_cache: Cache::new(1000),
+            normalize_cache: Cache::new(1000),
+            demand_control_runtime,
+            telemetry_context,
+            callback_subscriptions,
+        })
     }
 
     pub async fn new_from_config(

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -33,7 +33,8 @@ use hive_router_query_planner::{
     utils::parsing::safe_parse_schema,
 };
 use moka::future::Cache;
-use std::sync::Arc;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -77,9 +78,6 @@ pub enum SupergraphManagerError {
 
     #[error("Error from plugin: {0}")]
     PluginError(String),
-
-    #[error("Failed to parse supergraph SDL: {0}")]
-    ParseSupergraphError(#[from] graphql_tools::parser::schema::ParseError),
 }
 
 impl SchemaState {
@@ -89,22 +87,6 @@ impl SchemaState {
 
     pub fn is_ready(&self) -> bool {
         self.current_supergraph().is_some()
-    }
-
-    /// Builds a standalone `SchemaState` from a supergraph SDL string, with its own fresh
-    /// caches, demand-control runtime and callback subscriptions map. There is no background
-    /// loader and no reload channel: the caller (a plugin) owns the lifecycle and is expected
-    /// to build a new `SchemaState` whenever the schema variant changes.
-    ///
-    /// This is expensive (full planner build): construct once per schema variant, never per
-    /// request.
-    pub fn from_supergraph_sdl(
-        sdl: &str,
-        router_config: Arc<HiveRouterConfig>,
-        telemetry_context: Arc<TelemetryContext>,
-    ) -> Result<Self, SupergraphManagerError> {
-        let document = safe_parse_schema(sdl)?;
-        Self::from_supergraph_document(document, router_config, telemetry_context)
     }
 
     /// Same as [`Self::from_supergraph_sdl`], but takes an already-parsed supergraph document.
@@ -364,6 +346,57 @@ impl SchemaState {
     }
 }
 
+/// Router-owned cache mapping a plugin-provided `Arc<Document>` to the `Arc<SchemaState>` built
+/// from it. Keyed by allocation identity (`Arc::ptr_eq`), not document content, so plugins must
+/// reuse the same `Arc<Document>` per schema variant to get cache hits.
+///
+/// Strict FIFO eviction: the oldest inserted entry is evicted first once the cache is full,
+/// regardless of how often it was hit. Miss construction is serialized by the mutex; this is
+/// deliberately simple since schema variants and cache misses are expected to be rare.
+pub struct SchemaStateCache {
+    entries: Mutex<VecDeque<(Arc<Document>, Arc<SchemaState>)>>,
+}
+
+/// Maximum number of distinct schema-document variants kept resolved at once.
+const SCHEMA_STATE_CACHE_MAX_SIZE: usize = 10;
+
+impl Default for SchemaStateCache {
+    fn default() -> Self {
+        Self {
+            entries: Mutex::new(VecDeque::with_capacity(SCHEMA_STATE_CACHE_MAX_SIZE)),
+        }
+    }
+}
+
+impl SchemaStateCache {
+    /// Resolves `document` to its `Arc<SchemaState>`, building and caching it on a miss.
+    pub fn resolve(
+        &self,
+        document: Arc<Document>,
+        router_config: Arc<HiveRouterConfig>,
+        telemetry_context: Arc<TelemetryContext>,
+    ) -> Result<Arc<SchemaState>, SupergraphManagerError> {
+        let mut entries = self.entries.lock().unwrap();
+
+        if let Some((_, state)) = entries.iter().find(|(doc, _)| Arc::ptr_eq(doc, &document)) {
+            return Ok(state.clone());
+        }
+
+        let state = Arc::new(SchemaState::from_supergraph_document(
+            document.as_ref().clone(),
+            router_config,
+            telemetry_context,
+        )?);
+
+        if entries.len() >= SCHEMA_STATE_CACHE_MAX_SIZE {
+            entries.pop_front();
+        }
+        entries.push_back((document, state.clone()));
+
+        Ok(state)
+    }
+}
+
 pub struct SupergraphBackgroundLoader {
     loader: Box<dyn SupergraphLoader + Send + Sync>,
     sender: Arc<mpsc::Sender<String>>,
@@ -505,5 +538,164 @@ impl BackgroundTask for CallbackHeartbeatEnforcerTask {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod schema_state_cache_tests {
+    use super::*;
+
+    const TEST_SUPERGRAPH_SDL: &str =
+        include_str!("../../../plugin_examples/replace_schema/supergraph.graphql");
+
+    fn test_document() -> Arc<Document> {
+        // subgraph executor construction needs a process-wide rustls crypto provider; installing
+        // it repeatedly across tests is a harmless no-op (just logs a warning) but is very useful
+        // when running only this test in isolation, so we do it here instead of in a global test setup
+        crate::init_rustls_crypto_provider();
+        Arc::new(safe_parse_schema(TEST_SUPERGRAPH_SDL).expect("valid test supergraph SDL"))
+    }
+
+    fn test_config() -> Arc<HiveRouterConfig> {
+        Arc::new(HiveRouterConfig::default())
+    }
+
+    fn test_telemetry() -> Arc<TelemetryContext> {
+        Arc::new(TelemetryContext::from_propagation_config(
+            &Default::default(),
+        ))
+    }
+
+    #[test]
+    fn reusing_same_document_returns_same_state() {
+        let cache = SchemaStateCache::default();
+        let document = test_document();
+
+        let first = cache
+            .resolve(document.clone(), test_config(), test_telemetry())
+            .unwrap();
+        let second = cache
+            .resolve(document, test_config(), test_telemetry())
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(cache.entries.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn different_allocations_create_separate_entries() {
+        let cache = SchemaStateCache::default();
+
+        // Structurally identical documents, but distinct `Arc` allocations.
+        let a = test_document();
+        let b = test_document();
+        assert_eq!(a.as_ref(), b.as_ref());
+
+        let state_a = cache.resolve(a, test_config(), test_telemetry()).unwrap();
+        let state_b = cache.resolve(b, test_config(), test_telemetry()).unwrap();
+
+        assert!(!Arc::ptr_eq(&state_a, &state_b));
+        assert_eq!(cache.entries.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn eleventh_unique_document_evicts_the_first() {
+        let cache = SchemaStateCache::default();
+        let documents: Vec<Arc<Document>> = (0..11).map(|_| test_document()).collect();
+
+        for document in &documents[..10] {
+            cache
+                .resolve(document.clone(), test_config(), test_telemetry())
+                .unwrap();
+        }
+        assert_eq!(
+            cache.entries.lock().unwrap().len(),
+            SCHEMA_STATE_CACHE_MAX_SIZE
+        );
+
+        cache
+            .resolve(documents[10].clone(), test_config(), test_telemetry())
+            .unwrap();
+
+        let entries = cache.entries.lock().unwrap();
+        assert_eq!(entries.len(), SCHEMA_STATE_CACHE_MAX_SIZE);
+        assert!(!entries
+            .iter()
+            .any(|(doc, _)| Arc::ptr_eq(doc, &documents[0])));
+        assert!(entries
+            .iter()
+            .any(|(doc, _)| Arc::ptr_eq(doc, &documents[10])));
+    }
+
+    #[test]
+    fn cache_hits_do_not_refresh_fifo_order() {
+        let cache = SchemaStateCache::default();
+        let first = test_document();
+        let second = test_document();
+
+        cache
+            .resolve(first.clone(), test_config(), test_telemetry())
+            .unwrap();
+        cache
+            .resolve(second, test_config(), test_telemetry())
+            .unwrap();
+
+        // hitting the first (oldest) entry again must not move it to the back.
+        cache
+            .resolve(first.clone(), test_config(), test_telemetry())
+            .unwrap();
+
+        let entries = cache.entries.lock().unwrap();
+        assert!(Arc::ptr_eq(&entries.front().unwrap().0, &first));
+    }
+
+    #[test]
+    fn reusing_an_evicted_document_rebuilds_its_state() {
+        let cache = SchemaStateCache::default();
+        let evicted = test_document();
+
+        cache
+            .resolve(evicted.clone(), test_config(), test_telemetry())
+            .unwrap();
+        let first_state = cache.entries.lock().unwrap().front().unwrap().1.clone();
+
+        // fill the cache with 10 other unique documents so `evicted` falls off the front.
+        for _ in 0..10 {
+            cache
+                .resolve(test_document(), test_config(), test_telemetry())
+                .unwrap();
+        }
+        assert!(!cache
+            .entries
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(doc, _)| Arc::ptr_eq(doc, &evicted)));
+
+        let rebuilt_state = cache
+            .resolve(evicted, test_config(), test_telemetry())
+            .unwrap();
+        assert!(!Arc::ptr_eq(&first_state, &rebuilt_state));
+    }
+
+    #[test]
+    fn failed_build_does_not_evict_a_valid_cached_state() {
+        let cache = SchemaStateCache::default();
+        let valid = test_document();
+        cache
+            .resolve(valid.clone(), test_config(), test_telemetry())
+            .unwrap();
+
+        // a malformed subgraph endpoint URL fails executor construction gracefully (unlike a
+        // structurally-broken document, which would fail on the safe_parse_schema step
+        let invalid_sdl =
+            TEST_SUPERGRAPH_SDL.replace("http://0.0.0.0:4200/accounts", "not a valid url ::");
+        let invalid = Arc::new(safe_parse_schema(&invalid_sdl).expect("still parses as SDL"));
+        let result = cache.resolve(invalid, test_config(), test_telemetry());
+        assert!(result.is_err());
+
+        let entries = cache.entries.lock().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(Arc::ptr_eq(&entries.front().unwrap().0, &valid));
     }
 }

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -46,6 +46,7 @@ use crate::pipeline::persisted_documents::resolve::PersistedDocumentResolverErro
 use crate::pipeline::persisted_documents::PersistedDocumentsRuntime;
 use crate::pipeline::progressive_override::{OverrideLabelsCompileError, OverrideLabelsEvaluator};
 use crate::pipeline::sse;
+use crate::schema_state::SchemaStateCache;
 use crate::storage::StorageManager;
 
 pub type JwtClaimsCache = Cache<String, Arc<JwtTokenPayload>>;
@@ -329,6 +330,9 @@ pub struct RouterSharedState {
     pub active_subscriptions: ActiveSubscriptions,
     /// The storage manager for the router.
     pub storage_manager: Arc<StorageManager>,
+    /// Resolves a plugin-selected `Arc<Document>` (via `set_schema_document`) to its
+    /// `Arc<SchemaState>`, building and caching it on a miss.
+    pub schema_state_cache: SchemaStateCache,
 }
 
 impl RouterSharedState {
@@ -394,6 +398,7 @@ impl RouterSharedState {
             long_lived_client_count: Arc::new(AtomicUsize::new(0)),
             active_subscriptions,
             storage_manager,
+            schema_state_cache: SchemaStateCache::default(),
         })
     }
 }

--- a/lib/executor/src/plugins/hooks/on_graphql_validation.rs
+++ b/lib/executor/src/plugins/hooks/on_graphql_validation.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use graphql_tools::{
-    static_graphql::{query::Document as QueryDocument, schema::Document as SchemaDocument},
+    static_graphql::query::Document as QueryDocument,
     validation::{rules::ValidationRule, utils::ValidationError, validate::ValidationPlan},
 };
 use hive_router_query_planner::consumer_schema::ConsumerSchema;
@@ -32,12 +32,8 @@ pub struct OnGraphQLValidationStartHookPayload<'exec> {
     /// [Learn more about the context data sharing in the docs](https://the-guild.dev/graphql/hive/docs/router/extensibility/plugin_system#context-data-sharing)
     pub context: &'exec PluginContext,
     pub request_context: RequestContextApi,
-    /// The GraphQL Schema that the document will be validated against.
-    /// This is not the same with the supergraph. This is the public schema exposed by the router to the clients, which is generated from the supergraph and can be modified by the plugins.
-    /// The plugins can replace the input schema to be used for validation
-    /// and the new schema will be used in the validation process instead of the original one.
-    ///
-    /// [See an example to see when to override the schema](https://github.com/graphql-hive/router/blob/main/plugin_examples/feature_flags/src/plugin.rs)
+    /// The GraphQL schema that the document will be validated against.
+    /// This is the public schema exposed by the router, not the supergraph.
     pub schema: Arc<ConsumerSchema>,
     /// Parsed GraphQL document from the query string in the GraphQL parameters.
     /// It contains the Abstract Syntax Tree (AST) representation of the GraphQL query, mutation, or subscription
@@ -68,14 +64,6 @@ impl OnGraphQLValidationStartHookPayload<'_> {
         validation_plan: TValidationPlan,
     ) -> Self {
         self.validation_plan = Arc::new(validation_plan.into());
-        self
-    }
-    /// Override the GraphQL Schema that the document will be validated against.
-    /// [See an example to see when to override the schema](https://github.com/graphql-hive/router/blob/main/plugin_examples/feature_flags/src/plugin.rs)
-    pub fn with_schema<TSchema: Into<Arc<SchemaDocument>>>(mut self, schema: TSchema) -> Self {
-        let schema: Arc<SchemaDocument> = schema.into();
-        let new_consumer_schema = ConsumerSchema::from(schema);
-        self.schema = new_consumer_schema.into();
         self
     }
 }

--- a/lib/executor/src/plugins/hooks/on_http_request.rs
+++ b/lib/executor/src/plugins/hooks/on_http_request.rs
@@ -2,6 +2,7 @@ use ntex::{
     http::Response,
     web::{self, DefaultError, WebRequest},
 };
+use std::sync::Arc;
 
 use crate::{
     plugin_context::PluginContext,
@@ -69,6 +70,21 @@ pub struct OnHttpRequestHookPayload<'req> {
     /// ```
     pub context: &'req PluginContext,
     pub request_context: RequestContextApi,
+}
+
+impl<'req> OnHttpRequestHookPayload<'req> {
+    /// Overrides the schema used for this request. Set this to swap the entire GraphQL schema
+    /// (and everything derived from it: validation, introspection, planning, execution) for a
+    /// different one, on a per-request basis, e.g. to serve a different set of fields depending
+    /// on the caller.
+    ///
+    /// Example:
+    /// ```ignore
+    /// payload.set_schema_state(my_schema_state.clone());
+    /// ```
+    pub fn set_schema_state<T: Send + Sync + 'static>(&self, state: Arc<T>) {
+        self.router_http_request.extensions_mut().insert(state);
+    }
 }
 
 impl<'req> StartHookPayload<OnHttpResponseHookPayload<'req>, Response>

--- a/lib/executor/src/plugins/hooks/on_http_request.rs
+++ b/lib/executor/src/plugins/hooks/on_http_request.rs
@@ -78,7 +78,13 @@ impl<'req> OnHttpRequestHookPayload<'req> {
     /// different one, on a per-request basis, e.g. to serve a different set of fields depending
     /// on the caller.
     ///
-    /// Example:
+    /// ### Important
+    ///
+    /// The generic type `T` must be exactly `hive_router::SchemaState`. If any other type is passed,
+    /// the router will will silently fall back to the default schema state.
+    ///
+    /// ### Example
+    ///
     /// ```ignore
     /// payload.set_schema_state(my_schema_state.clone());
     /// ```

--- a/lib/executor/src/plugins/hooks/on_http_request.rs
+++ b/lib/executor/src/plugins/hooks/on_http_request.rs
@@ -81,7 +81,7 @@ impl<'req> OnHttpRequestHookPayload<'req> {
     /// ### Important
     ///
     /// The generic type `T` must be exactly `hive_router::SchemaState`. If any other type is passed,
-    /// the router will will silently fall back to the default schema state.
+    /// the router will silently fall back to the default schema state.
     ///
     /// ### Example
     ///

--- a/lib/executor/src/plugins/hooks/on_http_request.rs
+++ b/lib/executor/src/plugins/hooks/on_http_request.rs
@@ -1,3 +1,4 @@
+use graphql_tools::static_graphql::schema::Document;
 use ntex::{
     http::Response,
     web::{self, DefaultError, WebRequest},
@@ -78,18 +79,25 @@ impl<'req> OnHttpRequestHookPayload<'req> {
     /// different one, on a per-request basis, e.g. to serve a different set of fields depending
     /// on the caller.
     ///
+    /// The router resolves the document into an internally-owned schema state (building it on
+    /// the first request for that document, then reusing it) and stores that resolved state in
+    /// the request extensions after all `on_http_request` hooks have run.
+    ///
     /// ### Important
     ///
-    /// The generic type `T` must be exactly `hive_router::SchemaState`. If any other type is passed,
-    /// the router will silently fall back to the default schema state.
+    /// Plugins must retain and reuse the *same* `Arc<Document>` for each schema variant (e.g.
+    /// build it once in `on_plugin_init` and keep it in the plugin's state). The router matches
+    /// documents by allocation identity, so parsing or otherwise allocating a new `Document` per
+    /// request defeats the router's schema-state cache and causes an expensive `SchemaState`
+    /// rebuild on every request.
     ///
     /// ### Example
     ///
     /// ```ignore
-    /// payload.set_schema_state(my_schema_state.clone());
+    /// payload.set_schema_document(document.clone());
     /// ```
-    pub fn set_schema_state<T: Send + Sync + 'static>(&self, state: Arc<T>) {
-        self.router_http_request.extensions_mut().insert(state);
+    pub fn set_schema_document(&self, document: Arc<Document>) {
+        self.router_http_request.extensions_mut().insert(document);
     }
 }
 

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -108,6 +108,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,7 +220,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
- "term",
+ "term 1.2.1",
 ]
 
 [[package]]
@@ -366,7 +416,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.28.0",
  "syn 2.0.117",
  "thiserror 2.0.18",
 ]
@@ -674,9 +724,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -738,9 +788,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -958,6 +1008,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmac"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,8 +1090,14 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -1372,7 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1457,7 +1562,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.12",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1473,6 +1578,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1557,12 +1693,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -1590,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "dns-lookup"
-version = "2.1.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5597a4b7fe5275fc9dcf88ce26326bc8e4cb87d0130f33752d4c5f717793cf"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1608,31 +1765,30 @@ checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "domain"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7ff15f82df7d5086fb15dfc1c1e96598a6ded9829840a9bcfa1fa3ccd8d01d"
+checksum = "8c469892dddfeff64ecfdbc64cf059c77fb0decaeccd4d5d484394bdd6312bac"
 dependencies = [
  "bumpalo",
  "bytes",
  "domain-macros",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
+ "jiff",
  "log",
- "moka",
  "octseq",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "smallvec",
- "time",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "domain-macros"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1a6796ad411f6812d691955066ad27450196bfb181bb91b66a643cc3e8f5b7"
+checksum = "6fef7ef74e413e36d5364db163ca577ccb56f2f74377705d5f920ee3e1544127"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1862,6 +2018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "error-mapping-plugin-example"
 version = "0.0.1"
 dependencies = [
@@ -1907,6 +2069,12 @@ dependencies = [
  "rand 0.10.1",
  "tokio",
 ]
+
+[[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fancy-regex"
@@ -1974,7 +2142,7 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "papaya",
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2132,7 +2300,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2263,7 +2431,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graphql-tools"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "combine",
  "itoa",
@@ -2368,6 +2536,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashlink"
@@ -2449,8 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "hive-console-sdk"
-version = "0.3.14"
+version = "0.3.17"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-dropper-simple",
  "async-trait",
@@ -2463,13 +2635,14 @@ dependencies = [
  "lazy_static",
  "md5",
  "moka",
+ "rand 0.10.1",
  "recloser",
  "regex-automata",
  "regress",
  "reqwest",
  "reqwest-middleware",
- "reqwest-retry 0.8.0",
- "retry-policies 0.5.2",
+ "reqwest-retry",
+ "retry-policies",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2480,11 +2653,12 @@ dependencies = [
  "tracing",
  "typify",
  "vrl",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "hive-router"
-version = "0.0.63"
+version = "0.0.81"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2522,10 +2696,21 @@ dependencies = [
  "moka",
  "notify",
  "ntex",
+ "ntex-bytes",
  "ntex-codec",
+ "ntex-dispatcher",
+ "ntex-error",
+ "ntex-h2",
  "ntex-http",
  "ntex-io",
+ "ntex-macros",
  "ntex-net",
+ "ntex-router",
+ "ntex-rt",
+ "ntex-server",
+ "ntex-service",
+ "ntex-tls",
+ "ntex-util",
  "object_store",
  "percent-encoding",
  "prometheus",
@@ -2533,13 +2718,13 @@ dependencies = [
  "regex-automata",
  "reqwest",
  "reqwest-middleware",
- "reqwest-retry 0.8.0",
- "retry-policies 0.5.2",
+ "reqwest-retry",
+ "retry-policies",
  "rustls",
  "serde",
  "serde_json",
  "sonic-rs",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -2553,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-config"
-version = "0.0.37"
+version = "0.1.7"
 dependencies = [
  "config",
  "envconfig",
@@ -2566,7 +2751,7 @@ dependencies = [
  "jsonwebtoken",
  "once_cell",
  "regex-automata",
- "retry-policies 0.5.2",
+ "retry-policies",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -2578,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-internal"
-version = "0.0.25"
+version = "0.0.35"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2605,7 +2790,7 @@ dependencies = [
  "prometheus",
  "serde",
  "sonic-rs",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2619,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-plan-executor"
-version = "6.13.8"
+version = "6.21.1"
 dependencies = [
  "ahash",
  "async-stream",
@@ -2654,7 +2839,7 @@ dependencies = [
  "serde_json",
  "sonic-rs",
  "sonic-simd",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2665,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "hive-router-query-planner"
-version = "2.8.3"
+version = "2.10.9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "graphql-tools",
  "lazy-init",
  "petgraph 0.8.3",
@@ -2720,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2809,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3120,7 +3305,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -3158,18 +3343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "ipcrypt-rs"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +3358,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3388,80 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3321,7 +3585,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -3341,7 +3605,7 @@ dependencies = [
  "regex-syntax",
  "sha3",
  "string_cache",
- "term",
+ "term 1.2.1",
  "unicode-xid",
  "walkdir",
 ]
@@ -3392,7 +3656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da89dc9c0c2206f277b91858ce08ca66bf23d26023ffcbfe7d8e5fc434fe440e"
 dependencies = [
  "aws-lc-rs",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "chrono",
  "crossbeam-channel",
@@ -3406,7 +3670,7 @@ dependencies = [
  "log",
  "lru",
  "moka",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rand 0.9.4",
  "serde",
  "serde_json",
@@ -3480,6 +3744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -3588,9 +3861,9 @@ checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc"
@@ -3683,7 +3956,7 @@ dependencies = [
  "equivalent",
  "event-listener",
  "futures-util",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "smallvec",
  "tagptr",
@@ -3746,6 +4019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3d189da485332e96ba8a5ef646a311871abd7915bf06ac848a9117f19cf6e4"
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,11 +4032,23 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3815,7 +4106,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3833,17 +4124,17 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "ntex"
-version = "3.7.2"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4735978b410d8496a1d89bac416af3277f6d36e9ae56d1e3977b96b81ab8048"
+checksum = "4f0baaa4f3df86d4f7e84b9cf7153743496360c79c689152ca9a2f1172ca5c2f"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "derive_more",
  "encoding_rs",
  "env_logger",
@@ -3883,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-bytes"
-version = "1.6.8"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5ca9b5f31f38fcb91ad6a53c2bf9f70a5883b98fa1bf3ed47fcc2b2b1910aa"
+checksum = "c79595696d276a1be070159fb057e44c7b8b7c921f6690ddd3323cda71c70e92"
 dependencies = [
  "bytes",
  "serde",
@@ -3893,20 +4184,20 @@ dependencies = [
 
 [[package]]
 name = "ntex-codec"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f071b0c1daa379de93b4bbaf8ed822f12539901bdb15a5901cd15168f5e8eca"
+checksum = "80fb7929b59c6161a43f66e1c9ef94f87475b301bd6587a6647f9ba928df31db"
 dependencies = [
  "ntex-bytes",
 ]
 
 [[package]]
 name = "ntex-dispatcher"
-version = "3.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc658d0b4caced7d7cfeefaeddd50f6c80265dc98e944beae3ac6601337b267"
+checksum = "76e8f0df705437667567cf9a0328add598c950769b0cfec5cea0cd73c607ab55"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "ntex-codec",
  "ntex-io",
@@ -3917,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-error"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614a4c1c3cd23c231172fe20ab42bb66e8572e8c4cf282285723fc423b64834e"
+checksum = "8d47e8dee801da88cca194481cb2f04a5de7cb949e3e9785086fb1b6a010884d"
 dependencies = [
  "backtrace",
  "foldhash 0.2.0",
@@ -3929,11 +4220,11 @@ dependencies = [
 
 [[package]]
 name = "ntex-h2"
-version = "3.9.2"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e400e7ea01ad28eb530e1a34840f700718cb0e7191cfb9160554b04f464f88b"
+checksum = "462aedfed773643f8dce7b6173edcfeedc24f9dbf55a8f2c2fce3906163924f0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "foldhash 0.2.0",
  "log",
  "nanorand",
@@ -3953,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a02a55ca3286342030ba369d4176e280989e97958455963efce846e8abdca6"
+checksum = "034998dc254ad3283a6eee76fe89706c85e16b1e9a877e794951e75568dbc15c"
 dependencies = [
  "foldhash 0.2.0",
  "futures-core",
@@ -3969,17 +4260,20 @@ dependencies = [
 
 [[package]]
 name = "ntex-io"
-version = "3.9.2"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c1d3d9a67a9abcad8981967bb1f3c59ec2c34e442771d16ed33acf663f0361"
+checksum = "c28852591956578e02f2905bb9ff73b677ea53abf5b726dea57ac4a84191758b"
 dependencies = [
- "bitflags 2.11.1",
+ "backtrace",
+ "bitflags 2.13.0",
  "log",
  "ntex-bytes",
  "ntex-codec",
+ "ntex-rt",
  "ntex-service",
  "ntex-util",
  "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -3988,7 +4282,7 @@ version = "0.7.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e60f4a52aae6b07b8a4c560f05802be74c10c2924838f1007f48684233aaaa"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
  "sc",
@@ -3996,9 +4290,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-macros"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51138717dfe591b9b4063bf167ddcdc6fa8e3552157316f29f12c321493e3710"
+checksum = "6c3d0edf86b3b7168391cae05c637be4923b23968f7f65ead861d38cdfa3db1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4007,11 +4301,11 @@ dependencies = [
 
 [[package]]
 name = "ntex-net"
-version = "3.9.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c7c631404d704766913028124c60712457b1157923d85156aaf49fbd2551e9"
+checksum = "312bd7f8090f1dee5b3f0d9eaa3a29e1642341943ee63bef3299051b27dd1e55"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
  "log",
@@ -4060,36 +4354,41 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.14.1"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e4391bcd803ae4ed6a844127d55329d0e33cb4b18994346ab2b7c02222f3e7"
+checksum = "225e619aa588c9ef95940a7fb99e45077ed261646dfc5a1754ca1712126175c9"
 dependencies = [
  "async-channel",
  "async-task",
+ "atomic-waker",
+ "backtrace",
  "crossbeam-channel",
  "crossbeam-queue",
+ "ctrlc",
  "foldhash 0.2.0",
  "futures-timer",
+ "libc",
  "log",
  "ntex-error",
  "ntex-service",
- "oneshot 0.2.1",
- "parking_lot 0.12.5",
+ "oneshot",
+ "parking_lot",
  "scoped-tls",
+ "signal-hook",
  "swap-buffer-queue",
  "tokio",
 ]
 
 [[package]]
 name = "ntex-server"
-version = "3.9.0"
+version = "3.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ac36e4b11c0cf0ae53fea574a1ab37e0c54331eb78f0b5a5e02cf6604a1f04"
+checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
 dependencies = [
  "async-channel",
  "atomic-waker",
  "core_affinity",
- "ctrlc",
+ "libc",
  "log",
  "ntex-io",
  "ntex-net",
@@ -4097,8 +4396,7 @@ dependencies = [
  "ntex-rt",
  "ntex-service",
  "ntex-util",
- "oneshot 0.1.13",
- "signal-hook",
+ "oneshot",
  "socket2",
  "uuid",
 ]
@@ -4116,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-tls"
-version = "3.4.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e987231c62973660d743d599ddc26e82ed4f2f54050ce3e0f6d4bf8d3586106"
+checksum = "8fa8909d6cef273298d192c51345e1124200f6a655336848659464e7950de4cf"
 dependencies = [
  "log",
  "ntex-bytes",
@@ -4136,7 +4434,7 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b3da35d27b9a8c988f2c099d0cb2cf4d58b65007a2b98f74d32f0edd82725e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "foldhash 0.2.0",
  "futures-core",
  "futures-timer",
@@ -4293,6 +4591,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,7 +4629,7 @@ dependencies = [
  "hyper",
  "itertools",
  "md-5 0.10.6",
- "parking_lot 0.12.5",
+ "parking_lot",
  "percent-encoding",
  "quick-xml 0.39.4",
  "rand 0.10.1",
@@ -4341,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "octseq"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126c3ca37c9c44cec575247f43a3e4374d8927684f129d2beeb0d2cef262fe12"
+checksum = "182eab3e1cd9cdc0ecf1ce3342d9844f3dc7d098f0694569bfdf327b612d69fd"
 dependencies = [
  "bytes",
  "serde",
@@ -4375,6 +4683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "one-of-plugin-example"
 version = "0.0.1"
 dependencies = [
@@ -4382,12 +4696,6 @@ dependencies = [
  "hive-router",
  "serde",
 ]
-
-[[package]]
-name = "oneshot"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "oneshot"
@@ -4401,7 +4709,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -4645,37 +4953,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4686,7 +4969,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4932,6 +5215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4969,6 +5261,19 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term 0.7.0",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -5018,7 +5323,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.5",
+ "parking_lot",
  "protobuf",
  "thiserror 2.0.18",
 ]
@@ -5038,7 +5343,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -5287,7 +5592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.5",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -5430,20 +5735,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5476,7 +5783,7 @@ dependencies = [
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
- "parking_lot 0.12.5",
+ "parking_lot",
  "percent-encoding",
  "serde_json",
 ]
@@ -5533,10 +5840,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "relative-path"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "rend"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+
+[[package]]
+name = "replace-schema-plugin-example"
+version = "0.0.1"
+dependencies = [
+ "e2e",
+ "hive-router",
+ "http",
+]
 
 [[package]]
 name = "reqwest"
@@ -5600,27 +5925,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.17",
- "http",
- "hyper",
- "parking_lot 0.11.2",
- "reqwest",
- "reqwest-middleware",
- "retry-policies 0.4.0",
- "thiserror 1.0.69",
- "tokio",
- "wasm-timer",
-]
-
-[[package]]
-name = "reqwest-retry"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "105747e3a037fe5bf17458d794de91149e575b6183fc72c85623a44abb9683f5"
@@ -5633,7 +5937,7 @@ dependencies = [
  "hyper",
  "reqwest",
  "reqwest-middleware",
- "retry-policies 0.5.2",
+ "retry-policies",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5649,15 +5953,6 @@ dependencies = [
  "r2d2",
  "redis",
  "serde",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
-dependencies = [
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -5728,7 +6023,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -5830,7 +6125,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5914,6 +6209,25 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "clipboard-win",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.30.1",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+ "utf8parse",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "ryu"
@@ -6042,7 +6356,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -6145,7 +6459,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -6158,7 +6472,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6307,9 +6621,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -6327,9 +6641,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6342,6 +6656,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -6438,9 +6765,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -6471,6 +6798,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -6663,7 +7000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot 0.12.5",
+ "parking_lot",
  "phf_shared 0.11.3",
  "precomputed-hash",
 ]
@@ -6685,11 +7022,30 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6820,6 +7176,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -6975,7 +7342,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7162,7 +7529,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -7371,9 +7738,9 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typify"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+checksum = "8cdc2e612ea322c6e232d46a0b34607c8eb28978fd6060ecfb139f2a50db8d5f"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -7381,9 +7748,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+checksum = "691591f49550c0d371bc441d019c30ce241d4116aee7d68df7a9840d6c70bf8f"
 dependencies = [
  "heck 0.5.0",
  "log",
@@ -7401,9 +7768,9 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+checksum = "d41aea893c49cf95661389207b8af0c6254ff48b2c3ae1e4f3704777dbdfcf03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7472,6 +7839,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -7556,10 +7929,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.23.1"
+name = "utf8parse"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7602,9 +7981,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrl"
-version = "0.30.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d513609a4e7b19a3715b01978152b7132a6e512bde68736ab5f47d42b22ddc8"
+checksum = "772206835b5bca8719825d2ab9e6fb160cbfce8ac1dc0e5dffe22cbe77254468"
 dependencies = [
  "aes",
  "aes-siv",
@@ -7621,6 +8000,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "cidr",
+ "clap",
  "codespan-reporting",
  "community-id",
  "convert_case 0.7.1",
@@ -7633,8 +8013,10 @@ dependencies = [
  "domain",
  "dyn-clone",
  "encoding_rs",
+ "exitcode",
  "fancy-regex",
  "flate2",
+ "getrandom 0.3.4",
  "grok",
  "hex",
  "hmac 0.12.1",
@@ -7661,23 +8043,27 @@ dependencies = [
  "percent-encoding",
  "pest",
  "pest_derive",
+ "prettytable-rs",
  "prost 0.13.5",
  "prost-reflect",
  "psl",
  "psl-types",
  "publicsuffix",
  "quoted_printable",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
+ "relative-path",
  "reqwest",
  "reqwest-middleware",
- "reqwest-retry 0.7.0",
+ "reqwest-retry",
  "roxmltree",
  "rust_decimal",
+ "rustyline",
  "seahash",
  "serde",
  "serde_json",
  "serde_yaml",
+ "serde_yaml_ng",
  "sha-1",
  "sha2 0.10.9",
  "sha3",
@@ -7685,6 +8071,8 @@ dependencies = [
  "snafu 0.8.9",
  "snap",
  "strip-ansi-escapes",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "syslog_loose",
  "termcolor",
  "thiserror 2.0.18",
@@ -7695,6 +8083,7 @@ dependencies = [
  "url",
  "utf8-width",
  "uuid",
+ "webbrowser",
  "woothee",
  "xxhash-rust",
  "zstd",
@@ -7849,27 +8238,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -7883,7 +8257,7 @@ checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-utils",
  "slab",
  "wasm-bindgen",
@@ -7907,6 +8281,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
 ]
 
 [[package]]
@@ -8237,7 +8627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/plugin_examples/Cargo.toml
+++ b/plugin_examples/Cargo.toml
@@ -18,7 +18,8 @@ members = [
   "progressive_override_launchdarkly",
   "non_standard_request",
   "incoming_request_deduplication",
-  "error_mapping"
+  "error_mapping",
+  "replace_schema"
 ]
 
 [workspace.dependencies]

--- a/plugin_examples/feature_flags/src/plugin.rs
+++ b/plugin_examples/feature_flags/src/plugin.rs
@@ -1,46 +1,70 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use hive_router::{
     async_trait,
     graphql_tools::{
         ast::TypeDefinitionFields,
         parser::schema::Definition,
-        static_graphql::{query::Value, schema::TypeDefinition},
+        static_graphql::{
+            query::Value,
+            schema::{Document, EnumType, InputObjectType, ObjectType, TypeDefinition},
+        },
     },
     plugins::{
         hooks::{
-            on_graphql_validation::{
-                OnGraphQLValidationStartHookPayload, OnGraphQLValidationStartHookResult,
-            },
+            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+            on_supergraph_load::{
+                OnSupergraphLoadStartHookPayload, OnSupergraphLoadStartHookResult,
+            },
         },
         plugin_trait::{RouterPlugin, StartHookPayload},
     },
-    query_planner::state::supergraph_state::SchemaDocument,
-    DashMap,
 };
 
 #[derive(Default)]
+struct FeatureFlagSchemas {
+    supergraph: Option<Arc<Document>>,
+    variants: HashMap<String, Arc<Document>>,
+}
+
+#[derive(Default)]
 pub struct FeatureFlagsPlugin {
-    schema_with_flags_cache: DashMap<String, Arc<SchemaDocument>>,
+    schemas: Mutex<FeatureFlagSchemas>,
 }
 
 #[async_trait]
 impl RouterPlugin for FeatureFlagsPlugin {
     type Config = ();
+
     fn plugin_name() -> &'static str {
         "feature_flags"
     }
+
     fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
         payload.initialize_plugin_with_defaults()
     }
-    async fn on_graphql_validation<'exec>(
+
+    fn on_supergraph_reload<'exec>(
         &'exec self,
-        payload: OnGraphQLValidationStartHookPayload<'exec>,
-    ) -> OnGraphQLValidationStartHookResult<'exec> {
+        payload: OnSupergraphLoadStartHookPayload,
+    ) -> OnSupergraphLoadStartHookResult<'exec> {
+        let mut schemas = self.schemas.lock().unwrap();
+        schemas.supergraph = Some(Arc::new(payload.new_ast.clone()));
+        schemas.variants.clear();
+        payload.proceed()
+    }
+
+    fn on_http_request<'req>(
+        &'req self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
         let feature_flags_header = payload
             .router_http_request
-            .headers
+            .headers()
             .get("x-feature-flags")
             .and_then(|header_value| header_value.to_str().ok())
             .unwrap_or_default();
@@ -49,149 +73,128 @@ impl RouterPlugin for FeatureFlagsPlugin {
             .map(|tag| tag.trim().to_string())
             .collect();
 
-        // Let's sort the feature flags to ensure that the cache key is consistent regardless of the order of flags in the header
+        // sort the feature flags so header order does not change the cache key
         feature_flags.sort();
 
         let cache_key = feature_flags.join(",");
-
-        let cached_schema = self
-            .schema_with_flags_cache
+        let mut schemas = self.schemas.lock().unwrap();
+        let Some(supergraph) = schemas.supergraph.clone() else {
+            return payload.proceed();
+        };
+        let document = schemas
+            .variants
             .entry(cache_key)
-            .or_insert_with(|| {
-                let mut removed_definitions = vec![];
-                let mut removed_field_definitions = HashMap::new();
-
-                for definition in &payload.schema.document.definitions {
-                    if let Some(directives) = definition.directives() {
-                        if !should_keep_node(&feature_flags, directives) {
-                            removed_definitions.push(definition);
-                            continue;
-                        }
-                    }
-                        match definition.fields() {
-                            Some(TypeDefinitionFields::Fields(fields)) => {
-                                for field_def in fields {
-                                    if !should_keep_node(&feature_flags, &field_def.directives) {
-                                        if let Some(def_name) = definition.name() {
-                                            removed_field_definitions
-                                                .entry(def_name)
-                                                .or_insert_with(Vec::new)
-                                                .push(field_def.name.as_str())
-                                        }
-                                    }
-                                }
-                            }
-                            Some(TypeDefinitionFields::InputValues(input_values)) => {
-                                for input_value_def in input_values {
-                                    if !should_keep_node(
-                                        &feature_flags,
-                                        &input_value_def.directives,
-                                    ) {
-                                        if let Some(def_name) = definition.name() {
-                                            removed_field_definitions
-                                                .entry(def_name)
-                                                .or_insert_with(Vec::new)
-                                                .push(input_value_def.name.as_str());
-                                        }
-                                    }
-                                }
-                            }
-                            Some(TypeDefinitionFields::EnumValues(enum_values)) => {
-                                for enum_value_def in enum_values {
-                                    if !should_keep_node(&feature_flags, &enum_value_def.directives)
-                                    {
-                                        if let Some(def_name) = definition.name() {
-                                            removed_field_definitions
-                                                .entry(def_name)
-                                                .or_insert_with(Vec::new)
-                                                .push(enum_value_def.name.as_str());
-                                        }
-                                    }
-                                }
-                            }
-                            None => {}
-                        }
-                }
-
-                if removed_definitions.is_empty() && removed_field_definitions.is_empty() {
-                    Arc::clone(&payload.schema.document)
-                } else {
-                    let new_definitions = payload
-                        .schema
-                        .document
-                        .definitions
-                        .iter()
-                        .filter(|def| !removed_definitions.contains(def))
-                        .map(|def| {
-                            let Some(def_name) = def.name() else {
-                                return def.clone();
-                            };
-                            let Some(removed_fields_for_def) = removed_field_definitions.get(def_name) else {
-                                return def.clone();
-                            };
-                            match def {
-                                Definition::TypeDefinition(type_def) => match type_def {
-                                    TypeDefinition::Object(obj) => {
-                                        let new_fields = obj
-                                            .fields
-                                            .iter()
-                                            .filter(|field| {
-                                                !removed_fields_for_def.contains(&field.name.as_str())
-                                            })
-                                            .cloned()
-                                            .collect();
-                                        let new_obj = hive_router::graphql_tools::static_graphql::schema::ObjectType {
-                                            fields: new_fields,
-                                            ..obj.clone()
-                                        };
-                                        Definition::TypeDefinition(TypeDefinition::Object(new_obj))
-                                    }
-                                    TypeDefinition::InputObject(input_obj) => {
-                                        let new_input_values = input_obj
-                                            .fields
-                                            .iter()
-                                            .filter(|input_value| {
-                                                !removed_fields_for_def.contains(&input_value.name.as_str())
-                                            })
-                                            .cloned()
-                                            .collect();
-                                        let new_input_obj = hive_router::graphql_tools::static_graphql::schema::InputObjectType {
-                                            fields: new_input_values,
-                                            ..input_obj.clone()
-                                        };
-                                        Definition::TypeDefinition(TypeDefinition::InputObject(new_input_obj))
-                                    }
-                                    TypeDefinition::Enum(enum_def) => {
-                                        let new_enum_values = enum_def
-                                            .values
-                                            .iter()
-                                            .filter(|enum_value| {
-                                                !removed_fields_for_def.contains(&enum_value.name.as_str())
-                                            })
-                                            .cloned()
-                                            .collect();
-                                        let new_enum_def = hive_router::graphql_tools::static_graphql::schema::EnumType {
-                                            values: new_enum_values,
-                                            ..enum_def.clone()
-                                        };
-                                        Definition::TypeDefinition(TypeDefinition::Enum(new_enum_def))
-                                    }
-                                    _ => def.clone(),
-                                }
-                                _ => def.clone(),
-                            }
-                        })
-                        .collect();
-                    Arc::new(SchemaDocument {
-                        definitions: new_definitions,
-                    })
-                }
-            })
-            .value()
+            .or_insert_with(|| schema_for_features(&supergraph, &feature_flags))
             .clone();
+        drop(schemas);
 
-        payload.with_schema(cached_schema).proceed()
+        payload.set_schema_document(document);
+        payload.proceed()
     }
+}
+
+fn schema_for_features(document: &Arc<Document>, feature_flags: &[String]) -> Arc<Document> {
+    let mut removed_definitions = vec![];
+    let mut removed_field_definitions: HashMap<String, Vec<String>> = HashMap::new();
+
+    for definition in &document.definitions {
+        if let Some(directives) = definition.directives() {
+            if !should_keep_node(feature_flags, directives) {
+                if let Some(name) = definition.name() {
+                    removed_definitions.push(name.to_string());
+                }
+                continue;
+            }
+        }
+
+        let fields = match definition.fields() {
+            Some(TypeDefinitionFields::Fields(fields)) => fields
+                .iter()
+                .map(|field| (&field.name, &field.directives))
+                .collect::<Vec<_>>(),
+            Some(TypeDefinitionFields::InputValues(fields)) => fields
+                .iter()
+                .map(|field| (&field.name, &field.directives))
+                .collect(),
+            Some(TypeDefinitionFields::EnumValues(fields)) => fields
+                .iter()
+                .map(|field| (&field.name, &field.directives))
+                .collect(),
+            None => continue,
+        };
+
+        for (field_name, directives) in fields {
+            if !should_keep_node(feature_flags, directives) {
+                if let Some(definition_name) = definition.name() {
+                    removed_field_definitions
+                        .entry(definition_name.to_string())
+                        .or_default()
+                        .push(field_name.clone());
+                }
+            }
+        }
+    }
+
+    if removed_definitions.is_empty() && removed_field_definitions.is_empty() {
+        return document.clone();
+    }
+
+    let definitions = document
+        .definitions
+        .iter()
+        .filter(|definition| {
+            definition.name().map_or(true, |name| {
+                !removed_definitions.iter().any(|removed| removed == name)
+            })
+        })
+        .map(|definition| {
+            let Some(name) = definition.name() else {
+                return definition.clone();
+            };
+            let Some(removed_fields) = removed_field_definitions.get(name) else {
+                return definition.clone();
+            };
+
+            match definition {
+                Definition::TypeDefinition(TypeDefinition::Object(object)) => {
+                    Definition::TypeDefinition(TypeDefinition::Object(ObjectType {
+                        fields: object
+                            .fields
+                            .iter()
+                            .filter(|field| !removed_fields.contains(&field.name))
+                            .cloned()
+                            .collect(),
+                        ..object.clone()
+                    }))
+                }
+                Definition::TypeDefinition(TypeDefinition::InputObject(input_object)) => {
+                    Definition::TypeDefinition(TypeDefinition::InputObject(InputObjectType {
+                        fields: input_object
+                            .fields
+                            .iter()
+                            .filter(|field| !removed_fields.contains(&field.name))
+                            .cloned()
+                            .collect(),
+                        ..input_object.clone()
+                    }))
+                }
+                Definition::TypeDefinition(TypeDefinition::Enum(enum_definition)) => {
+                    Definition::TypeDefinition(TypeDefinition::Enum(EnumType {
+                        values: enum_definition
+                            .values
+                            .iter()
+                            .filter(|value| !removed_fields.contains(&value.name))
+                            .cloned()
+                            .collect(),
+                        ..enum_definition.clone()
+                    }))
+                }
+                _ => definition.clone(),
+            }
+        })
+        .collect();
+
+    Arc::new(Document { definitions })
 }
 
 fn should_keep_node(

--- a/plugin_examples/replace_schema/Cargo.toml
+++ b/plugin_examples/replace_schema/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "replace-schema-plugin-example"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+authors = ["The Guild"]
+repository = "https://github.com/graphql-hive/router"
+homepage = "https://github.com/graphql-hive/router"
+publish = false
+
+[lib]
+
+[[bin]]
+name = "hive_router_with_replace_schema"
+path = "src/main.rs"
+
+[dependencies]
+hive-router = { version = "*", path = "../../bin/router" }
+
+[dev-dependencies]
+e2e = { version = "*", path = "../../e2e" }
+http = { workspace = true }

--- a/plugin_examples/replace_schema/router.config.yaml
+++ b/plugin_examples/replace_schema/router.config.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: supergraph.graphql
+plugins:
+  replace_schema:
+    enabled: true

--- a/plugin_examples/replace_schema/src/lib.rs
+++ b/plugin_examples/replace_schema/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod plugin;
+#[cfg(test)]
+pub mod test;

--- a/plugin_examples/replace_schema/src/main.rs
+++ b/plugin_examples/replace_schema/src/main.rs
@@ -1,0 +1,17 @@
+use hive_router::{
+    configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
+    router_entrypoint, PluginRegistry, RouterGlobalAllocator,
+};
+
+configure_global_allocator!();
+
+#[hive_router::main]
+async fn main() -> Result<(), RouterInitError> {
+    init_rustls_crypto_provider();
+
+    router_entrypoint(
+        PluginRegistry::new()
+            .register::<replace_schema_plugin_example::plugin::ReplaceSchemaPlugin>(),
+    )
+    .await
+}

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -26,8 +26,7 @@ const SUPERGRAPH_SDL: &str = include_str!("../supergraph.graphql");
 /// schema) per request, in `on_http_request`, and have it hold for the entire pipeline: parsing,
 /// validation, normalization, planning, execution *and* introspection.
 ///
-/// Unlike stripping the schema at the validation stage (see the `feature_flags` example),
-/// overriding the schema document also affects introspection, because introspection is built
+/// Overriding the schema document also affects introspection, because introspection is built
 /// from the same resolved schema state that parsing/validation/planning use.
 ///
 /// Here we pre-parse one supergraph document per feature bundle (stripping `@feature`-tagged

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -4,7 +4,7 @@ use hive_router::{
     async_trait,
     graphql_tools::{
         ast::TypeDefinitionFields,
-        parser::schema::Definition,
+        parser::schema::{Definition, ParseError},
         static_graphql::{
             query::Value,
             schema::{Document, EnumType, InputObjectType, ObjectType, TypeDefinition},
@@ -18,25 +18,28 @@ use hive_router::{
         plugin_trait::{RouterPlugin, StartHookPayload},
     },
     query_planner::utils::parsing::safe_parse_schema,
-    HiveRouterConfig, SchemaState, SupergraphManagerError, TelemetryContext,
 };
 
 const SUPERGRAPH_SDL: &str = include_str!("../supergraph.graphql");
 
-/// This example shows how a plugin can pick a whole `SchemaState` (not just a schema document)
-/// per request, in `on_http_request`, and have it hold for the entire pipeline: parsing,
+/// This example shows how a plugin can pick a whole schema document (not just a validation-time
+/// schema) per request, in `on_http_request`, and have it hold for the entire pipeline: parsing,
 /// validation, normalization, planning, execution *and* introspection.
 ///
 /// Unlike stripping the schema at the validation stage (see the `feature_flags` example),
-/// overriding the `SchemaState` also affects introspection, because `IntrospectionContext` is
-/// built from the same `SupergraphData` that parsing/validation/planning use.
+/// overriding the schema document also affects introspection, because introspection is built
+/// from the same resolved schema state that parsing/validation/planning use.
 ///
-/// Here we pre-build one `SchemaState` per feature bundle from the supergraph SDL (stripping
-/// `@feature`-tagged types/fields from the *supergraph* document, not the public schema - the
-/// public/consumer schema is derived by the router from whatever we hand it) and pick between
-/// them using the `x-schema-variant` request header.
+/// Here we pre-parse one supergraph document per feature bundle (stripping `@feature`-tagged
+/// types/fields from the *supergraph* document, not the public schema - the public/consumer
+/// schema is derived by the router from whatever we hand it) and pick between them using the
+/// `x-schema-variant` request header.
+///
+/// The plugin only owns stable `Arc<Document>`s. The router resolves each document to its own
+/// internally-owned `SchemaState` (building it once on the first request that selects it, then
+/// reusing it for later requests with the same `Arc<Document>`).
 pub struct ReplaceSchemaPlugin {
-    variants: HashMap<&'static str, Arc<SchemaState>>,
+    variants: HashMap<&'static str, Arc<Document>>,
 }
 
 #[async_trait]
@@ -48,27 +51,15 @@ impl RouterPlugin for ReplaceSchemaPlugin {
     }
 
     fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
-        let router_config = Arc::new(HiveRouterConfig::default());
-        let telemetry_context = Arc::new(TelemetryContext::from_propagation_config(
-            &Default::default(),
-        ));
-
+        // Parse each schema variant once here and keep the `Arc<Document>` around for the
+        // lifetime of the plugin. `on_http_request` must hand the router the *same* `Arc` every
+        // time a variant is selected - constructing a fresh document per request would defeat
+        // the router's schema-state cache and force an expensive rebuild on every request.
         let mut variants = HashMap::new();
-        variants.insert(
-            "full",
-            Arc::new(build_schema_state(
-                &[],
-                router_config.clone(),
-                telemetry_context.clone(),
-            )?),
-        );
+        variants.insert("full", Arc::new(build_document(&[])?));
         variants.insert(
             "basic",
-            Arc::new(build_schema_state(
-                &["inStock", "shippingEstimate"],
-                router_config,
-                telemetry_context,
-            )?),
+            Arc::new(build_document(&["inStock", "shippingEstimate"])?),
         );
 
         payload.initialize_plugin(Self { variants })
@@ -85,25 +76,20 @@ impl RouterPlugin for ReplaceSchemaPlugin {
             .and_then(|value| value.to_str().ok())
             .unwrap_or("full");
 
-        if let Some(schema_state) = self.variants.get(variant) {
-            payload.set_schema_state(schema_state.clone());
+        if let Some(document) = self.variants.get(variant) {
+            payload.set_schema_document(document.clone());
         }
 
         payload.proceed()
     }
 }
 
-/// Builds a `SchemaState` from the supergraph SDL, with the given `@feature`-tagged types/fields
-/// stripped from the supergraph document (so they disappear from planning, validation *and*
-/// introspection alike). An empty `disabled_features` keeps the schema as-is.
-fn build_schema_state(
-    disabled_features: &[&str],
-    router_config: Arc<HiveRouterConfig>,
-    telemetry_context: Arc<TelemetryContext>,
-) -> Result<SchemaState, SupergraphManagerError> {
+/// Builds a supergraph document with the given `@feature`-tagged types/fields stripped (so they
+/// disappear from planning, validation *and* introspection alike). An empty `disabled_features`
+/// keeps the schema as-is.
+fn build_document(disabled_features: &[&str]) -> Result<Document, ParseError> {
     let document = safe_parse_schema(SUPERGRAPH_SDL)?;
-    let document = strip_disabled_features(document, disabled_features);
-    SchemaState::from_supergraph_document(document, router_config, telemetry_context)
+    Ok(strip_disabled_features(document, disabled_features))
 }
 
 fn strip_disabled_features(document: Document, disabled_features: &[&str]) -> Document {

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -1,0 +1,209 @@
+use std::{collections::HashMap, sync::Arc};
+
+use hive_router::{
+    async_trait,
+    graphql_tools::{
+        ast::TypeDefinitionFields,
+        parser::schema::Definition,
+        static_graphql::{
+            query::Value,
+            schema::{Document, EnumType, InputObjectType, ObjectType, TypeDefinition},
+        },
+    },
+    plugins::{
+        hooks::{
+            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        },
+        plugin_trait::{RouterPlugin, StartHookPayload},
+    },
+    query_planner::utils::parsing::safe_parse_schema,
+    HiveRouterConfig, SchemaState, TelemetryContext,
+};
+
+const SUPERGRAPH_SDL: &str = include_str!("../supergraph.graphql");
+
+/// This example shows how a plugin can pick a whole `SchemaState` (not just a schema document)
+/// per request, in `on_http_request`, and have it hold for the entire pipeline: parsing,
+/// validation, normalization, planning, execution *and* introspection.
+///
+/// Unlike stripping the schema at the validation stage (see the `feature_flags` example),
+/// overriding the `SchemaState` also affects introspection, because `IntrospectionContext` is
+/// built from the same `SupergraphData` that parsing/validation/planning use.
+///
+/// Here we pre-build one `SchemaState` per feature bundle from the supergraph SDL (stripping
+/// `@feature`-tagged types/fields from the *supergraph* document, not the public schema - the
+/// public/consumer schema is derived by the router from whatever we hand it) and pick between
+/// them using the `x-schema-variant` request header.
+pub struct ReplaceSchemaPlugin {
+    variants: HashMap<&'static str, Arc<SchemaState>>,
+}
+
+#[async_trait]
+impl RouterPlugin for ReplaceSchemaPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "replace_schema"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        let router_config = Arc::new(HiveRouterConfig::default());
+        let telemetry_context = Arc::new(TelemetryContext::from_propagation_config(
+            &Default::default(),
+        ));
+
+        let mut variants = HashMap::new();
+        variants.insert(
+            "full",
+            Arc::new(build_schema_state(
+                &[],
+                router_config.clone(),
+                telemetry_context.clone(),
+            )?),
+        );
+        variants.insert(
+            "basic",
+            Arc::new(build_schema_state(
+                &["inStock", "shippingEstimate"],
+                router_config,
+                telemetry_context,
+            )?),
+        );
+
+        payload.initialize_plugin(Self { variants })
+    }
+
+    fn on_http_request<'req>(
+        &'req self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
+        let variant = payload
+            .router_http_request
+            .headers()
+            .get("x-schema-variant")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("full");
+
+        if let Some(schema_state) = self.variants.get(variant) {
+            payload.set_schema_state(schema_state.clone());
+        }
+
+        payload.proceed()
+    }
+}
+
+/// Builds a `SchemaState` from the supergraph SDL, with the given `@feature`-tagged types/fields
+/// stripped from the supergraph document (so they disappear from planning, validation *and*
+/// introspection alike). An empty `disabled_features` keeps the schema as-is.
+fn build_schema_state(
+    disabled_features: &[&str],
+    router_config: Arc<HiveRouterConfig>,
+    telemetry_context: Arc<TelemetryContext>,
+) -> Result<SchemaState, Box<dyn std::error::Error>> {
+    let document = safe_parse_schema(SUPERGRAPH_SDL)?;
+    let document = strip_disabled_features(document, disabled_features);
+    Ok(SchemaState::from_supergraph_document(
+        document,
+        router_config,
+        telemetry_context,
+    )?)
+}
+
+fn strip_disabled_features(document: Document, disabled_features: &[&str]) -> Document {
+    let mut removed_definitions = vec![];
+    let mut removed_fields: HashMap<String, Vec<String>> = HashMap::new();
+
+    for definition in &document.definitions {
+        if let Some(directives) = definition.directives() {
+            if has_disabled_feature(disabled_features, directives) {
+                removed_definitions.push(definition.clone());
+                continue;
+            }
+        }
+        let Some(def_name) = definition.name() else {
+            continue;
+        };
+        if let Some(TypeDefinitionFields::Fields(fields)) = definition.fields() {
+            for field in fields {
+                if has_disabled_feature(disabled_features, &field.directives) {
+                    removed_fields
+                        .entry(def_name.to_string())
+                        .or_default()
+                        .push(field.name.clone());
+                }
+            }
+        }
+    }
+
+    let definitions = document
+        .definitions
+        .into_iter()
+        .filter(|def| !removed_definitions.contains(def))
+        .map(|def| {
+            let Some(def_name) = def.name().map(str::to_string) else {
+                return def;
+            };
+            let Some(fields_to_remove) = removed_fields.get(&def_name) else {
+                return def;
+            };
+            match def {
+                Definition::TypeDefinition(TypeDefinition::Object(obj)) => {
+                    Definition::TypeDefinition(TypeDefinition::Object(ObjectType {
+                        fields: obj
+                            .fields
+                            .into_iter()
+                            .filter(|field| !fields_to_remove.contains(&field.name))
+                            .collect(),
+                        ..obj
+                    }))
+                }
+                Definition::TypeDefinition(TypeDefinition::InputObject(input_obj)) => {
+                    Definition::TypeDefinition(TypeDefinition::InputObject(InputObjectType {
+                        fields: input_obj
+                            .fields
+                            .into_iter()
+                            .filter(|field| !fields_to_remove.contains(&field.name))
+                            .collect(),
+                        ..input_obj
+                    }))
+                }
+                Definition::TypeDefinition(TypeDefinition::Enum(enum_def)) => {
+                    Definition::TypeDefinition(TypeDefinition::Enum(EnumType {
+                        values: enum_def
+                            .values
+                            .into_iter()
+                            .filter(|value| !fields_to_remove.contains(&value.name))
+                            .collect(),
+                        ..enum_def
+                    }))
+                }
+                other => other,
+            }
+        })
+        .collect();
+
+    Document { definitions }
+}
+
+/// Whether this node is tagged `@feature(name: ...)` for one of the disabled features.
+fn has_disabled_feature(
+    disabled_features: &[&str],
+    directives: &[hive_router::graphql_tools::static_graphql::schema::Directive],
+) -> bool {
+    for directive in directives {
+        if directive.name.as_str() != "feature" {
+            continue;
+        }
+        for (argument_name, argument_value) in &directive.arguments {
+            if argument_name == "name" {
+                if let Value::String(feature_name) = argument_value {
+                    if disabled_features.contains(&feature_name.as_str()) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -107,19 +107,19 @@ fn build_schema_state(
 }
 
 fn strip_disabled_features(document: Document, disabled_features: &[&str]) -> Document {
-    let mut removed_definitions = vec![];
+    let mut removed_definitions: Vec<String> = vec![];
     let mut removed_fields: HashMap<String, Vec<String>> = HashMap::new();
 
     for definition in &document.definitions {
-        if let Some(directives) = definition.directives() {
-            if has_disabled_feature(disabled_features, directives) {
-                removed_definitions.push(definition.clone());
-                continue;
-            }
-        }
         let Some(def_name) = definition.name() else {
             continue;
         };
+        if let Some(directives) = definition.directives() {
+            if has_disabled_feature(disabled_features, directives) {
+                removed_definitions.push(def_name.to_string());
+                continue;
+            }
+        }
         if let Some(TypeDefinitionFields::Fields(fields)) = definition.fields() {
             for field in fields {
                 if has_disabled_feature(disabled_features, &field.directives) {
@@ -135,7 +135,11 @@ fn strip_disabled_features(document: Document, disabled_features: &[&str]) -> Do
     let definitions = document
         .definitions
         .into_iter()
-        .filter(|def| !removed_definitions.contains(def))
+        .filter(|def| {
+            def.name().map_or(true, |name| {
+                !removed_definitions.contains(&name.to_string())
+            })
+        })
         .map(|def| {
             let Some(def_name) = def.name().map(str::to_string) else {
                 return def;

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -18,7 +18,7 @@ use hive_router::{
         plugin_trait::{RouterPlugin, StartHookPayload},
     },
     query_planner::utils::parsing::safe_parse_schema,
-    HiveRouterConfig, SchemaState, TelemetryContext,
+    HiveRouterConfig, SchemaState, SupergraphManagerError, TelemetryContext,
 };
 
 const SUPERGRAPH_SDL: &str = include_str!("../supergraph.graphql");
@@ -100,14 +100,10 @@ fn build_schema_state(
     disabled_features: &[&str],
     router_config: Arc<HiveRouterConfig>,
     telemetry_context: Arc<TelemetryContext>,
-) -> Result<SchemaState, Box<dyn std::error::Error>> {
+) -> Result<SchemaState, SupergraphManagerError> {
     let document = safe_parse_schema(SUPERGRAPH_SDL)?;
     let document = strip_disabled_features(document, disabled_features);
-    Ok(SchemaState::from_supergraph_document(
-        document,
-        router_config,
-        telemetry_context,
-    )?)
+    SchemaState::from_supergraph_document(document, router_config, telemetry_context)
 }
 
 fn strip_disabled_features(document: Document, disabled_features: &[&str]) -> Document {

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -136,9 +136,8 @@ fn strip_disabled_features(document: Document, disabled_features: &[&str]) -> Do
         .definitions
         .into_iter()
         .filter(|def| {
-            def.name().map_or(true, |name| {
-                !removed_definitions.contains(&name.to_string())
-            })
+            def.name()
+                .map_or(true, |name| !removed_definitions.iter().any(|d| d == name))
         })
         .map(|def| {
             let Some(def_name) = def.name().map(str::to_string) else {

--- a/plugin_examples/replace_schema/src/test.rs
+++ b/plugin_examples/replace_schema/src/test.rs
@@ -122,4 +122,89 @@ mod tests {
         }
         "###);
     }
+
+    /// A plugin whose selected document always fails `SchemaState` construction (a malformed
+    /// subgraph endpoint URL), used to assert the router returns an internal error instead of
+    /// silently falling back to the router's default schema.
+    mod broken_schema_plugin {
+        use std::sync::Arc;
+
+        use hive_router::{
+            async_trait,
+            graphql_tools::static_graphql::schema::Document,
+            plugins::{
+                hooks::{
+                    on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+                    on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+                },
+                plugin_trait::{RouterPlugin, StartHookPayload},
+            },
+            query_planner::utils::parsing::safe_parse_schema,
+        };
+
+        const SUPERGRAPH_SDL: &str = include_str!("../supergraph.graphql");
+
+        pub struct BrokenSchemaPlugin {
+            document: Arc<Document>,
+        }
+
+        #[async_trait]
+        impl RouterPlugin for BrokenSchemaPlugin {
+            type Config = ();
+
+            fn plugin_name() -> &'static str {
+                "broken_schema"
+            }
+
+            fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+                let broken_sdl =
+                    SUPERGRAPH_SDL.replace("http://0.0.0.0:4200/accounts", "not a valid url ::");
+                let document = safe_parse_schema(&broken_sdl)?;
+                payload.initialize_plugin(Self {
+                    document: Arc::new(document),
+                })
+            }
+
+            fn on_http_request<'req>(
+                &'req self,
+                payload: OnHttpRequestHookPayload<'req>,
+            ) -> OnHttpRequestHookResult<'req> {
+                payload.set_schema_document(self.document.clone());
+                payload.proceed()
+            }
+        }
+    }
+
+    #[ntex::test]
+    async fn failed_schema_state_build_returns_internal_error_not_default_schema() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                include_str!("../router.config.yaml").replace("replace_schema:", "broken_schema:"),
+            )
+            .register_plugin::<broken_schema_plugin::BrokenSchemaPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    topProducts(first: 1) {
+                        name
+                    }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+
+        // Must not silently fall back to the router's default (working) schema: the plugin
+        // selected a document whose `SchemaState` fails to build, so the request must fail.
+        assert_eq!(res.status(), 500);
+    }
 }

--- a/plugin_examples/replace_schema/src/test.rs
+++ b/plugin_examples/replace_schema/src/test.rs
@@ -1,0 +1,125 @@
+#[cfg(test)]
+mod tests {
+    use e2e::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
+    use hive_router::ntex;
+
+    #[ntex::test]
+    async fn basic_variant_hides_feature_fields_from_validation_and_introspection() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("../plugin_examples/replace_schema/router.config.yaml")
+            .register_plugin::<crate::plugin::ReplaceSchemaPlugin>()
+            .build()
+            .start()
+            .await;
+
+        // The default (no header) variant is the "full" schema: shippingEstimate is queryable.
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    topProducts(first: 1) {
+                        name
+                        shippingEstimate
+                    }
+                }
+                "#,
+                None,
+                None,
+            )
+            .await;
+        assert_eq!(res.status(), 200);
+
+        // With the "basic" variant, shippingEstimate has been stripped from the supergraph
+        // before planning, so it's a validation error, same as if the field never existed.
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    topProducts(first: 1) {
+                        name
+                        shippingEstimate
+                    }
+                }
+                "#,
+                None,
+                e2e::some_header_map! {
+                    "x-schema-variant" => "basic"
+                },
+            )
+            .await;
+        assert_eq!(res.status(), 400);
+        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        {
+          "errors": [
+            {
+              "message": "Cannot query field \"shippingEstimate\" on type \"Product\".",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 25
+                }
+              ],
+              "extensions": {
+                "code": "FieldsOnCorrectType"
+              }
+            }
+          ]
+        }
+        "###);
+
+        // Introspection respects the override too: shippingEstimate and inStock are entirely
+        // gone from the "basic" variant's `Product` type, not just rejected by validation.
+        let res = router
+            .send_graphql_request(
+                r#"
+                query {
+                    __type(name: "Product") {
+                        fields {
+                            name
+                        }
+                    }
+                }
+                "#,
+                None,
+                e2e::some_header_map! {
+                    "x-schema-variant" => "basic"
+                },
+            )
+            .await;
+        assert_eq!(res.status(), 200);
+        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        {
+          "data": {
+            "__type": {
+              "fields": [
+                {
+                  "name": "upc"
+                },
+                {
+                  "name": "weight"
+                },
+                {
+                  "name": "price"
+                },
+                {
+                  "name": "name"
+                },
+                {
+                  "name": "reviews"
+                },
+                {
+                  "name": "notes"
+                },
+                {
+                  "name": "internal"
+                }
+              ]
+            }
+          }
+        }
+        "###);
+    }
+}

--- a/plugin_examples/replace_schema/supergraph.graphql
+++ b/plugin_examples/replace_schema/supergraph.graphql
@@ -1,0 +1,121 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+directive @feature(
+    name: String!
+) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://0.0.0.0:4200/accounts")
+  INVENTORY
+    @join__graph(name: "inventory", url: "http://0.0.0.0:4200/inventory")
+  PRODUCTS @join__graph(name: "products", url: "http://0.0.0.0:4200/products")
+  REVIEWS @join__graph(name: "reviews", url: "http://0.0.0.0:4200/reviews")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc") {
+  upc: String!
+  weight: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+  price: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY) @feature(name: "inStock")
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight") @feature(name: "shippingEstimate")
+  name: String @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  notes: String @join__field(graph: PRODUCTS)
+  internal: String @join__field(graph: PRODUCTS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS) {
+  me: User @join__field(graph: ACCOUNTS)
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  users: [User] @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  body: String
+  product: Product
+  author: User @join__field(graph: REVIEWS, provides: "username")
+}
+
+type User
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS)
+  username: String
+    @join__field(graph: ACCOUNTS)
+    @join__field(graph: REVIEWS, external: true)
+  birthday: Int @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}


### PR DESCRIPTION
### This PR is being superseded by #1284

<details>

<summary>Description</summary>

Allow a plugin to select a supergraph document during `on_http_request` and have it hold for the entire request pipeline, including validation, normalization, planning, execution, and introspection. Previously, plugins could only replace the validation schema through `on_graphql_validation`, so fields hidden from validation could still appear through `__schema` and `__type` introspection.

The new `on_http_request` hook API accepts a schema document:

```rust
fn on_http_request<'req>(
    &'req self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookResult<'req> {
    if let Some(document) = self.schema_document_for_request(&payload) {
        payload.set_schema_document(document.clone());
    }
    payload.proceed()
}
```

The plugin owns stable `Arc<Document>` schema variants. After all `on_http_request` hooks run, the router resolves the selected document into an internal `Arc<SchemaState>` and stores that state in request extensions. The existing HTTP and WebSocket entry points then use that request-specific state for the full operation lifecycle.

### Why resolve a whole `SchemaState` internally?

The request pipeline consumes both:

- the current `SupergraphData`
- schema-coupled state, including the plan, validation, normalization, and demand-control formula caches

These caches are not all keyed by the schema checksum. Replacing only `SupergraphData` could therefore allow schema B to reuse normalized operations, query plans, or demand-control formulas produced under schema A.

Each selected document is instead resolved to its own `SchemaState`, which contains its own `SupergraphData`, query planner, caches, demand-control runtime, and callback subscriptions map. This keeps schema-derived state isolated while letting repeated requests reuse the expensive planner build. The request-deduplication fingerprint already includes `schema_checksum`, so request deduplication also remains isolated across schema variants.

Keeping `SchemaState` internal also avoids exposing router configuration and telemetry internals to plugins. The router builds each state with its actual `HiveRouterConfig` and `TelemetryContext`.

### Schema-state cache

The router keeps up to 10 plugin-selected schema states in a fixed-size cache:

- Documents are keyed by `Arc` allocation identity, using `Arc::ptr_eq`.
- The first request for a document builds its `SchemaState` synchronously.
- Later requests using the same `Arc<Document>` reuse the existing state.
- The cache uses strict FIFO eviction. When an 11ht document is inserted, the oldest inserted document is evicted.
- Cache hits do not refresh the eviction order. (is this ok?)
- Eviction only removes the cache's reference.<br/>
  Meaning, in-flight requests and subscriptions holding the evicted `Arc<SchemaState>` continue safely.
- Selecting an evicted document again rebuilds its state.
- A failed build is not cached and does not evict a valid entry.
- A failed build returns HTTP 500 instead of falling back to the default schema, because fallback could expose fields the plugin intended to remove or change.

Miss construction is serialized so concurrent first requests cannot build the same cached state more than once.

### Drop `with_schema` from the `on_graphql_validation` plugin hook

Remove `OnGraphQLValidationStartHookPayload::with_schema`. Method was broken by design, it replaced the schema only for validation while parsing, introspection, normalization, planning, and execution continued using the request's original schema state. This could make a field disappear during validation while remaining visible through introspection, and it could leave schema-derived caches and planning state inconsistent with the schema used to validate the operation.

Plugins that need a request-specific schema should now build and retain a stable `Arc<Document>` for each schema variant and select it in `on_http_request`:

```rust
fn on_http_request<'req>(
    &'req self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookResult<'req> {
    payload.set_schema_document(self.document_for_request(&payload).clone());
    payload.proceed()
}
```

### Stable document responsibility

Plugins must construct each schema variant once and retain the same `Arc<Document>` in their own state. Parsing a document or allocating a new `Arc<Document>` per request defeats cache reuse and triggers an expensive planner build for every request.

For example:

```rust
pub struct ReplaceSchemaPlugin {
    variants: HashMap<&'static str, Arc<Document>>,
}

fn on_http_request<'req>(
    &'req self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookResult<'req> {
    if let Some(document) = self.variants.get("basic") {
        payload.set_schema_document(document.clone());
    }

    payload.proceed()
}
```

See [`plugin_examples/replace_schema`](https://github.com/graphql-hive/router/tree/main/plugin_examples/replace_schema) for a complete example that builds stable feature-specific documents and selects one from a request header.

### Caveats for plugin authors

- Building a `SchemaState` includes a full query planner build. The first request for each document therefore has additional latency.
- Router-side supergraph reloads do not mutate or invalidate cached plugin-selected states and do not force-close subscriptions using them.
- `on_http_request` is synchronous. External feature or project lookups must be refreshed asynchronously in the plugin lifecycle so the hook only performs a synchronous lookup from request data to a stable `Arc<Document>`.

### TODO

- [ ] plugin-selected states do not register callback heartbeat enforcer background task
- [ ] document schema state cache has a max cap of 10, is this ok? should it be configurable? should the plugin author be able to manually evict?
- [ ] docs

</details>