### PR TITLE
fix(router, query-planner): root types are no longer hard-coded

### DIFF
--- a/.changeset/root_types_hardcoded.md
+++ b/.changeset/root_types_hardcoded.md
@@ -1,0 +1,14 @@
+---
+hive-router-plan-executor: patch
+hive-router-query-planner: patch
+hive-router: patch
+graphql-tools: patch
+node-addon: patch
+hive-console-sdk: patch
+hive-router-internal: patch
+hive-apollo-router-plugin: patch
+---
+
+# Support custom GraphQL root type names
+
+Hive Router now reads `query`, `mutation`, and `subscription` root type names from the schema instead of assuming they are named `Query`, `Mutation`, and `Subscription`.

--- a/bin/differential/src/main.rs
+++ b/bin/differential/src/main.rs
@@ -127,7 +127,11 @@ impl<'a> QueryGenerator<'a> {
 
     pub fn generate(mut self) -> QueryCase {
         let operation_name = "GeneratedQuery".to_string();
-        let root = self.schema.query_type_name().to_string();
+        let root = self
+            .schema
+            .query_type_name()
+            .expect("schema must have a query type")
+            .to_string();
         let selections = self.selection_set_for_type(&root, 0, SelectionContext::Root);
 
         let variables_json = self.render_variables_json();

--- a/bin/router/benches/router_benches.rs
+++ b/bin/router/benches/router_benches.rs
@@ -49,6 +49,12 @@ fn authorization_benchmark(c: &mut Criterion) {
         let normalized = normalize_operation(supergraph, &parsed, None).unwrap();
         let (root_type_name, projection_plan) =
             FieldProjectionPlan::from_operation(&normalized.operation, &metadata);
+        let root_type_name = root_type_name.to_string();
+        let operation_kind = normalized
+            .operation
+            .operation_kind
+            .clone()
+            .unwrap_or(OperationKind::Query);
         let partitioned_operation = partition_operation(normalized.operation);
         let hashes = hash_normalized_operation(
             &partitioned_operation.downstream_operation,
@@ -57,6 +63,7 @@ fn authorization_benchmark(c: &mut Criterion) {
 
         GraphQLNormalizationPayload {
             root_type_name,
+            operation_kind,
             projection_plan: Arc::new(projection_plan),
             operation_for_plan: Arc::new(partitioned_operation.downstream_operation),
             operation_for_introspection: partitioned_operation

--- a/bin/router/src/pipeline/authorization/mod.rs
+++ b/bin/router/src/pipeline/authorization/mod.rs
@@ -230,7 +230,7 @@ pub fn apply_authorization_to_operation(
     };
 
     let operation_filter_output = OperationFilter::new(schema_metadata).filter(
-        normalized_payload.root_type_name,
+        &normalized_payload.root_type_name,
         &normalized_payload.operation_for_plan.selection_set,
         variable_payload,
         |selection| match selection {

--- a/bin/router/src/pipeline/authorization/tests.rs
+++ b/bin/router/src/pipeline/authorization/tests.rs
@@ -78,8 +78,13 @@ impl SupergraphTestData {
         let parsed_query = parse_query(operation).unwrap();
         let doc = normalize_operation(&self.supergraph_state, &parsed_query, None).unwrap();
         let operation = doc.operation;
+        let operation_kind = operation
+            .operation_kind
+            .clone()
+            .unwrap_or(OperationKind::Query);
         let (root_type_name, projection_plan) =
             FieldProjectionPlan::from_operation(&operation, &self.schema_metadata);
+        let root_type_name = root_type_name.to_string();
         let partitioned_operation = partition_operation(operation);
         let operation_for_plan = Arc::new(partitioned_operation.downstream_operation);
         let operation_for_introspection =
@@ -90,6 +95,7 @@ impl SupergraphTestData {
 
         let payload = GraphQLNormalizationPayload {
             root_type_name,
+            operation_kind,
             projection_plan: Arc::new(projection_plan),
             operation_for_plan,
             operation_for_plan_hash: hashes.operation_for_plan_hash,

--- a/bin/router/src/pipeline/demand_control/runtime.rs
+++ b/bin/router/src/pipeline/demand_control/runtime.rs
@@ -295,7 +295,7 @@ impl DemandControlRuntime {
         actual_plans_by_fetch_hash: &mut Option<AHashMap<u64, CompiledSubgraphActualCostPlan>>,
     ) -> FormulaFetchNode {
         let default_list_size = self.default_list_size_for_subgraph(service_name);
-        let root_type = supergraph_state.root_type_name(operation_kind);
+        let root_type = supergraph_state.expect_root_type_name(operation_kind);
         if let Some(actual_plans_by_fetch_hash) = actual_plans_by_fetch_hash {
             actual_plans_by_fetch_hash
                 .entry(operation.hash)

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -132,7 +132,8 @@ pub async fn execute_plan<'exec>(
             extensions,
             client_request: planned_request.client_request_details,
             introspection_context: introspection_context.into(),
-            operation_type_name: planned_request.normalized_payload.root_type_name,
+            operation_type_name: planned_request.normalized_payload.root_type_name.clone(),
+            operation_kind: planned_request.normalized_payload.operation_kind.clone(),
             jwt_auth_forwarding: jwt_auth_forwarding.map(|j| j.into()),
             graphql_error_recorder: app_state.telemetry_context.metrics.graphql.error_recorder(),
             demand_control_context: planned_request

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -491,10 +491,9 @@ pub async fn execute_planned_request<'exec>(
         operation: OperationDetails {
             name: normalize_payload.operation_for_plan.name.as_deref(),
             kind: match normalize_payload.operation_for_plan.operation_kind {
-                Some(OperationKind::Query) => "query",
+                None | Some(OperationKind::Query) => "query",
                 Some(OperationKind::Mutation) => "mutation",
                 Some(OperationKind::Subscription) => "subscription",
-                None => "query",
             },
             query: graphql_params.get_query()?,
         },
@@ -739,7 +738,7 @@ pub async fn execute_pipeline<'exec>(
                 &variable_payload,
                 &query_plan_payload,
                 normalize_payload.operation_for_plan.as_ref(),
-                normalize_payload.root_type_name,
+                normalize_payload.root_type_name.as_str(),
                 normalize_payload.normalized_operation_hash,
                 (&normalize_payload.operation_identity).into(),
             )

--- a/bin/router/src/pipeline/normalize.rs
+++ b/bin/router/src/pipeline/normalize.rs
@@ -34,7 +34,8 @@ pub struct GraphQLNormalizationPayload {
     pub operation_for_introspection: Option<Arc<OperationDefinition>>,
     pub operation_for_introspection_hash: Option<u64>,
     pub normalized_operation_hash: u64,
-    pub root_type_name: &'static str,
+    pub root_type_name: String,
+    pub operation_kind: OperationKind,
     pub projection_plan: Arc<Vec<FieldProjectionPlan>>,
     pub operation_identity: OperationIdentity,
 }
@@ -65,13 +66,16 @@ impl GraphQLNormalizationPayload {
     ) -> Arc<GraphQLNormalizationPayload> {
         let hashes =
             hash_normalized_operation(&new_operation, self.operation_for_introspection.as_deref());
+
         Arc::new(GraphQLNormalizationPayload {
             operation_for_plan: Arc::new(new_operation),
             operation_for_plan_hash: hashes.operation_for_plan_hash,
+            // These are cheap Arc clones
             operation_for_introspection: self.operation_for_introspection.clone(),
             operation_for_introspection_hash: hashes.operation_for_introspection_hash,
             normalized_operation_hash: hashes.combined_operation_hash,
-            root_type_name: self.root_type_name,
+            root_type_name: self.root_type_name.clone(),
+            operation_kind: self.operation_kind.clone(),
             projection_plan: Arc::new(new_projection_plan),
             operation_identity: self.operation_identity.clone(),
         })
@@ -166,8 +170,13 @@ pub async fn normalize_request_with_cache(
                 );
 
                 let operation = doc.operation;
+                let operation_kind = operation
+                    .operation_kind
+                    .clone()
+                    .unwrap_or(OperationKind::Query);
                 let (root_type_name, projection_plan) =
                     FieldProjectionPlan::from_operation(&operation, &supergraph.metadata);
+                let root_type_name = root_type_name.to_string();
                 let partitioned_operation = partition_operation(operation);
 
                 let operation_for_plan = Arc::new(partitioned_operation.downstream_operation);
@@ -181,6 +190,7 @@ pub async fn normalize_request_with_cache(
 
                 let payload = GraphQLNormalizationPayload {
                     root_type_name,
+                    operation_kind,
                     projection_plan: Arc::new(projection_plan),
                     operation_for_plan,
                     operation_for_plan_hash: hashes.operation_for_plan_hash,

--- a/lib/executor/src/execution/demand_control/mod.rs
+++ b/lib/executor/src/execution/demand_control/mod.rs
@@ -278,7 +278,8 @@ pub fn compile_actual_subgraph_cost_plan(
     supergraph_state: &SupergraphState,
 ) -> CompiledSubgraphActualCostPlan {
     let operation_def = &operation.document.operation;
-    let root_type_name = supergraph_state.root_type_name(operation_def.operation_kind.as_ref());
+    let root_type_name =
+        supergraph_state.expect_root_type_name(operation_def.operation_kind.as_ref());
 
     // Detect if every top-level selection is a `_entities` field (with or without alias).
     // This covers FlattenFetch (single `_entities`) and BatchFetch (multiple `_eN: _entities`).

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -123,7 +123,8 @@ pub struct QueryPlanExecutionOpts<'exec> {
     pub extensions: ExecutionResultExtensions<'exec>,
     pub client_request: Arc<ClientRequestDetails<'exec>>,
     pub introspection_context: Arc<IntrospectionContext>,
-    pub operation_type_name: &'static str,
+    pub operation_type_name: String,
+    pub operation_kind: OperationKind,
     pub executors: Arc<SubgraphExecutorMap>,
     pub jwt_auth_forwarding: Option<Arc<JwtAuthForwardingPlan>>,
     pub graphql_error_recorder: Option<GraphQLErrorMetricsRecorder>,
@@ -380,7 +381,8 @@ pub async fn execute_query_plan<'exec>(
                         path_params: client_path_params.clone(),
                     }.into(),
                     introspection_context: opts.introspection_context.clone(),
-                    operation_type_name: opts.operation_type_name,
+                    operation_type_name: opts.operation_type_name.clone(),
+                    operation_kind: opts.operation_kind.clone(),
                     executors: opts.executors.clone(),
                     jwt_auth_forwarding: opts.jwt_auth_forwarding.clone(),
                     initial_errors,
@@ -434,7 +436,7 @@ async fn execute_query_plan_with_data<'exec>(
 ) -> Result<PlanExecutionOutput, PlanExecutionError> {
     let mut errors = opts.initial_errors;
 
-    let dedupe_subgraph_requests = opts.operation_type_name == "Query";
+    let dedupe_subgraph_requests = opts.operation_kind.is_query();
 
     let mut on_end_callbacks = vec![];
 
@@ -564,7 +566,7 @@ async fn execute_query_plan_with_data<'exec>(
     cache_control::finalize(
         &mut exec_ctx.response_headers_aggregator,
         // force no-store for mutations and errors (execution or graphql errors)
-        opts.operation_type_name == "Mutation" || !errors.is_empty(),
+        opts.operation_kind.is_mutation() || !errors.is_empty(),
         // response_storage.len() counts subgraphs that returned bytes, which is
         // exactly what we need: a plugin hook can short-circuit with a bytes-less
         // SubgraphResponse, but in that case it also produces no cache-control header,
@@ -641,7 +643,7 @@ async fn execute_query_plan_with_data<'exec>(
         &data,
         errors,
         &opts.extensions,
-        opts.operation_type_name,
+        opts.operation_type_name.as_str(),
         &opts.projection_plan,
         &opts.variable_values.variables_map,
         response_size_estimate,

--- a/lib/executor/src/introspection/resolve.rs
+++ b/lib/executor/src/introspection/resolve.rs
@@ -13,7 +13,6 @@ use hive_router_query_planner::ast::{
     selection_set::{FieldSelection, SelectionSet},
     value::Value as AstValue,
 };
-use hive_router_query_planner::state::supergraph_state::OperationKind;
 use sonic_rs::JsonValueTrait;
 
 use crate::execution::plan::CoerceVariablesPayload;
@@ -559,9 +558,13 @@ fn resolve_schema_selections<'exec>(
                 }
                 "queryType" => {
                     let query_type = ctx
-                        .schema
-                        .type_by_name(ctx.schema.query_type_name())
-                        .expect("Query type not found");
+                        .metadata
+                        .query_type_name
+                        .as_ref()
+                        .and_then(|name| ctx.schema.type_by_name(name))
+                        // SAFETY: The query type is guaranteed to exist,
+                        // every schema has a query type.
+                        .expect("invariant violation: query type is guaranteed to exist because every schema must have a query type");
                     resolve_type_definition(query_type, &inner_field.selections, ctx)
                 }
                 "mutationType" => ctx
@@ -611,19 +614,9 @@ pub fn resolve_introspection<'exec>(
     ctx: &'exec IntrospectionContext,
 ) -> Value<'exec> {
     let root_selection_set = &operation_definition.selection_set;
-
-    let root_type_name = operation_definition
-        .operation_kind
-        .as_ref()
-        .map(|kind| match kind {
-            OperationKind::Query => ctx.schema.query_type_name(),
-            OperationKind::Mutation => ctx.schema.mutation_type_name().unwrap_or("Mutation"),
-            OperationKind::Subscription => ctx
-                .schema
-                .subscription_type_name()
-                .unwrap_or("Subscription"),
-        })
-        .unwrap_or_else(|| ctx.schema.query_type_name());
+    let root_type_name = ctx
+        .metadata
+        .expect_root_type_name(operation_definition.operation_kind.as_ref());
 
     let mut data =
         resolve_root_introspection_selections(root_type_name, &root_selection_set.items, ctx);

--- a/lib/executor/src/introspection/schema.rs
+++ b/lib/executor/src/introspection/schema.rs
@@ -4,7 +4,9 @@ use graphql_tools::parser::{
     query::Type,
     schema::{Definition, TypeDefinition},
 };
-use hive_router_query_planner::consumer_schema::ConsumerSchema;
+use hive_router_query_planner::{
+    consumer_schema::ConsumerSchema, state::supergraph_state::OperationKind,
+};
 
 #[derive(Debug)]
 pub struct FieldTypeInfo {
@@ -71,9 +73,9 @@ pub struct SchemaMetadata {
     pub scalar_types: HashSet<String>,
     pub union_types: HashSet<String>,
     pub interface_types: HashSet<String>,
-    pub query_type: Option<String>,
-    pub mutation_type: Option<String>,
-    pub subscription_type: Option<String>,
+    pub query_type_name: Option<String>,
+    pub mutation_type_name: Option<String>,
+    pub subscription_type_name: Option<String>,
 }
 
 impl SchemaMetadata {
@@ -101,6 +103,28 @@ impl SchemaMetadata {
     /// Returns None if the type is not an interface or has no implementors.
     pub fn get_possible_types(&self, interface_name: &str) -> Option<&HashSet<String>> {
         self.possible_types.map.get(interface_name)
+    }
+
+    /// panics if the root type is not found for the given operation kind.
+    /// Use only when you are sure the root type is present,
+    /// like after the operation was validated to have matching root type.
+    pub fn expect_root_type_name(&self, operation_kind: Option<&OperationKind>) -> &str {
+        let root_type_name = match operation_kind {
+            None | Some(OperationKind::Query) => &self.query_type_name,
+            Some(OperationKind::Mutation) => &self.mutation_type_name,
+            Some(OperationKind::Subscription) => &self.subscription_type_name,
+        };
+
+        root_type_name
+            .as_deref()
+            // SAFETY: The root type is guaranteed to exist for the given operation kind,
+            // as the operation was validated.
+            .unwrap_or_else(|| {
+                panic!(
+                    "Root type not found for operation kind: {:?}",
+                    operation_kind
+                )
+            })
     }
 }
 
@@ -147,24 +171,11 @@ impl SchemaWithMetadata for ConsumerSchema {
         let mut union_types: HashSet<String> = HashSet::default();
         let mut interface_types: HashSet<String> = HashSet::default();
 
-        let mut query_type: Option<String> = None;
-        let mut mutation_type: Option<String> = None;
-        let mut subscription_type: Option<String> = None;
-        let mut found_schema_definition: bool = false;
-
         for definition in &self.document.definitions {
             match definition {
-                Definition::SchemaDefinition(schema_definition) => {
-                    found_schema_definition = true;
-                    query_type = schema_definition.query.as_deref().map(|n| n.to_string());
-                    mutation_type = schema_definition.mutation.as_deref().map(|n| n.to_string());
-                    subscription_type = schema_definition
-                        .subscription
-                        .as_deref()
-                        .map(|n| n.to_string());
-                }
                 Definition::TypeDefinition(TypeDefinition::Enum(enum_type)) => {
                     let name = enum_type.name.to_string();
+
                     let mut values = HashSet::default();
                     for enum_value in &enum_type.values {
                         values.insert(enum_value.name.to_string());
@@ -173,22 +184,6 @@ impl SchemaWithMetadata for ConsumerSchema {
                 }
                 Definition::TypeDefinition(TypeDefinition::Object(object_type)) => {
                     let name = object_type.name.to_string();
-
-                    if !found_schema_definition {
-                        match name.as_str() {
-                            "Query" => {
-                                query_type = Some(name.clone());
-                            }
-                            "Mutation" => {
-                                mutation_type = Some(name.clone());
-                            }
-                            "Subscription" => {
-                                subscription_type = Some(name.clone());
-                            }
-                            _ => {}
-                        }
-                    }
-
                     object_types.insert(name.clone());
                     let fields = type_fields.entry(name).or_default();
                     for field in &object_type.fields {
@@ -247,6 +242,10 @@ impl SchemaWithMetadata for ConsumerSchema {
             }
         }
 
+        let query_type_name = self.document.query_type_name().cloned();
+        let mutation_type_name = self.document.mutation_type_name().cloned();
+        let subscription_type_name = self.document.subscription_type_name().cloned();
+
         let mut final_possible_types: HashMap<String, HashSet<String>> = HashMap::default();
         // Re-iterate over the possible_types
         for (definition_name_of_x, first_possible_types_of_x) in &first_possible_types {
@@ -273,9 +272,9 @@ impl SchemaWithMetadata for ConsumerSchema {
             scalar_types,
             union_types,
             interface_types,
-            query_type,
-            mutation_type,
-            subscription_type,
+            query_type_name,
+            mutation_type_name,
+            subscription_type_name,
         }
     }
 }

--- a/lib/executor/src/plugins/hooks/on_graphql_analysis.rs
+++ b/lib/executor/src/plugins/hooks/on_graphql_analysis.rs
@@ -87,9 +87,9 @@ impl<'exec> OnGraphqlAnalysisHookPayload<'exec> {
         let operation = self.filtered_operation_for_plan;
 
         let root_type_name = match operation.operation_kind {
-            None | Some(OperationKind::Query) => schema_metadata.query_type.as_deref(),
-            Some(OperationKind::Mutation) => schema_metadata.mutation_type.as_deref(),
-            Some(OperationKind::Subscription) => schema_metadata.subscription_type.as_deref(),
+            None | Some(OperationKind::Query) => schema_metadata.query_type_name.as_deref(),
+            Some(OperationKind::Mutation) => schema_metadata.mutation_type_name.as_deref(),
+            Some(OperationKind::Subscription) => schema_metadata.subscription_type_name.as_deref(),
         }
         .expect("root type name not found in schema metadata");
 

--- a/lib/executor/src/projection/plan.rs
+++ b/lib/executor/src/projection/plan.rs
@@ -226,16 +226,23 @@ impl FieldProjectionCondition {
 
 impl FieldProjectionPlan {
     #[instrument(level = "trace", skip_all)]
-    pub fn from_operation(
-        operation: &OperationDefinition,
-        schema_metadata: &SchemaMetadata,
-    ) -> (&'static str, Vec<FieldProjectionPlan>) {
+    pub fn from_operation<'a>(
+        operation: &'a OperationDefinition,
+        schema_metadata: &'a SchemaMetadata,
+    ) -> (&'a str, Vec<FieldProjectionPlan>) {
         let root_type_name = match operation.operation_kind {
-            Some(OperationKind::Query) => "Query",
-            Some(OperationKind::Mutation) => "Mutation",
-            Some(OperationKind::Subscription) => "Subscription",
-            None => "Query",
-        };
+            None | Some(OperationKind::Query) => schema_metadata.query_type_name.as_ref(),
+            Some(OperationKind::Mutation) => schema_metadata.mutation_type_name.as_ref(),
+            Some(OperationKind::Subscription) => schema_metadata.subscription_type_name.as_ref(),
+        }
+        .unwrap_or_else(|| {
+            // SAFETY: operation was validated already,
+            // so the matching root type should be present
+            panic!(
+                "No root type found for operation kind: {:?}",
+                operation.operation_kind
+            );
+        });
 
         let mut plans = Self::from_selection_set(
             &operation.selection_set,

--- a/lib/graphql-tools/src/ast/ext.rs
+++ b/lib/graphql-tools/src/ast/ext.rs
@@ -94,54 +94,20 @@ impl schema::Document {
         None
     }
 
-    fn schema_definition(&self) -> &schema::SchemaDefinition {
-        lazy_static! {
-            static ref DEFAULT_SCHEMA_DEF: schema::SchemaDefinition = {
-                schema::SchemaDefinition {
-                    query: Some("Query".to_string()),
-                    ..Default::default()
-                }
-            };
-        }
-        self.definitions
-            .iter()
-            .find_map(|definition| match definition {
-                schema::Definition::SchemaDefinition(schema_definition) => Some(schema_definition),
-                _ => None,
-            })
-            .unwrap_or(&*DEFAULT_SCHEMA_DEF)
-    }
-
     pub fn query_type(&self) -> &ObjectType {
-        let schema_definition = self.schema_definition();
-        self.object_type_by_name(
-            schema_definition
-                .query
-                .as_ref()
-                .unwrap_or(&QUERY_TYPE_DEFAULT_NAME),
-        )
-        .unwrap()
+        self.query_type_name()
+            .and_then(|name| self.object_type_by_name(name))
+            .expect("invariant violation: every valid schema must define a query type")
     }
 
     pub fn mutation_type(&self) -> Option<&ObjectType> {
-        let schema_definition = self.schema_definition();
-        self.object_type_by_name(
-            schema_definition
-                .mutation
-                .as_ref()
-                .unwrap_or(&MUTATION_TYPE_DEFAULT_NAME),
-        )
+        self.mutation_type_name()
+            .and_then(|name| self.object_type_by_name(name))
     }
 
     pub fn subscription_type(&self) -> Option<&ObjectType> {
-        let schema_definition = self.schema_definition();
-
-        self.object_type_by_name(
-            schema_definition
-                .subscription
-                .as_ref()
-                .unwrap_or(&SUBSCRIPTION_TYPE_DEFAULT_NAME),
-        )
+        self.subscription_type_name()
+            .and_then(|name| self.object_type_by_name(name))
     }
 
     fn object_type_by_name(&self, name: &str) -> Option<&ObjectType> {
@@ -240,34 +206,6 @@ impl schema::Document {
         }
 
         false
-    }
-
-    pub fn query_type_name(&self) -> &str {
-        "Query"
-    }
-
-    pub fn mutation_type_name(&self) -> Option<&str> {
-        for def in &self.definitions {
-            if let schema::Definition::SchemaDefinition(schema_def) = def {
-                if let Some(name) = schema_def.mutation.as_ref() {
-                    return Some(name.as_str());
-                }
-            }
-        }
-
-        self.type_by_name("Mutation").map(|typ| typ.name())
-    }
-
-    pub fn subscription_type_name(&self) -> Option<&str> {
-        for def in &self.definitions {
-            if let schema::Definition::SchemaDefinition(schema_def) = def {
-                if let Some(name) = schema_def.subscription.as_ref() {
-                    return Some(name.as_str());
-                }
-            }
-        }
-
-        self.type_by_name("Subscription").map(|typ| typ.name())
     }
 }
 

--- a/lib/graphql-tools/src/ast/operation_visitor.rs
+++ b/lib/graphql-tools/src/ast/operation_visitor.rs
@@ -183,43 +183,9 @@ fn visit_definitions<'a, Visitor, UserContext>(
             Definition::Operation(operation) => match operation {
                 OperationDefinition::Query(_) => Some(&context.schema.query_type().name),
                 OperationDefinition::SelectionSet(_) => Some(&context.schema.query_type().name),
-                OperationDefinition::Mutation(_) => {
-                    context.schema.mutation_type().map(|t| &t.name).or_else(|| {
-                        // Awkward hack but enables me to move forward
-                        // Somehow the `mutation_type()` gives None, even though `Mutation` type is defined in the schema.
-                        if let Some(type_definition) = context.schema.type_by_name("Mutation") {
-                            return match type_definition {
-                                crate::parser::schema::TypeDefinition::Object(object_type) => {
-                                    Some(&object_type.name)
-                                }
-                                _ => None,
-                            };
-                        }
-
-                        None
-                    })
-                }
+                OperationDefinition::Mutation(_) => context.schema.mutation_type().map(|t| &t.name),
                 OperationDefinition::Subscription(_) => {
-                    context
-                        .schema
-                        .subscription_type()
-                        .map(|t| &t.name)
-                        .or_else(|| {
-                            // Awkward hack but enables me to move forward
-                            // Somehow the `subscription_type()` gives None, even though `Subscription` type is defined in the schema.
-                            if let Some(type_definition) =
-                                context.schema.type_by_name("Subscription")
-                            {
-                                return match type_definition {
-                                    crate::parser::schema::TypeDefinition::Object(object_type) => {
-                                        Some(&object_type.name)
-                                    }
-                                    _ => None,
-                                };
-                            }
-
-                            None
-                        })
+                    context.schema.subscription_type().map(|t| &t.name)
                 }
             },
         };
@@ -752,5 +718,78 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         _: &mut UserContext,
         _: &(String, Value),
     ) {
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct RecordingVisitor {
+        seen_types: Vec<Option<String>>,
+    }
+
+    impl<'a> OperationVisitor<'a, ()> for RecordingVisitor {
+        fn enter_operation_definition(
+            &mut self,
+            context: &mut OperationVisitorContext<'a>,
+            _user_context: &mut (),
+            _operation: &'a OperationDefinition,
+        ) {
+            self.seen_types.push(
+                context
+                    .current_type()
+                    .map(|type_def| type_def.name().to_string()),
+            );
+        }
+    }
+
+    fn assert_seen_type(schema_sdl: &str, operation: &str, expected: &str) {
+        let schema = crate::parser::parse_schema::<String>(schema_sdl)
+            .expect("valid schema")
+            .into_static();
+        let operation_doc = crate::parser::parse_query::<String>(operation)
+            .expect("valid operation")
+            .into_static();
+
+        let mut context = OperationVisitorContext::new(&operation_doc, &schema);
+        let mut visitor = RecordingVisitor {
+            seen_types: Vec::new(),
+        };
+
+        visit_document(&mut visitor, &operation_doc, &mut context, &mut ());
+
+        assert_eq!(visitor.seen_types.len(), 1);
+        assert_eq!(visitor.seen_types[0], Some(expected.to_string()));
+    }
+
+    #[test]
+    fn default_root_type_names() {
+        let schema = "
+            type Query { hello: String }
+            type Mutation { doThing: String }
+            type Subscription { onThing: String }
+        ";
+
+        assert_seen_type(schema, "mutation { doThing }", "Mutation");
+        assert_seen_type(schema, "subscription { onThing }", "Subscription");
+    }
+
+    #[test]
+    fn renamed_root_types() {
+        let schema = "
+            schema {
+              query: RootQuery
+              mutation: RootMutation
+              subscription: RootSubscription
+            }
+
+            type RootQuery { hello: String }
+            type RootMutation { doThing: String }
+            type RootSubscription { onThing: String }
+        ";
+
+        assert_seen_type(schema, "mutation { doThing }", "RootMutation");
+        assert_seen_type(schema, "subscription { onThing }", "RootSubscription");
     }
 }

--- a/lib/graphql-tools/src/parser/schema/ast.rs
+++ b/lib/graphql-tools/src/parser/schema/ast.rs
@@ -10,6 +10,50 @@ pub struct Document<'a, T: Text<'a>> {
     pub definitions: Vec<Definition<'a, T>>,
 }
 
+impl<'a, T: Text<'a>> Document<'a, T> {
+    pub fn new(definitions: Vec<Definition<'a, T>>) -> Self {
+        Document { definitions }
+    }
+
+    pub fn query_type_name(&self) -> Option<&T::Value> {
+        self.root_type_name("Query", |sd| &sd.query)
+    }
+
+    pub fn mutation_type_name(&self) -> Option<&T::Value> {
+        self.root_type_name("Mutation", |sd| &sd.mutation)
+    }
+
+    pub fn subscription_type_name(&self) -> Option<&T::Value> {
+        self.root_type_name("Subscription", |sd| &sd.subscription)
+    }
+
+    fn root_type_name(
+        &self,
+        default_name: &str,
+        schema_definition_field: impl for<'s> Fn(&'s SchemaDefinition<'a, T>) -> &'s Option<T::Value>,
+    ) -> Option<&T::Value> {
+        let mut fallback = None;
+
+        for definition in &self.definitions {
+            match definition {
+                Definition::SchemaDefinition(schema_definition) => {
+                    if let Some(name) = schema_definition_field(schema_definition).as_ref() {
+                        return Some(name);
+                    }
+                }
+                Definition::TypeDefinition(TypeDefinition::Object(object))
+                    if fallback.is_none() && object.name.as_ref() == default_name =>
+                {
+                    fallback = Some(&object.name);
+                }
+                _ => {}
+            }
+        }
+
+        fallback
+    }
+}
+
 impl<'a> Document<'a, String> {
     pub fn into_static(self) -> Document<'static, String> {
         // To support both reference and owned values in the AST,

--- a/lib/graphql-tools/src/parser/schema/grammar.rs
+++ b/lib/graphql-tools/src/parser/schema/grammar.rs
@@ -693,7 +693,7 @@ where
 {
     let mut tokens = TokenStream::new(s);
     let (doc, _) = many1(parser(definition))
-        .map(|d| Document { definitions: d })
+        .map(Document::new)
         .skip(eof())
         .parse_stream(&mut tokens)
         .into_result()
@@ -716,15 +716,13 @@ mod test {
     fn one_field() {
         assert_eq!(
             ast("schema { query: Query }"),
-            Document {
-                definitions: vec![Definition::SchemaDefinition(SchemaDefinition {
-                    position: Pos { line: 1, column: 1 },
-                    directives: vec![],
-                    query: Some("Query".into()),
-                    mutation: None,
-                    subscription: None
-                })],
-            }
+            Document::new(vec![Definition::SchemaDefinition(SchemaDefinition {
+                position: Pos { line: 1, column: 1 },
+                directives: vec![],
+                query: Some("Query".into()),
+                mutation: None,
+                subscription: None
+            })])
         );
     }
 }

--- a/lib/query-planner/fixture/tests/renamed-root-types.supergraph.graphql
+++ b/lib/query-planner/fixture/tests/renamed-root-types.supergraph.graphql
@@ -1,0 +1,84 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: RootQuery
+  mutation: RootMutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+input AddProductInput @join__type(graph: A) {
+  name: String!
+  price: Float!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://localhost:4200/renamed/a")
+  B @join__graph(name: "b", url: "http://localhost:4200/renamed/b")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type RootMutation
+  @join__type(graph: A)
+  @join__type(graph: B) {
+  addProduct(input: AddProductInput!): Product! @join__field(graph: A)
+  delete: Int! @join__field(graph: B)
+}
+
+type Product @join__type(graph: A, key: "id") @join__type(graph: B, key: "id") {
+  id: ID!
+  name: String! @join__field(graph: A)
+  price: Float! @join__field(graph: A) @join__field(graph: B, external: true)
+  isExpensive: Boolean! @join__field(graph: B, requires: "price")
+  isAvailable: Boolean! @join__field(graph: B)
+}
+
+type RootQuery @join__type(graph: A) @join__type(graph: B) {
+  product(id: ID!): Product! @join__field(graph: A)
+  products: [Product!]! @join__field(graph: A)
+}

--- a/lib/query-planner/src/ast/hash.rs
+++ b/lib/query-planner/src/ast/hash.rs
@@ -68,9 +68,9 @@ pub fn ast_hash(query: &OperationDefinition) -> u64 {
 impl ASTHash for &OperationKind {
     fn ast_hash<H: Hasher, const ORDER_INDEPENDENT: bool>(&self, hasher: &mut H) {
         match self {
-            OperationKind::Query => "Query".hash(hasher),
-            OperationKind::Mutation => "Mutation".hash(hasher),
-            OperationKind::Subscription => "Subscription".hash(hasher),
+            OperationKind::Query => "kind:query".hash(hasher),
+            OperationKind::Mutation => "kind:mutation".hash(hasher),
+            OperationKind::Subscription => "kind:subscription".hash(hasher),
         }
     }
 }
@@ -430,7 +430,7 @@ mod tests {
 
         // Snapshot test: compare against a known, pre-calculated hash.
         // If the hashing logic changes, this value will need to be updated.
-        let expected_hash = 3221166439930069003;
+        let expected_hash = 4628017135056249916;
         assert_eq!(
             hash1, expected_hash,
             "AST hash does not match the snapshot value. If this change is intentional, update the snapshot."

--- a/lib/query-planner/src/ast/minification/error.rs
+++ b/lib/query-planner/src/ast/minification/error.rs
@@ -2,6 +2,8 @@
 pub enum MinificationError {
     #[error("Type not found: {0}")]
     TypeNotFound(String),
+    #[error("Type not found for operation kind: {0}")]
+    TypeForOperationNotFound(String),
     #[error("Field '{0}' not found in type '{1}'")]
     FieldNotFound(String, String),
     #[error("Unsupported fragment spread")]

--- a/lib/query-planner/src/ast/minification/mod.rs
+++ b/lib/query-planner/src/ast/minification/mod.rs
@@ -28,11 +28,12 @@ fn get_root_type_name<'a>(
         Some(OperationKind::Mutation) => supergraph
             .mutation_type
             .as_ref()
-            .ok_or_else(|| MinificationError::TypeNotFound("Mutation".to_string()))?,
-        Some(OperationKind::Subscription) => supergraph
-            .subscription_type
-            .as_ref()
-            .ok_or_else(|| MinificationError::TypeNotFound("Subscription".to_string()))?,
+            .ok_or_else(|| MinificationError::TypeForOperationNotFound("mutation".to_string()))?,
+        Some(OperationKind::Subscription) => {
+            supergraph.subscription_type.as_ref().ok_or_else(|| {
+                MinificationError::TypeForOperationNotFound("subscription".to_string())
+            })?
+        }
     })
 }
 

--- a/lib/query-planner/src/ast/normalization/context.rs
+++ b/lib/query-planner/src/ast/normalization/context.rs
@@ -1,11 +1,30 @@
 use graphql_tools::parser::query as query_ast;
 
-use crate::state::supergraph_state::SupergraphState;
+use crate::{
+    ast::normalization::error::NormalizationError, state::supergraph_state::SupergraphState,
+};
 
 pub struct RootTypes<'a> {
     pub query: Option<&'a str>,
     pub mutation: Option<&'a str>,
     pub subscription: Option<&'a str>,
+}
+
+impl<'a> RootTypes<'a> {
+    pub fn query_type_name(&self) -> Result<&'a str, NormalizationError> {
+        self.query
+            .ok_or_else(|| NormalizationError::TypeForOperationNotFound {
+                kind: "query".to_string(),
+            })
+    }
+
+    pub fn mutation_type_name(&self) -> Option<&'a str> {
+        self.mutation
+    }
+
+    pub fn subscription_type_name(&self) -> Option<&'a str> {
+        self.subscription
+    }
 }
 
 pub struct NormalizationContext<'a> {
@@ -14,20 +33,6 @@ pub struct NormalizationContext<'a> {
     pub supergraph: &'a SupergraphState,
     pub root_types: RootTypes<'a>,
     pub subgraph_name: Option<&'a String>,
-}
-
-impl<'a> NormalizationContext<'a> {
-    pub fn query_type_name(&self) -> &'a str {
-        self.root_types.query.unwrap_or("Query")
-    }
-
-    pub fn mutation_type_name(&self) -> &'a str {
-        self.root_types.mutation.unwrap_or("Mutation")
-    }
-
-    pub fn subscription_type_name(&self) -> &'a str {
-        self.root_types.subscription.unwrap_or("Subscription")
-    }
 }
 
 impl<'a> From<&'a SupergraphState> for RootTypes<'a> {

--- a/lib/query-planner/src/ast/normalization/error.rs
+++ b/lib/query-planner/src/ast/normalization/error.rs
@@ -12,6 +12,9 @@ pub enum NormalizationError {
     #[error("An operation was expected, but none were present.")]
     OperationNotFound,
 
+    #[error("Type for operation kind '{kind}' not found.")]
+    TypeForOperationNotFound { kind: String },
+
     #[error("Schema type '{type_name}' not found.")]
     SchemaTypeNotFound { type_name: String },
 

--- a/lib/query-planner/src/ast/normalization/pipeline/flatten_fragments.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/flatten_fragments.rs
@@ -26,9 +26,7 @@ pub type PossibleTypesMap<'a> = HashMap<&'a str, HashSet<&'a str>>;
 #[inline]
 pub fn flatten_fragments(ctx: &mut NormalizationContext) -> Result<(), NormalizationError> {
     let possible_types = build_possible_types_map(ctx);
-    let query_type_name = ctx.query_type_name();
-    let mutation_type_name = ctx.mutation_type_name();
-    let subscription_type_name = ctx.subscription_type_name();
+    let query_type_name = ctx.root_types.query_type_name()?;
 
     for definition in &mut ctx.document.definitions {
         if let Definition::Operation(op_def) = definition {
@@ -37,12 +35,22 @@ pub fn flatten_fragments(ctx: &mut NormalizationContext) -> Result<(), Normaliza
                 OperationDefinition::Query(Query { selection_set, .. }) => {
                     (query_type_name, selection_set)
                 }
-                OperationDefinition::Mutation(Mutation { selection_set, .. }) => {
-                    (mutation_type_name, selection_set)
-                }
-                OperationDefinition::Subscription(Subscription { selection_set, .. }) => {
-                    (subscription_type_name, selection_set)
-                }
+                OperationDefinition::Mutation(Mutation { selection_set, .. }) => (
+                    ctx.root_types.mutation_type_name().ok_or_else(|| {
+                        NormalizationError::TypeForOperationNotFound {
+                            kind: "mutation".to_string(),
+                        }
+                    })?,
+                    selection_set,
+                ),
+                OperationDefinition::Subscription(Subscription { selection_set, .. }) => (
+                    ctx.root_types.subscription_type_name().ok_or_else(|| {
+                        NormalizationError::TypeForOperationNotFound {
+                            kind: "subscription".to_string(),
+                        }
+                    })?,
+                    selection_set,
+                ),
             };
 
             let root_type_def =

--- a/lib/query-planner/src/ast/normalization/pipeline/flatten_matching_object_fragments.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/flatten_matching_object_fragments.rs
@@ -12,46 +12,57 @@ pub fn flatten_matching_object_fragments(
     ctx: &mut NormalizationContext,
 ) -> Result<(), NormalizationError> {
     let supergraph = ctx.supergraph;
-    let query_type_name = ctx.query_type_name().to_string();
-    let mutation_type_name = ctx.mutation_type_name().to_string();
-    let subscription_type_name = ctx.subscription_type_name().to_string();
+    let query_type_name = ctx.root_types.query_type_name()?;
 
     for definition in &mut ctx.document.definitions {
         match definition {
             Definition::Operation(op_def) => match op_def {
                 OperationDefinition::SelectionSet(selection_set) => {
-                    let root_def = supergraph
-                        .definitions
-                        .get(query_type_name.as_str())
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: query_type_name.clone(),
+                    let root_def =
+                        supergraph.definitions.get(query_type_name).ok_or_else(|| {
+                            NormalizationError::SchemaTypeNotFound {
+                                type_name: query_type_name.to_string(),
+                            }
                         })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }
                 OperationDefinition::Query(Query { selection_set, .. }) => {
-                    let root_def = supergraph
-                        .definitions
-                        .get(query_type_name.as_str())
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: query_type_name.clone(),
+                    let root_def =
+                        supergraph.definitions.get(query_type_name).ok_or_else(|| {
+                            NormalizationError::SchemaTypeNotFound {
+                                type_name: query_type_name.to_string(),
+                            }
                         })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }
                 OperationDefinition::Mutation(Mutation { selection_set, .. }) => {
-                    let root_def = supergraph
-                        .definitions
-                        .get(mutation_type_name.as_str())
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: mutation_type_name.clone(),
+                    let mutation_type_name =
+                        ctx.root_types.mutation_type_name().ok_or_else(|| {
+                            NormalizationError::TypeForOperationNotFound {
+                                kind: "mutation".to_string(),
+                            }
                         })?;
+                    let root_def =
+                        supergraph
+                            .definitions
+                            .get(mutation_type_name)
+                            .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
+                                type_name: mutation_type_name.to_string(),
+                            })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }
                 OperationDefinition::Subscription(Subscription { selection_set, .. }) => {
+                    let subscription_type_name = ctx
+                        .root_types
+                        .subscription_type_name()
+                        .ok_or_else(|| NormalizationError::TypeForOperationNotFound {
+                            kind: "subscription".to_string(),
+                        })?;
                     let root_def = supergraph
                         .definitions
-                        .get(subscription_type_name.as_str())
+                        .get(subscription_type_name)
                         .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: subscription_type_name.clone(),
+                            type_name: subscription_type_name.to_string(),
                         })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }

--- a/lib/query-planner/src/ast/normalization/pipeline/merge_inline_fragments.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/merge_inline_fragments.rs
@@ -11,46 +11,57 @@ use crate::utils::ast::equal_directives_arr;
 #[inline]
 pub fn merge_inline_fragments(ctx: &mut NormalizationContext) -> Result<(), NormalizationError> {
     let supergraph = ctx.supergraph;
-    let query_type_name = ctx.query_type_name().to_string();
-    let mutation_type_name = ctx.mutation_type_name().to_string();
-    let subscription_type_name = ctx.subscription_type_name().to_string();
+    let query_type_name = ctx.root_types.query_type_name()?;
 
     for definition in &mut ctx.document.definitions {
         match definition {
             Definition::Operation(op_def) => match op_def {
                 OperationDefinition::SelectionSet(selection_set) => {
-                    let root_def = supergraph
-                        .definitions
-                        .get(query_type_name.as_str())
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: query_type_name.clone(),
+                    let root_def =
+                        supergraph.definitions.get(query_type_name).ok_or_else(|| {
+                            NormalizationError::SchemaTypeNotFound {
+                                type_name: query_type_name.to_string(),
+                            }
                         })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }
                 OperationDefinition::Query(Query { selection_set, .. }) => {
-                    let root_def = supergraph
-                        .definitions
-                        .get(query_type_name.as_str())
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: query_type_name.clone(),
+                    let root_def =
+                        supergraph.definitions.get(query_type_name).ok_or_else(|| {
+                            NormalizationError::SchemaTypeNotFound {
+                                type_name: query_type_name.to_string(),
+                            }
                         })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }
                 OperationDefinition::Mutation(Mutation { selection_set, .. }) => {
-                    let root_def = supergraph
-                        .definitions
-                        .get(mutation_type_name.as_str())
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: mutation_type_name.clone(),
+                    let mutation_type_name =
+                        ctx.root_types.mutation_type_name().ok_or_else(|| {
+                            NormalizationError::TypeForOperationNotFound {
+                                kind: "mutation".to_string(),
+                            }
                         })?;
+                    let root_def =
+                        supergraph
+                            .definitions
+                            .get(mutation_type_name)
+                            .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
+                                type_name: mutation_type_name.to_string(),
+                            })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }
                 OperationDefinition::Subscription(Subscription { selection_set, .. }) => {
+                    let subscription_type_name = ctx
+                        .root_types
+                        .subscription_type_name()
+                        .ok_or_else(|| NormalizationError::TypeForOperationNotFound {
+                            kind: "subscription".to_string(),
+                        })?;
                     let root_def = supergraph
                         .definitions
-                        .get(subscription_type_name.as_str())
+                        .get(subscription_type_name)
                         .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: subscription_type_name.clone(),
+                            type_name: subscription_type_name.to_string(),
                         })?;
                     handle_selection_set(supergraph, selection_set, root_def)?;
                 }

--- a/lib/query-planner/src/ast/normalization/pipeline/type_expand.rs
+++ b/lib/query-planner/src/ast/normalization/pipeline/type_expand.rs
@@ -66,56 +66,56 @@ pub fn type_expand(ctx: &mut NormalizationContext) -> Result<(), NormalizationEr
         }
     }
 
-    let query_type_name = ctx.query_type_name();
-    let mutation_type_name = ctx.mutation_type_name();
-    let subscription_type_name = ctx.subscription_type_name();
+    let supergraph = ctx.supergraph;
+    let definitions = &mut ctx.document.definitions;
 
-    for definition in &mut ctx.document.definitions {
-        match definition {
-            Definition::Operation(op_def) => match op_def {
-                OperationDefinition::SelectionSet(selection_set) => {
-                    let root =
-                        ctx.supergraph
-                            .definitions
-                            .get(query_type_name)
-                            .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                                type_name: "Query".to_string(),
-                            })?;
-                    handle_selection_set(ctx.supergraph, &possible_types, root, selection_set)?;
-                }
-                OperationDefinition::Query(Query { selection_set, .. }) => {
-                    let root =
-                        ctx.supergraph
-                            .definitions
-                            .get(query_type_name)
-                            .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                                type_name: "Query".to_string(),
-                            })?;
-                    handle_selection_set(ctx.supergraph, &possible_types, root, selection_set)?;
-                }
-                OperationDefinition::Mutation(Mutation { selection_set, .. }) => {
-                    let root = ctx
-                        .supergraph
-                        .definitions
-                        .get(mutation_type_name)
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: "Mutation".to_string(),
-                        })?;
-                    handle_selection_set(ctx.supergraph, &possible_types, root, selection_set)?;
-                }
-                OperationDefinition::Subscription(Subscription { selection_set, .. }) => {
-                    let root = ctx
-                        .supergraph
-                        .definitions
-                        .get(subscription_type_name)
-                        .ok_or_else(|| NormalizationError::SchemaTypeNotFound {
-                            type_name: "Subscription".to_string(),
-                        })?;
-                    handle_selection_set(ctx.supergraph, &possible_types, root, selection_set)?;
-                }
-            },
-            Definition::Fragment(_) => {}
-        }
+    for definition in definitions {
+        let selection_set_and_root_name = match definition {
+            Definition::Operation(OperationDefinition::SelectionSet(selection_set)) => {
+                Some((selection_set, ctx.root_types.query_type_name()?))
+            }
+            Definition::Operation(OperationDefinition::Query(Query { selection_set, .. })) => {
+                Some((selection_set, ctx.root_types.query_type_name()?))
+            }
+
+            Definition::Operation(OperationDefinition::Mutation(Mutation {
+                selection_set,
+                ..
+            })) => Some((
+                selection_set,
+                ctx.root_types.mutation_type_name().ok_or_else(|| {
+                    NormalizationError::TypeForOperationNotFound {
+                        kind: "mutation".to_string(),
+                    }
+                })?,
+            )),
+
+            Definition::Operation(OperationDefinition::Subscription(Subscription {
+                selection_set,
+                ..
+            })) => Some((
+                selection_set,
+                ctx.root_types.subscription_type_name().ok_or_else(|| {
+                    NormalizationError::TypeForOperationNotFound {
+                        kind: "subscription".to_string(),
+                    }
+                })?,
+            )),
+
+            Definition::Fragment(_) => None,
+        };
+
+        let Some((selection_set, root_type_name)) = selection_set_and_root_name else {
+            continue;
+        };
+
+        let root = supergraph.definitions.get(root_type_name).ok_or_else(|| {
+            NormalizationError::SchemaTypeNotFound {
+                type_name: root_type_name.to_owned(),
+            }
+        })?;
+
+        handle_selection_set(supergraph, &possible_types, root, selection_set)?;
     }
 
     Ok(())

--- a/lib/query-planner/src/consumer_schema/mod.rs
+++ b/lib/query-planner/src/consumer_schema/mod.rs
@@ -40,6 +40,13 @@ impl ConsumerSchema {
         let introspection_schema = include_str!("introspection_schema.graphql");
         let mut parsed_introspection_schema =
             graphql_tools::parser::schema::parse_schema(introspection_schema).unwrap();
+
+        let query_type_name = result
+            .query_type_name()
+            .map(|name| name.to_string())
+            // SAFETY: Supergraph is guaranteed to have a query type, it's one of the validation rules
+            .expect("Query type not found in schema");
+
         parsed_introspection_schema
             .definitions
             .iter_mut()
@@ -54,7 +61,7 @@ impl ConsumerSchema {
                                     query_def,
                                 )) = d
                                 {
-                                    query_def.name == "Query"
+                                    query_def.name == query_type_name
                                 } else {
                                     false
                                 }

--- a/lib/query-planner/src/consumer_schema/prune_inacessible.rs
+++ b/lib/query-planner/src/consumer_schema/prune_inacessible.rs
@@ -36,8 +36,8 @@ impl<'a, T: Text<'a> + Clone> SchemaTransformer<'a, T> for PruneInaccessible {
         &mut self,
         document: &Document<'a, T>,
     ) -> TransformedValue<Document<'a, T>> {
-        let new_doc = Document {
-            definitions: document
+        let new_doc = Document::new(
+            document
                 .definitions
                 .iter()
                 .filter(|def| match def {
@@ -65,7 +65,7 @@ impl<'a, T: Text<'a> + Clone> SchemaTransformer<'a, T> for PruneInaccessible {
                 })
                 .cloned()
                 .collect(),
-        };
+        );
 
         self.default_transform_document(&new_doc)
     }
@@ -127,5 +127,66 @@ impl<'a, T: Text<'a> + Clone> SchemaTransformer<'a, T> for PruneInaccessible {
             .collect();
 
         self.default_transform_fields(&new_fields)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::parsing::parse_schema;
+
+    #[test]
+    fn prune_preserves_root_type_names() {
+        let schema = parse_schema(
+            "
+            type Query { hello: String }
+            type Mutation { doThing: String }
+            type Subscription { onThing: String }
+            ",
+        );
+
+        let result = PruneInaccessible::prune(&schema);
+
+        assert_eq!(result.query_type_name().map(|s| s.as_str()), Some("Query"));
+        assert_eq!(
+            result.mutation_type_name().map(|s| s.as_str()),
+            Some("Mutation")
+        );
+        assert_eq!(
+            result.subscription_type_name().map(|s| s.as_str()),
+            Some("Subscription")
+        );
+    }
+
+    #[test]
+    fn prune_preserves_renamed_root_type_names() {
+        let schema = parse_schema(
+            "
+            schema {
+              query: RootQuery
+              mutation: RootMutation
+              subscription: RootSubscription
+            }
+
+            type RootQuery { hello: String }
+            type RootMutation { doThing: String }
+            type RootSubscription { onThing: String }
+            ",
+        );
+
+        let result = PruneInaccessible::prune(&schema);
+
+        assert_eq!(
+            result.query_type_name().map(|s| s.as_str()),
+            Some("RootQuery")
+        );
+        assert_eq!(
+            result.mutation_type_name().map(|s| s.as_str()),
+            Some("RootMutation")
+        );
+        assert_eq!(
+            result.subscription_type_name().map(|s| s.as_str()),
+            Some("RootSubscription")
+        );
     }
 }

--- a/lib/query-planner/src/consumer_schema/strip_schema_internals.rs
+++ b/lib/query-planner/src/consumer_schema/strip_schema_internals.rs
@@ -86,8 +86,8 @@ impl<'a, T: Text<'a> + Clone> SchemaTransformer<'a, T> for StripSchemaInternals 
         &mut self,
         document: &Document<'a, T>,
     ) -> TransformedValue<Document<'a, T>> {
-        let new_doc = Document {
-            definitions: document
+        let new_doc = Document::new(
+            document
                 .definitions
                 .iter()
                 .filter(|def| match def {
@@ -117,7 +117,7 @@ impl<'a, T: Text<'a> + Clone> SchemaTransformer<'a, T> for StripSchemaInternals 
                 })
                 .cloned()
                 .collect(),
-        };
+        );
 
         self.default_transform_document(&new_doc)
     }

--- a/lib/query-planner/src/federation_spec/mod.rs
+++ b/lib/query-planner/src/federation_spec/mod.rs
@@ -44,8 +44,8 @@ fn normalize_fields_argument_value_mut(
         None,
         Some(RootTypes {
             query: Some(type_name),
-            mutation: None,
-            subscription: None,
+            mutation: supergraph.mutation_type.as_deref(),
+            subscription: supergraph.subscription_type.as_deref(),
         }),
         Some(subgraph_name),
     )

--- a/lib/query-planner/src/graph/edge.rs
+++ b/lib/query-planner/src/graph/edge.rs
@@ -7,8 +7,9 @@ use std::{
 use petgraph::graph::EdgeReference as GraphEdgeReference;
 
 use crate::{
-    ast::type_aware_selection::TypeAwareSelection, federation_spec::directives::JoinFieldDirective,
-    state::supergraph_state::SubgraphName,
+    ast::type_aware_selection::TypeAwareSelection,
+    federation_spec::directives::JoinFieldDirective,
+    state::supergraph_state::{OperationKind, SubgraphName},
 };
 
 #[derive(Debug)]
@@ -159,6 +160,7 @@ impl Display for OverrideLabel {
 pub enum Edge {
     SubgraphEntrypoint {
         name: SubgraphName,
+        operation_kind: OperationKind,
     },
     FieldMove(Box<FieldMove>),
     ReentryMove(ReentryMove),

--- a/lib/query-planner/src/graph/mod.rs
+++ b/lib/query-planner/src/graph/mod.rs
@@ -551,6 +551,7 @@ impl Graph {
                             tail,
                             Edge::SubgraphEntrypoint {
                                 name: state.resolve_graph_id(graph_id)?,
+                                operation_kind: root_type.clone(),
                             },
                         );
                     }

--- a/lib/query-planner/src/planner/fetch/fetch_graph.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_graph.rs
@@ -306,6 +306,7 @@ fn create_noop_fetch_step(
         flags,
         condition: None,
         kind: FetchStepKind::Root,
+        operation_kind: OperationKind::Query,
         input_rewrites: None,
         output_rewrites: None,
         variable_usages: None,
@@ -345,6 +346,7 @@ fn create_fetch_step_for_entity_call(
         flags,
         condition: condition.cloned(),
         kind: FetchStepKind::Entity,
+        operation_kind: OperationKind::Query,
         input_rewrites: None,
         output_rewrites: None,
         variable_usages: None,
@@ -354,11 +356,14 @@ fn create_fetch_step_for_entity_call(
     })
 }
 
+// TODO: simplfy args
+#[allow(clippy::too_many_arguments)]
 fn create_fetch_step_for_root_move(
     fetch_graph: &mut FetchGraph<SingleTypeFetchStep>,
     root_step_index: NodeIndex,
     subgraph_name: &SubgraphName,
     type_name: &str,
+    operation_kind: OperationKind,
     mutation_field_position: MutationFieldPosition,
     response_path: &MergePath,
     condition: Option<&Condition>,
@@ -372,6 +377,7 @@ fn create_fetch_step_for_root_move(
         flags: FetchStepFlags::empty(),
         condition: condition.cloned(),
         kind: FetchStepKind::Root,
+        operation_kind,
         variable_usages: None,
         variable_definitions: None,
         input_rewrites: None,
@@ -1024,6 +1030,7 @@ fn process_subgraph_entrypoint_edge(
     parent_fetch_step_index: NodeIndex,
     subgraph_name: &SubgraphName,
     type_name: &str,
+    operation_kind: OperationKind,
     created_from_requires: bool,
 ) -> Result<Vec<NodeIndex>, FetchGraphError> {
     let fetch_step_index = create_fetch_step_for_root_move(
@@ -1031,6 +1038,7 @@ fn process_subgraph_entrypoint_edge(
         parent_fetch_step_index,
         subgraph_name,
         type_name,
+        operation_kind,
         query_node.mutation_field_position,
         &MergePath::default(),
         None,
@@ -1145,6 +1153,7 @@ fn process_subgraph_reentry(
         parent_fetch_step_index,
         subgraph_name,
         type_name,
+        OperationKind::Query,
         query_node.mutation_field_position,
         &child_response_path,
         condition,
@@ -1822,7 +1831,10 @@ fn process_query_node(
         let edge = graph.edge(edge_index)?;
 
         match edge {
-            Edge::SubgraphEntrypoint { name, .. } => {
+            Edge::SubgraphEntrypoint {
+                name,
+                operation_kind,
+            } => {
                 let tail_node_index = graph.get_edge_tail(&edge_index)?;
                 let tail_node = graph.node(tail_node_index)?;
                 let type_name = match tail_node {
@@ -1841,6 +1853,7 @@ fn process_query_node(
                     parent_fetch_step_index,
                     name,
                     type_name,
+                    operation_kind.clone(),
                     created_from_requires,
                 )
             }

--- a/lib/query-planner/src/planner/fetch/fetch_step_data.rs
+++ b/lib/query-planner/src/planner/fetch/fetch_step_data.rs
@@ -17,7 +17,7 @@ use crate::{
         plan_nodes::FetchRewrite,
         tree::query_tree_node::MutationFieldPosition,
     },
-    state::supergraph_state::SubgraphName,
+    state::supergraph_state::{OperationKind, SubgraphName},
 };
 
 bitflags! {
@@ -38,6 +38,7 @@ pub struct FetchStepData<State> {
     pub input: FetchStepSelections<State>,
     pub output: FetchStepSelections<State>,
     pub kind: FetchStepKind,
+    pub operation_kind: OperationKind,
     pub flags: FetchStepFlags,
     pub condition: Option<Condition>,
     pub variable_usages: Option<BTreeSet<String>>,
@@ -222,6 +223,7 @@ impl FetchStepData<SingleTypeFetchStep> {
             input: self.input.into_multi_type(),
             output: self.output.into_multi_type(),
             kind: self.kind,
+            operation_kind: self.operation_kind,
             flags: self.flags,
             condition: self.condition,
             variable_usages: self.variable_usages,

--- a/lib/query-planner/src/planner/fetch/selections.rs
+++ b/lib/query-planner/src/planner/fetch/selections.rs
@@ -39,18 +39,27 @@ impl Display for FetchStepSelections<SingleTypeFetchStep> {
     }
 }
 
-impl From<&FetchStepSelections<MultiTypeFetchStep>> for SelectionSet {
-    fn from(value: &FetchStepSelections<MultiTypeFetchStep>) -> Self {
-        if value.selections.len() == 1 {
-            let (type_name, selections) = value.selections.iter().next().unwrap();
+impl FetchStepSelections<MultiTypeFetchStep> {
+    /// Meant for input and output of entity calls.
+    pub fn to_non_root_selection_set(&self) -> SelectionSet {
+        self.wrap_in_type_fragments()
+    }
 
-            if type_name == "Query" || type_name == "Mutation" || type_name == "Subscription" {
+    pub fn to_root_selection_set(&self, root_type_name: &str) -> SelectionSet {
+        if self.selections.len() == 1 {
+            let (type_name, selections) = self.selections.iter().next().unwrap();
+
+            if type_name == root_type_name {
                 return selections.clone();
             }
         }
 
+        self.wrap_in_type_fragments()
+    }
+
+    fn wrap_in_type_fragments(&self) -> SelectionSet {
         SelectionSet {
-            items: value
+            items: self
                 .selections
                 .iter()
                 .map(|(type_name, selections)| {
@@ -131,7 +140,7 @@ fn clear_top_level_fragment_conditions(type_name: &str, selection_set: &mut Sele
 }
 
 /// Attempts to lift a common condition from the top-level inline fragments for
-/// `type_name` into the wrapper `... on Type` fragment we build in `From`.
+/// `type_name` into the wrapper `... on Type` fragment we build in `wrap_in_type_fragments`.
 ///
 /// Lifting is valid when every top-level item is an inline fragment on the same
 /// type and they all share the same condition. That condition may be
@@ -648,7 +657,7 @@ mod tests {
             "#,
         );
         insta::assert_snapshot!(
-            format!("{}", PrettySelectionSet((&fetch_selections).into())),
+            format!("{}", PrettySelectionSet(fetch_selections.to_non_root_selection_set())),
             @r#"
               ... on Book @skip(if: $title) {
                 sku
@@ -673,7 +682,7 @@ mod tests {
         );
 
         insta::assert_snapshot!(
-          format!("{}", PrettySelectionSet((&fetch_selections).into())),
+          format!("{}", PrettySelectionSet(fetch_selections.to_non_root_selection_set())),
             @r#"
               ... on Book @include(if: $x) {
                 ... on Book {
@@ -703,7 +712,7 @@ mod tests {
         );
 
         insta::assert_snapshot!(
-          format!("{}", PrettySelectionSet((&fetch_selections).into())),
+          format!("{}", PrettySelectionSet(fetch_selections.to_non_root_selection_set())),
             @r#"
               ... on Book {
                 ... on Book @include(if: $x) {
@@ -733,7 +742,7 @@ mod tests {
         );
 
         insta::assert_snapshot!(
-          format!("{}", PrettySelectionSet((&fetch_selections).into())),
+          format!("{}", PrettySelectionSet(fetch_selections.to_non_root_selection_set())),
             @r#"
               ... on Book @include(if: $x) {
                 title

--- a/lib/query-planner/src/planner/plan_nodes.rs
+++ b/lib/query-planner/src/planner/plan_nodes.rs
@@ -302,20 +302,35 @@ fn custom_scalar_paths_from_fetch_output(
     state.into_custom_scalar_paths()
 }
 
-pub fn custom_scalar_paths_for_type_selection(
-    type_name: &str,
+/// A dedicated function to produce custom scalar paths based on a `_entities` selection set.
+///
+/// Why? The regular `custom_scalar_paths_for_type_selection` requires a starting type name,
+/// which is not available for `_entities` selections.
+///
+/// The entity calls are always built from top-level `... on Type` fragments,
+/// so the starting type name is not needed.
+///
+/// Each fragment is visited using its own type condition.
+pub fn custom_scalar_paths_for_entities_selection(
     selection_set: &SelectionSet,
     supergraph: &SupergraphState,
 ) -> Option<CustomScalarPaths> {
     let mut state = CustomScalarPathState::default();
     let mut response_path = Vec::new();
-    collect_custom_scalar_path_state(
-        &mut state,
-        &mut response_path,
-        type_name,
-        selection_set,
-        supergraph,
-    );
+
+    for item in &selection_set.items {
+        if let SelectionItem::InlineFragment(fragment) = item {
+            response_path.clear();
+            collect_custom_scalar_path_state(
+                &mut state,
+                &mut response_path,
+                &fragment.type_condition,
+                &fragment.selections,
+                supergraph,
+            );
+        }
+    }
+
     state.into_custom_scalar_paths()
 }
 
@@ -638,7 +653,7 @@ impl PlanNode {
 fn create_input_selection_set(
     input_selections: &FetchStepSelections<MultiTypeFetchStep>,
 ) -> SelectionSet {
-    let selection_set: SelectionSet = input_selections.into();
+    let selection_set = input_selections.to_non_root_selection_set();
 
     selection_set.strip_for_plan_input()
 }
@@ -666,7 +681,7 @@ fn create_output_operation(
         selection_set: SelectionSet {
             items: vec![SelectionItem::Field(FieldSelection {
                 name: "_entities".to_string(),
-                selections: (&step.output).into(),
+                selections: step.output.to_non_root_selection_set(),
                 alias: None,
                 arguments: Some(
                     (
@@ -685,17 +700,6 @@ fn create_output_operation(
     let document = minify_operation(operation_def, supergraph).expect("Failed to minify");
 
     SubgraphFetchOperation::from_anonymous_operation(document)
-}
-
-impl From<&FetchStepData<MultiTypeFetchStep>> for OperationKind {
-    fn from(step: &FetchStepData<MultiTypeFetchStep>) -> Self {
-        match step.input.iter().next().unwrap().0.as_str() {
-            "Query" => OperationKind::Query,
-            "Mutation" => OperationKind::Mutation,
-            "Subscription" => OperationKind::Subscription,
-            _ => OperationKind::Query,
-        }
-    }
 }
 
 impl FetchNode {
@@ -720,10 +724,11 @@ impl FetchNode {
                 output_rewrites: step.output_rewrites.clone(),
             },
             false => {
+                let root_type_name = supergraph.expect_root_type_name(Some(&step.operation_kind));
                 let operation_def = OperationDefinition {
                     name: None,
-                    operation_kind: Some(step.into()),
-                    selection_set: (&step.output).into(),
+                    operation_kind: Some(step.operation_kind.clone()),
+                    selection_set: step.output.to_root_selection_set(root_type_name),
                     variable_definitions: step.variable_definitions.clone(),
                 };
                 let document =
@@ -733,7 +738,7 @@ impl FetchNode {
                     id: step.id,
                     service_name: step.service_name.0.clone(),
                     variable_usages: step.variable_usages.clone(),
-                    operation_kind: Some(step.into()),
+                    operation_kind: Some(step.operation_kind.clone()),
                     operation: SubgraphFetchOperation::from_anonymous_operation(document),
                     custom_scalar_paths: custom_scalar_paths_from_fetch_output(
                         &step.output,

--- a/lib/query-planner/src/planner/query_plan/optimize.rs
+++ b/lib/query-planner/src/planner/query_plan/optimize.rs
@@ -69,7 +69,7 @@ use crate::{
     },
     planner::error::QueryPlanError,
     planner::plan_nodes::{
-        custom_scalar_paths_for_type_selection, BatchFetchNode, CustomScalarPaths, EntityBatch,
+        custom_scalar_paths_for_entities_selection, BatchFetchNode, CustomScalarPaths, EntityBatch,
         EntityBatchAlias, FetchRewrite, FlattenNodePath, PlanNode,
     },
     state::supergraph_state::{OperationKind, SupergraphState, TypeNode},
@@ -170,8 +170,7 @@ impl<'a> BatchFetchBuilder<'a> {
                 omit_from_response: false,
             }));
 
-        if let Some(alias_paths) = custom_scalar_paths_for_type_selection(
-            &representative.type_name,
+        if let Some(alias_paths) = custom_scalar_paths_for_entities_selection(
             &representative.entities_selection,
             supergraph,
         ) {
@@ -313,7 +312,6 @@ struct EntityFetch {
     service_name: String,
     flatten_path: FlattenNodePath,
     variable_usages: Option<BTreeSet<String>>,
-    type_name: String,
     requires: SelectionSet,
     entities_selection: SelectionSet,
     input_rewrites: Option<Vec<FetchRewrite>>,
@@ -407,16 +405,6 @@ impl EntityFetch {
             service_name: fetch_node.service_name.clone(),
             flatten_path: flatten_node.path.clone(),
             variable_usages: fetch_node.variable_usages.clone(),
-            type_name: entities_selection
-                .items
-                .iter()
-                .find_map(|item| match item {
-                    SelectionItem::InlineFragment(fragment) => {
-                        Some(fragment.type_condition.clone())
-                    }
-                    _ => None,
-                })
-                .unwrap_or_else(|| "Query".to_string()),
             requires,
             entities_selection,
             input_rewrites,

--- a/lib/query-planner/src/state/supergraph_state.rs
+++ b/lib/query-planner/src/state/supergraph_state.rs
@@ -31,6 +31,8 @@ pub type SchemaDocument = input::Document<'static, String>;
 pub enum SupergraphStateError {
     #[error("Subgraph not found: '{0}'")]
     SubgraphNotFound(String),
+    #[error("Root type not found for operation kind: '{0}'")]
+    RootTypeNotFound(OperationKind),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -711,15 +713,37 @@ impl SupergraphState {
         result
     }
 
-    pub fn root_type_name(&self, operation_kind: Option<&OperationKind>) -> &str {
+    pub fn root_type_name(
+        &self,
+        operation_kind: Option<&OperationKind>,
+    ) -> Result<&str, SupergraphStateError> {
         match operation_kind {
-            Some(OperationKind::Query) => &self.query_type,
-            Some(OperationKind::Mutation) => self.mutation_type.as_deref().unwrap_or("Mutation"),
-            Some(OperationKind::Subscription) => {
-                self.subscription_type.as_deref().unwrap_or("Subscription")
+            None | Some(OperationKind::Query) => Ok(&self.query_type),
+            Some(OperationKind::Mutation) => {
+                self.mutation_type
+                    .as_deref()
+                    .ok_or(SupergraphStateError::RootTypeNotFound(
+                        OperationKind::Mutation,
+                    ))
             }
-            None => &self.query_type,
+            Some(OperationKind::Subscription) => {
+                self.subscription_type
+                    .as_deref()
+                    .ok_or(SupergraphStateError::RootTypeNotFound(
+                        OperationKind::Subscription,
+                    ))
+            }
         }
+    }
+
+    /// panics if the root type is not found for the given operation kind.
+    /// Use only when you are sure the root type is present,
+    /// like after the operation was validated to have matching root type.
+    pub fn expect_root_type_name(&self, operation_kind: Option<&OperationKind>) -> &str {
+        self.root_type_name(operation_kind)
+            // SAFETY: The root type is guaranteed to exist for the given operation kind,
+            // as the operation was validated.
+            .unwrap_or_else(|err| panic!("{}", err))
     }
 }
 
@@ -741,6 +765,14 @@ impl OperationKind {
             OperationKind::Mutation => "mutation",
             OperationKind::Subscription => "subscription",
         }
+    }
+
+    pub fn is_query(&self) -> bool {
+        matches!(self, OperationKind::Query)
+    }
+
+    pub fn is_mutation(&self) -> bool {
+        matches!(self, OperationKind::Mutation)
     }
 }
 

--- a/lib/query-planner/src/tests/mod.rs
+++ b/lib/query-planner/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod object_entities;
 mod override_requires;
 mod overrides;
 mod provides;
+mod renamed_root_types;
 mod requires;
 mod requires_circular;
 mod requires_fragments;

--- a/lib/query-planner/src/tests/renamed_root_types.rs
+++ b/lib/query-planner/src/tests/renamed_root_types.rs
@@ -1,0 +1,134 @@
+use crate::{
+    tests::testkit::{build_query_plan_with_defaults, init_logger},
+    utils::parsing::parse_operation,
+};
+use std::error::Error;
+
+#[test]
+fn query_on_renamed_root_query_type() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          product(id: "1") {
+            name
+            price
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/renamed-root-types.supergraph.graphql",
+        document,
+    )?;
+
+    let json = sonic_rs::to_string_pretty(&query_plan).unwrap_or_default();
+
+    // The root type is named RootQuery, but the operation kind should still be "query"
+    assert!(
+        json.contains(r#""operationKind": "query""#),
+        "Expected operationKind to be 'query', got:\n{}",
+        json
+    );
+    assert!(
+        !json.contains(r#""operationKind": "mutation""#),
+        "Should not contain mutation operation kind"
+    );
+
+    // Display format should not show 'mutation' keyword (it's a query)
+    let display = format!("{}", query_plan);
+    assert!(
+        !display.contains("mutation"),
+        "Display should not contain 'mutation' keyword for a query operation:\n{}",
+        display
+    );
+
+    insta::assert_snapshot!(display, @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          product(id: "1") {
+            name
+            price
+          }
+        }
+      },
+    },
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn mutation_on_renamed_root_mutation_type() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        mutation {
+          addProduct(input: { name: "new", price: 599.99 }) {
+            name
+            price
+            isExpensive
+            isAvailable
+          }
+        }
+        "#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/renamed-root-types.supergraph.graphql",
+        document,
+    )?;
+
+    let json = sonic_rs::to_string_pretty(&query_plan).unwrap_or_default();
+
+    // The root type is named RootMutation, but the operation kind should still be "mutation"
+    assert!(
+        json.contains(r#""operationKind": "mutation""#),
+        "Expected operationKind to be 'mutation', got:\n{}",
+        json
+    );
+
+    // Display format should show 'mutation' keyword
+    let display = format!("{}", query_plan);
+    assert!(
+        display.contains("mutation"),
+        "Display should contain 'mutation' keyword for a mutation operation:\n{}",
+        display
+    );
+
+    insta::assert_snapshot!(display, @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          mutation {
+            addProduct(input: {name: "new", price: 599.99}) {
+              __typename
+              name
+              price
+              id
+            }
+          }
+        },
+        Flatten(path: "addProduct") {
+          Fetch(service: "b") {
+            {
+              ... on Product {
+                __typename
+                price
+                id
+              }
+            } =>
+            {
+              ... on Product {
+                isExpensive
+                isAvailable
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+
+    Ok(())
+}

--- a/lib/query-planner/src/utils/schema_transformer.rs
+++ b/lib/query-planner/src/utils/schema_transformer.rs
@@ -82,22 +82,24 @@ pub trait SchemaTransformer<'a, T: Text<'a> + Clone> {
         &mut self,
         document: &Document<'a, T>,
     ) -> TransformedValue<Document<'a, T>> {
-        let mut next_document = Document {
-            definitions: Vec::new(),
-        };
+        // We collect a list of definitions first, and construct the `Document` at the end,
+        // because when `Document` is created, we store the root types in it.
+        // If we'd construct the empty `Document` first, the root types would be empty,
+        // or had to be recomputed from `.definitions` after each change.
+        let mut transformed_definitions = Vec::with_capacity(document.definitions.len());
         let mut has_changes = false;
 
         for definition in document.definitions.clone() {
             match self.transform_definition(&definition) {
-                Transformed::Keep => next_document.definitions.push(definition),
+                Transformed::Keep => transformed_definitions.push(definition),
                 Transformed::Replace(replacement) => {
                     has_changes = true;
-                    next_document.definitions.push(replacement)
+                    transformed_definitions.push(replacement)
                 }
             }
         }
         if has_changes {
-            TransformedValue::Replace(next_document)
+            TransformedValue::Replace(Document::new(transformed_definitions))
         } else {
             TransformedValue::Keep
         }


### PR DESCRIPTION
Removes the assumption that GraphQL root types are always named `Query`, `Mutation`, and `Subscription`

We now reads the real root type names from the schema and tracks the operation kind. It also adds tests for renamed root types.

Closes https://github.com/graphql-hive/router/issues/1231 