### PR TITLE
fix(router): replace `sonyflake` with `uuid::v7` for generating request-id for logging

### DIFF
--- a/.changeset/replaced_logging_request_id_generator.md
+++ b/.changeset/replaced_logging_request_id_generator.md
@@ -10,4 +10,4 @@ Version `0.0.85` introduced new logging runtime that uses `Sonyflake` crate to g
 
 The `Sonyflake` runtime can fail on some OS configurations. 
 
-This change replaces the `Sonyflake` runtime with `Ulid` generator, that's more fail-safe.
+This change replaces the `Sonyflake` runtime with `uuid` generator, that's more fail-safe.

--- a/.changeset/replaced_logging_request_id_generator.md
+++ b/.changeset/replaced_logging_request_id_generator.md
@@ -1,0 +1,13 @@
+---
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Replaced logging request-id generator
+
+Version `0.0.85` introduced new logging runtime that uses `Sonyflake` crate to generate request-id in requests that doesn't have it passed via HTTP headers. 
+
+The `Sonyflake` runtime can fail on some OS configurations. 
+
+This change replaces the `Sonyflake` runtime with `Ulid` generator, that's more fail-safe.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,6 @@ dependencies = [
  "prometheus",
  "serde",
  "sonic-rs",
- "sonyflake",
  "strum 0.28.0",
  "thiserror 2.0.19",
  "tokio",
@@ -2763,6 +2762,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ulid",
  "vrl",
 ]
 
@@ -3302,15 +3302,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "iri-string"
@@ -3978,12 +3969,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "no-std-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "node-addon"
@@ -5152,38 +5137,6 @@ name = "plugin-template"
 version = "0.0.1"
 dependencies = [
  "hive-router",
-]
-
-[[package]]
-name = "pnet_base"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
-dependencies = [
- "no-std-net",
-]
-
-[[package]]
-name = "pnet_datalink"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
-dependencies = [
- "ipnetwork",
- "libc",
- "pnet_base",
- "pnet_sys",
- "winapi",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -6921,17 +6874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "sonyflake"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bcd9b6dfb17bf52cefb3db84a111267d8f2db88087d9cd1a46aa57de3cfcc1"
-dependencies = [
- "chrono",
- "pnet_datalink",
- "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "ulid",
+ "uuid",
  "vrl",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ recloser = "1.3.1"
 notify = "8.2.0"
 ipnet = "2.12.0"
 ulid = "3.0.0"
+uuid = { version = "1.24.0" }
 
 # Telemetry
 opentelemetry = "0.32.0"

--- a/lib/executor/Cargo.toml
+++ b/lib/executor/Cargo.toml
@@ -64,7 +64,7 @@ sonic-simd = "0.1.2"
 async-stream = "0.3.6"
 futures-util = "0.3.31"
 ulid = { workspace = true }
-uuid = { version = "1.23.2", features = ["v4", "fast-rng"] }
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 subgraphs = { path = "../../bench/subgraphs" }

--- a/lib/internal/Cargo.toml
+++ b/lib/internal/Cargo.toml
@@ -71,7 +71,7 @@ tracing = { workspace = true }
 tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true }
 tonic = { workspace = true }
-ulid = { workspace = true }
+uuid = { workspace = true, features = ["v7", "fast-rng"] }
 chrono = "0.4.45"
 
 [dev-dependencies]

--- a/lib/internal/Cargo.toml
+++ b/lib/internal/Cargo.toml
@@ -71,7 +71,7 @@ tracing = { workspace = true }
 tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true }
 tonic = { workspace = true }
-sonyflake = "0.5.1"
+ulid = { workspace = true }
 chrono = "0.4.45"
 
 [dev-dependencies]

--- a/lib/internal/src/telemetry/logging/request_id.rs
+++ b/lib/internal/src/telemetry/logging/request_id.rs
@@ -5,7 +5,7 @@ use http::{HeaderMap, HeaderName};
 use ntex::web::HttpRequest;
 use opentelemetry::trace::TraceContextExt;
 use tokio::task::futures::TaskLocalFuture;
-use ulid::Ulid;
+use uuid::Uuid;
 
 use crate::telemetry::otel;
 
@@ -94,7 +94,7 @@ impl RequestIdentifierExtractor {
             return req_id_header.to_string();
         }
 
-        Ulid::generate().to_string()
+        Uuid::now_v7().to_string()
     }
 }
 

--- a/lib/internal/src/telemetry/logging/request_id.rs
+++ b/lib/internal/src/telemetry/logging/request_id.rs
@@ -1,22 +1,16 @@
-use std::{
-    future::Future,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{future::Future, sync::Arc};
 
 use hive_router_config::log::CorrelationConfig;
 use http::{HeaderMap, HeaderName};
 use ntex::web::HttpRequest;
 use opentelemetry::trace::TraceContextExt;
-use sonyflake::Sonyflake;
 use tokio::task::futures::TaskLocalFuture;
-use tracing::warn;
+use ulid::Ulid;
 
-use crate::telemetry::{logging::targets, otel};
+use crate::telemetry::otel;
 
 #[derive(Clone)]
 pub struct RequestIdentifierExtractor {
-    generator: Sonyflake,
     cfg: CorrelationConfig,
 }
 
@@ -43,10 +37,7 @@ impl RequestIdentifiers {
 
 impl RequestIdentifierExtractor {
     pub fn new(cfg: CorrelationConfig) -> Self {
-        Self {
-            generator: Sonyflake::new().expect("Sonyflake generator should initialize successfully; ensure system clock is correct and network interfaces are available"),
-            cfg,
-        }
+        Self { cfg }
     }
 
     pub fn extract(
@@ -103,25 +94,7 @@ impl RequestIdentifierExtractor {
             return req_id_header.to_string();
         }
 
-        match self.generator.next_id() {
-            Ok(id) => {
-                return id.to_string();
-            }
-            Err(e) => {
-                warn!(
-                    target: targets::CORE,
-                    error = %e,
-                    "Failed to generate local request id, will fallback to timestamp"
-                );
-            }
-        }
-
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time went backwards, please confirm your system/os clock")
-            .as_secs();
-
-        format!("{}", timestamp)
+        Ulid::generate().to_string()
     }
 }
 


### PR DESCRIPTION
Version `0.0.85` introduced new logging runtime that uses `Sonyflake` crate to generate request-id in requests that doesn't have it passed via HTTP headers. 

The `Sonyflake` runtime can fail on some OS configurations. 

This change replaces the `Sonyflake` runtime with `uuid` generator, that's more fail-safe.
