### PR TITLE
feat(router): Multiplex and reuse WebSocket subgraph connections

### DIFF
--- a/.changeset/add_websocket_connection_reuse_and_execution_mode_configuration.md
+++ b/.changeset/add_websocket_connection_reuse_and_execution_mode_configuration.md
@@ -1,0 +1,70 @@
+---
+hive-router-config: minor
+hive-router-internal: patch
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Add WebSocket connection reuse and execution mode configuration
+
+WebSocket-enabled subgraphs can now configure connection reuse and choose how queries and mutations are transported.
+
+Configure defaults for all subgraphs under `traffic_shaping.all.websocket`:
+
+```yaml
+subscriptions:
+  websocket:
+    subgraphs:
+      reviews:
+        path: /reviews/ws
+
+traffic_shaping:
+  all:
+    pool_idle_timeout: 50s # default
+    websocket:
+      reuse_connections: true
+      execute_mode: reuse_existing
+```
+
+`reuse_connections` defaults to `true`:
+
+- `true` multiplexes matching operations over initialized pooled WebSocket connections
+- `false` opens a dedicated connection for each WebSocket operation
+
+`execute_mode` defaults to `http` and supports:
+
+- `http`: queries and mutations always use HTTP
+- `reuse_existing`: queries and mutations use an initialized matching WebSocket when available, otherwise they immediately use HTTP
+- `websocket`: queries and mutations use WebSocket, creating or joining a pooled connection when reuse is enabled
+
+Settings can be overridden per subgraph. Omitted WebSocket fields inherit the global value:
+
+```yaml
+traffic_shaping:
+  all:
+    pool_idle_timeout: 50s # default
+    websocket:
+      reuse_connections: true
+      execute_mode: reuse_existing
+
+  subgraphs:
+    payments:
+      pool_idle_timeout: 5s
+      websocket:
+        reuse_connections: false
+        execute_mode: websocket
+```
+
+In this example, other WebSocket-enabled subgraphs opportunistically reuse initialized connections. `payments` sends each operation over a dedicated WebSocket.
+
+Pooled WebSockets use the effective `pool_idle_timeout`. A per-subgraph value overrides `traffic_shaping.all.pool_idle_timeout` for both HTTP and WebSocket pools. Active WebSocket operations do not expire.
+
+Connection matching uses the inbound headers selected by `traffic_shaping.router.dedupe.headers`, even when router request deduplication is disabled. Include every header that can affect connection-scoped authentication, authorization, cookies, or tenant identity:
+
+```yaml
+traffic_shaping:
+  router:
+    dedupe:
+      headers:
+        include: [authorization, cookie, x-tenant]
+```

--- a/.changeset/add_websocket_connection_reuse_and_execution_mode_configuration.md
+++ b/.changeset/add_websocket_connection_reuse_and_execution_mode_configuration.md
@@ -13,6 +13,7 @@ Configure defaults for all subgraphs under `traffic_shaping.all.websocket`:
 
 ```yaml
 subscriptions:
+  enabled: true
   websocket:
     subgraphs:
       reviews:

--- a/.changeset/multiplex_and_reuse_websocket_subgraph_connections.md
+++ b/.changeset/multiplex_and_reuse_websocket_subgraph_connections.md
@@ -1,0 +1,50 @@
+---
+hive-router: minor
+---
+
+# Multiplex and reuse WebSocket subgraph connections
+
+The router can now multiplex GraphQL operations over shared `graphql-transport-ws` subgraph connections.
+
+Subscriptions with the same subgraph and inbound connection identity reuse one initialized connection instead of opening one WebSocket per operation. Different operations retain independent streams while sharing the physical connection.
+
+Queries and mutations can also reuse a connection opened by a subscription:
+
+```yaml
+subscriptions:
+  websocket:
+    subgraphs:
+      reviews:
+        path: /reviews/ws
+
+traffic_shaping:
+  all:
+    websocket:
+      reuse_connections: true
+      execute_mode: reuse_existing
+```
+
+With this configuration:
+
+1. A subscription initializes the pooled `reviews` connection.
+2. Matching subscriptions multiplex over it.
+3. Matching queries and mutations use it while it remains initialized.
+4. A query or mutation uses HTTP when the connection is missing, expired, or still initializing.
+
+Use WebSocket for every operation by selecting `websocket` mode:
+
+```yaml
+traffic_shaping:
+  all:
+    websocket:
+      reuse_connections: true
+      execute_mode: websocket
+```
+
+The first operation initializes the connection, concurrent operations join that initialization, and later matching operations reuse the initialized connection.
+
+Once an operation selects WebSocket, transport failures and timeouts are returned to the client without retrying over HTTP. This prevents a mutation that may have reached the subgraph from being executed twice.
+
+Idle pooled connections close after the effective `pool_idle_timeout`. Active operations keep the connection open, and dropping one operation cancels only that operation without closing the shared connection.
+
+The router also exposes WebSocket pool telemetry for active connections and operations, initialization success and failure, initialization waiters, reuse lookup hits and misses, and connection closure reasons. These metrics help measure reuse hit rate, multiplexing, connection churn, handshake failures, and per-subgraph pool usage.

--- a/.changeset/multiplex_and_reuse_websocket_subgraph_connections.md
+++ b/.changeset/multiplex_and_reuse_websocket_subgraph_connections.md
@@ -12,6 +12,7 @@ Queries and mutations can also reuse a connection opened by a subscription:
 
 ```yaml
 subscriptions:
+  enabled: true
   websocket:
     subgraphs:
       reviews:

--- a/bench/subgraphs/lib.rs
+++ b/bench/subgraphs/lib.rs
@@ -100,21 +100,27 @@ pub enum HTTPStreamingSubscriptionProtocol {
 pub fn subgraphs_app(
     subscriptions_protocol: HTTPStreamingSubscriptionProtocol,
 ) -> (Router<()>, Arc<AtomicUsize>) {
+    let accounts_schema = accounts::get_subgraph();
+    let inventory_schema = inventory::get_subgraph();
+    let products_schema = products::get_subgraph();
     let (reviews_schema, active_subscriptions) = reviews::get_subgraph();
     let router = Router::new()
-        .route(
-            "/accounts",
-            post_service(GraphQL::new(accounts::get_subgraph())),
+        .route_service(
+            "/accounts/ws",
+            GraphQLSubscription::new(accounts_schema.clone()),
         )
+        .route("/accounts", post_service(GraphQL::new(accounts_schema)))
         .route("/books", post_service(GraphQL::new(books::get_subgraph())))
-        .route(
-            "/inventory",
-            post_service(GraphQL::new(inventory::get_subgraph())),
+        .route_service(
+            "/inventory/ws",
+            GraphQLSubscription::new(inventory_schema.clone()),
         )
-        .route(
-            "/products",
-            post_service(GraphQL::new(products::get_subgraph())),
+        .route("/inventory", post_service(GraphQL::new(inventory_schema)))
+        .route_service(
+            "/products/ws",
+            GraphQLSubscription::new(products_schema.clone()),
         )
+        .route("/products", post_service(GraphQL::new(products_schema)))
         .route_service(
             "/reviews/ws",
             GraphQLSubscription::new(reviews_schema.clone()),

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -13,6 +13,7 @@ use hive_router_plan_executor::execution::plan::{
     execute_query_plan, CoerceVariablesPayload, ExecutionResultExtensions, PlanExecutionOutput,
     QueryPlanExecutionOpts, QueryPlanExecutionResult,
 };
+use hive_router_plan_executor::executors::common::ConnectionFingerprint;
 use hive_router_plan_executor::headers::response::ResponseHeaderSink;
 
 use hive_router_plan_executor::introspection::resolve::IntrospectionContext;
@@ -41,6 +42,7 @@ pub struct PlannedRequest<'req> {
     pub initial_errors: Vec<GraphQLError>,
     pub demand_control_execution_context: Option<DemandControlExecutionContext>,
     pub plugin_req_state: Option<PluginRequestState<'req>>,
+    pub connection_fingerprint: Option<ConnectionFingerprint>,
 }
 
 #[inline]
@@ -150,6 +152,7 @@ pub async fn execute_plan<'exec>(
             ),
             response_header_sink,
             error_masking_runtime: app_state.error_masking.clone(),
+            connection_fingerprint: planned_request.connection_fingerprint,
         })
         .await?;
 

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -411,7 +411,7 @@ pub async fn graphql_request_handler(
             .enabled;
 
         // establish a connection fingerprint only if dedupe or multiplexing is enabled
-        let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_connection_reuse_enabled)
+        let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_reuse_enabled)
             .then(|| connection_fingerprint(
                 req.method(),
                 req.path(),

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -409,9 +409,13 @@ pub async fn graphql_request_handler(
             .router
             .dedupe
             .enabled;
+        let websocket_reuse_enabled = shared_state
+            .router_config
+            .traffic_shaping
+            .any_websocket_connection_reuse_enabled();
 
         // establish a connection fingerprint only if dedupe or multiplexing is enabled
-        let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_reuse_enabled)
+        let connection_fingerprint = (request_dedupe_enabled || websocket_reuse_enabled)
             .then(|| connection_fingerprint(
                 req.method(),
                 req.path(),

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -14,6 +14,7 @@ use hive_router_plan_executor::{
         },
         plan::{CoerceVariablesPayload, PlanExecutionOutput, QueryPlanExecutionResult},
     },
+    executors::common::{ConnectionFingerprint, InboundRequestFingerprint},
     headers::response::{ResponseHeaderAggregator, ResponseHeaderSink},
     hooks::{
         on_graphql_analysis::{OnGraphqlAnalysisHookPayload, OnGraphqlAnalysisHookResult},
@@ -409,6 +410,16 @@ pub async fn graphql_request_handler(
             .dedupe
             .enabled;
 
+        // establish a connection fingerprint only if dedupe or multiplexing is enabled
+        let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_connection_reuse_enabled)
+            .then(|| connection_fingerprint(
+                req.method(),
+                req.path(),
+                &request_headers,
+                &shared_state.in_flight_requests_header_policy,
+                supergraph.snapshot.cache_id,
+            ));
+
         let fingerprint = if request_dedupe_enabled
             && matches!(
                 normalize_payload.operation_for_plan.operation_kind,
@@ -422,11 +433,9 @@ pub async fn graphql_request_handler(
                 .map_or(0, hash_graphql_extensions);
 
             Some(inbound_request_fingerprint(
-                req.method(),
-                req.path(),
-                &request_headers,
-                &shared_state.in_flight_requests_header_policy,
-                supergraph.snapshot.cache_id,
+                // let chains are only allowed in Rust 2024 or later... so we assert
+                // connection_fingerprint because it will be present when request_dedupe_enabled
+                connection_fingerprint.expect("dedupe computes a connection fingerprint"),
                 normalize_payload.normalized_operation_hash,
                 variables_hash,
                 extensions_hash,
@@ -455,6 +464,7 @@ pub async fn graphql_request_handler(
                 response_mode,
                 guard,
                 response_header_sink.clone(),
+                connection_fingerprint,
             )
         };
 
@@ -538,6 +548,7 @@ pub async fn execute_planned_request<'exec>(
     response_mode: &'exec ResponseMode,
     guard: Option<SharedRouterResponseGuard>,
     response_header_sink: ResponseHeaderSink,
+    connection_fingerprint: Option<ConnectionFingerprint>,
 ) -> Result<SharedRouterResponse, PipelineError> {
     let jwt_request_details = match &shared_state.jwt_auth_runtime {
         Some(jwt_auth_runtime) => match jwt_auth_runtime
@@ -591,6 +602,7 @@ pub async fn execute_planned_request<'exec>(
         plugin_req_state,
         request_context,
         response_header_sink.clone(),
+        connection_fingerprint,
     )
     .await?
     {
@@ -718,6 +730,7 @@ pub async fn execute_pipeline<'exec>(
     plugin_req_state: Option<PluginRequestState<'exec>>,
     request_context: &SharedRequestContext,
     response_header_sink: ResponseHeaderSink,
+    connection_fingerprint: Option<ConnectionFingerprint>,
 ) -> Result<QueryPlanExecutionResult, PipelineError> {
     if normalize_payload.operation_for_introspection.is_some() {
         handle_introspection_policy(&shared_state.introspection_policy, &client_request_details)?;
@@ -868,6 +881,7 @@ pub async fn execute_pipeline<'exec>(
             .collect(),
         demand_control_execution_context,
         plugin_req_state,
+        connection_fingerprint,
     };
 
     execute_plan(
@@ -880,39 +894,41 @@ pub async fn execute_pipeline<'exec>(
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn inbound_request_fingerprint(
+pub fn connection_fingerprint(
     method: &Method,
     path: &str,
     request_headers: &HeaderMap,
-    dedupe_header_policy: &RouterRequestDedupeHeaderPolicy,
-    supergraph_cache_id: u64,
-    normalized_operation_hash: u64,
-    variables_hash: u64,
-    extensions_hash: u64,
-) -> u64 {
+    header_policy: &RouterRequestDedupeHeaderPolicy,
+    schema_checksum: u64,
+) -> ConnectionFingerprint {
     let mut hasher = Xxh3::new();
 
     let mut headers: Vec<(&str, &str)> = request_headers
         .iter()
-        .filter(|(name, _)| dedupe_header_policy.should_include(name.as_str()))
-        .filter_map(|(name, value)| value.to_str().ok().map(|v_str| (name.as_str(), v_str)))
+        .filter(|(name, _)| header_policy.should_include(name.as_str()))
+        .filter_map(|(name, value)| value.to_str().ok().map(|value| (name.as_str(), value)))
         .collect();
-    headers.sort_unstable_by(|(left_name, left_value), (right_name, right_value)| {
-        left_name
-            .cmp(right_name)
-            .then_with(|| left_value.cmp(right_value))
-    });
+    headers.sort_unstable();
 
     method.hash(&mut hasher);
     path.hash(&mut hasher);
     headers.hash(&mut hasher);
-    supergraph_cache_id.hash(&mut hasher);
+    schema_checksum.hash(&mut hasher);
+    ConnectionFingerprint::from_hash(hasher.finish())
+}
+
+pub fn inbound_request_fingerprint(
+    connection: ConnectionFingerprint,
+    normalized_operation_hash: u64,
+    variables_hash: u64,
+    extensions_hash: u64,
+) -> InboundRequestFingerprint {
+    let mut hasher = Xxh3::new();
+    connection.hash(&mut hasher);
     normalized_operation_hash.hash(&mut hasher);
     variables_hash.hash(&mut hasher);
     extensions_hash.hash(&mut hasher);
-
-    hasher.finish()
+    InboundRequestFingerprint::from_hash(hasher.finish())
 }
 
 pub fn hash_graphql_variables(variables: &HashMap<String, Value>) -> u64 {
@@ -981,5 +997,41 @@ fn hash_graphql_value(value: &Value, hasher: &mut Xxh3) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn connection_fingerprint_is_order_independent_and_separate_from_operation() {
+        let policy = RouterRequestDedupeHeaderPolicy::Include(HashSet::from([
+            "authorization".to_string(),
+            "x-tenant".to_string(),
+        ]));
+        let mut first = HeaderMap::new();
+        first.insert("authorization".parse().unwrap(), "token".parse().unwrap());
+        first.insert("x-tenant".parse().unwrap(), "one".parse().unwrap());
+        first.insert("ignored".parse().unwrap(), "a".parse().unwrap());
+        let mut second = HeaderMap::new();
+        second.insert("ignored".parse().unwrap(), "b".parse().unwrap());
+        second.insert("x-tenant".parse().unwrap(), "one".parse().unwrap());
+        second.insert("authorization".parse().unwrap(), "token".parse().unwrap());
+
+        let connection = connection_fingerprint(&Method::POST, "/graphql", &first, &policy, 7);
+        assert_eq!(
+            connection,
+            connection_fingerprint(&Method::POST, "/graphql", &second, &policy, 7)
+        );
+        assert_ne!(
+            inbound_request_fingerprint(connection, 1, 2, 3),
+            inbound_request_fingerprint(connection, 2, 2, 3)
+        );
+        assert_eq!(
+            connection,
+            connection_fingerprint(&Method::POST, "/graphql", &first, &policy, 7)
+        );
     }
 }

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -502,8 +502,12 @@ async fn handle_text_frame(
 
                   let request_dedupe_enabled =
                       shared_state.router_config.traffic_shaping.router.dedupe.enabled;
+                  let websocket_reuse_enabled = shared_state
+                      .router_config
+                      .traffic_shaping
+                      .any_websocket_connection_reuse_enabled();
 
-                  let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_reuse_enabled)
+                  let connection_fingerprint = (request_dedupe_enabled || websocket_reuse_enabled)
                     .then(|| connection_fingerprint(
                       &Method::POST,
                       ws_uri.path(),

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -503,7 +503,7 @@ async fn handle_text_frame(
                   let request_dedupe_enabled =
                       shared_state.router_config.traffic_shaping.router.dedupe.enabled;
 
-                  let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_connection_reuse_enabled)
+                  let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_reuse_enabled)
                     .then(|| connection_fingerprint(
                       &Method::POST,
                       ws_uri.path(),

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -42,9 +42,9 @@ use crate::pipeline::error::PipelineError;
 use crate::pipeline::execute_planned_request;
 use crate::pipeline::header::{ResponseMode, SingleContentType, StreamContentType};
 use crate::pipeline::{
-    hash_graphql_extensions, hash_graphql_variables, inbound_request_fingerprint,
-    normalize::normalize_request_with_cache, parser::parse_operation_with_cache, usage_reporting,
-    validation::validate_operation_with_cache,
+    connection_fingerprint, hash_graphql_extensions, hash_graphql_variables,
+    inbound_request_fingerprint, normalize::normalize_request_with_cache,
+    parser::parse_operation_with_cache, usage_reporting, validation::validate_operation_with_cache,
 };
 use crate::schema_state::SchemaState;
 use crate::shared_state::{RouterSharedState, SharedRouterResponse};
@@ -503,6 +503,15 @@ async fn handle_text_frame(
                   let request_dedupe_enabled =
                       shared_state.router_config.traffic_shaping.router.dedupe.enabled;
 
+                  let connection_fingerprint = (request_dedupe_enabled || shared_state.websocket_connection_reuse_enabled)
+                    .then(|| connection_fingerprint(
+                      &Method::POST,
+                      ws_uri.path(),
+                      headers.as_ref(),
+                      &shared_state.in_flight_requests_header_policy,
+                      supergraph.snapshot.cache_id,
+                    ));
+
                   let fingerprint = if request_dedupe_enabled
                       && matches!(
                           normalize_payload.operation_for_plan.operation_kind,
@@ -515,11 +524,9 @@ async fn handle_text_frame(
                           .as_ref()
                           .map_or(0, hash_graphql_extensions);
                       Some(inbound_request_fingerprint(
-                          &Method::POST,
-                          ws_uri.path(),
-                          headers.as_ref(),
-                          &shared_state.in_flight_requests_header_policy,
-                          supergraph.snapshot.cache_id,
+                          // let chains are only allowed in Rust 2024 or later... so we assert
+                          // connection_fingerprint because it will be present when request_dedupe_enabled
+                          connection_fingerprint.expect("dedupe computes a connection fingerprint"),
                           normalize_payload.normalized_operation_hash,
                           variables_hash,
                           extensions_hash,
@@ -568,7 +575,8 @@ async fn handle_text_frame(
                       request_context,
                       &response_mode,
                       guard,
-                      response_header_sink.clone()
+                      response_header_sink.clone(),
+                      connection_fingerprint,
                   );
 
                   let shared_response = if let Some(fp) = fingerprint {

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -333,7 +333,7 @@ pub struct RouterSharedState {
     pub plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
     pub in_flight_requests: RouterInflightRequestsMap,
     pub in_flight_requests_header_policy: RouterRequestDedupeHeaderPolicy,
-    pub websocket_connection_reuse_enabled: bool,
+    pub websocket_reuse_enabled: bool,
     /// Tracks the number of active long-lived clients (websockets + http streams)
     pub long_lived_client_count: Arc<AtomicUsize>,
     /// Tracks all active subscriptions from clients to the router.
@@ -406,7 +406,8 @@ impl RouterSharedState {
                 .dedupe
                 .headers)
                 .into(),
-            websocket_connection_reuse_enabled: router_config.subscriptions.websocket.is_some(),
+            // TODO: actually toggle, but decide how and where
+            websocket_reuse_enabled: router_config.subscriptions.websocket.is_some(),
             long_lived_client_count: Arc::new(AtomicUsize::new(0)),
             active_subscriptions,
             storage_manager,

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -15,6 +15,7 @@ use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::coprocessor::{CoprocessorError, CoprocessorRuntime};
 use hive_router_plan_executor::execution::error_masking::ErrorMaskingRuntime;
 use hive_router_plan_executor::execution::plan::FailedExecutionResult;
+use hive_router_plan_executor::executors::common::InboundRequestFingerprint;
 use hive_router_plan_executor::extensions::{
     compile::compile_extensions_plan, plan::ExtensionsPlan,
 };
@@ -51,7 +52,7 @@ use crate::pipeline::sse;
 use crate::storage::StorageManager;
 
 pub type JwtClaimsCache = Cache<String, Arc<JwtTokenPayload>>;
-pub type RouterInflightRequestsMap = InFlightMap<u64, SharedRouterResponse>;
+pub type RouterInflightRequestsMap = InFlightMap<InboundRequestFingerprint, SharedRouterResponse>;
 
 #[derive(Clone)]
 pub enum RouterRequestDedupeHeaderPolicy {
@@ -96,7 +97,8 @@ impl From<&TrafficShapingRouterDedupeHeadersConfig> for RouterRequestDedupeHeade
     }
 }
 
-pub type SharedRouterResponseGuard = InFlightCleanupGuard<u64, SharedRouterResponse>;
+pub type SharedRouterResponseGuard =
+    InFlightCleanupGuard<InboundRequestFingerprint, SharedRouterResponse>;
 
 #[derive(Clone)]
 pub enum SharedRouterResponse {
@@ -331,6 +333,7 @@ pub struct RouterSharedState {
     pub plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
     pub in_flight_requests: RouterInflightRequestsMap,
     pub in_flight_requests_header_policy: RouterRequestDedupeHeaderPolicy,
+    pub websocket_connection_reuse_enabled: bool,
     /// Tracks the number of active long-lived clients (websockets + http streams)
     pub long_lived_client_count: Arc<AtomicUsize>,
     /// Tracks all active subscriptions from clients to the router.
@@ -403,6 +406,7 @@ impl RouterSharedState {
                 .dedupe
                 .headers)
                 .into(),
+            websocket_connection_reuse_enabled: router_config.subscriptions.websocket.is_some(),
             long_lived_client_count: Arc::new(AtomicUsize::new(0)),
             active_subscriptions,
             storage_manager,

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -333,7 +333,6 @@ pub struct RouterSharedState {
     pub plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
     pub in_flight_requests: RouterInflightRequestsMap,
     pub in_flight_requests_header_policy: RouterRequestDedupeHeaderPolicy,
-    pub websocket_reuse_enabled: bool,
     /// Tracks the number of active long-lived clients (websockets + http streams)
     pub long_lived_client_count: Arc<AtomicUsize>,
     /// Tracks all active subscriptions from clients to the router.
@@ -406,8 +405,6 @@ impl RouterSharedState {
                 .dedupe
                 .headers)
                 .into(),
-            // TODO: actually toggle, but decide how and where
-            websocket_reuse_enabled: router_config.subscriptions.websocket.is_some(),
             long_lived_client_count: Arc::new(AtomicUsize::new(0)),
             active_subscriptions,
             storage_manager,

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@
 |[**subscriptions**](#subscriptions)|`object`|Configuration for subscriptions.<br/>Default: `{"broadcast_capacity":0,"enabled":false,"subgraph_buffer_capacity":0}`<br/>||
 |[**supergraph**](#supergraph)|`object`|Configuration for the Federation supergraph source. By default, the router will use a local file-based supergraph source (`./supergraph.graphql`).<br/>||
 |[**telemetry**](#telemetry)|`object`|Default: `{"client_identification":{"ip_header":null,"name_header":"graphql-client-name","version_header":"graphql-client-version"},"hive":null,"metrics":{"exporters":[],"instrumentation":{"common":{"histogram":{"aggregation":"explicit","bytes":{"buckets":[128,512,1024,2048,4096,8192,16384,32768,65536,131072,262144,524288,1048576,2097152,3145728,4194304,5242880],"record_min_max":false},"seconds":{"buckets":[0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10],"record_min_max":false}}},"instruments":{}}},"resource":{"attributes":{}},"tracing":{"collect":{"max_attributes_per_event":16,"max_attributes_per_link":32,"max_attributes_per_span":128,"max_events_per_span":128,"parent_based_sampler":false,"sampling":1},"exporters":[],"instrumentation":{"spans":{"mode":"spec_compliant"}},"propagation":{"b3":false,"baggage":false,"jaeger":false,"trace_context":true}}}`<br/>||
-|[**traffic\_shaping**](#traffic_shaping)|`object`|Configuration for the traffic-shaping of the executor. Use these configurations to control how requests are being executed to subgraphs.<br/>Default: `{"all":{"allow_only_http2":false,"circuit_breaker":null,"dedupe_enabled":true,"forward_operation_name":false,"pool_idle_timeout":"50s","request_timeout":"30s"},"max_connections_per_host":100,"router":{"dedupe":{"enabled":false,"headers":"all"},"max_long_lived_clients":128,"request_timeout":"1m"}}`<br/>||
+|[**traffic\_shaping**](#traffic_shaping)|`object`|Configuration for the traffic-shaping of the executor. Use these configurations to control how requests are being executed to subgraphs.<br/>Default: `{"all":{"allow_only_http2":false,"circuit_breaker":null,"dedupe_enabled":true,"forward_operation_name":false,"pool_idle_timeout":"50s","request_timeout":"30s","websocket":{}},"max_connections_per_host":100,"router":{"dedupe":{"enabled":false,"headers":"all"},"max_long_lived_clients":128,"request_timeout":"1m"}}`<br/>||
 |[**websocket**](#websocket)|`object`|Configuration of router's WebSocket server.<br/>Default: `{"enabled":false,"headers":{"persist":false,"source":"connection"},"path":null}`<br/>||
 
 **Additional Properties:** not allowed   
@@ -230,6 +230,7 @@ traffic_shaping:
     forward_operation_name: false
     pool_idle_timeout: 50s
     request_timeout: 30s
+    websocket: {}
   max_connections_per_host: 100
   router:
     dedupe:
@@ -4063,7 +4064,7 @@ Configuration for the traffic-shaping of the executor. Use these configurations 
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**all**](#traffic_shapingall)|`object`|The default configuration that will be applied to all subgraphs, unless overridden by a specific subgraph configuration.<br/>Default: `{"allow_only_http2":false,"circuit_breaker":null,"dedupe_enabled":true,"forward_operation_name":false,"pool_idle_timeout":"50s","request_timeout":"30s"}`<br/>||
+|[**all**](#traffic_shapingall)|`object`|The default configuration that will be applied to all subgraphs, unless overridden by a specific subgraph configuration.<br/>Default: `{"allow_only_http2":false,"circuit_breaker":null,"dedupe_enabled":true,"forward_operation_name":false,"pool_idle_timeout":"50s","request_timeout":"30s","websocket":{}}`<br/>||
 |**max\_connections\_per\_host**|`integer`|Limits the concurrent amount of requests/connections per host/subgraph.<br/>Default: `100`<br/>Format: `"uint"`<br/>Minimum: `0`<br/>||
 |[**router**](#traffic_shapingrouter)|`object`|Configuration for the router itself, e.g., for handling incoming requests, or other router-level traffic shaping configurations.<br/>Default: `{"dedupe":{"enabled":false,"headers":"all"},"max_long_lived_clients":128,"request_timeout":"1m"}`<br/>||
 |[**subgraphs**](#traffic_shapingsubgraphs)|`object`|Optional per-subgraph configurations that will override the default configuration for specific subgraphs.<br/>||
@@ -4079,6 +4080,7 @@ all:
   forward_operation_name: false
   pool_idle_timeout: 50s
   request_timeout: 30s
+  websocket: {}
 max_connections_per_host: 100
 router:
   dedupe:
@@ -4104,9 +4106,10 @@ The default configuration that will be applied to all subgraphs, unless overridd
 |[**circuit\_breaker**](#traffic_shapingallcircuit_breaker)|`object`, `null`|Circuit Breaker configuration for all subgraphs.<br/>||
 |**dedupe\_enabled**|`boolean`|Enables/disables request deduplication to subgraphs.<br/><br/>When requests exactly matches the hashing mechanism (e.g., subgraph name, URL, headers, query, variables), and are executed at the same time, they will<br/>be deduplicated by sharing the response of other in-flight requests.<br/>Default: `true`<br/>||
 |**forward\_operation\_name**|`boolean`|When enabled, forwards client operation name to subgraphs.<br/>The operation name will fetch node id and operation name from the client request.<br/>Format: <Client Operation Name>__<Fetch Node ID><br/>Default: `false`<br/>||
-|**pool\_idle\_timeout**|`string`|Timeout for idle sockets being kept-alive.<br/>Default: `"50s"`<br/>||
+|**pool\_idle\_timeout**|`string`|Controls how long idle pooled connections remain available for reuse by default.<br/><br/>This timeout applies to both HTTP connection pools and pooled WebSocket connections for<br/>every subgraph that does not provide an override. Active WebSocket operations are never<br/>expired by this setting. Their idle timer starts only after the last operation on the<br/>pooled connection finishes.<br/><br/>Defaults to 50 seconds.<br/>Default: `"50s"`<br/>||
 |**request\_timeout**||Optional timeout configuration for requests to subgraphs.<br/><br/>Example with a fixed duration:<br/>```yaml<br/>  timeout:<br/>    duration: 5s<br/>```<br/><br/>Or with a VRL expression that can return a duration based on the operation kind:<br/>```yaml<br/>  timeout:<br/>    expression: \|<br/>     if (.request.operation.type == "mutation") {<br/>       "10s"<br/>     } else {<br/>       "15s"<br/>     }<br/>```<br/>Default: `"30s"`<br/>||
 |[**tls**](#traffic_shapingalltls)|`object`, `null`|||
+|[**websocket**](#traffic_shapingallwebsocket)|`object`|Default WebSocket connection reuse and execution behavior for subgraphs.<br/>Default: `{}`<br/>||
 
 **Additional Properties:** not allowed   
 **Example**
@@ -4118,6 +4121,7 @@ dedupe_enabled: true
 forward_operation_name: false
 pool_idle_timeout: 50s
 request_timeout: 30s
+websocket: {}
 
 ```
 
@@ -4210,6 +4214,23 @@ Either an exact HTTP status code (integer 100-599 or its string form, e.g. 503) 
 |----|----|-----------|--------|
 |**cert\_file**|||yes|
 |**key\_file**|`string`|Format: `"path"`<br/>|yes|
+
+**Additional Properties:** not allowed   
+   
+<a name="traffic_shapingallwebsocket"></a>
+#### traffic\_shaping\.all\.websocket: object
+
+Default WebSocket connection reuse and execution behavior for subgraphs.
+
+Per-subgraph values under `traffic_shaping.subgraphs.<name>.websocket` take precedence.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**execute\_mode**||Controls whether queries and mutations use WebSocket-enabled subgraphs.<br/><br/>The default is `http`, preserving HTTP execution unless WebSocket execution is explicitly<br/>enabled. Subscriptions continue to use the protocol selected under `subscriptions`.<br/>At the per-subgraph level omission inherits the `all` value.<br/>||
+|**reuse\_connections**|`boolean`, `null`|Enables multiplexing operations over matching initialized WebSocket connections.<br/><br/>When enabled, subscriptions retain initialized connections in a pool and can share one<br/>physical connection. Queries and mutations use that pool according to `execute_mode`.<br/>When disabled, each WebSocket operation owns a dedicated connection.<br/><br/>A pooled connection is discovered using two values:<br/><br/>1. The resolved WebSocket endpoint. Endpoint overrides and expressions are evaluated first,<br/>   then the configured WebSocket path is applied. Connections to different resolved<br/>   endpoints are never considered a match.<br/>2. The inbound connection fingerprint. This fingerprint contains the inbound HTTP method,<br/>   request path, selected inbound headers, and schema checksum. It deliberately excludes the<br/>   GraphQL operation, variables, and extensions, allowing different operations from the<br/>   same connection identity to share one physical WebSocket.<br/><br/>Header selection uses `traffic_shaping.router.dedupe.headers`, even when router request<br/>deduplication itself is disabled. The default is `all`. If a custom header selection is<br/>configured, it must include every inbound header that can change the authentication,<br/>authorization, cookie, or tenant identity sent in `connection_init`. Excluding such a<br/>header can make requests with different identities appear to match and reuse the same<br/>authenticated connection.<br/><br/>A subscription can create the matching pool entry. With `execute_mode: reuse_existing`, a<br/>query or mutation uses the connection only after it is fully initialized. A missing entry<br/>or one still waiting for `connection_ack` falls back to HTTP. With<br/>`execute_mode: websocket`, queries and mutations may create a missing entry or join an<br/>initialization already in progress.<br/><br/>For example, the following configuration lets subscriptions create shared connections and<br/>lets queries and mutations reuse them when available:<br/><br/>```yaml<br/>traffic_shaping:<br/>  all:<br/>    websocket:<br/>      reuse_connections: true<br/>      execute_mode: reuse_existing<br/>  router:<br/>    dedupe:<br/>      headers:<br/>        include: [authorization, cookie, x-tenant]<br/>```<br/><br/>The following keeps reuse enabled globally but gives one subgraph a dedicated connection<br/>for every WebSocket operation:<br/><br/>```yaml<br/>traffic_shaping:<br/>  all:<br/>    websocket:<br/>      reuse_connections: true<br/>  subgraphs:<br/>    payments:<br/>      websocket:<br/>        reuse_connections: false<br/>```<br/><br/>Idle pooled connections use the effective `pool_idle_timeout` from traffic shaping. At the<br/>`all` level `reuse_connections` defaults to `true`. At the per-subgraph level omission<br/>inherits the `all` value.<br/>||
 
 **Additional Properties:** not allowed   
    
@@ -4310,9 +4331,10 @@ Optional per-subgraph configurations that will override the default configuratio
 |[**circuit\_breaker**](#traffic_shapingsubgraphsadditionalpropertiescircuit_breaker)|`object`, `null`|Circuit Breaker configuration for the subgraph.<br/>||
 |**dedupe\_enabled**|`boolean`, `null`|Enables/disables request deduplication to subgraphs.<br/><br/>When requests exactly matches the hashing mechanism (e.g., subgraph name, URL, headers, query, variables), and are executed at the same time, they will<br/>be deduplicated by sharing the response of other in-flight requests.<br/>||
 |**forward\_operation\_name**|`boolean`, `null`|When enabled, forwards client operation name to the selected subgraph.<br/>The operation name will include fetch node id and operation name from the client request.<br/>Format: <Client Operation Name>__<Fetch Node ID><br/><br/>This setting takes precedence over the value set in `all` section.<br/>||
-|**pool\_idle\_timeout**|`string`, `null`|Timeout for idle sockets being kept-alive.<br/>||
+|**pool\_idle\_timeout**|`string`, `null`|Overrides how long idle pooled connections for this subgraph remain available for reuse.<br/><br/>This timeout applies to both the HTTP connection pool and pooled WebSocket connections for<br/>this subgraph. Active WebSocket operations are never expired by this setting. Their idle<br/>timer starts only after the last operation on the pooled connection finishes.<br/><br/>When omitted, `traffic_shaping.all.pool_idle_timeout` is used.<br/>||
 |**request\_timeout**||Optional timeout configuration for requests to subgraphs.<br/><br/>Example with a fixed duration:<br/>```yaml<br/>  timeout:<br/>    duration: 5s<br/>```<br/><br/>Or with a VRL expression that can return a duration based on the operation kind:<br/>```yaml<br/>  timeout:<br/>    expression: \|<br/>     if (.request.operation.type == "mutation") {<br/>       "10s"<br/>     } else {<br/>       "15s"<br/>     }<br/>```<br/>||
 |[**tls**](#traffic_shapingsubgraphsadditionalpropertiestls)|`object`, `null`|||
+|[**websocket**](#traffic_shapingsubgraphsadditionalpropertieswebsocket)|`object`, `null`|Overrides WebSocket connection reuse and execution behavior for this subgraph.<br/>||
 
 **Additional Properties:** not allowed   
 **Example**
@@ -4410,6 +4432,23 @@ Either an exact HTTP status code (integer 100-599 or its string form, e.g. 503) 
 |----|----|-----------|--------|
 |**cert\_file**|||yes|
 |**key\_file**|`string`|Format: `"path"`<br/>|yes|
+
+**Additional Properties:** not allowed   
+   
+<a name="traffic_shapingsubgraphsadditionalpropertieswebsocket"></a>
+##### traffic\_shaping\.subgraphs\.additionalProperties\.websocket: object,null
+
+Overrides WebSocket connection reuse and execution behavior for this subgraph.
+
+Omitted fields inherit their values from `traffic_shaping.all.websocket`.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**execute\_mode**||Controls whether queries and mutations use WebSocket-enabled subgraphs.<br/><br/>The default is `http`, preserving HTTP execution unless WebSocket execution is explicitly<br/>enabled. Subscriptions continue to use the protocol selected under `subscriptions`.<br/>At the per-subgraph level omission inherits the `all` value.<br/>||
+|**reuse\_connections**|`boolean`, `null`|Enables multiplexing operations over matching initialized WebSocket connections.<br/><br/>When enabled, subscriptions retain initialized connections in a pool and can share one<br/>physical connection. Queries and mutations use that pool according to `execute_mode`.<br/>When disabled, each WebSocket operation owns a dedicated connection.<br/><br/>A pooled connection is discovered using two values:<br/><br/>1. The resolved WebSocket endpoint. Endpoint overrides and expressions are evaluated first,<br/>   then the configured WebSocket path is applied. Connections to different resolved<br/>   endpoints are never considered a match.<br/>2. The inbound connection fingerprint. This fingerprint contains the inbound HTTP method,<br/>   request path, selected inbound headers, and schema checksum. It deliberately excludes the<br/>   GraphQL operation, variables, and extensions, allowing different operations from the<br/>   same connection identity to share one physical WebSocket.<br/><br/>Header selection uses `traffic_shaping.router.dedupe.headers`, even when router request<br/>deduplication itself is disabled. The default is `all`. If a custom header selection is<br/>configured, it must include every inbound header that can change the authentication,<br/>authorization, cookie, or tenant identity sent in `connection_init`. Excluding such a<br/>header can make requests with different identities appear to match and reuse the same<br/>authenticated connection.<br/><br/>A subscription can create the matching pool entry. With `execute_mode: reuse_existing`, a<br/>query or mutation uses the connection only after it is fully initialized. A missing entry<br/>or one still waiting for `connection_ack` falls back to HTTP. With<br/>`execute_mode: websocket`, queries and mutations may create a missing entry or join an<br/>initialization already in progress.<br/><br/>For example, the following configuration lets subscriptions create shared connections and<br/>lets queries and mutations reuse them when available:<br/><br/>```yaml<br/>traffic_shaping:<br/>  all:<br/>    websocket:<br/>      reuse_connections: true<br/>      execute_mode: reuse_existing<br/>  router:<br/>    dedupe:<br/>      headers:<br/>        include: [authorization, cookie, x-tenant]<br/>```<br/><br/>The following keeps reuse enabled globally but gives one subgraph a dedicated connection<br/>for every WebSocket operation:<br/><br/>```yaml<br/>traffic_shaping:<br/>  all:<br/>    websocket:<br/>      reuse_connections: true<br/>  subgraphs:<br/>    payments:<br/>      websocket:<br/>        reuse_connections: false<br/>```<br/><br/>Idle pooled connections use the effective `pool_idle_timeout` from traffic shaping. At the<br/>`all` level `reuse_connections` defaults to `true`. At the per-subgraph level omission<br/>inherits the `all` value.<br/>||
 
 **Additional Properties:** not allowed   
    

--- a/e2e/configs/websocket_pool.yaml
+++ b/e2e/configs/websocket_pool.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../supergraph.graphql
+subscriptions:
+  enabled: true
+  websocket:
+    subgraphs:
+      reviews:
+        path: /reviews/ws
+traffic_shaping:
+  all:
+    pool_idle_timeout: 5s
+    websocket:
+      execute_mode: reuse_existing
+  router:
+    dedupe:
+      headers: none

--- a/e2e/src/demand_control/enforcement.rs
+++ b/e2e/src/demand_control/enforcement.rs
@@ -180,7 +180,8 @@ mod enforcement_tests {
             .await;
 
         let wsconn = router.ws().await;
-        let mut client = WsClient::init(wsconn, None)
+        let mut client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
 
@@ -197,7 +198,11 @@ mod enforcement_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload, None).await;
+        let mut stream = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
         let first = stream.next().await.expect("Expected a rejection response");
         let errors = first
             .errors

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -80,6 +80,8 @@ mod tls;
 mod traffic_shaping;
 #[cfg(test)]
 mod websocket;
+#[cfg(test)]
+mod websocket_pool;
 
 pub use insta;
 pub use mockito;

--- a/e2e/src/subscriptions.rs
+++ b/e2e/src/subscriptions.rs
@@ -1599,14 +1599,19 @@ mod subscriptions_e2e_tests {
         };
 
         let wsconn = router.ws().await;
-        let mut ws_client = WsClient::init(wsconn, None)
+        let mut ws_client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
         let ws_payload = SubscribePayload {
             query: query.into(),
             ..Default::default()
         };
-        let mut ws_stream = ws_client.subscribe(ws_payload, None).await;
+        let mut ws_stream = ws_client
+            .subscribe(ws_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         let (sub_sse, sub_multipart) = tokio::join!(
             router.send_graphql_request(query, None, sse_headers),
@@ -1689,14 +1694,19 @@ mod subscriptions_e2e_tests {
         "#;
 
         let wsconn = router.ws().await;
-        let mut ws_client = WsClient::init(wsconn, None)
+        let mut ws_client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
         let ws_payload = SubscribePayload {
             query: query.into(),
             ..Default::default()
         };
-        let mut ws_stream = ws_client.subscribe(ws_payload, None).await;
+        let mut ws_stream = ws_client
+            .subscribe(ws_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         // consume 3 events from sub1 to let the source stream advance
         let response = ws_stream.next().await.unwrap();

--- a/e2e/src/telemetry/subscription_metrics.rs
+++ b/e2e/src/telemetry/subscription_metrics.rs
@@ -212,14 +212,19 @@ mod subscription_metrics_e2e_tests {
         "#;
 
         let wsconn = router.ws().await;
-        let mut ws_client = WsClient::init(wsconn, None)
+        let mut ws_client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
         let ws_payload = SubscribePayload {
             query: query.into(),
             ..Default::default()
         };
-        let mut ws_stream = ws_client.subscribe(ws_payload, None).await;
+        let mut ws_stream = ws_client
+            .subscribe(ws_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         // drain the finite stream so subscribe/unsubscribe both happen while the router runs
         let mut received = 0;

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -234,6 +234,7 @@ pub struct TestSubgraphsBuilder {
     on_request: Option<Arc<OnRequest>>,
     rustls_config: Option<RustlsConfig>,
     delay: Option<Duration>,
+    path_delay: Option<(String, Duration)>,
     http2_only: bool,
 }
 
@@ -243,6 +244,7 @@ impl TestSubgraphsBuilder {
             on_request: None,
             rustls_config: None,
             delay: None,
+            path_delay: None,
             subscriptions_protocol: HTTPStreamingSubscriptionProtocol::default(),
             http2_only: false,
         }
@@ -280,6 +282,16 @@ impl TestSubgraphsBuilder {
         self
     }
 
+    /// Adds a cooperative asynchronous delay to requests matching the given path.
+    ///
+    /// Use this instead of sleeping inside `with_on_request`, whose synchronous callback would
+    /// block the shared Tokio runtime and could stall unrelated requests or parallel tests. This
+    /// delay yields to the runtime and leaves requests for every other path unaffected.
+    pub fn with_path_delay(mut self, path: impl Into<String>, delay: Duration) -> Self {
+        self.path_delay = Some((path.into(), delay));
+        self
+    }
+
     /// Enables HTTP/2 only mode (h2c) for the test subgraph server.
     /// When enabled, the server will only accept HTTP/2 connections over plain TCP.
     #[allow(unused)]
@@ -293,6 +305,7 @@ impl TestSubgraphsBuilder {
             on_request: self.on_request,
             rustls_config: self.rustls_config,
             delay: self.delay,
+            path_delay: self.path_delay,
             subscriptions_protocol: self.subscriptions_protocol,
             http2_only: self.http2_only,
             handle: None,
@@ -319,6 +332,7 @@ pub struct TestSubgraphs<State> {
     on_request: Option<Arc<OnRequest>>,
     rustls_config: Option<RustlsConfig>,
     delay: Option<Duration>,
+    path_delay: Option<(String, Duration)>,
     http2_only: bool,
     handle: Option<TestSubgraphsHandle>,
     _state: PhantomData<State>,
@@ -450,6 +464,19 @@ impl TestSubgraphs<Built> {
                 },
             ));
         }
+        if let Some((path, delay)) = self.path_delay.clone() {
+            app = app.layer(axum::middleware::from_fn(
+                move |req: axum::extract::Request, next: axum::middleware::Next| {
+                    let path = path.clone();
+                    async move {
+                        if req.uri().path() == path {
+                            tokio::time::sleep(delay).await;
+                        }
+                        next.run(req).await
+                    }
+                },
+            ));
+        }
         // record_requests must be outermost so it logs the request before any blocking on_request handler runs
         app = app.layer(axum::middleware::from_fn_with_state(
             middleware_state.clone(),
@@ -492,6 +519,7 @@ impl TestSubgraphs<Built> {
             on_request: self.on_request,
             rustls_config: rustls_config_clone,
             delay: self.delay,
+            path_delay: self.path_delay,
             subscriptions_protocol: self.subscriptions_protocol,
             http2_only: self.http2_only,
             handle: Some(TestSubgraphsHandle {

--- a/e2e/src/websocket.rs
+++ b/e2e/src/websocket.rs
@@ -30,7 +30,8 @@ mod websocket_e2e_tests {
 
         let wsconn = router.ws().await;
 
-        let mut client = WsClient::init(wsconn, None)
+        let mut client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
 
@@ -47,7 +48,11 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(execution_request, None).await;
+        let mut stream = client
+            .subscribe(execution_request, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         let response = stream.next().await.expect("Expected a response");
 
@@ -80,7 +85,8 @@ mod websocket_e2e_tests {
 
         let wsconn = router.ws().await;
 
-        let mut client = WsClient::init(wsconn, None)
+        let mut client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
 
@@ -97,7 +103,11 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload, None).await;
+        let mut stream = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         let mut received_count = 0;
         while let Some(response) = stream.next().await {
@@ -134,7 +144,8 @@ mod websocket_e2e_tests {
 
         let wsconn = router.ws().await;
 
-        let mut client = WsClient::init(wsconn, None)
+        let mut client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
 
@@ -150,7 +161,11 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream1 = client.subscribe(subscribe_payload1, None).await;
+        let mut stream1 = client
+            .subscribe(subscribe_payload1, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         let subscribe_payload = SubscribePayload {
             query: r#"
@@ -164,7 +179,11 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream2 = client.subscribe(subscribe_payload, None).await;
+        let mut stream2 = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         let mut count1 = 0;
         let mut count2 = 0;
@@ -242,15 +261,13 @@ mod websocket_e2e_tests {
 
         let wsconn = router.ws().await;
 
-        let mut client = WsClient::init(
-            wsconn,
-            Some(ConnectionInitPayload::new(HashMap::from([(
+        let mut client = WsClient::new(wsconn)
+            .init(Some(ConnectionInitPayload::new(HashMap::from([(
                 "x-context".to_string(),
                 json!("my-init_payload-value"),
-            )]))),
-        )
-        .await
-        .expect("Failed to init WsClient");
+            )]))))
+            .await
+            .expect("Failed to init WsClient");
 
         let subscribe_payload = SubscribePayload {
             query: r#"
@@ -265,7 +282,11 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload, None).await;
+        let mut stream = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         stream.next().await.expect("Expected a response");
 
@@ -311,7 +332,8 @@ mod websocket_e2e_tests {
 
         let wsconn = router.ws().await;
 
-        let mut client = WsClient::init(wsconn, None)
+        let mut client = WsClient::new(wsconn)
+            .init(None)
             .await
             .expect("Failed to init WsClient");
 
@@ -332,7 +354,11 @@ mod websocket_e2e_tests {
             ..Default::default()
         };
 
-        let mut stream = client.subscribe(subscribe_payload, None).await;
+        let mut stream = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
 
         stream.next().await.expect("Expected a response");
 
@@ -380,15 +406,13 @@ mod websocket_e2e_tests {
 
         let wsconn = router.ws().await;
 
-        let mut client = WsClient::init(
-            wsconn,
-            Some(ConnectionInitPayload::new(HashMap::from([(
+        let mut client = WsClient::new(wsconn)
+            .init(Some(ConnectionInitPayload::new(HashMap::from([(
                 "x-context".to_string(),
                 json!("my-init_payload-value"),
-            )]))),
-        )
-        .await
-        .expect("Failed to init WsClient");
+            )]))))
+            .await
+            .expect("Failed to init WsClient");
 
         let subscribe_payload = SubscribePayload {
             query: r#"
@@ -408,7 +432,11 @@ mod websocket_e2e_tests {
         };
 
         // merging headers
-        let mut stream = client.subscribe(subscribe_payload, None).await;
+        let mut stream = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
         stream.next().await.expect("Expected a response");
 
         let subscribe_payload = SubscribePayload {
@@ -425,7 +453,11 @@ mod websocket_e2e_tests {
         };
 
         // missing headers in extensions, should've been merged
-        let mut stream = client.subscribe(subscribe_payload, None).await;
+        let mut stream = client
+            .subscribe(subscribe_payload, None)
+            .await
+            .expect("Failed to subscribe")
+            .map(|response| response.expect("WebSocket response failed"));
         stream.next().await.expect("Expected a response");
 
         let products_requests = subgraphs

--- a/e2e/src/websocket_pool.rs
+++ b/e2e/src/websocket_pool.rs
@@ -7,26 +7,6 @@ mod websocket_pool_e2e_tests {
 
     use crate::testkit::{some_header_map, ClientResponseExt, TestRouter, TestSubgraphs};
 
-    const POOL_CONFIG: &str = r#"
-        supergraph:
-            source: file
-            path: supergraph.graphql
-        subscriptions:
-            enabled: true
-            websocket:
-                subgraphs:
-                    reviews:
-                        path: /reviews/ws
-        traffic_shaping:
-            all:
-                pool_idle_timeout: 5s
-                websocket:
-                    execute_mode: reuse_existing
-            router:
-                dedupe:
-                    headers: none
-    "#;
-
     const LOOPING_SUBSCRIPTION: &str = r#"
         subscription {
             reviewAddedLooping(intervalInMs: 20) {
@@ -56,7 +36,7 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG)
+            .file_config("configs/websocket_pool.yaml")
             .build()
             .start()
             .await;
@@ -95,7 +75,7 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG)
+            .file_config("configs/websocket_pool.yaml")
             .build()
             .start()
             .await;
@@ -135,7 +115,7 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG)
+            .file_config("configs/websocket_pool.yaml")
             .build()
             .start()
             .await;
@@ -169,7 +149,7 @@ mod websocket_pool_e2e_tests {
             .await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG)
+            .file_config("configs/websocket_pool.yaml")
             .build()
             .start()
             .await;
@@ -259,11 +239,252 @@ mod websocket_pool_e2e_tests {
     }
 
     #[ntex::test]
+    async fn http_mode_does_not_reuse_an_initialized_connection() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        websocket:
+                            execute_mode: http
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let mut subscription = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, sse_headers())
+            .await;
+        subscription.next().await.unwrap().unwrap();
+
+        let response = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(response.get("data").is_some() && response.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "http mode must ignore an eligible pooled websocket"
+        );
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1
+        );
+    }
+
+    #[ntex::test]
+    async fn websocket_mode_initializes_and_reuses_a_connection_for_queries() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 5s
+                        websocket:
+                            execute_mode: websocket
+                    subgraphs:
+                        products:
+                            websocket:
+                                execute_mode: http
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let first = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+        let second = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(first.get("data").is_some() && first.get("errors").is_none());
+        assert!(second.get("data").is_some() && second.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("products")
+                .unwrap_or_default()
+                .len(),
+            2,
+            "the products subgraph override should keep its fetches on HTTP"
+        );
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "websocket mode should initialize once and reuse the pooled connection"
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews").is_none(),
+            "websocket mode should not execute the review fetch over HTTP"
+        );
+    }
+
+    #[ntex::test]
+    async fn websocket_mode_without_reuse_opens_one_connection_per_query() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        websocket:
+                            reuse_connections: false
+                            execute_mode: websocket
+                    subgraphs:
+                        products:
+                            websocket:
+                                execute_mode: http
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let first = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+        let second = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(first.get("data").is_some() && first.get("errors").is_none());
+        assert!(second.get("data").is_some() && second.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            2,
+            "disabled reuse should open a dedicated websocket for each query"
+        );
+        assert!(subgraphs.get_requests_log("reviews").is_none());
+    }
+
+    #[ntex::test]
+    async fn disabled_connection_reuse_gives_each_subscription_its_own_connection() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 5s
+                        websocket:
+                            reuse_connections: false
+                            execute_mode: http
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let first = router.send_graphql_request(
+            "subscription { reviewAdded(step: 2, intervalInMs: 0) { id } }",
+            None,
+            sse_headers(),
+        );
+        let second = router.send_graphql_request(
+            "subscription { reviewAdded(step: 3, intervalInMs: 0) { id } }",
+            None,
+            sse_headers(),
+        );
+        let (first, second) = tokio::join!(first, second);
+        let (first, second) = tokio::join!(first.string_body(), second.string_body());
+
+        assert!(first.contains("event: complete"));
+        assert!(second.contains("event: complete"));
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            2,
+            "disabling reuse should preserve one WebSocket per subscription"
+        );
+    }
+
+    #[ntex::test]
     async fn dropping_one_operation_leaves_the_connection_reusable() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG)
+            .file_config("configs/websocket_pool.yaml")
             .build()
             .start()
             .await;
@@ -305,7 +526,27 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG.replace("pool_idle_timeout: 5s", "pool_idle_timeout: 50ms"))
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 50ms
+                        websocket:
+                            execute_mode: reuse_existing
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
             .build()
             .start()
             .await;
@@ -341,7 +582,27 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG.replace("pool_idle_timeout: 5s", "pool_idle_timeout: 50ms"))
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 50ms
+                        websocket:
+                            execute_mode: reuse_existing
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
             .build()
             .start()
             .await;
@@ -385,10 +646,28 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG.replace(
-                "headers: none",
-                "headers:\n                        include: [x-tenant]",
-            ))
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 5s
+                        websocket:
+                            execute_mode: reuse_existing
+                    router:
+                        dedupe:
+                            headers:
+                                include: [x-tenant]
+                "#,
+            )
             .build()
             .start()
             .await;
@@ -419,6 +698,87 @@ mod websocket_pool_e2e_tests {
     }
 
     #[ntex::test]
+    async fn query_reuses_only_a_matching_selected_header_fingerprint() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        websocket:
+                            execute_mode: reuse_existing
+                    router:
+                        dedupe:
+                            headers:
+                                include: [x-tenant]
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+        let headers = |tenant: &'static str, ignored: &'static str, accept| {
+            let mut headers = some_header_map! {
+                http::header::HeaderName::from_static("x-tenant") => tenant,
+                http::header::HeaderName::from_static("x-ignored") => ignored
+            }
+            .unwrap();
+            if accept {
+                headers.insert(http::header::ACCEPT, "text/event-stream".parse().unwrap());
+            }
+            Some(headers)
+        };
+
+        let mut subscription = router
+            .send_graphql_request(
+                LOOPING_SUBSCRIPTION,
+                None,
+                headers("one", "subscription", true),
+            )
+            .await;
+        subscription.next().await.unwrap().unwrap();
+
+        let mismatch = router
+            .send_graphql_request(REVIEWS_QUERY, None, headers("two", "subscription", false))
+            .await
+            .json_body()
+            .await;
+        let matching = router
+            .send_graphql_request(REVIEWS_QUERY, None, headers("one", "query", false))
+            .await
+            .json_body()
+            .await;
+
+        assert!(mismatch.get("data").is_some() && mismatch.get("errors").is_none());
+        assert!(matching.get("data").is_some() && matching.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "a different selected header must miss the pool"
+        );
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "unselected headers must not change the connection fingerprint"
+        );
+    }
+
+    #[ntex::test]
     async fn deduplicated_query_leader_uses_the_initialized_connection() {
         let subgraphs = TestSubgraphs::builder()
             .with_delay(Duration::from_millis(50))
@@ -427,7 +787,7 @@ mod websocket_pool_e2e_tests {
             .await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG)
+            .file_config("configs/websocket_pool.yaml")
             .build()
             .start()
             .await;

--- a/e2e/src/websocket_pool.rs
+++ b/e2e/src/websocket_pool.rs
@@ -14,12 +14,14 @@ mod websocket_pool_e2e_tests {
         subscriptions:
             enabled: true
             websocket:
-                all:
-                    idle_timeout: 5s
                 subgraphs:
                     reviews:
                         path: /reviews/ws
         traffic_shaping:
+            all:
+                pool_idle_timeout: 5s
+                websocket:
+                    execute_mode: reuse_existing
             router:
                 dedupe:
                     headers: none
@@ -205,7 +207,7 @@ mod websocket_pool_e2e_tests {
     }
 
     #[ntex::test]
-    async fn queries_and_mutations_never_create_websocket_connections() {
+    async fn http_mode_never_creates_websocket_connections_for_queries_or_mutations() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
@@ -303,7 +305,7 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG.replace("idle_timeout: 5s", "idle_timeout: 50ms"))
+            .inline_config(POOL_CONFIG.replace("pool_idle_timeout: 5s", "pool_idle_timeout: 50ms"))
             .build()
             .start()
             .await;
@@ -339,7 +341,7 @@ mod websocket_pool_e2e_tests {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
-            .inline_config(POOL_CONFIG.replace("idle_timeout: 5s", "idle_timeout: 50ms"))
+            .inline_config(POOL_CONFIG.replace("pool_idle_timeout: 5s", "pool_idle_timeout: 50ms"))
             .build()
             .start()
             .await;

--- a/e2e/src/websocket_pool.rs
+++ b/e2e/src/websocket_pool.rs
@@ -577,6 +577,140 @@ mod websocket_pool_e2e_tests {
         );
     }
 
+    // actually testing pool_idle_timeout
+    #[ntex::test]
+    async fn websocket_mode_reconnects_after_pool_idle_timeout() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 50ms
+                        websocket:
+                            execute_mode: websocket
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let first = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+        let second = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(first.get("data").is_some() && first.get("errors").is_none());
+        assert!(second.get("data").is_some() && second.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "queries before the idle timeout should reuse one websocket"
+        );
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let third = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(third.get("data").is_some() && third.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            2,
+            "the first websocket should close after the idle timeout"
+        );
+        assert!(subgraphs.get_requests_log("reviews").is_none());
+    }
+
+    #[ntex::test]
+    async fn subgraph_pool_idle_timeout_overrides_the_global_timeout() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                traffic_shaping:
+                    all:
+                        pool_idle_timeout: 50ms
+                        websocket:
+                            execute_mode: reuse_existing
+                    subgraphs:
+                        reviews:
+                            pool_idle_timeout: 5s
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let subscription = router
+            .send_graphql_request(
+                "subscription { reviewAdded(step: 11, intervalInMs: 0) { id } }",
+                None,
+                sse_headers(),
+            )
+            .await;
+        assert!(subscription.string_body().await.contains("event: complete"));
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let response = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(response.get("data").is_some() && response.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "the reviews override should keep the pooled websocket alive"
+        );
+        assert!(subgraphs.get_requests_log("reviews").is_none());
+    }
+
     #[ntex::test]
     async fn idle_connection_expires_and_query_falls_back_to_http() {
         let subgraphs = TestSubgraphs::builder().build().start().await;

--- a/e2e/src/websocket_pool.rs
+++ b/e2e/src/websocket_pool.rs
@@ -366,6 +366,144 @@ mod websocket_pool_e2e_tests {
     }
 
     #[ntex::test]
+    async fn websocket_mode_executes_every_subgraph_fetch_over_websocket() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    websocket:
+                        subgraphs:
+                            reviews:
+                                path: /reviews/ws
+                            accounts:
+                                path: /accounts/ws
+                            inventory:
+                                path: /inventory/ws
+                            products:
+                                path: /products/ws
+                traffic_shaping:
+                    all:
+                        websocket:
+                            execute_mode: websocket
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // run 3 queries making sure we're using the pool
+        for _ in 0..3 {
+            let response = router
+                .send_graphql_request(
+                    r#"
+                    fragment User on User {
+                        id
+                        username
+                        name
+                    }
+
+                    fragment Review on Review {
+                        id
+                        body
+                    }
+
+                    fragment Product on Product {
+                        inStock
+                        name
+                        price
+                        shippingEstimate
+                        upc
+                        weight
+                    }
+
+                    query TestQuery {
+                        users {
+                            ...User
+                            reviews {
+                                ...Review
+                                product {
+                                    ...Product
+                                    reviews {
+                                        ...Review
+                                        author {
+                                            ...User
+                                            reviews {
+                                                ...Review
+                                                product {
+                                                    ...Product
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        topProducts(first: 1) {
+                            ...Product
+                            reviews {
+                                ...Review
+                                author {
+                                    ...User
+                                    reviews {
+                                        ...Review
+                                        product {
+                                            ...Product
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "#,
+                    None,
+                    None,
+                )
+                .await
+                .json_body()
+                .await;
+
+            // response is too big for snapshot assertion, so just do a bunch of sanity checks
+            assert!(response.get("errors").is_none(), "{response}");
+            assert_eq!(
+                response["data"]["users"][0]["name"].as_str(),
+                Some("Uri Goldshtein")
+            );
+            assert_eq!(
+                response["data"]["topProducts"][0]["name"].as_str(),
+                Some("Table")
+            );
+            assert_eq!(
+                response["data"]["topProducts"][0]["inStock"].as_bool(),
+                Some(true)
+            );
+            assert_eq!(
+                response["data"]["topProducts"][0]["reviews"][0]["id"].as_str(),
+                Some("1")
+            );
+        }
+
+        for subgraph in ["accounts", "inventory", "products", "reviews"] {
+            assert_eq!(
+                subgraphs
+                    .get_requests_log(&format!("{subgraph}/ws"))
+                    .unwrap_or_default()
+                    .len(),
+                1,
+                "{subgraph} should use one websocket"
+            );
+            assert!(subgraphs.get_requests_log(subgraph).is_none());
+        }
+    }
+
+    #[ntex::test]
     async fn websocket_mode_without_reuse_opens_one_connection_per_query() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()

--- a/e2e/src/websocket_pool.rs
+++ b/e2e/src/websocket_pool.rs
@@ -1,0 +1,466 @@
+#[cfg(test)]
+mod websocket_pool_e2e_tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use sonic_rs::JsonValueTrait;
+
+    use crate::testkit::{some_header_map, ClientResponseExt, TestRouter, TestSubgraphs};
+
+    const POOL_CONFIG: &str = r#"
+        supergraph:
+            source: file
+            path: supergraph.graphql
+        subscriptions:
+            enabled: true
+            websocket:
+                all:
+                    idle_timeout: 5s
+                subgraphs:
+                    reviews:
+                        path: /reviews/ws
+        traffic_shaping:
+            router:
+                dedupe:
+                    headers: none
+    "#;
+
+    const LOOPING_SUBSCRIPTION: &str = r#"
+        subscription {
+            reviewAddedLooping(intervalInMs: 20) {
+                id
+            }
+        }
+    "#;
+
+    const REVIEWS_QUERY: &str = r#"
+        query {
+            topProducts(first: 1) {
+                reviews {
+                    id
+                }
+            }
+        }
+    "#;
+
+    fn sse_headers() -> Option<http::HeaderMap> {
+        some_header_map! {
+            http::header::ACCEPT => "text/event-stream"
+        }
+    }
+
+    #[ntex::test]
+    async fn concurrent_subscriptions_share_one_websocket_connection() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG)
+            .build()
+            .start()
+            .await;
+
+        let first = router.send_graphql_request(
+            "subscription { reviewAdded(step: 2, intervalInMs: 0) { id } }",
+            None,
+            sse_headers(),
+        );
+        let second = router.send_graphql_request(
+            "subscription { reviewAdded(step: 3, intervalInMs: 0) { id } }",
+            None,
+            sse_headers(),
+        );
+        let (first, second) = tokio::join!(first, second);
+        let (first, second) = tokio::join!(first.string_body(), second.string_body());
+
+        assert!(first.contains(r#""id":"1""#) && first.contains("event: complete"));
+        assert!(second.contains(r#""id":"1""#) && second.contains("event: complete"));
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "concurrent initialization should perform one websocket upgrade"
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews").is_none(),
+            "websocket subscriptions should not use the reviews HTTP endpoint"
+        );
+    }
+
+    #[ntex::test]
+    async fn different_operations_multiplex_on_the_initialized_connection() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG)
+            .build()
+            .start()
+            .await;
+
+        let mut subscription = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, sse_headers())
+            .await;
+        subscription.next().await.unwrap().unwrap();
+
+        let first = router.send_graphql_request(REVIEWS_QUERY, None, None);
+        let second = router.send_graphql_request(
+            "query { topProducts(first: 2) { reviews { body } } }",
+            None,
+            None,
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        let first = first.json_body().await;
+        let second = second.json_body().await;
+        assert!(first.get("data").is_some() && first.get("errors").is_none());
+        assert!(second.get("data").is_some() && second.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews").is_none(),
+            "both review entity fetches should use the pooled websocket"
+        );
+    }
+
+    #[ntex::test]
+    async fn query_uses_http_when_no_initialized_connection_exists() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG)
+            .build()
+            .start()
+            .await;
+
+        let response = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(response.get("data").is_some());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews")
+                .unwrap_or_default()
+                .len(),
+            1
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews/ws").is_none(),
+            "a query must not initialize a websocket"
+        );
+    }
+
+    #[ntex::test]
+    async fn query_uses_http_while_the_matching_connection_is_initializing() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_path_delay("/reviews/ws", Duration::from_millis(300))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG)
+            .build()
+            .start()
+            .await;
+
+        let subscription = router.send_graphql_request(
+            "subscription { reviewAdded(step: 11, intervalInMs: 0) { id } }",
+            None,
+            sse_headers(),
+        );
+        let query = async {
+            for _ in 0..100 {
+                if subgraphs.get_requests_log("reviews/ws").is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            assert!(
+                subgraphs.get_requests_log("reviews/ws").is_some(),
+                "subscription did not begin websocket initialization"
+            );
+            router.send_graphql_request(REVIEWS_QUERY, None, None).await
+        };
+        let (subscription, query) = tokio::join!(subscription, query);
+
+        assert!(subscription.string_body().await.contains("event: complete"));
+        assert!(query.json_body().await.get("data").is_some());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "a query must not wait for a connecting websocket"
+        );
+    }
+
+    #[ntex::test]
+    async fn queries_and_mutations_never_create_websocket_connections() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                    websocket:
+                        subgraphs:
+                            products:
+                                path: /reviews/ws
+                traffic_shaping:
+                    router:
+                        dedupe:
+                            headers: none
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let query = router
+            .send_graphql_request("query { topProducts(first: 1) { name } }", None, None)
+            .await
+            .json_body()
+            .await;
+        let mutation = router
+            .send_graphql_request("mutation { reentryTest { ok } }", None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(query.get("data").is_some());
+        assert!(mutation.get("data").is_some());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("products")
+                .unwrap_or_default()
+                .len(),
+            2
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews/ws").is_none(),
+            "execute-only traffic must not perform a websocket upgrade"
+        );
+    }
+
+    #[ntex::test]
+    async fn dropping_one_operation_leaves_the_connection_reusable() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG)
+            .build()
+            .start()
+            .await;
+
+        let mut subscription = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, sse_headers())
+            .await;
+        subscription.next().await.unwrap().unwrap();
+        drop(subscription);
+
+        for _ in 0..100 {
+            if subgraphs.active_subscriptions() == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(subgraphs.active_subscriptions(), 0);
+
+        let response = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(response.get("data").is_some() && response.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "cancelling a logical operation must not close the pooled connection"
+        );
+        assert!(subgraphs.get_requests_log("reviews").is_none());
+    }
+
+    #[ntex::test]
+    async fn active_operation_prevents_idle_expiry() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG.replace("idle_timeout: 5s", "idle_timeout: 50ms"))
+            .build()
+            .start()
+            .await;
+
+        let mut subscription = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, sse_headers())
+            .await;
+        subscription.next().await.unwrap().unwrap();
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let response = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(response.get("data").is_some() && response.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews").is_none(),
+            "an active operation must keep the connection out of the idle state"
+        );
+    }
+
+    #[ntex::test]
+    async fn idle_connection_expires_and_query_falls_back_to_http() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG.replace("idle_timeout: 5s", "idle_timeout: 50ms"))
+            .build()
+            .start()
+            .await;
+
+        let subscription = router
+            .send_graphql_request(
+                "subscription { reviewAdded(step: 11, intervalInMs: 0) { id } }",
+                None,
+                sse_headers(),
+            )
+            .await;
+        assert!(subscription.string_body().await.contains("event: complete"));
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let response = router
+            .send_graphql_request(REVIEWS_QUERY, None, None)
+            .await
+            .json_body()
+            .await;
+
+        assert!(response.get("data").is_some());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "an expired pool entry should be an HTTP miss"
+        );
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1
+        );
+    }
+
+    #[ntex::test]
+    async fn included_headers_isolate_connection_fingerprints() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG.replace(
+                "headers: none",
+                "headers:\n                        include: [x-tenant]",
+            ))
+            .build()
+            .start()
+            .await;
+        let tenant = |value: &str| {
+            some_header_map! {
+                http::header::ACCEPT => "text/event-stream",
+                http::header::HeaderName::from_static("x-tenant") => value
+            }
+        };
+
+        let mut first = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, tenant("one"))
+            .await;
+        first.next().await.unwrap().unwrap();
+        let mut second = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, tenant("two"))
+            .await;
+        second.next().await.unwrap().unwrap();
+
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            2,
+            "different included identity headers must not share a connection"
+        );
+    }
+
+    #[ntex::test]
+    async fn deduplicated_query_leader_uses_the_initialized_connection() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(50))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(POOL_CONFIG)
+            .build()
+            .start()
+            .await;
+
+        let mut subscription = router
+            .send_graphql_request(LOOPING_SUBSCRIPTION, None, sse_headers())
+            .await;
+        subscription.next().await.unwrap().unwrap();
+
+        let first = router.send_graphql_request(REVIEWS_QUERY, None, None);
+        let second = router.send_graphql_request(REVIEWS_QUERY, None, None);
+        let (first, second) = tokio::join!(first, second);
+
+        let first = first.json_body().await;
+        let second = second.json_body().await;
+        assert!(first.get("data").is_some() && first.get("errors").is_none());
+        assert!(second.get("data").is_some() && second.get("errors").is_none());
+        assert_eq!(
+            subgraphs
+                .get_requests_log("products")
+                .unwrap_or_default()
+                .len(),
+            1,
+            "deduplicated followers should not execute their own plan"
+        );
+        assert!(
+            subgraphs.get_requests_log("reviews").is_none(),
+            "the deduplication leader should use the initialized websocket"
+        );
+        assert_eq!(
+            subgraphs
+                .get_requests_log("reviews/ws")
+                .unwrap_or_default()
+                .len(),
+            1
+        );
+    }
+}

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -37,6 +37,7 @@ use crate::execution::client_request_details::OperationDetails;
 use crate::execution::demand_control::DemandControlExecutionContext;
 use crate::execution::error_masking::ErrorMaskingRuntime;
 use crate::execution::operation_name::OperationNameFactory;
+use crate::executors::common::ConnectionFingerprint;
 use crate::headers::cache_control;
 use crate::{
     execution::{
@@ -137,6 +138,7 @@ pub struct QueryPlanExecutionOpts<'exec> {
     pub operation_name_factory: OperationNameFactory,
     pub response_header_sink: ResponseHeaderSink,
     pub error_masking_runtime: Arc<Option<ErrorMaskingRuntime>>,
+    pub connection_fingerprint: Option<ConnectionFingerprint>,
 }
 
 pub struct PlanSubscriptionOutput {
@@ -302,6 +304,7 @@ pub async fn execute_query_plan<'exec>(
             raw_variable_values: None,
             extensions: None,
             custom_scalar_paths: fetch_node.custom_scalar_paths.as_ref(),
+            connection_fingerprint: opts.connection_fingerprint,
         };
 
         // TODO: otel instrumentation and stuff
@@ -417,6 +420,7 @@ pub async fn execute_query_plan<'exec>(
                     demand_control_context: opts.demand_control_context.clone(),
                     response_header_sink: response_header_sink.clone(),
                     error_masking_runtime: opts.error_masking_runtime.clone(),
+                    connection_fingerprint: opts.connection_fingerprint,
                 };
                 match execute_query_plan_with_data(response.data, opts).await {
                     Ok(result) => yield result.body,
@@ -526,6 +530,7 @@ async fn execute_query_plan_with_data<'exec>(
         demand_control_context: opts.demand_control_context.clone(),
         plugin_req_state: opts.plugin_req_state.as_ref(),
         operation_name_factory: &opts.operation_name_factory,
+        connection_fingerprint: opts.connection_fingerprint,
     };
 
     if let Some(node) = &opts.query_plan.node {
@@ -704,6 +709,7 @@ pub struct Executor<'exec> {
     pub demand_control_context: Option<Arc<DemandControlExecutionContext>>,
     pub plugin_req_state: Option<&'exec PluginRequestState<'exec>>,
     pub operation_name_factory: &'exec OperationNameFactory,
+    pub connection_fingerprint: Option<ConnectionFingerprint>,
 }
 
 pub enum ExecutionJob<'exec> {
@@ -1626,6 +1632,7 @@ impl<'exec> Executor<'exec> {
                 headers: headers_map,
                 extensions: None,
                 custom_scalar_paths: opts.custom_scalar_paths,
+                connection_fingerprint: self.connection_fingerprint,
             };
 
             let client_document_hash_str = opts.operation.hash.to_string();
@@ -1948,6 +1955,7 @@ mod tests {
             demand_control_context: None,
             plugin_req_state: None,
             operation_name_factory: &OperationNameFactory::default(),
+            connection_fingerprint: None,
         };
 
         let data: ResponseValue = sonic_rs::from_str(
@@ -2065,6 +2073,7 @@ mod tests {
             demand_control_context: None,
             plugin_req_state: None,
             operation_name_factory: &OperationNameFactory::default(),
+            connection_fingerprint: None,
         };
 
         let mock_a = subgraph_a

--- a/lib/executor/src/executors/common.rs
+++ b/lib/executor/src/executors/common.rs
@@ -47,6 +47,41 @@ pub type SubgraphExecutorBoxedArc = Arc<Box<SubgraphExecutorType>>;
 
 pub type SubgraphRequestExtensions = HashMap<String, Value>;
 
+/// Identifies the inbound connection context that may be reused across GraphQL operations.
+///
+/// The hash covers the request method, path, selected inbound headers, and schema checksum. It
+/// deliberately excludes operation data, variables, and extensions so different operations from
+/// the same authenticated connection context can share an initialized subgraph connection.
+///
+/// This type is can be used as a connection pool key.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ConnectionFingerprint(u64);
+
+impl ConnectionFingerprint {
+    /// Wraps a hash produced from connection-scoped request inputs.
+    pub fn from_hash(hash: u64) -> Self {
+        Self(hash)
+    }
+}
+
+/// Identifies one complete inbound GraphQL request for in-flight request deduplication.
+///
+/// The hash extends a [`ConnectionFingerprint`] with the normalized operation, variables, and
+/// extensions hashes. Identical values may share one execution and its response. Different
+/// operations therefore have different request fingerprints even when they are eligible to share
+/// the same pooled connection.
+///
+/// This type is used only for request deduplication and must not be used as a connection pool key.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct InboundRequestFingerprint(u64);
+
+impl InboundRequestFingerprint {
+    /// Wraps a hash produced from a connection fingerprint and operation-scoped inputs.
+    pub fn from_hash(hash: u64) -> Self {
+        Self(hash)
+    }
+}
+
 pub struct SubgraphExecutionRequest<'a> {
     /// Holds the query string to be executed.
     /// The query string contains an anonymous GraphQL document.
@@ -61,6 +96,10 @@ pub struct SubgraphExecutionRequest<'a> {
     pub raw_variable_values: Option<Vec<(&'a str, Vec<u8>)>>,
     pub extensions: Option<SubgraphRequestExtensions>,
     pub custom_scalar_paths: Option<&'a CustomScalarPaths>,
+    /// Identifies an existing pooled connection that may execute this request.
+    ///
+    /// `None` disables pooled lookup and preserves the request's normal transport behavior.
+    pub connection_fingerprint: Option<ConnectionFingerprint>,
 }
 
 impl SubgraphExecutionRequest<'_> {

--- a/lib/executor/src/executors/common.rs
+++ b/lib/executor/src/executors/common.rs
@@ -53,7 +53,7 @@ pub type SubgraphRequestExtensions = HashMap<String, Value>;
 /// deliberately excludes operation data, variables, and extensions so different operations from
 /// the same authenticated connection context can share an initialized subgraph connection.
 ///
-/// This type is can be used as a connection pool key.
+/// This type can be used as a connection pool key.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ConnectionFingerprint(u64);
 

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -89,6 +89,12 @@ pub enum SubgraphExecutorError {
     #[error("WebSocket executor arbiter channel closed unexpectedly")]
     #[strum(serialize = "SUBGRAPH_WEBSOCKET_ARBITER_CHANNEL_CLOSED")]
     WebSocketArbiterChannelClosed,
+    #[error("WebSocket command channel capacity must be greater than zero")]
+    #[strum(serialize = "SUBGRAPH_WEBSOCKET_INVALID_BUFFER_CAPACITY")]
+    WebSocketInvalidBufferCapacity,
+    #[error("WebSocket client operation failed: {0}")]
+    #[strum(serialize = "SUBGRAPH_WEBSOCKET_CLIENT_FAILURE")]
+    WebSocketClientFailure(String),
     #[error("Failed to parse multipart boundary from Content-Type header: {0}")]
     #[strum(serialize = "SUBGRAPH_SUBSCRIPTION_MULTIPART_BOUNDARY_PARSE_FAILURE")]
     MultipartBoundaryParseFailure(String),

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -89,9 +89,6 @@ pub enum SubgraphExecutorError {
     #[error("WebSocket executor arbiter channel closed unexpectedly")]
     #[strum(serialize = "SUBGRAPH_WEBSOCKET_ARBITER_CHANNEL_CLOSED")]
     WebSocketArbiterChannelClosed,
-    #[error("WebSocket command channel capacity must be greater than zero")]
-    #[strum(serialize = "SUBGRAPH_WEBSOCKET_INVALID_BUFFER_CAPACITY")]
-    WebSocketInvalidBufferCapacity,
     #[error("WebSocket client operation failed: {0}")]
     #[strum(serialize = "SUBGRAPH_WEBSOCKET_CLIENT_FAILURE")]
     WebSocketClientFailure(String),

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -5,7 +5,9 @@ use http::{uri::InvalidUri, HeaderMap, StatusCode};
 use rustls::server::VerifierBuilderError;
 use strum::IntoStaticStr;
 
-use crate::response::subgraph_response::SubgraphResponse;
+use crate::{
+    executors::websocket_client::WsClientError, response::subgraph_response::SubgraphResponse,
+};
 
 #[derive(thiserror::Error, Debug, IntoStaticStr)]
 pub enum SubgraphExecutorError {
@@ -91,7 +93,7 @@ pub enum SubgraphExecutorError {
     WebSocketArbiterChannelClosed,
     #[error("WebSocket client operation failed: {0}")]
     #[strum(serialize = "SUBGRAPH_WEBSOCKET_CLIENT_FAILURE")]
-    WebSocketClientFailure(String),
+    WebSocketClientFailure(#[from] WsClientError),
     #[error("Failed to parse multipart boundary from Content-Type header: {0}")]
     #[strum(serialize = "SUBGRAPH_SUBSCRIPTION_MULTIPART_BOUNDARY_PARSE_FAILURE")]
     MultipartBoundaryParseFailure(String),

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -514,7 +514,7 @@ mod tests {
     #[test]
     fn subscribe_payload_rejects_invalid_raw_variable_json() {
         let mut request = make_request("query($id: ID!) { user(id: $id) { id } }", 5, None);
-        request.raw_variable_values = Some(HashMap::from([("id", b"{".to_vec())]));
+        request.raw_variable_values = Some(vec![("id", b"{".to_vec())]);
 
         assert!(matches!(
             SubscribePayload::try_from(request),

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -85,7 +85,7 @@ pub struct SubscribePayload {
 
 pub fn build_subscribe_payload(
     execution_request: SubgraphExecutionRequest<'_>,
-) -> (SubscribePayload, Option<ConnectionInitPayload>) {
+) -> SubscribePayload {
     let variables: Option<HashMap<String, Value>> = match &execution_request.variables {
         Some(variables) => {
             if variables.is_empty() {
@@ -121,18 +121,16 @@ pub fn build_subscribe_payload(
         }
         None => execution_request.query.to_string(),
     };
-    let subscribe_payload = SubscribePayload {
+    SubscribePayload {
         query,
-        operation_name: execution_request.operation_name.map(|s| s.to_string()),
+        operation_name: execution_request.operation_name,
         variables,
         extensions: execution_request.extensions,
-    };
-    let init_payload = if execution_request.headers.is_empty() {
-        None
-    } else {
-        Some(execution_request.headers.into())
-    };
-    (subscribe_payload, init_payload)
+    }
+}
+
+pub fn build_connection_init_payload(headers: http::HeaderMap) -> Option<ConnectionInitPayload> {
+    (!headers.is_empty()).then(|| headers.into())
 }
 
 #[derive(
@@ -475,6 +473,7 @@ mod tests {
             raw_variable_values: None,
             extensions: None,
             custom_scalar_paths: None,
+            connection_fingerprint: None,
         }
     }
 
@@ -486,7 +485,7 @@ mod tests {
             Some("GetMe_accounts_0".to_string()),
         );
 
-        let (payload, _) = build_subscribe_payload(request);
+        let payload = build_subscribe_payload(request);
 
         assert_eq!(payload.query, "query GetMe_accounts_0 { me { id } }");
         assert_eq!(payload.operation_name.as_deref(), Some("GetMe_accounts_0"));
@@ -496,7 +495,7 @@ mod tests {
     fn build_subscribe_payload_without_operation_name_keeps_original_query() {
         let request = make_request("query { me { id } }", 5, None);
 
-        let (payload, _) = build_subscribe_payload(request);
+        let payload = build_subscribe_payload(request);
 
         assert_eq!(payload.query, "query { me { id } }");
         assert_eq!(payload.operation_name, None);
@@ -506,7 +505,7 @@ mod tests {
     fn build_subscribe_payload_inlines_name_for_shorthand_query() {
         let request = make_request("{ me { id } }", 0, Some("GetMe_accounts_0".to_string()));
 
-        let (payload, _) = build_subscribe_payload(request);
+        let payload = build_subscribe_payload(request);
 
         assert_eq!(payload.query, "query GetMe_accounts_0 { me { id } }");
     }

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -87,21 +87,19 @@ pub struct SubscribePayload {
 pub fn build_subscribe_payload(
     execution_request: SubgraphExecutionRequest<'_>,
 ) -> SubscribePayload {
-    let variables: Option<HashMap<String, Value>> = match &execution_request.variables {
-        Some(variables) => {
-            if variables.is_empty() {
-                None
-            } else {
-                Some(
-                    variables
-                        .iter()
-                        .map(|(k, v)| (k.to_string(), (*v).clone()))
-                        .collect(),
-                )
-            }
-        }
-        None => None,
-    };
+    let mut variables: HashMap<String, Value> = execution_request
+        .variables
+        .unwrap_or_default()
+        .iter()
+        .map(|(key, value)| (key.to_string(), (*value).clone()))
+        .collect();
+    for (key, value) in execution_request.raw_variable_values.unwrap_or_default() {
+        variables.insert(
+            key.to_string(),
+            sonic_rs::from_slice(&value).expect("raw variable values must contain valid JSON"),
+        );
+    }
+    let variables = (!variables.is_empty()).then_some(variables);
     let query = match &execution_request.operation_name {
         Some(operation_name) => {
             let pos = execution_request.document_name_write_pos;

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -83,6 +83,7 @@ pub struct SubscribePayload {
     pub extensions: Option<HashMap<String, Value>>,
 }
 
+// TODO: can we instead impl the Into/From trait?
 pub fn build_subscribe_payload(
     execution_request: SubgraphExecutionRequest<'_>,
 ) -> SubscribePayload {
@@ -129,6 +130,7 @@ pub fn build_subscribe_payload(
     }
 }
 
+// TODO: can we instead impl the Into/From trait?
 pub fn build_connection_init_payload(headers: http::HeaderMap) -> Option<ConnectionInitPayload> {
     (!headers.is_empty()).then(|| headers.into())
 }

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -8,7 +8,10 @@ use std::collections::HashMap;
 use strum::AsRefStr;
 use tracing::error;
 
-use crate::{executors::common::SubgraphExecutionRequest, response::graphql_error::GraphQLError};
+use crate::{
+    executors::{common::SubgraphExecutionRequest, error::SubgraphExecutorError},
+    response::graphql_error::GraphQLError,
+};
 
 pub const WS_SUBPROTOCOL: &str = "graphql-transport-ws";
 
@@ -83,8 +86,10 @@ pub struct SubscribePayload {
     pub extensions: Option<HashMap<String, Value>>,
 }
 
-impl From<SubgraphExecutionRequest<'_>> for SubscribePayload {
-    fn from(execution_request: SubgraphExecutionRequest<'_>) -> Self {
+impl TryFrom<SubgraphExecutionRequest<'_>> for SubscribePayload {
+    type Error = SubgraphExecutorError;
+
+    fn try_from(execution_request: SubgraphExecutionRequest<'_>) -> Result<Self, Self::Error> {
         let mut variables: HashMap<String, Value> = execution_request
             .variables
             .unwrap_or_default()
@@ -94,7 +99,9 @@ impl From<SubgraphExecutionRequest<'_>> for SubscribePayload {
         for (key, value) in execution_request.raw_variable_values.unwrap_or_default() {
             variables.insert(
                 key.to_string(),
-                sonic_rs::from_slice(&value).expect("raw variable values must contain valid JSON"),
+                sonic_rs::from_slice(&value).map_err(|error| {
+                    SubgraphExecutorError::VariablesSerializationFailure(key.to_string(), error)
+                })?,
             );
         }
         let variables = (!variables.is_empty()).then_some(variables);
@@ -118,12 +125,12 @@ impl From<SubgraphExecutionRequest<'_>> for SubscribePayload {
             }
             None => execution_request.query.to_string(),
         };
-        SubscribePayload {
+        Ok(SubscribePayload {
             query,
             operation_name: execution_request.operation_name,
             variables,
             extensions: execution_request.extensions,
-        }
+        })
     }
 }
 
@@ -479,7 +486,7 @@ mod tests {
             Some("GetMe_accounts_0".to_string()),
         );
 
-        let payload = SubscribePayload::from(request);
+        let payload = SubscribePayload::try_from(request).unwrap();
 
         assert_eq!(payload.query, "query GetMe_accounts_0 { me { id } }");
         assert_eq!(payload.operation_name.as_deref(), Some("GetMe_accounts_0"));
@@ -489,7 +496,7 @@ mod tests {
     fn subscribe_payload_from_request_without_operation_name_keeps_original_query() {
         let request = make_request("query { me { id } }", 5, None);
 
-        let payload = SubscribePayload::from(request);
+        let payload = SubscribePayload::try_from(request).unwrap();
 
         assert_eq!(payload.query, "query { me { id } }");
         assert_eq!(payload.operation_name, None);
@@ -499,8 +506,19 @@ mod tests {
     fn subscribe_payload_from_request_inlines_name_for_shorthand_query() {
         let request = make_request("{ me { id } }", 0, Some("GetMe_accounts_0".to_string()));
 
-        let payload = SubscribePayload::from(request);
+        let payload = SubscribePayload::try_from(request).unwrap();
 
         assert_eq!(payload.query, "query GetMe_accounts_0 { me { id } }");
+    }
+
+    #[test]
+    fn subscribe_payload_rejects_invalid_raw_variable_json() {
+        let mut request = make_request("query($id: ID!) { user(id: $id) { id } }", 5, None);
+        request.raw_variable_values = Some(HashMap::from([("id", b"{".to_vec())]));
+
+        assert!(matches!(
+            SubscribePayload::try_from(request),
+            Err(SubgraphExecutorError::VariablesSerializationFailure(name, _)) if name == "id"
+        ));
     }
 }

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -83,54 +83,48 @@ pub struct SubscribePayload {
     pub extensions: Option<HashMap<String, Value>>,
 }
 
-// TODO: can we instead impl the Into/From trait?
-pub fn build_subscribe_payload(
-    execution_request: SubgraphExecutionRequest<'_>,
-) -> SubscribePayload {
-    let mut variables: HashMap<String, Value> = execution_request
-        .variables
-        .unwrap_or_default()
-        .iter()
-        .map(|(key, value)| (key.to_string(), (*value).clone()))
-        .collect();
-    for (key, value) in execution_request.raw_variable_values.unwrap_or_default() {
-        variables.insert(
-            key.to_string(),
-            sonic_rs::from_slice(&value).expect("raw variable values must contain valid JSON"),
-        );
-    }
-    let variables = (!variables.is_empty()).then_some(variables);
-    let query = match &execution_request.operation_name {
-        Some(operation_name) => {
-            let pos = execution_request.document_name_write_pos;
-            let input = execution_request.query;
-            let mut result = String::with_capacity(input.len() + operation_name.len() + 6);
-            if pos == 0 && input.starts_with('{') {
-                result.push_str("query ");
-                result.push_str(operation_name);
-                result.push(' ');
-                result.push_str(input);
-            } else {
-                result.push_str(&input[..pos]);
-                result.push(' ');
-                result.push_str(operation_name);
-                result.push_str(&input[pos..]);
-            }
-            result
+impl From<SubgraphExecutionRequest<'_>> for SubscribePayload {
+    fn from(execution_request: SubgraphExecutionRequest<'_>) -> Self {
+        let mut variables: HashMap<String, Value> = execution_request
+            .variables
+            .unwrap_or_default()
+            .iter()
+            .map(|(key, value)| (key.to_string(), (*value).clone()))
+            .collect();
+        for (key, value) in execution_request.raw_variable_values.unwrap_or_default() {
+            variables.insert(
+                key.to_string(),
+                sonic_rs::from_slice(&value).expect("raw variable values must contain valid JSON"),
+            );
         }
-        None => execution_request.query.to_string(),
-    };
-    SubscribePayload {
-        query,
-        operation_name: execution_request.operation_name,
-        variables,
-        extensions: execution_request.extensions,
+        let variables = (!variables.is_empty()).then_some(variables);
+        let query = match &execution_request.operation_name {
+            Some(operation_name) => {
+                let pos = execution_request.document_name_write_pos;
+                let input = execution_request.query;
+                let mut result = String::with_capacity(input.len() + operation_name.len() + 6);
+                if pos == 0 && input.starts_with('{') {
+                    result.push_str("query ");
+                    result.push_str(operation_name);
+                    result.push(' ');
+                    result.push_str(input);
+                } else {
+                    result.push_str(&input[..pos]);
+                    result.push(' ');
+                    result.push_str(operation_name);
+                    result.push_str(&input[pos..]);
+                }
+                result
+            }
+            None => execution_request.query.to_string(),
+        };
+        SubscribePayload {
+            query,
+            operation_name: execution_request.operation_name,
+            variables,
+            extensions: execution_request.extensions,
+        }
     }
-}
-
-// TODO: can we instead impl the Into/From trait?
-pub fn build_connection_init_payload(headers: http::HeaderMap) -> Option<ConnectionInitPayload> {
-    (!headers.is_empty()).then(|| headers.into())
 }
 
 #[derive(
@@ -478,34 +472,34 @@ mod tests {
     }
 
     #[test]
-    fn build_subscribe_payload_inlines_operation_name_in_query() {
+    fn subscribe_payload_from_request_inlines_operation_name_in_query() {
         let request = make_request(
             "query { me { id } }",
             5,
             Some("GetMe_accounts_0".to_string()),
         );
 
-        let payload = build_subscribe_payload(request);
+        let payload = SubscribePayload::from(request);
 
         assert_eq!(payload.query, "query GetMe_accounts_0 { me { id } }");
         assert_eq!(payload.operation_name.as_deref(), Some("GetMe_accounts_0"));
     }
 
     #[test]
-    fn build_subscribe_payload_without_operation_name_keeps_original_query() {
+    fn subscribe_payload_from_request_without_operation_name_keeps_original_query() {
         let request = make_request("query { me { id } }", 5, None);
 
-        let payload = build_subscribe_payload(request);
+        let payload = SubscribePayload::from(request);
 
         assert_eq!(payload.query, "query { me { id } }");
         assert_eq!(payload.operation_name, None);
     }
 
     #[test]
-    fn build_subscribe_payload_inlines_name_for_shorthand_query() {
+    fn subscribe_payload_from_request_inlines_name_for_shorthand_query() {
         let request = make_request("{ me { id } }", 0, Some("GetMe_accounts_0".to_string()));
 
-        let payload = build_subscribe_payload(request);
+        let payload = SubscribePayload::from(request);
 
         assert_eq!(payload.query, "query GetMe_accounts_0 { me { id } }");
     }

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -826,6 +826,7 @@ mod tests {
             raw_variable_values: None,
             extensions: None,
             custom_scalar_paths: None,
+            connection_fingerprint: None,
         };
 
         let body = build_request_body(&execution_request).expect("request body should serialize");

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -171,8 +171,8 @@ pub struct SubgraphExecutorMap {
     /// See [`ConnectionFingerprint`] for more information about connection fingerprinting.
     ///
     /// Subscription executors populate it, while query and mutation execution only performs
-    /// initialized-only lookups. Pool keys include the logical subgraph and inbound connection
-    /// fingerprint.
+    /// initialized-only lookups. Pool keys include the logical subgraph, resolved WebSocket
+    /// endpoint, and inbound connection fingerprint.
     websocket_pool: Arc<WebSocketPool>,
 }
 impl SubgraphExecutorMap {
@@ -397,8 +397,18 @@ impl SubgraphExecutorMap {
                             execution_request
                                 .connection_fingerprint
                                 .and_then(|fingerprint| {
-                                    let id = WebSocketConnectionId::new(subgraph_name, fingerprint);
-                                    self.websocket_pool.get_initialized(&id)
+                                    self.subscription_executors_by_subgraph
+                                        .get(subgraph_name)
+                                        .and_then(|endpoints| {
+                                            endpoints.get(&endpoint_str).and_then(|executor| {
+                                                let id = WebSocketConnectionId::new(
+                                                    subgraph_name,
+                                                    executor.endpoint().clone(),
+                                                    fingerprint,
+                                                );
+                                                self.websocket_pool.get_initialized(&id)
+                                            })
+                                        })
                                 });
                         self.telemetry_context
                             .metrics

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -171,8 +171,8 @@ pub struct SubgraphExecutorMap {
     /// See [`ConnectionFingerprint`] for more information about connection fingerprinting.
     ///
     /// Subscription executors populate it, while query and mutation execution only performs
-    /// initialized-only lookups. Pool keys include both the resolved endpoint and the inbound
-    /// connection fingerprint, preventing reuse across destinations or connection identities.
+    /// initialized-only lookups. Pool keys include the logical subgraph and inbound connection
+    /// fingerprint.
     websocket_pool: Arc<WebSocketPool>,
 }
 impl SubgraphExecutorMap {
@@ -394,19 +394,7 @@ impl SubgraphExecutorMap {
                         // used when the subscription initialized the pool entry. missing identity,
                         // missing entries, and entries still connecting are immediate HTTp misses
                         if let Some(fingerprint) = execution_request.connection_fingerprint {
-                            // TODO: do something to not parse the endpoint over and over again
-                            // also make sure to update the traffic_shaping config comments/documentation
-                            let endpoint_uri = endpoint_str.parse::<Uri>().map_err(|e| {
-                                SubgraphExecutorError::EndpointParseFailure(
-                                    endpoint_str.to_string(),
-                                    e,
-                                )
-                            })?;
-                            let id = WebSocketConnectionId {
-                                endpoint: self
-                                    .convert_to_websocket_endpoint(subgraph_name, &endpoint_uri)?,
-                                fingerprint,
-                            };
+                            let id = WebSocketConnectionId::new(subgraph_name, fingerprint);
                             if let Some(pooled) = self.websocket_pool.get_initialized(&id) {
                                 self.telemetry_context
                                     .metrics

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -392,7 +392,7 @@ impl SubgraphExecutorMap {
                     WebSocketExecuteMode::ReuseExisting if reuse_connections => {
                         // reusing an existing connection requires the same connection fingerprint
                         // used when the subscription initialized the pool entry. missing identity,
-                        // missing entries, and entries still connecting are immediate HTTp misses
+                        // missing entries, and entries still connecting are immediate HTTP misses
                         let pooled =
                             execution_request
                                 .connection_fingerprint

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -393,22 +393,21 @@ impl SubgraphExecutorMap {
                         // reusing an existing connection requires the same connection fingerprint
                         // used when the subscription initialized the pool entry. missing identity,
                         // missing entries, and entries still connecting are immediate HTTp misses
-                        if let Some(fingerprint) = execution_request.connection_fingerprint {
-                            let id = WebSocketConnectionId::new(subgraph_name, fingerprint);
-                            if let Some(pooled) = self.websocket_pool.get_initialized(&id) {
-                                self.telemetry_context
-                                    .metrics
-                                    .subscriptions
-                                    .record_websocket_pool_execute_hit();
-                                executor = Arc::new(
-                                    Box::new(pooled) as Box<dyn SubgraphExecutor + Send + Sync>
-                                );
-                            } else {
-                                self.telemetry_context
-                                    .metrics
-                                    .subscriptions
-                                    .record_websocket_pool_execute_miss();
-                            }
+                        let pooled =
+                            execution_request
+                                .connection_fingerprint
+                                .and_then(|fingerprint| {
+                                    let id = WebSocketConnectionId::new(subgraph_name, fingerprint);
+                                    self.websocket_pool.get_initialized(&id)
+                                });
+                        self.telemetry_context
+                            .metrics
+                            .websocket_pool
+                            .record_connection_lookup(subgraph_name, pooled.is_some());
+                        if let Some(pooled) = pooled {
+                            executor = Arc::new(
+                                Box::new(pooled) as Box<dyn SubgraphExecutor + Send + Sync>
+                            );
                         }
                     }
                     WebSocketExecuteMode::Websocket => {

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -414,7 +414,6 @@ impl SubgraphExecutorMap {
                         // the configured WebSocket executor initializes a pooled connection when
                         // reuse is enabled, or creates a dedicated connection for this operation
                         // when reuse is disabled
-                        let endpoint_str = self.resolve_endpoint(subgraph_name, client_request)?;
                         executor =
                             self.get_or_create_subscription_executor(subgraph_name, &endpoint_str)?;
                     }

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -50,6 +50,7 @@ use crate::{
         http_callback::{CallbackSubscriptionsMap, HttpCallbackSubgraphExecutor},
         tls::{build_https_client_config, build_https_connector, get_merged_tls_config},
         websocket::WsSubgraphExecutor,
+        websocket_pool::{WebSocketConnectionId, WebSocketPool},
     },
     hooks::on_subgraph_execute::{
         OnSubgraphExecuteEndHookPayload, OnSubgraphExecuteStartHookPayload,
@@ -165,6 +166,14 @@ pub struct SubgraphExecutorMap {
     telemetry_context: Arc<TelemetryContext>,
     /// Shared map of active HTTP callback subscriptions
     callback_subscriptions: CallbackSubscriptionsMap,
+    /// Shared pool of initialized subgraph WebSocket connections.
+    ///
+    /// See [`ConnectionFingerprint`] for more information about connection fingerprinting.
+    ///
+    /// Subscription executors populate it, while query and mutation execution only performs
+    /// initialized-only lookups. Pool keys include both the resolved endpoint and the inbound
+    /// connection fingerprint, preventing reuse across destinations or connection identities.
+    websocket_pool: Arc<WebSocketPool>,
 }
 impl SubgraphExecutorMap {
     pub fn new(
@@ -202,6 +211,7 @@ impl SubgraphExecutorMap {
             global_timeout,
             telemetry_context,
             callback_subscriptions: Arc::new(DashMap::new()),
+            websocket_pool: Arc::new(WebSocketPool::default()),
         })
     }
 
@@ -306,7 +316,12 @@ impl SubgraphExecutorMap {
             }
         }
 
-        let mut executor = self.get_or_create_http_executor(subgraph_name, client_request)?;
+        // resolve once because both the normal http executor and any websocket pool lookup must
+        // use the same destination, including request-dependent endpoint overrides
+        let endpoint_str = self.resolve_endpoint(subgraph_name, client_request)?;
+        let mut executor = self.get_or_create_http_executor(subgraph_name, &endpoint_str)?;
+        // keep the exact original executor so plugin replacement can be detected after hooks run
+        let http_executor = executor.clone();
 
         let timeout = self.resolve_subgraph_timeout(subgraph_name, client_request)?;
 
@@ -344,6 +359,54 @@ impl SubgraphExecutorMap {
             // Give the ownership back to variables
             execution_request = start_payload.execution_request;
             executor = start_payload.executor;
+        }
+
+        // plugins run before opportunistic websocket routing so their decisions always win
+        // over the router's transport preference
+        //
+        // a plugin can either return a response immediately or replace the executor. only
+        // consider the pool when neither happened and the original http executor is still
+        // selected. ptr_eq checks that exact executor identity without requiring trait-object
+        // equality
+        if execution_result.is_none() && Arc::ptr_eq(&executor, &http_executor) {
+            // requests without a connection fingerprint cannot safely match a pooled connection
+            if let Some(fingerprint) = execution_request.connection_fingerprint {
+                // only subgraphs configured for graphql-transport-ws can have matching entries
+                if self
+                    .config
+                    .subscriptions
+                    .get_protocol_for_subgraph(subgraph_name)
+                    == SubscriptionProtocol::WebSocket
+                {
+                    // TODO: somehow get rid of this parse thing, it should not run on every request
+                    // basically the WebSocketConnectionId fingerprint should be enough, right?
+                    let endpoint_uri = endpoint_str.parse::<Uri>().map_err(|e| {
+                        SubgraphExecutorError::EndpointParseFailure(endpoint_str.to_string(), e)
+                    })?;
+                    // the resolved endpoint is part of the key so the same inbound identity
+                    // cannot share a connection across different subgraph destinations
+                    let id = WebSocketConnectionId {
+                        endpoint: self.websocket_endpoint(subgraph_name, &endpoint_uri)?,
+                        fingerprint,
+                    };
+                    // this lookup returns initialized entries only. a missing or connecting
+                    // entry is an immediate http fallback; execute never creates or waits for a
+                    // websocket connection
+                    if let Some(pooled) = self.websocket_pool.get_initialized(&id) {
+                        self.telemetry_context
+                            .metrics
+                            .subscriptions
+                            .record_websocket_pool_execute_hit();
+                        executor =
+                            Arc::new(Box::new(pooled) as Box<dyn SubgraphExecutor + Send + Sync>);
+                    } else {
+                        self.telemetry_context
+                            .metrics
+                            .subscriptions
+                            .record_websocket_pool_execute_miss();
+                    }
+                }
+            }
         }
 
         let mut execution_result = match execution_result {
@@ -580,22 +643,25 @@ impl SubgraphExecutorMap {
         }
     }
 
+    /// Returns the HTTP executor for an already resolved endpoint.
+    ///
+    /// Endpoint resolution happens in `execute` so HTTP selection and WebSocket pool matching use
+    /// one destination. Resolving again could evaluate an endpoint expression twice and produce
+    /// mismatched transports.
     fn get_or_create_http_executor(
         &self,
         subgraph_name: &str,
-        client_request: &ClientRequestDetails<'_>,
+        endpoint_str: &str,
     ) -> Result<SubgraphExecutorBoxedArc, SubgraphExecutorError> {
-        let endpoint_str = self.resolve_endpoint(subgraph_name, client_request)?;
-
         if let Some(executor) = self
             .http_executors_by_subgraph
             .get(subgraph_name)
-            .and_then(|endpoints| endpoints.get(&endpoint_str).map(|e| e.clone()))
+            .and_then(|endpoints| endpoints.get(endpoint_str).map(|e| e.clone()))
         {
             return Ok(executor);
         }
 
-        self.register_executor(subgraph_name, &endpoint_str, false)
+        self.register_executor(subgraph_name, endpoint_str, false)
     }
 
     fn get_or_create_subscription_executor(
@@ -641,6 +707,55 @@ impl SubgraphExecutorMap {
     fn register_static_endpoint(&self, subgraph_name: &str, endpoint_str: &str) {
         self.static_endpoints_by_subgraph
             .insert(subgraph_name.to_string(), endpoint_str.to_string());
+    }
+
+    /// Converts a resolved HTTP endpoint into the exact WebSocket pool key endpoint.
+    ///
+    /// The configured WebSocket path takes precedence over the resolved endpoint path. This must
+    /// match the endpoint built for `WsSubgraphExecutor`, otherwise subscriptions would populate a
+    /// different pool key than query and mutation execution looks up.
+    fn websocket_endpoint(
+        &self,
+        subgraph_name: &str,
+        endpoint_uri: &Uri,
+    ) -> Result<Uri, SubgraphExecutorError> {
+        let ws_scheme = match endpoint_uri.scheme_str() {
+            Some("https") => "wss",
+            _ => "ws",
+        };
+        let path_and_query = self
+            .config
+            .subscriptions
+            .get_websocket_path(subgraph_name)
+            .or_else(|| endpoint_uri.path_and_query().map(|path| path.as_str()))
+            // fallback to default if neither is set, but this should never happen
+            .unwrap_or_default();
+
+        // build the final WebSocket URI
+        Uri::builder()
+            .scheme(ws_scheme)
+            .authority(
+                endpoint_uri
+                    .authority()
+                    .map(|authority| authority.as_str())
+                    .unwrap_or_default(),
+            )
+            .path_and_query(path_and_query)
+            .build()
+            .map_err(|error| {
+                SubgraphExecutorError::WebSocketEndpointBuildFailure(
+                    format!(
+                        "{}://{}{}",
+                        ws_scheme,
+                        endpoint_uri
+                            .authority()
+                            .map(|authority| authority.as_str())
+                            .unwrap_or_default(),
+                        path_and_query
+                    ),
+                    error,
+                )
+            })
     }
 
     /// Registers a subgraph executor for the given subgraph name and endpoint URL.
@@ -707,45 +822,7 @@ impl SubgraphExecutorMap {
                 Ok(http_executor)
             }
             SubscriptionProtocol::WebSocket => {
-                let ws_scheme = match endpoint_uri.scheme_str() {
-                    Some("https") => "wss",
-                    _ => "ws",
-                };
-
-                // take the path from the subscription config or use the one from the endpoint
-                let path_and_query = self
-                    .config
-                    .subscriptions
-                    .get_websocket_path(subgraph_name)
-                    .or_else(|| endpoint_uri.path_and_query().map(|pq| pq.as_str()))
-                    // fallback to default if neither is set, but this should never happen
-                    .unwrap_or_default();
-
-                // build the final WebSocket URI
-                let ws_endpoint_uri = Uri::builder()
-                    .scheme(ws_scheme)
-                    .authority(
-                        endpoint_uri
-                            .authority()
-                            .map(|a| a.as_str())
-                            .unwrap_or_default(),
-                    )
-                    .path_and_query(path_and_query)
-                    .build()
-                    .map_err(|e| {
-                        SubgraphExecutorError::WebSocketEndpointBuildFailure(
-                            format!(
-                                "{}://{}{}",
-                                ws_scheme,
-                                endpoint_uri
-                                    .authority()
-                                    .map(|a| a.as_str())
-                                    .unwrap_or_default(),
-                                path_and_query
-                            ),
-                            e,
-                        )
-                    })?;
+                let ws_endpoint_uri = self.websocket_endpoint(subgraph_name, &endpoint_uri)?;
 
                 // Resolve TLS config for the subgraph (merging global + per-subgraph)
                 let tls_config = get_merged_tls_config(
@@ -768,6 +845,12 @@ impl SubgraphExecutorMap {
                     ws_tls_config,
                     self.config.subscriptions.subgraph_buffer_capacity,
                     self.telemetry_context.clone(),
+                    // every websocket subscription executor contributes to the same pool so
+                    // normal execution can reuse connections initialized by subscriptions
+                    self.websocket_pool.clone(),
+                    self.config
+                        .subscriptions
+                        .get_websocket_idle_timeout(subgraph_name),
                 )
                 .to_boxed_arc();
 

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -12,7 +12,7 @@ use hive_router_config::{
     override_subgraph_urls::UrlOrExpression,
     primitives::value_or_expression::ValueOrExpression,
     subscriptions::SubscriptionProtocol,
-    traffic_shaping::{DurationOrExpression, StatusCodeMatcher},
+    traffic_shaping::{DurationOrExpression, StatusCodeMatcher, WebSocketExecuteMode},
     HiveRouterConfig,
 };
 use hive_router_internal::{
@@ -369,42 +369,71 @@ impl SubgraphExecutorMap {
         // selected. ptr_eq checks that exact executor identity without requiring trait-object
         // equality
         if execution_result.is_none() && Arc::ptr_eq(&executor, &http_executor) {
-            // requests without a connection fingerprint cannot safely match a pooled connection
-            if let Some(fingerprint) = execution_request.connection_fingerprint {
-                // only subgraphs configured for graphql-transport-ws can have matching entries
-                if self
+            // WebSocket endpoint configuration declares capability, while traffic shaping decides
+            // whether ordinary query and mutation fetches are allowed to use that capability
+            if self
+                .config
+                .subscriptions
+                .get_protocol_for_subgraph(subgraph_name)
+                == SubscriptionProtocol::WebSocket
+            {
+                let reuse_connections = self
                     .config
-                    .subscriptions
-                    .get_protocol_for_subgraph(subgraph_name)
-                    == SubscriptionProtocol::WebSocket
+                    .traffic_shaping
+                    .websocket_reuse_connections(subgraph_name);
+                match self
+                    .config
+                    .traffic_shaping
+                    .websocket_execute_mode(subgraph_name)
                 {
-                    // TODO: somehow get rid of this parse thing, it should not run on every request
-                    // basically the WebSocketConnectionId fingerprint should be enough, right?
-                    let endpoint_uri = endpoint_str.parse::<Uri>().map_err(|e| {
-                        SubgraphExecutorError::EndpointParseFailure(endpoint_str.to_string(), e)
-                    })?;
-                    // the resolved endpoint is part of the key so the same inbound identity
-                    // cannot share a connection across different subgraph destinations
-                    let id = WebSocketConnectionId {
-                        endpoint: self
-                            .convert_to_websocket_endpoint(subgraph_name, &endpoint_uri)?,
-                        fingerprint,
-                    };
-                    // this lookup returns initialized entries only. a missing or connecting
-                    // entry is an immediate http fallback; execute never creates or waits for a
-                    // websocket connection
-                    if let Some(pooled) = self.websocket_pool.get_initialized(&id) {
-                        self.telemetry_context
-                            .metrics
-                            .subscriptions
-                            .record_websocket_pool_execute_hit();
+                    WebSocketExecuteMode::Http => {
+                        // keep defaults, nothing to do here
+                    }
+                    WebSocketExecuteMode::ReuseExisting if reuse_connections => {
+                        // reusing an existing connection requires the same connection fingerprint
+                        // used when the subscription initialized the pool entry. missing identity,
+                        // missing entries, and entries still connecting are immediate HTTp misses
+                        if let Some(fingerprint) = execution_request.connection_fingerprint {
+                            // TODO: do something to not parse the endpoint over and over again
+                            // also make sure to update the traffic_shaping config comments/documentation
+                            let endpoint_uri = endpoint_str.parse::<Uri>().map_err(|e| {
+                                SubgraphExecutorError::EndpointParseFailure(
+                                    endpoint_str.to_string(),
+                                    e,
+                                )
+                            })?;
+                            let id = WebSocketConnectionId {
+                                endpoint: self
+                                    .convert_to_websocket_endpoint(subgraph_name, &endpoint_uri)?,
+                                fingerprint,
+                            };
+                            if let Some(pooled) = self.websocket_pool.get_initialized(&id) {
+                                self.telemetry_context
+                                    .metrics
+                                    .subscriptions
+                                    .record_websocket_pool_execute_hit();
+                                executor = Arc::new(
+                                    Box::new(pooled) as Box<dyn SubgraphExecutor + Send + Sync>
+                                );
+                            } else {
+                                self.telemetry_context
+                                    .metrics
+                                    .subscriptions
+                                    .record_websocket_pool_execute_miss();
+                            }
+                        }
+                    }
+                    WebSocketExecuteMode::Websocket => {
+                        // the configured WebSocket executor initializes a pooled connection when
+                        // reuse is enabled, or creates a dedicated connection for this operation
+                        // when reuse is disabled
+                        let endpoint_str = self.resolve_endpoint(subgraph_name, client_request)?;
                         executor =
-                            Arc::new(Box::new(pooled) as Box<dyn SubgraphExecutor + Send + Sync>);
-                    } else {
-                        self.telemetry_context
-                            .metrics
-                            .subscriptions
-                            .record_websocket_pool_execute_miss();
+                            self.get_or_create_subscription_executor(subgraph_name, &endpoint_str)?;
+                    }
+                    WebSocketExecuteMode::ReuseExisting => {
+                        // reuse is disabled (reuse_connections=false), so there cannot be
+                        // an eligible pooled connection. keep defaults, nothing further to do
                     }
                 }
             }
@@ -538,7 +567,8 @@ impl SubgraphExecutorMap {
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
-        let executor = self.get_or_create_subscription_executor(subgraph_name, client_request)?;
+        let endpoint_str = self.resolve_endpoint(subgraph_name, client_request)?;
+        let executor = self.get_or_create_subscription_executor(subgraph_name, &endpoint_str)?;
         let timeout = self.resolve_subgraph_timeout(subgraph_name, client_request)?;
         debug!(target: targets::EXECUTOR, operation = execution_request.query, dedupe = execution_request.dedupe, subgraph = subgraph_name, executor = executor.executor_name(), "subscribing subgraph request");
         summary::record(|s| s.record_subgraph(subgraph_name));
@@ -665,22 +695,24 @@ impl SubgraphExecutorMap {
         self.register_executor(subgraph_name, endpoint_str, false)
     }
 
+    /// Returns the subscription transport executor for an already resolved endpoint.
+    ///
+    /// Query and mutation WebSocket routing uses this variant so request-dependent endpoint
+    /// expressions are evaluated exactly once before transport selection.
     fn get_or_create_subscription_executor(
         &self,
         subgraph_name: &str,
-        client_request: &ClientRequestDetails<'_>,
+        endpoint_str: &str,
     ) -> Result<SubgraphExecutorBoxedArc, SubgraphExecutorError> {
-        let endpoint_str = self.resolve_endpoint(subgraph_name, client_request)?;
-
         if let Some(executor) = self
             .subscription_executors_by_subgraph
             .get(subgraph_name)
-            .and_then(|endpoints| endpoints.get(&endpoint_str).map(|e| e.clone()))
+            .and_then(|endpoints| endpoints.get(endpoint_str).map(|e| e.clone()))
         {
             return Ok(executor);
         }
 
-        self.register_executor(subgraph_name, &endpoint_str, true)
+        self.register_executor(subgraph_name, endpoint_str, true)
     }
 
     /// Registers a new HTTP subgraph executor for the given subgraph name and endpoint URL.
@@ -850,9 +882,11 @@ impl SubgraphExecutorMap {
                     // every websocket subscription executor contributes to the same pool so
                     // normal execution can reuse connections initialized by subscriptions
                     self.websocket_pool.clone(),
+                    // WebSocket pooling uses the same inherited lifetime as the HTTP pool.
+                    self.config.traffic_shaping.pool_idle_timeout(subgraph_name),
                     self.config
-                        .subscriptions
-                        .get_websocket_idle_timeout(subgraph_name),
+                        .traffic_shaping
+                        .websocket_reuse_connections(subgraph_name),
                 )
                 .to_boxed_arc();
 
@@ -952,10 +986,8 @@ impl SubgraphExecutorMap {
             return Ok(config);
         };
 
-        let pool_idle_timeout = subgraph_config
-            .pool_idle_timeout
-            .unwrap_or(self.config.traffic_shaping.all.pool_idle_timeout);
-        // Override client only if pool idle timeout is customized, TLS config is provided, or allow_only_http2 differs
+        let pool_idle_timeout = self.config.traffic_shaping.pool_idle_timeout(subgraph_name);
+        // A separate client is needed when connection lifetime or protocol settings differ.
         let subgraph_allow_only_http2 = subgraph_config
             .allow_only_http2
             .unwrap_or(self.config.traffic_shaping.all.allow_only_http2);

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -386,7 +386,8 @@ impl SubgraphExecutorMap {
                     // the resolved endpoint is part of the key so the same inbound identity
                     // cannot share a connection across different subgraph destinations
                     let id = WebSocketConnectionId {
-                        endpoint: self.websocket_endpoint(subgraph_name, &endpoint_uri)?,
+                        endpoint: self
+                            .convert_to_websocket_endpoint(subgraph_name, &endpoint_uri)?,
                         fingerprint,
                     };
                     // this lookup returns initialized entries only. a missing or connecting
@@ -714,7 +715,7 @@ impl SubgraphExecutorMap {
     /// The configured WebSocket path takes precedence over the resolved endpoint path. This must
     /// match the endpoint built for `WsSubgraphExecutor`, otherwise subscriptions would populate a
     /// different pool key than query and mutation execution looks up.
-    fn websocket_endpoint(
+    fn convert_to_websocket_endpoint(
         &self,
         subgraph_name: &str,
         endpoint_uri: &Uri,
@@ -822,7 +823,8 @@ impl SubgraphExecutorMap {
                 Ok(http_executor)
             }
             SubscriptionProtocol::WebSocket => {
-                let ws_endpoint_uri = self.websocket_endpoint(subgraph_name, &endpoint_uri)?;
+                let ws_endpoint_uri =
+                    self.convert_to_websocket_endpoint(subgraph_name, &endpoint_uri)?;
 
                 // Resolve TLS config for the subgraph (merging global + per-subgraph)
                 let tls_config = get_merged_tls_config(

--- a/lib/executor/src/executors/mod.rs
+++ b/lib/executor/src/executors/mod.rs
@@ -12,3 +12,4 @@ pub mod tls;
 pub mod websocket;
 pub mod websocket_client;
 pub mod websocket_common;
+pub mod websocket_pool;

--- a/lib/executor/src/executors/subscription_buffer.rs
+++ b/lib/executor/src/executors/subscription_buffer.rs
@@ -83,19 +83,29 @@ pub async fn drain_into<S>(
 ) where
     S: Stream<Item = SubscriptionItem> + Unpin,
 {
-    while let Some(item) = source.next().await {
-        if matches!(
-            try_send_or_drop(
-                &tx,
-                item,
-                telemetry_context,
-                transport,
-                subgraph_name,
-                endpoint
-            ),
-            SendOutcome::Closed
-        ) {
-            break;
+    loop {
+        // waiting only for source.next() keeps a silent upstream operation alive after the
+        // receiver is dropped, so watch tx.closed() to cancel it immediately
+        tokio::select! {
+            item = source.next() => {
+                let Some(item) = item else {
+                    break;
+                };
+                if matches!(
+                    try_send_or_drop(
+                        &tx,
+                        item,
+                        telemetry_context,
+                        transport,
+                        subgraph_name,
+                        endpoint
+                    ),
+                    SendOutcome::Closed
+                ) {
+                    break;
+                }
+            }
+            _ = tx.closed() => break,
         }
     }
 }

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -90,13 +90,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                             },
                         )
                         .await?;
-                    // TODO: should this be recorded here? execute hit is more like
-                    // there's an active connection and execute was routed through it
-                    // because execute_mode allowed it. see lib/executor/src/executors/map.rs
-                    self.telemetry_context
-                        .metrics
-                        .subscriptions
-                        .record_websocket_pool_execute_hit();
                     executor.execute(execution_request, None, None).await
                 };
                 return match timeout {
@@ -208,12 +201,6 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                         },
                     )
                     .await?;
-                // TODO: not necessarey a hit, couldve been freshyl initialised. do rethink
-                // this analytics/metrics story instead...
-                self.telemetry_context
-                    .metrics
-                    .subscriptions
-                    .record_websocket_pool_subscription_hit();
                 return executor.subscribe(execution_request, None).await;
             }
         }

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -159,11 +159,10 @@ impl SubgraphExecutor for WsSubgraphExecutor {
 
                 let mut stream = client
                     .subscribe(subscribe_payload, custom_scalar_paths)
-                    .await
-                    .map_err(SubgraphExecutorError::from)?;
+                    .await?;
 
                 match stream.next().await {
-                    Some(response) => response.map_err(SubgraphExecutorError::from),
+                    Some(response) => Ok(response?),
                     None => Err(SubgraphExecutorError::WebSocketStreamClosedEmpty(
                         endpoint.to_string(),
                     )),

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -111,7 +111,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
 
         let headers = execution_request.headers.clone();
         let init_payload = (!headers.is_empty()).then(|| headers.into());
-        let subscribe_payload = execution_request.into();
+        let subscribe_payload = execution_request.try_into()?;
 
         let (tx, rx) = oneshot::channel();
 
@@ -217,7 +217,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let headers = execution_request.headers.clone();
         let init_payload = (!headers.is_empty()).then(|| headers.into());
-        let subscribe_payload = execution_request.into();
+        let subscribe_payload = execution_request.try_into()?;
 
         debug!(
             target: targets::WEBSOCKET_CLIENT,

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -74,7 +74,11 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
         if self.reuse_connections {
             if let Some(fingerprint) = execution_request.connection_fingerprint {
-                let id = WebSocketConnectionId::new(self.subgraph_name.clone(), fingerprint);
+                let id = WebSocketConnectionId::new(
+                    self.subgraph_name.clone(),
+                    self.endpoint.clone(),
+                    fingerprint,
+                );
                 let operation = async {
                     let executor = self
                         .pool
@@ -186,7 +190,11 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     > {
         if self.reuse_connections {
             if let Some(fingerprint) = execution_request.connection_fingerprint {
-                let id = WebSocketConnectionId::new(self.subgraph_name.clone(), fingerprint);
+                let id = WebSocketConnectionId::new(
+                    self.subgraph_name.clone(),
+                    self.endpoint.clone(),
+                    fingerprint,
+                );
                 let executor = self
                     .pool
                     .get_or_initialize(

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -28,6 +28,7 @@ pub struct WsSubgraphExecutor {
     telemetry_context: Arc<TelemetryContext>,
     pool: Arc<WebSocketPool>,
     idle_timeout: Duration,
+    reuse_connections: bool,
 }
 
 impl WsSubgraphExecutor {
@@ -39,6 +40,7 @@ impl WsSubgraphExecutor {
         telemetry_context: Arc<TelemetryContext>,
         pool: Arc<WebSocketPool>,
         idle_timeout: Duration,
+        reuse_connections: bool,
     ) -> Self {
         Self {
             subgraph_name,
@@ -48,6 +50,7 @@ impl WsSubgraphExecutor {
             telemetry_context,
             pool,
             idle_timeout,
+            reuse_connections,
         }
     }
 }
@@ -68,6 +71,34 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         timeout: Option<Duration>,
         _plugin_req_state: Option<&'a crate::plugin_context::PluginRequestState<'a>>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
+        if self.reuse_connections {
+            if let Some(fingerprint) = execution_request.connection_fingerprint {
+                let executor = self
+                    .pool
+                    .get_or_initialize(
+                        WebSocketConnectionId {
+                            endpoint: self.endpoint.clone(),
+                            fingerprint,
+                        },
+                        WebSocketInit {
+                            headers: execution_request.headers.clone(),
+                            tls_config: self.tls_config.clone(),
+                            subgraph_name: self.subgraph_name.clone(),
+                            buffer_capacity: self.buffer_capacity,
+                            idle_timeout: self.idle_timeout,
+                            telemetry_context: self.telemetry_context.clone(),
+                        },
+                    )
+                    .await?;
+                // TODO: not necessarey a hit, couldve been freshyl initialised
+                self.telemetry_context
+                    .metrics
+                    .subscriptions
+                    .record_websocket_pool_execute_hit();
+                return executor.execute(execution_request, timeout, None).await;
+            }
+        }
+
         let endpoint = self.endpoint.clone();
         let subgraph_name = self.subgraph_name.clone();
         let tls_config = self.tls_config.clone();
@@ -149,7 +180,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     async fn subscribe<'a>(
         &self,
         execution_request: SubgraphExecutionRequest<'a>,
-        _timeout: Option<Duration>,
+        timeout: Option<Duration>,
     ) -> Result<
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
@@ -166,29 +197,32 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let connection_fingerprint = execution_request.connection_fingerprint;
 
-        if let Some(fingerprint) = connection_fingerprint {
-            let executor = self
-                .pool
-                .get_or_initialize(
-                    WebSocketConnectionId {
-                        endpoint: self.endpoint.clone(),
-                        fingerprint,
-                    },
-                    WebSocketInit {
-                        headers: execution_request.headers.clone(),
-                        tls_config: self.tls_config.clone(),
-                        subgraph_name: self.subgraph_name.clone(),
-                        buffer_capacity: self.buffer_capacity,
-                        idle_timeout: self.idle_timeout,
-                        telemetry_context: self.telemetry_context.clone(),
-                    },
-                )
-                .await?;
-            self.telemetry_context
-                .metrics
-                .subscriptions
-                .record_websocket_pool_subscription_hit();
-            return executor.subscribe(execution_request, _timeout).await;
+        if self.reuse_connections {
+            if let Some(fingerprint) = connection_fingerprint {
+                let executor = self
+                    .pool
+                    .get_or_initialize(
+                        WebSocketConnectionId {
+                            endpoint: self.endpoint.clone(),
+                            fingerprint,
+                        },
+                        WebSocketInit {
+                            headers: execution_request.headers.clone(),
+                            tls_config: self.tls_config.clone(),
+                            subgraph_name: self.subgraph_name.clone(),
+                            buffer_capacity: self.buffer_capacity,
+                            idle_timeout: self.idle_timeout,
+                            telemetry_context: self.telemetry_context.clone(),
+                        },
+                    )
+                    .await?;
+                // TODO: not necessarey a hit, couldve been freshyl initialised
+                self.telemetry_context
+                    .metrics
+                    .subscriptions
+                    .record_websocket_pool_subscription_hit();
+                return executor.subscribe(execution_request, timeout).await;
+            }
         }
 
         let headers = execution_request.headers.clone();

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -90,7 +90,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                             },
                         )
                         .await?;
-                    // TODO: not necessarey a hit, couldve been freshyl initialised
+                    // TODO: should this be recorded here? execute hit is more like
+                    // there's an active connection and execute was routed through it
+                    // because execute_mode allowed it. see lib/executor/src/executors/map.rs
                     self.telemetry_context
                         .metrics
                         .subscriptions
@@ -207,7 +209,8 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                         },
                     )
                     .await?;
-                // TODO: not necessarey a hit, couldve been freshyl initialised
+                // TODO: not necessarey a hit, couldve been freshyl initialised. do rethink
+                // this analytics/metrics story instead...
                 self.telemetry_context
                     .metrics
                     .subscriptions

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -15,9 +15,12 @@ use hive_router_internal::telemetry::TelemetryContext;
 
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
-use crate::executors::graphql_transport_ws::build_subscribe_payload;
+use crate::executors::graphql_transport_ws::{
+    build_connection_init_payload, build_subscribe_payload,
+};
 use crate::executors::subscription_buffer::drain_into;
-use crate::executors::websocket_client::{connect, WsClient};
+use crate::executors::websocket_client::{self, WsClient};
+use crate::executors::websocket_pool::{WebSocketConnectionId, WebSocketInit, WebSocketPool};
 use crate::response::subgraph_response::SubgraphResponse;
 
 pub struct WsSubgraphExecutor {
@@ -26,6 +29,8 @@ pub struct WsSubgraphExecutor {
     tls_config: Option<Arc<rustls::ClientConfig>>,
     buffer_capacity: usize,
     telemetry_context: Arc<TelemetryContext>,
+    pool: Arc<WebSocketPool>,
+    idle_timeout: Duration,
 }
 
 impl WsSubgraphExecutor {
@@ -35,6 +40,8 @@ impl WsSubgraphExecutor {
         tls_config: Option<Arc<rustls::ClientConfig>>,
         buffer_capacity: usize,
         telemetry_context: Arc<TelemetryContext>,
+        pool: Arc<WebSocketPool>,
+        idle_timeout: Duration,
     ) -> Self {
         Self {
             subgraph_name,
@@ -42,6 +49,8 @@ impl WsSubgraphExecutor {
             tls_config,
             buffer_capacity,
             telemetry_context,
+            pool,
+            idle_timeout,
         }
     }
 }
@@ -59,7 +68,7 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     async fn execute<'a>(
         &self,
         execution_request: SubgraphExecutionRequest<'a>,
-        _timeout: Option<Duration>,
+        timeout: Option<Duration>,
         _plugin_req_state: Option<&'a crate::plugin_context::PluginRequestState<'a>>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
         let endpoint = self.endpoint.clone();
@@ -72,7 +81,8 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             "establishing WebSocket connection to subgraph"
         );
 
-        let (subscribe_payload, init_payload) = build_subscribe_payload(execution_request);
+        let init_payload = build_connection_init_payload(execution_request.headers.clone());
+        let subscribe_payload = build_subscribe_payload(execution_request);
 
         let (tx, rx) = oneshot::channel();
 
@@ -85,17 +95,17 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         // or earlier if connect/init fails.
         rt::spawn(async move {
             let result = async {
-                let connection = match connect(&endpoint, tls_config).await {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        return Err(SubgraphExecutorError::WebSocketConnectFailure(
+                let wsconn = websocket_client::connect(&endpoint, tls_config)
+                    .await
+                    .map_err(|e| {
+                        SubgraphExecutorError::WebSocketConnectFailure(
                             endpoint.to_string(),
                             e.to_string(),
-                        ));
-                    }
-                };
+                        )
+                    })?;
+                let client = WsClient::new(wsconn);
 
-                let mut client = match WsClient::init(connection, init_payload).await {
+                let mut client = match client.init(init_payload).await {
                     Ok(client) => client,
                     Err(e) => {
                         return Err(SubgraphExecutorError::WebSocketHandshakeFailure(
@@ -113,10 +123,11 @@ impl SubgraphExecutor for WsSubgraphExecutor {
 
                 let mut stream = client
                     .subscribe(subscribe_payload, custom_scalar_paths)
-                    .await;
+                    .await
+                    .map_err(SubgraphExecutorError::from)?;
 
                 match stream.next().await {
-                    Some(response) => Ok(response),
+                    Some(response) => response.map_err(SubgraphExecutorError::from),
                     None => Err(SubgraphExecutorError::WebSocketStreamClosedEmpty(
                         endpoint.to_string(),
                     )),
@@ -127,8 +138,14 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             let _ = tx.send(result);
         });
 
-        rx.await
-            .map_err(|_| SubgraphExecutorError::WebSocketArbiterChannelClosed)?
+        let response = async {
+            rx.await
+                .map_err(|_| SubgraphExecutorError::WebSocketArbiterChannelClosed)?
+        };
+        match timeout {
+            Some(timeout) => tokio::time::timeout(timeout, response).await?,
+            None => response.await,
+        }
     }
 
     async fn subscribe<'a>(
@@ -149,8 +166,35 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         let subgraph_name = self.subgraph_name.clone();
         let tls_config = self.tls_config.clone();
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
+        let connection_fingerprint = execution_request.connection_fingerprint;
 
-        let (subscribe_payload, init_payload) = build_subscribe_payload(execution_request);
+        if let Some(fingerprint) = connection_fingerprint {
+            let executor = self
+                .pool
+                .get_or_initialize(
+                    WebSocketConnectionId {
+                        endpoint: self.endpoint.clone(),
+                        fingerprint,
+                    },
+                    WebSocketInit {
+                        headers: execution_request.headers.clone(),
+                        tls_config: self.tls_config.clone(),
+                        subgraph_name: self.subgraph_name.clone(),
+                        buffer_capacity: self.buffer_capacity,
+                        idle_timeout: self.idle_timeout,
+                        telemetry_context: self.telemetry_context.clone(),
+                    },
+                )
+                .await?;
+            self.telemetry_context
+                .metrics
+                .subscriptions
+                .record_websocket_pool_subscription_hit();
+            return executor.subscribe(execution_request, _timeout).await;
+        }
+
+        let init_payload = build_connection_init_payload(execution_request.headers.clone());
+        let subscribe_payload = build_subscribe_payload(execution_request);
 
         debug!(
             target: targets::WEBSOCKET_CLIENT,
@@ -168,8 +212,8 @@ impl SubgraphExecutor for WsSubgraphExecutor {
         // If the channel fills due to back-pressure, the latest event is dropped (with a
         // warning log) and the subscription continues.
         drop(rt::spawn(async move {
-            let connection = match connect(&endpoint, tls_config).await {
-                Ok(conn) => conn,
+            let wsconn = match websocket_client::connect(&endpoint, tls_config).await {
+                Ok(client) => client,
                 Err(e) => {
                     let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketConnectFailure(
                         endpoint.to_string(),
@@ -178,8 +222,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                     return;
                 }
             };
+            let client = WsClient::new(wsconn);
 
-            let mut client = match WsClient::init(connection, init_payload).await {
+            let mut client = match client.init(init_payload).await {
                 Ok(client) => client,
                 Err(e) => {
                     let _ = tx.try_send(Err(SubgraphExecutorError::WebSocketHandshakeFailure(
@@ -204,10 +249,16 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                     SubscriptionTransport::WebSocket,
                 );
 
-            let stream = client
+            let stream = match client
                 .subscribe(subscribe_payload, custom_scalar_paths)
                 .await
-                .map(Ok);
+            {
+                Ok(stream) => stream.map(|item| item.map_err(SubgraphExecutorError::from)),
+                Err(error) => {
+                    let _ = tx.try_send(Err(error.into()));
+                    return;
+                }
+            };
 
             drain_into(
                 stream,

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -15,9 +15,6 @@ use hive_router_internal::telemetry::TelemetryContext;
 
 use crate::executors::common::{SubgraphExecutionRequest, SubgraphExecutor};
 use crate::executors::error::SubgraphExecutorError;
-use crate::executors::graphql_transport_ws::{
-    build_connection_init_payload, build_subscribe_payload,
-};
 use crate::executors::subscription_buffer::drain_into;
 use crate::executors::websocket_client::{self, WsClient};
 use crate::executors::websocket_pool::{WebSocketConnectionId, WebSocketInit, WebSocketPool};
@@ -81,8 +78,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             "establishing WebSocket connection to subgraph"
         );
 
-        let init_payload = build_connection_init_payload(execution_request.headers.clone());
-        let subscribe_payload = build_subscribe_payload(execution_request);
+        let headers = execution_request.headers.clone();
+        let init_payload = (!headers.is_empty()).then(|| headers.into());
+        let subscribe_payload = execution_request.into();
 
         let (tx, rx) = oneshot::channel();
 
@@ -193,8 +191,9 @@ impl SubgraphExecutor for WsSubgraphExecutor {
             return executor.subscribe(execution_request, _timeout).await;
         }
 
-        let init_payload = build_connection_init_payload(execution_request.headers.clone());
-        let subscribe_payload = build_subscribe_payload(execution_request);
+        let headers = execution_request.headers.clone();
+        let init_payload = (!headers.is_empty()).then(|| headers.into());
+        let subscribe_payload = execution_request.into();
 
         debug!(
             target: targets::WEBSOCKET_CLIENT,

--- a/lib/executor/src/executors/websocket.rs
+++ b/lib/executor/src/executors/websocket.rs
@@ -32,6 +32,7 @@ pub struct WsSubgraphExecutor {
 }
 
 impl WsSubgraphExecutor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         subgraph_name: String,
         endpoint: http::Uri,
@@ -73,29 +74,33 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
         if self.reuse_connections {
             if let Some(fingerprint) = execution_request.connection_fingerprint {
-                let executor = self
-                    .pool
-                    .get_or_initialize(
-                        WebSocketConnectionId {
-                            endpoint: self.endpoint.clone(),
-                            fingerprint,
-                        },
-                        WebSocketInit {
-                            headers: execution_request.headers.clone(),
-                            tls_config: self.tls_config.clone(),
-                            subgraph_name: self.subgraph_name.clone(),
-                            buffer_capacity: self.buffer_capacity,
-                            idle_timeout: self.idle_timeout,
-                            telemetry_context: self.telemetry_context.clone(),
-                        },
-                    )
-                    .await?;
-                // TODO: not necessarey a hit, couldve been freshyl initialised
-                self.telemetry_context
-                    .metrics
-                    .subscriptions
-                    .record_websocket_pool_execute_hit();
-                return executor.execute(execution_request, timeout, None).await;
+                let id = WebSocketConnectionId::new(self.subgraph_name.clone(), fingerprint);
+                let operation = async {
+                    let executor = self
+                        .pool
+                        .get_or_initialize(
+                            id,
+                            WebSocketInit {
+                                endpoint: self.endpoint.clone(),
+                                headers: execution_request.headers.clone(),
+                                tls_config: self.tls_config.clone(),
+                                buffer_capacity: self.buffer_capacity,
+                                idle_timeout: self.idle_timeout,
+                                telemetry_context: self.telemetry_context.clone(),
+                            },
+                        )
+                        .await?;
+                    // TODO: not necessarey a hit, couldve been freshyl initialised
+                    self.telemetry_context
+                        .metrics
+                        .subscriptions
+                        .record_websocket_pool_execute_hit();
+                    executor.execute(execution_request, None, None).await
+                };
+                return match timeout {
+                    Some(timeout) => tokio::time::timeout(timeout, operation).await?,
+                    None => operation.await,
+                };
             }
         }
 
@@ -180,36 +185,22 @@ impl SubgraphExecutor for WsSubgraphExecutor {
     async fn subscribe<'a>(
         &self,
         execution_request: SubgraphExecutionRequest<'a>,
-        timeout: Option<Duration>,
+        _timeout: Option<Duration>,
     ) -> Result<
         BoxStream<'static, Result<SubgraphResponse<'static>, SubgraphExecutorError>>,
         SubgraphExecutorError,
     > {
-        // buffer decouples the emitting subgraph from slow downstream consumers, dropping
-        // messages under backpressure instead of throttling the subgraph
-        let (tx, mut rx) = mpsc::channel::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>(
-            self.buffer_capacity,
-        );
-
-        let endpoint = self.endpoint.clone();
-        let subgraph_name = self.subgraph_name.clone();
-        let tls_config = self.tls_config.clone();
-        let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
-        let connection_fingerprint = execution_request.connection_fingerprint;
-
         if self.reuse_connections {
-            if let Some(fingerprint) = connection_fingerprint {
+            if let Some(fingerprint) = execution_request.connection_fingerprint {
+                let id = WebSocketConnectionId::new(self.subgraph_name.clone(), fingerprint);
                 let executor = self
                     .pool
                     .get_or_initialize(
-                        WebSocketConnectionId {
-                            endpoint: self.endpoint.clone(),
-                            fingerprint,
-                        },
+                        id,
                         WebSocketInit {
+                            endpoint: self.endpoint.clone(),
                             headers: execution_request.headers.clone(),
                             tls_config: self.tls_config.clone(),
-                            subgraph_name: self.subgraph_name.clone(),
                             buffer_capacity: self.buffer_capacity,
                             idle_timeout: self.idle_timeout,
                             telemetry_context: self.telemetry_context.clone(),
@@ -221,10 +212,20 @@ impl SubgraphExecutor for WsSubgraphExecutor {
                     .metrics
                     .subscriptions
                     .record_websocket_pool_subscription_hit();
-                return executor.subscribe(execution_request, timeout).await;
+                return executor.subscribe(execution_request, None).await;
             }
         }
 
+        // buffer decouples the emitting subgraph from slow downstream consumers, dropping
+        // messages under backpressure instead of throttling the subgraph
+        let (tx, mut rx) = mpsc::channel::<Result<SubgraphResponse<'static>, SubgraphExecutorError>>(
+            self.buffer_capacity,
+        );
+
+        let endpoint = self.endpoint.clone();
+        let subgraph_name = self.subgraph_name.clone();
+        let tls_config = self.tls_config.clone();
+        let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let headers = execution_request.headers.clone();
         let init_payload = (!headers.is_empty()).then(|| headers.into());
         let subscribe_payload = execution_request.into();

--- a/lib/executor/src/executors/websocket_client.rs
+++ b/lib/executor/src/executors/websocket_client.rs
@@ -15,7 +15,10 @@ use ntex::{
 use tracing::{debug, error, trace};
 
 use crate::{
-    executors::graphql_transport_ws::{SubscribePayload, WS_SUBPROTOCOL},
+    executors::{
+        error::SubgraphExecutorError,
+        graphql_transport_ws::{SubscribePayload, WS_SUBPROTOCOL},
+    },
     response::subgraph_response::SubgraphResponse,
 };
 use crate::{
@@ -54,9 +57,11 @@ pub enum WsInitError {
     InvalidMessage,
     #[error("Wrong message received before connection acknowledgement")]
     WrongMessageBeforeAck,
+    #[error("Failed to send connection initialization message: {0}")]
+    SendFailed(ws::error::ProtocolError),
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum WsClientError {
     #[error("Connection closed")]
     ConnectionClosed,
@@ -64,6 +69,10 @@ pub enum WsClientError {
     MessageDispatcherClosed,
     #[error("Failed to deserialize payload")]
     FailedToDeserializePayload,
+    #[error("Failed to send WebSocket message: {0}")]
+    SendFailed(ws::error::ProtocolError),
+    #[error("WebSocket subscription ID exhausted")]
+    SubscriptionIdExhausted,
 }
 
 impl WsClientError {
@@ -72,7 +81,15 @@ impl WsClientError {
             WsClientError::ConnectionClosed => "WS_CONNECTION_CLOSED",
             WsClientError::MessageDispatcherClosed => "WS_MESSAGE_DISPATCHER_CLOSED",
             WsClientError::FailedToDeserializePayload => "WS_FAILED_TO_DESERIALIZE_PAYLOAD",
+            WsClientError::SendFailed(_) => "WS_SEND_FAILED",
+            WsClientError::SubscriptionIdExhausted => "WS_SUBSCRIPTION_ID_EXHAUSTED",
         }
+    }
+}
+
+impl From<WsClientError> for SubgraphExecutorError {
+    fn from(err: WsClientError) -> Self {
+        Self::WebSocketClientFailure(err.to_string())
     }
 }
 
@@ -130,9 +147,12 @@ pub async fn connect(
     }
 }
 
+type WsResponse = Result<SubgraphResponse<'static>, WsClientError>;
+pub(crate) type WsResponseStream = LocalBoxStream<'static, WsResponse>;
+
 #[derive(Clone)]
 struct ClientSubscription {
-    sender: mpsc::Sender<SubgraphResponse<'static>>,
+    sender: mpsc::Sender<WsResponse>,
     custom_scalar_paths: Option<CustomScalarPaths>,
 }
 
@@ -147,14 +167,29 @@ type WsStateRef = Rc<RefCell<WsState<ClientSubscription>>>;
 /// Supports multiplexing multiple subscriptions over a single WebSocket connection,
 /// it does so by spawning a background task to handle incoming messages and dispatch them
 /// to the appropriate subscription streams as well as handling connection-level messages.
-pub struct WsClient {
+pub struct Connected {
+    connection: WsConnection<Sealed>,
+}
+
+pub struct Initialized {
     sink: ws::WsSink,
     state: WsStateRef,
     next_subscription_id: u64,
     _heartbeat_stop_tx: Option<oneshot::Sender<()>>,
+    dispatcher_done_rx: Option<oneshot::Receiver<WsClientError>>,
 }
 
-impl WsClient {
+pub struct WsClient<State> {
+    state: State,
+}
+
+impl WsClient<Connected> {
+    pub fn new(connection: WsConnection<Sealed>) -> Self {
+        Self {
+            state: Connected { connection },
+        }
+    }
+
     /// Initialize a new GraphQL over WebSocket client.
     ///
     /// This sends the connection init message and waits for the server to acknowledge.
@@ -164,13 +199,13 @@ impl WsClient {
     ///
     /// Returns an error if the connection is closed before acknowledgement.
     pub async fn init(
-        connection: WsConnection<Sealed>,
+        self,
         payload: Option<ConnectionInitPayload>,
-    ) -> Result<Self, WsInitError> {
+    ) -> Result<WsClient<Initialized>, WsInitError> {
         debug!(target: targets::WEBSOCKET_CLIENT, "Initialising WebSocket client connection");
 
-        let sink = connection.sink();
-        let mut receiver = connection.receiver();
+        let sink = self.state.connection.sink();
+        let mut receiver = self.state.connection.receiver();
 
         let (acknowledged_tx, acknowledged_rx) = oneshot::channel();
 
@@ -189,7 +224,9 @@ impl WsClient {
         ));
 
         // send init and wait for ack or connection close
-        let _ = sink.send(ClientMessage::init(payload)).await;
+        sink.send(ClientMessage::init(payload))
+            .await
+            .map_err(WsInitError::SendFailed)?;
         loop {
             match receiver.next().await {
                 Some(Ok(frame)) => {
@@ -251,25 +288,47 @@ impl WsClient {
 
         let dispatcher_state = state.clone();
         let dispatcher_sink = sink.clone();
+        let (dispatcher_done_tx, dispatcher_done_rx) = oneshot::channel();
         rt::spawn(async move {
             let _guard = DispatcherGuard {
                 state: dispatcher_state.clone(),
             };
-            dispatch_loop(receiver, dispatcher_sink, dispatcher_state).await;
+            let error = dispatch_loop(receiver, dispatcher_sink, dispatcher_state.clone()).await;
+            for (_, subscription) in dispatcher_state.borrow_mut().subscriptions.drain() {
+                let _ = subscription.sender.send(Err(error.clone()));
+                subscription.sender.close();
+            }
+            let _ = dispatcher_done_tx.send(error);
         });
 
-        Ok(Self {
-            sink,
-            state,
-            next_subscription_id: 1,
-            _heartbeat_stop_tx: Some(heartbeat_stop_tx),
+        Ok(WsClient {
+            state: Initialized {
+                sink,
+                state,
+                next_subscription_id: 1,
+                _heartbeat_stop_tx: Some(heartbeat_stop_tx),
+                dispatcher_done_rx: Some(dispatcher_done_rx),
+            },
         })
     }
+}
 
-    fn next_subscription_id(&mut self) -> String {
-        let id = self.next_subscription_id;
-        self.next_subscription_id += 1;
-        id.to_string()
+impl WsClient<Initialized> {
+    fn next_subscription_id(&mut self) -> Result<String, WsClientError> {
+        let id = self.state.next_subscription_id;
+        self.state.next_subscription_id = self
+            .state
+            .next_subscription_id
+            .checked_add(1)
+            .ok_or(WsClientError::SubscriptionIdExhausted)?;
+        Ok(id.to_string())
+    }
+
+    pub fn take_dispatcher_done(&mut self) -> oneshot::Receiver<WsClientError> {
+        self.state
+            .dispatcher_done_rx
+            .take()
+            .expect("dispatcher completion receiver can only be taken once")
     }
 
     /// Execute a GraphQL operation (query, mutation, or subscription) over WebSocket.
@@ -282,12 +341,12 @@ impl WsClient {
         &mut self,
         subscribe_payload: SubscribePayload,
         custom_scalar_paths: Option<CustomScalarPaths>,
-    ) -> LocalBoxStream<'static, SubgraphResponse<'static>> {
-        let subscribe_id = self.next_subscription_id();
+    ) -> Result<WsResponseStream, WsClientError> {
+        let subscribe_id = self.next_subscription_id()?;
 
         let (tx, rx) = mpsc::channel();
 
-        self.state.borrow_mut().subscriptions.insert(
+        self.state.state.borrow_mut().subscriptions.insert(
             subscribe_id.clone(),
             ClientSubscription {
                 sender: tx,
@@ -295,20 +354,28 @@ impl WsClient {
             },
         );
 
-        let _ = self
+        self.state
             .sink
             .send(ClientMessage::subscribe(
                 subscribe_id.clone(),
                 subscribe_payload,
             ))
-            .await;
+            .await
+            .map_err(|e| {
+                self.state
+                    .state
+                    .borrow_mut()
+                    .subscriptions
+                    .remove(&subscribe_id);
+                WsClientError::SendFailed(e)
+            })?;
 
         trace!(target: targets::WEBSOCKET_CLIENT, subscription_id = %subscribe_id, "Subscribe message sent");
 
-        let state = self.state.clone();
-        let sink = self.sink.clone();
+        let state = self.state.state.clone();
+        let sink = self.state.sink.clone();
 
-        Box::pin(async_stream::stream! {
+        Ok(Box::pin(async_stream::stream! {
             let mut rx = rx;
             let _guard = SubscriptionGuard {
                 state,
@@ -320,11 +387,11 @@ impl WsClient {
                 // the response specific to THIS subscription (matching by id)
                 yield response;
             }
-        })
+        }))
     }
 }
 
-impl Drop for WsClient {
+impl Drop for Initialized {
     fn drop(&mut self) {
         // heartbeat_stop_tx will be dropped automatically, stopping the heartbeat task
 
@@ -374,7 +441,7 @@ async fn dispatch_loop(
     mut receiver: mpsc::Receiver<Result<ws::Frame, WsError<()>>>,
     sink: WsSink,
     state: WsStateRef,
-) {
+) -> WsClientError {
     loop {
         match receiver.next().await {
             Some(Ok(frame)) => {
@@ -382,35 +449,29 @@ async fn dispatch_loop(
                     Ok(text) => {
                         if let Some(msg) = handle_text_frame(text, &state) {
                             if send_and_is_closed(sink.clone(), msg).await {
-                                return;
+                                return WsClientError::ConnectionClosed;
                             }
                         }
                     }
                     Err(FrameNotParsedToText::Message(msg)) => {
                         if send_and_is_closed(sink.clone(), msg).await {
-                            return;
+                            return WsClientError::ConnectionClosed;
                         }
                     }
                     Err(FrameNotParsedToText::Closed) => {
                         // notify all subscriptions that the connection was closed
-                        for (_, subscription) in state.borrow_mut().subscriptions.drain() {
-                            let _ = subscription
-                                .sender
-                                .send(WsClientError::ConnectionClosed.into());
-                            subscription.sender.close();
-                        }
-                        return;
+                        return WsClientError::ConnectionClosed;
                     }
                     Err(FrameNotParsedToText::None) => {}
                 }
             }
             Some(Err(e)) => {
                 error!(target: targets::WEBSOCKET_CLIENT, error = ?e, "Dispatch loop WebSocket receiver error");
-
-                return;
+                // TODO: should we return a message dispatcher error instead of closed?
+                return WsClientError::MessageDispatcherClosed;
             }
             None => {
-                return;
+                return WsClientError::MessageDispatcherClosed;
             }
         }
     }
@@ -426,7 +487,7 @@ impl Drop for DispatcherGuard {
         for (_, subscription) in self.state.borrow_mut().subscriptions.drain() {
             let _ = subscription
                 .sender
-                .send(WsClientError::ConnectionClosed.into());
+                .send(Err(WsClientError::ConnectionClosed));
             subscription.sender.close();
         }
     }
@@ -461,11 +522,11 @@ fn handle_text_frame(text: String, state: &WsStateRef) -> Option<ws::Message> {
                     payload_bytes,
                     subscription.custom_scalar_paths.as_ref(),
                 ) {
-                    Ok(response) => response,
+                    Ok(response) => Ok(response),
                     Err(e) => {
                         tracing::error!(target: targets::WEBSOCKET_CLIENT, error = ?e, "Failed to deserialize payload");
 
-                        WsClientError::FailedToDeserializePayload.into()
+                        Err(WsClientError::FailedToDeserializePayload)
                     }
                 };
                 // TODO: should we be strict and close the connection if id did not match any subscription?
@@ -475,10 +536,10 @@ fn handle_text_frame(text: String, state: &WsStateRef) -> Option<ws::Message> {
         }
         ServerMessage::Error { id, payload } => {
             if let Some(subscription) = state.borrow_mut().subscriptions.remove(&id) {
-                let _ = subscription.sender.send(SubgraphResponse {
+                let _ = subscription.sender.send(Ok(SubgraphResponse {
                     errors: Some(payload),
                     ..Default::default()
-                });
+                }));
                 subscription.sender.close();
             }
             None
@@ -534,7 +595,7 @@ mod tests {
 
         assert!(handle_text_frame(text, &state).is_none());
 
-        let response = rx.next().await.expect("response");
+        let response = rx.next().await.expect("response").expect("valid response");
         let data = response.data.as_object().unwrap();
         assert!(data[0].1.as_raw_json().is_some());
     }

--- a/lib/executor/src/executors/websocket_client.rs
+++ b/lib/executor/src/executors/websocket_client.rs
@@ -15,10 +15,7 @@ use ntex::{
 use tracing::{debug, error, trace};
 
 use crate::{
-    executors::{
-        error::SubgraphExecutorError,
-        graphql_transport_ws::{SubscribePayload, WS_SUBPROTOCOL},
-    },
+    executors::graphql_transport_ws::{SubscribePayload, WS_SUBPROTOCOL},
     response::subgraph_response::SubgraphResponse,
 };
 use crate::{
@@ -58,7 +55,7 @@ pub enum WsInitError {
     #[error("Wrong message received before connection acknowledgement")]
     WrongMessageBeforeAck,
     #[error("Failed to send connection initialization message: {0}")]
-    SendFailed(ws::error::ProtocolError),
+    SendFailed(#[from] ws::error::ProtocolError),
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -70,7 +67,7 @@ pub enum WsClientError {
     #[error("Failed to deserialize payload")]
     FailedToDeserializePayload,
     #[error("Failed to send WebSocket message: {0}")]
-    SendFailed(ws::error::ProtocolError),
+    SendFailed(#[from] ws::error::ProtocolError),
     #[error("WebSocket subscription ID exhausted")]
     SubscriptionIdExhausted,
 }
@@ -84,12 +81,6 @@ impl WsClientError {
             WsClientError::SendFailed(_) => "WS_SEND_FAILED",
             WsClientError::SubscriptionIdExhausted => "WS_SUBSCRIPTION_ID_EXHAUSTED",
         }
-    }
-}
-
-impl From<WsClientError> for SubgraphExecutorError {
-    fn from(err: WsClientError) -> Self {
-        Self::WebSocketClientFailure(err.to_string())
     }
 }
 
@@ -226,9 +217,7 @@ impl WsClient<Connected> {
         ));
 
         // send init and wait for ack or connection close
-        sink.send(ClientMessage::init(payload))
-            .await
-            .map_err(WsInitError::SendFailed)?;
+        sink.send(ClientMessage::init(payload)).await?;
         loop {
             match receiver.next().await {
                 Some(Ok(frame)) => {
@@ -368,8 +357,7 @@ impl WsClient<Initialized> {
                 subscribe_id.clone(),
                 subscribe_payload,
             ))
-            .await
-            .map_err(WsClientError::SendFailed)?;
+            .await?;
         guard.send_complete = true;
 
         trace!(target: targets::WEBSOCKET_CLIENT, subscription_id = %subscribe_id, "Subscribe message sent");

--- a/lib/executor/src/executors/websocket_client.rs
+++ b/lib/executor/src/executors/websocket_client.rs
@@ -356,6 +356,12 @@ impl WsClient<Initialized> {
             },
         );
 
+        let mut guard = SubscriptionGuard {
+            state: self.state.state.clone(),
+            sink: self.state.sink.clone(),
+            id: Some(subscribe_id.clone()),
+            send_complete: false,
+        };
         self.state
             .sink
             .send(ClientMessage::subscribe(
@@ -363,27 +369,14 @@ impl WsClient<Initialized> {
                 subscribe_payload,
             ))
             .await
-            .map_err(|e| {
-                self.state
-                    .state
-                    .borrow_mut()
-                    .subscriptions
-                    .remove(&subscribe_id);
-                WsClientError::SendFailed(e)
-            })?;
+            .map_err(WsClientError::SendFailed)?;
+        guard.send_complete = true;
 
         trace!(target: targets::WEBSOCKET_CLIENT, subscription_id = %subscribe_id, "Subscribe message sent");
 
-        let state = self.state.state.clone();
-        let sink = self.state.sink.clone();
-
         Ok(Box::pin(async_stream::stream! {
             let mut rx = rx;
-            let _guard = SubscriptionGuard {
-                state,
-                sink,
-                id: subscribe_id,
-            };
+            let _guard = guard;
 
             while let Some(response) = rx.next().await {
                 // the response specific to THIS subscription (matching by id)
@@ -408,31 +401,30 @@ impl Drop for Initialized {
     }
 }
 
+/// Cleans up protocol state when a subscribe write is canceled before it completes.
+///
 /// Ensures a subscription is cleaned up when dropped.
 struct SubscriptionGuard {
     state: WsStateRef,
     sink: WsSink,
-    id: String,
+    id: Option<String>,
+    send_complete: bool,
 }
 
 impl Drop for SubscriptionGuard {
     fn drop(&mut self) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
         // only send complete message if the subscription is still active - client cancelled.
         // if the server sent the complete/error message, the subscription would've been removed
         // by the dispatcher so no complete message would be sent from the client back to the server
-        if self
-            .state
-            .borrow_mut()
-            .subscriptions
-            .remove(&self.id)
-            .is_some()
-        {
-            let id = self.id.clone();
+        if self.state.borrow_mut().subscriptions.remove(&id).is_some() && self.send_complete {
             let sink = self.sink.clone();
 
             // sending is async, so spawn a task to do it
             rt::spawn(async move {
-                let _ = sink.send(ClientMessage::complete(id.clone())).await;
+                let _ = sink.send(ClientMessage::complete(id)).await;
             });
         }
     }

--- a/lib/executor/src/executors/websocket_client.rs
+++ b/lib/executor/src/executors/websocket_client.rs
@@ -124,6 +124,7 @@ pub async fn connect(
         };
 
         let ws_client = NtexWsClient::builder(uri)
+            .max_frame_size(16 * 1024 * 1024) // default is 64kB which is too small
             .protocols([WS_SUBPROTOCOL])
             .timeout(ntex::time::Seconds(60))
             .rustls(tls_config)
@@ -135,6 +136,7 @@ pub async fn connect(
         Ok(ws_client.connect().await?.seal())
     } else if scheme == "ws" {
         let ws_client = NtexWsClient::builder(uri)
+            .max_frame_size(16 * 1024 * 1024) // default is 64kB which is too small
             .protocols([WS_SUBPROTOCOL])
             .timeout(ntex::time::Seconds(60))
             .build(SharedCfg::default())

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -43,13 +43,19 @@ type PoolEntries = DashMap<WebSocketConnectionId, PoolEntry>;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WebSocketConnectionId {
     subgraph_name: Arc<str>,
+    endpoint: Uri,
     fingerprint: ConnectionFingerprint,
 }
 
 impl WebSocketConnectionId {
-    pub fn new(subgraph_name: impl Into<Arc<str>>, fingerprint: ConnectionFingerprint) -> Self {
+    pub fn new(
+        subgraph_name: impl Into<Arc<str>>,
+        endpoint: Uri,
+        fingerprint: ConnectionFingerprint,
+    ) -> Self {
         Self {
             subgraph_name: subgraph_name.into(),
+            endpoint,
             fingerprint,
         }
     }

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -308,13 +308,9 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
     async fn subscribe<'a>(
         &self,
         execution_request: SubgraphExecutionRequest<'a>,
-        timeout: Option<Duration>,
+        _timeout: Option<Duration>,
     ) -> Result<BoxStream<'static, SubscriptionItem>, SubgraphExecutorError> {
-        let submit = self.submit(execution_request, self.buffer_capacity);
-        let mut responses = match timeout {
-            Some(timeout) => tokio::time::timeout(timeout, submit).await??,
-            None => submit.await?,
-        };
+        let mut responses = self.submit(execution_request, self.buffer_capacity).await?;
         let operation_guard = self
             .telemetry_context
             .metrics

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -6,8 +6,12 @@ use std::{
 use async_trait::async_trait;
 use dashmap::{mapref::entry::Entry, DashMap};
 use futures::{stream::BoxStream, StreamExt};
-use hive_router_internal::{
-    telemetry::metrics::subscription_metrics::SubscriptionTransport, telemetry::TelemetryContext,
+use hive_router_internal::telemetry::{
+    metrics::{
+        subscription_metrics::SubscriptionTransport,
+        websocket_pool_metrics::{WebSocketPoolConnectionCloseReason, WebSocketPoolOperationType},
+    },
+    TelemetryContext,
 };
 use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
 use http::{HeaderMap, Uri};
@@ -157,17 +161,16 @@ impl WebSocketPool {
         };
 
         if let Some(generation) = generation {
-            init.telemetry_context
-                .metrics
-                .subscriptions
-                .record_websocket_pool_initialization_started();
-
             let cleanup = InitializationCleanup::new(self.entries.clone(), id.clone(), generation);
             let telemetry_context = init.telemetry_context.clone();
             rt::spawn(async move {
                 let mut cleanup = cleanup;
                 match initialize_connection(&cleanup.entries, &cleanup.id, init).await {
                     Ok(connection) => {
+                        telemetry_context
+                            .metrics
+                            .websocket_pool
+                            .record_connection_initialization(&cleanup.id.subgraph_name, true);
                         let executor = connection.executor.clone();
                         let Some(waiters) = cleanup.publish(executor.clone()) else {
                             return;
@@ -181,8 +184,8 @@ impl WebSocketPool {
                     Err(error) => {
                         telemetry_context
                             .metrics
-                            .subscriptions
-                            .record_websocket_pool_initialization_failed();
+                            .websocket_pool
+                            .record_connection_initialization(&cleanup.id.subgraph_name, false);
                         let waiters = cleanup.remove();
                         notify_waiters(waiters, Err(error));
                     }
@@ -191,8 +194,8 @@ impl WebSocketPool {
         } else {
             init.telemetry_context
                 .metrics
-                .subscriptions
-                .record_websocket_pool_initialization_joined();
+                .websocket_pool
+                .record_connection_initialization_waiter(&id.subgraph_name);
         }
 
         wait_rx
@@ -410,8 +413,8 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
         let _operation_guard = self
             .telemetry_context
             .metrics
-            .subscriptions
-            .active_subgraph_operation(&self.id.subgraph_name);
+            .websocket_pool
+            .active_operation(&self.id.subgraph_name, WebSocketPoolOperationType::Execute);
         let operation = async {
             let mut responses = self.submit(execution_request, 1).await?;
             responses.recv().await.ok_or_else(|| {
@@ -429,15 +432,24 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
         execution_request: SubgraphExecutionRequest<'a>,
         _timeout: Option<Duration>,
     ) -> Result<BoxStream<'static, SubscriptionItem>, SubgraphExecutorError> {
+        let pool_operation_guard = self
+            .telemetry_context
+            .metrics
+            .websocket_pool
+            .active_operation(
+                &self.id.subgraph_name,
+                WebSocketPoolOperationType::Subscribe,
+            );
         // timeout covers queueing and the subscribe write, not the lifetime of the returned stream.
         let mut responses = self.submit(execution_request, self.buffer_capacity).await?;
-        let operation_guard = self
+        let subscription_operation_guard = self
             .telemetry_context
             .metrics
             .subscriptions
             .active_subgraph_operation(&self.id.subgraph_name);
         Ok(Box::pin(async_stream::stream! {
-            let _operation_guard = operation_guard;
+            let _pool_operation_guard = pool_operation_guard;
+            let _subscription_operation_guard = subscription_operation_guard;
             while let Some(item) = responses.recv().await {
                 yield item;
             }
@@ -527,8 +539,8 @@ impl ConnectionOwner {
         let subgraph_name = self.subgraph_name.clone();
         let _connection_guard = telemetry_context
             .metrics
-            .subscriptions
-            .active_subgraph_connection(&subgraph_name, SubscriptionTransport::WebSocket);
+            .websocket_pool
+            .active_connection(&subgraph_name);
         let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
         let mut active_operations = 0usize;
         let idle_timer = tokio::time::sleep(self.idle_timeout);
@@ -636,12 +648,15 @@ impl ConnectionOwner {
             let _ = command.ready.send(Err(shutdown.command_error()));
         }
 
-        if matches!(shutdown, ConnectionShutdown::Idle) {
-            self.telemetry_context
-                .metrics
-                .subscriptions
-                .record_websocket_pool_idle_expiration();
-        }
+        let reason = match shutdown {
+            ConnectionShutdown::Idle => WebSocketPoolConnectionCloseReason::Idle,
+            ConnectionShutdown::Dispatcher(_) => WebSocketPoolConnectionCloseReason::Dispatcher,
+            ConnectionShutdown::CommandsClosed => WebSocketPoolConnectionCloseReason::PoolDropped,
+        };
+        self.telemetry_context
+            .metrics
+            .websocket_pool
+            .record_connection_closed(&self.subgraph_name, reason);
     }
 }
 

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use dashmap::{mapref::entry::Entry, DashMap};
 use futures::{stream::BoxStream, StreamExt};
 use hive_router_internal::telemetry::{
+    logging::targets,
     metrics::{
         subscription_metrics::SubscriptionTransport,
         websocket_pool_metrics::{WebSocketPoolConnectionCloseReason, WebSocketPoolOperationType},
@@ -20,6 +21,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::Instant,
 };
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     executors::{
@@ -112,12 +114,19 @@ impl WebSocketPool {
         &self,
         id: &WebSocketConnectionId,
     ) -> Option<Arc<PooledWebSocketExecutor>> {
-        self.entries.get(id).and_then(|entry| match entry.value() {
+        let executor = self.entries.get(id).and_then(|entry| match entry.value() {
             PoolEntry::Initialized(executor) if !executor.commands.is_closed() => {
                 Some(executor.clone())
             }
             PoolEntry::Connecting(_) | PoolEntry::Initialized(_) => None,
-        })
+        });
+        trace!(
+            target: targets::WEBSOCKET_POOL,
+            subgraph = %id.subgraph_name,
+            found = executor.is_some(),
+            "looked up WebSocket pool connection"
+        );
+        executor
     }
 
     pub async fn get_or_initialize(
@@ -129,6 +138,12 @@ impl WebSocketPool {
         let (wait_rx, generation) = match self.entries.entry(id.clone()) {
             Entry::Occupied(mut entry) => match entry.get_mut() {
                 PoolEntry::Initialized(executor) if !executor.commands.is_closed() => {
+                    trace!(
+                        target: targets::WEBSOCKET_POOL,
+                        subgraph = %id.subgraph_name,
+                        endpoint = %endpoint,
+                        "reusing WebSocket pool connection"
+                    );
                     return Ok(executor.clone());
                 }
                 PoolEntry::Connecting(connecting) => {
@@ -161,8 +176,15 @@ impl WebSocketPool {
         };
 
         if let Some(generation) = generation {
+            debug!(
+                target: targets::WEBSOCKET_POOL,
+                subgraph = %id.subgraph_name,
+                endpoint = %endpoint,
+                "initializing WebSocket pool connection"
+            );
             let cleanup = InitializationCleanup::new(self.entries.clone(), id.clone(), generation);
             let telemetry_context = init.telemetry_context.clone();
+            let log_endpoint = endpoint.clone();
             rt::spawn(async move {
                 let mut cleanup = cleanup;
                 match initialize_connection(&cleanup.entries, &cleanup.id, init).await {
@@ -173,8 +195,21 @@ impl WebSocketPool {
                             .record_connection_initialization(&cleanup.id.subgraph_name, true);
                         let executor = connection.executor.clone();
                         let Some(waiters) = cleanup.publish(executor.clone()) else {
+                            debug!(
+                                target: targets::WEBSOCKET_POOL,
+                                subgraph = %cleanup.id.subgraph_name,
+                                endpoint = %log_endpoint,
+                                "discarding stale WebSocket pool connection initialization"
+                            );
                             return;
                         };
+                        info!(
+                            target: targets::WEBSOCKET_POOL,
+                            subgraph = %cleanup.id.subgraph_name,
+                            endpoint = %log_endpoint,
+                            waiting_requests = waiters.len(),
+                            "WebSocket pool connection initialized"
+                        );
 
                         // publication happens first, so even an immediately exiting owner can only
                         // evict the initialized generation it actually owns.
@@ -186,12 +221,25 @@ impl WebSocketPool {
                             .metrics
                             .websocket_pool
                             .record_connection_initialization(&cleanup.id.subgraph_name, false);
+                        warn!(
+                            target: targets::WEBSOCKET_POOL,
+                            subgraph = %cleanup.id.subgraph_name,
+                            endpoint = %log_endpoint,
+                            error = %error,
+                            "failed to initialize WebSocket pool connection"
+                        );
                         let waiters = cleanup.remove();
                         notify_waiters(waiters, Err(error));
                     }
                 }
             });
         } else {
+            debug!(
+                target: targets::WEBSOCKET_POOL,
+                subgraph = %id.subgraph_name,
+                endpoint = %endpoint,
+                "waiting for WebSocket pool connection initialization"
+            );
             init.telemetry_context
                 .metrics
                 .websocket_pool
@@ -200,7 +248,15 @@ impl WebSocketPool {
 
         wait_rx
             .await
-            .map_err(|_| SubgraphExecutorError::WebSocketArbiterChannelClosed)?
+            .map_err(|_| {
+                warn!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %id.subgraph_name,
+                    endpoint = %endpoint,
+                    "WebSocket pool connection initialization stopped before completion"
+                );
+                SubgraphExecutorError::WebSocketArbiterChannelClosed
+            })?
             .map_err(|error| error.into_executor_error(&endpoint))
     }
 }
@@ -350,13 +406,23 @@ pub struct PooledWebSocketExecutor {
 impl PooledWebSocketExecutor {
     fn evict_if_current(&self) {
         if let Some(entries) = self.entries.upgrade() {
-            entries.remove_if(&self.id, |_, entry| {
-                matches!(
-                    entry,
-                    PoolEntry::Initialized(current)
-                        if current.commands.same_channel(&self.commands)
-                )
-            });
+            if entries
+                .remove_if(&self.id, |_, entry| {
+                    matches!(
+                        entry,
+                        PoolEntry::Initialized(current)
+                            if current.commands.same_channel(&self.commands)
+                    )
+                })
+                .is_some()
+            {
+                debug!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %self.id.subgraph_name,
+                    endpoint = %self.endpoint,
+                    "evicted WebSocket pool connection"
+                );
+            }
         }
     }
 
@@ -368,6 +434,12 @@ impl PooledWebSocketExecutor {
         // reserve first so canceled callers do not build payloads or occupy response buffers while
         // waiting behind a full shared command queue.
         let permit = self.commands.reserve().await.map_err(|_| {
+            debug!(
+                target: targets::WEBSOCKET_POOL,
+                subgraph = %self.id.subgraph_name,
+                endpoint = %self.endpoint,
+                "WebSocket pool connection closed before operation could be queued"
+            );
             self.evict_if_current();
             SubgraphExecutorError::WebSocketArbiterChannelClosed
         })?;
@@ -385,8 +457,23 @@ impl PooledWebSocketExecutor {
 
         match ready_rx.await {
             Ok(Ok(())) => Ok(receiver),
-            Ok(Err(error)) => Err(error.into()),
+            Ok(Err(error)) => {
+                warn!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %self.id.subgraph_name,
+                    endpoint = %self.endpoint,
+                    error = %error,
+                    "failed to start operation on WebSocket pool connection"
+                );
+                Err(error.into())
+            }
             Err(_) => {
+                debug!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %self.id.subgraph_name,
+                    endpoint = %self.endpoint,
+                    "WebSocket pool connection closed while starting operation"
+                );
                 self.evict_if_current();
                 Err(SubgraphExecutorError::WebSocketArbiterChannelClosed)
             }
@@ -649,9 +736,34 @@ impl ConnectionOwner {
         }
 
         let reason = match shutdown {
-            ConnectionShutdown::Idle => WebSocketPoolConnectionCloseReason::Idle,
-            ConnectionShutdown::Dispatcher(_) => WebSocketPoolConnectionCloseReason::Dispatcher,
-            ConnectionShutdown::CommandsClosed => WebSocketPoolConnectionCloseReason::PoolDropped,
+            ConnectionShutdown::Idle => {
+                info!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %self.subgraph_name,
+                    endpoint = %self.endpoint,
+                    "closing idle WebSocket pool connection"
+                );
+                WebSocketPoolConnectionCloseReason::Idle
+            }
+            ConnectionShutdown::Dispatcher(error) => {
+                warn!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %self.subgraph_name,
+                    endpoint = %self.endpoint,
+                    error = %error,
+                    "WebSocket pool connection dispatcher stopped"
+                );
+                WebSocketPoolConnectionCloseReason::Dispatcher
+            }
+            ConnectionShutdown::CommandsClosed => {
+                info!(
+                    target: targets::WEBSOCKET_POOL,
+                    subgraph = %self.subgraph_name,
+                    endpoint = %self.endpoint,
+                    "WebSocket pool dropped, closing connection"
+                );
+                WebSocketPoolConnectionCloseReason::PoolDropped
+            }
         };
         self.telemetry_context
             .metrics

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -445,7 +445,7 @@ impl PooledWebSocketExecutor {
         })?;
 
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
-        let payload = execution_request.into();
+        let payload = SubscribePayload::try_from(execution_request)?;
         let (responses, receiver) = mpsc::channel(response_capacity);
         let (ready, ready_rx) = oneshot::channel();
         permit.send(ConnectionCommand {

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -1,0 +1,441 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use futures::{channel::oneshot, stream::BoxStream, StreamExt};
+use hive_router_internal::{
+    telemetry::metrics::subscription_metrics::SubscriptionTransport, telemetry::TelemetryContext,
+};
+use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
+use http::Uri;
+use ntex::rt;
+use tokio::sync::mpsc;
+
+use crate::{
+    executors::{
+        common::{ConnectionFingerprint, SubgraphExecutionRequest, SubgraphExecutor},
+        error::SubgraphExecutorError,
+        graphql_transport_ws::{
+            build_connection_init_payload, build_subscribe_payload, SubscribePayload,
+        },
+        subscription_buffer::{drain_into, try_send_or_drop},
+        websocket_client::{self, WsClient, WsClientError},
+    },
+    plugin_context::PluginRequestState,
+    response::subgraph_response::SubgraphResponse,
+};
+
+type SubscriptionItem = Result<SubgraphResponse<'static>, SubgraphExecutorError>;
+type InitResult = Result<Arc<PooledWebSocketExecutor>, PoolInitError>;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct WebSocketConnectionId {
+    pub endpoint: Uri,
+    pub fingerprint: ConnectionFingerprint,
+}
+
+// TODO: use thiserror and transparent and whatever to inherit errors #[from]
+#[derive(Clone)]
+enum PoolInitError {
+    Connect(String),
+    Handshake(String),
+}
+
+impl PoolInitError {
+    fn into_executor_error(self, endpoint: &Uri) -> SubgraphExecutorError {
+        match self {
+            Self::Connect(error) => {
+                SubgraphExecutorError::WebSocketConnectFailure(endpoint.to_string(), error)
+            }
+            Self::Handshake(error) => {
+                SubgraphExecutorError::WebSocketHandshakeFailure(endpoint.to_string(), error)
+            }
+        }
+    }
+}
+
+struct ConnectingEntry {
+    waiters: Vec<oneshot::Sender<InitResult>>,
+}
+
+enum PoolEntry {
+    Connecting(ConnectingEntry),
+    Initialized(Arc<PooledWebSocketExecutor>),
+}
+
+pub struct WebSocketInit {
+    pub headers: http::HeaderMap,
+    pub tls_config: Option<Arc<rustls::ClientConfig>>,
+    pub subgraph_name: String,
+    pub buffer_capacity: usize,
+    pub idle_timeout: Duration,
+    pub telemetry_context: Arc<TelemetryContext>,
+}
+
+pub struct WebSocketPool {
+    entries: Arc<DashMap<WebSocketConnectionId, PoolEntry>>,
+}
+
+impl Default for WebSocketPool {
+    fn default() -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+        }
+    }
+}
+
+impl WebSocketPool {
+    pub fn get_initialized(
+        &self,
+        id: &WebSocketConnectionId,
+    ) -> Option<Arc<PooledWebSocketExecutor>> {
+        self.entries.get(id).and_then(|entry| match entry.value() {
+            PoolEntry::Initialized(executor) => Some(executor.clone()),
+            PoolEntry::Connecting(_) => None,
+        })
+    }
+
+    pub async fn get_or_initialize(
+        &self,
+        id: WebSocketConnectionId,
+        init: WebSocketInit,
+    ) -> Result<Arc<PooledWebSocketExecutor>, SubgraphExecutorError> {
+        let (wait_tx, wait_rx) = oneshot::channel();
+        let initialize = match self.entries.entry(id.clone()) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => match entry.get_mut() {
+                PoolEntry::Initialized(executor) => return Ok(executor.clone()),
+                PoolEntry::Connecting(connecting) => {
+                    init.telemetry_context
+                        .metrics
+                        .subscriptions
+                        .record_websocket_pool_initialization_joined();
+                    connecting.waiters.push(wait_tx);
+                    false
+                }
+            },
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                init.telemetry_context
+                    .metrics
+                    .subscriptions
+                    .record_websocket_pool_initialization_started();
+                entry.insert(PoolEntry::Connecting(ConnectingEntry {
+                    waiters: vec![wait_tx],
+                }));
+                true
+            }
+        };
+
+        if initialize {
+            let entries = self.entries.clone();
+            let task_id = id.clone();
+            let telemetry_context = init.telemetry_context.clone();
+            rt::spawn(async move {
+                let initialized =
+                    initialize_connection(entries.clone(), task_id.clone(), init).await;
+                if initialized.is_err() {
+                    telemetry_context
+                        .metrics
+                        .subscriptions
+                        .record_websocket_pool_initialization_failed();
+                }
+                let waiters = match entries.remove(&task_id) {
+                    Some((_, PoolEntry::Connecting(connecting))) => connecting.waiters,
+                    Some((_, initialized @ PoolEntry::Initialized(_))) => {
+                        entries.insert(task_id.clone(), initialized);
+                        Vec::new()
+                    }
+                    None => Vec::new(),
+                };
+
+                let result = match initialized {
+                    Ok((executor, start_owner)) => {
+                        entries.insert(task_id, PoolEntry::Initialized(executor.clone()));
+                        let _ = start_owner.send(());
+                        Ok(executor)
+                    }
+                    Err(error) => Err(error),
+                };
+                for waiter in waiters {
+                    let _ = waiter.send(result.clone());
+                }
+            });
+        }
+
+        wait_rx
+            .await
+            .map_err(|_| SubgraphExecutorError::WebSocketArbiterChannelClosed)?
+            .map_err(|error| error.into_executor_error(&id.endpoint))
+    }
+}
+
+async fn initialize_connection(
+    entries: Arc<DashMap<WebSocketConnectionId, PoolEntry>>,
+    id: WebSocketConnectionId,
+    init: WebSocketInit,
+) -> Result<(Arc<PooledWebSocketExecutor>, oneshot::Sender<()>), PoolInitError> {
+    let wsconn = websocket_client::connect(&id.endpoint, init.tls_config)
+        .await
+        .map_err(|error| PoolInitError::Connect(error.to_string()))?;
+    let client = WsClient::new(wsconn);
+    let mut client = client
+        .init(build_connection_init_payload(init.headers))
+        .await
+        .map_err(|error| PoolInitError::Handshake(error.to_string()))?;
+    let dispatcher_done = client.take_dispatcher_done();
+    let (commands, task_commands) = mpsc::channel(init.buffer_capacity);
+    let executor = Arc::new(PooledWebSocketExecutor {
+        endpoint: id.endpoint.clone(),
+        commands,
+        telemetry_context: init.telemetry_context.clone(),
+        subgraph_name: init.subgraph_name.clone(),
+        buffer_capacity: init.buffer_capacity,
+        entries: Arc::downgrade(&entries),
+        id: id.clone(),
+    });
+
+    let task_executor = executor.clone();
+    let (start_owner, start_owner_rx) = oneshot::channel();
+    rt::spawn(async move {
+        if start_owner_rx.await.is_err() {
+            return;
+        }
+        let _connection_guard = init
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_connection(&init.subgraph_name, SubscriptionTransport::WebSocket);
+        own_connection(
+            client,
+            dispatcher_done,
+            task_commands,
+            task_executor,
+            id,
+            entries,
+            init.idle_timeout,
+        )
+        .await;
+    });
+
+    Ok((executor, start_owner))
+}
+
+enum ConnectionCommand {
+    Subscribe {
+        payload: SubscribePayload,
+        custom_scalar_paths: Option<CustomScalarPaths>,
+        responses: mpsc::Sender<SubscriptionItem>,
+    },
+}
+
+pub struct PooledWebSocketExecutor {
+    endpoint: Uri,
+    commands: mpsc::Sender<ConnectionCommand>,
+    telemetry_context: Arc<TelemetryContext>,
+    subgraph_name: String,
+    buffer_capacity: usize,
+    entries: std::sync::Weak<DashMap<WebSocketConnectionId, PoolEntry>>,
+    id: WebSocketConnectionId,
+}
+
+impl PooledWebSocketExecutor {
+    async fn submit(
+        &self,
+        execution_request: SubgraphExecutionRequest<'_>,
+        response_capacity: usize,
+    ) -> Result<mpsc::Receiver<SubscriptionItem>, SubgraphExecutorError> {
+        let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
+        let payload = build_subscribe_payload(execution_request);
+        let (responses, receiver) = mpsc::channel(response_capacity);
+        if self
+            .commands
+            .send(ConnectionCommand::Subscribe {
+                payload,
+                custom_scalar_paths,
+                responses,
+            })
+            .await
+            .is_err()
+        {
+            if let Some(entries) = self.entries.upgrade() {
+                entries.remove_if(&self.id, |_, entry| {
+                    matches!(
+                        entry,
+                        PoolEntry::Initialized(current)
+                            if current.commands.same_channel(&self.commands)
+                    )
+                });
+            }
+            return Err(SubgraphExecutorError::WebSocketArbiterChannelClosed);
+        }
+        Ok(receiver)
+    }
+}
+
+#[async_trait]
+impl SubgraphExecutor for PooledWebSocketExecutor {
+    fn executor_name(&self) -> &str {
+        "pooled-websocket"
+    }
+
+    fn endpoint(&self) -> &Uri {
+        &self.endpoint
+    }
+
+    async fn execute<'a>(
+        &self,
+        execution_request: SubgraphExecutionRequest<'a>,
+        timeout: Option<Duration>,
+        _plugin_req_state: Option<&'a PluginRequestState<'a>>,
+    ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
+        let endpoint = self.endpoint.to_string();
+        let _operation_guard = self
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_operation(&self.subgraph_name);
+        let operation = async {
+            let mut responses = self.submit(execution_request, 1).await?;
+            responses
+                .recv()
+                .await
+                .ok_or(SubgraphExecutorError::WebSocketStreamClosedEmpty(endpoint))?
+        };
+        match timeout {
+            Some(timeout) => tokio::time::timeout(timeout, operation).await?,
+            None => operation.await,
+        }
+    }
+
+    async fn subscribe<'a>(
+        &self,
+        execution_request: SubgraphExecutionRequest<'a>,
+        timeout: Option<Duration>,
+    ) -> Result<BoxStream<'static, SubscriptionItem>, SubgraphExecutorError> {
+        let submit = self.submit(execution_request, self.buffer_capacity);
+        let mut responses = match timeout {
+            Some(timeout) => tokio::time::timeout(timeout, submit).await??,
+            None => submit.await?,
+        };
+        let operation_guard = self
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_operation(&self.subgraph_name);
+        Ok(Box::pin(async_stream::stream! {
+            let _operation_guard = operation_guard;
+            while let Some(item) = responses.recv().await {
+                yield item;
+            }
+        }))
+    }
+}
+
+#[async_trait]
+impl SubgraphExecutor for Arc<PooledWebSocketExecutor> {
+    fn executor_name(&self) -> &str {
+        (**self).executor_name()
+    }
+
+    fn endpoint(&self) -> &Uri {
+        (**self).endpoint()
+    }
+
+    async fn execute<'a>(
+        &self,
+        execution_request: SubgraphExecutionRequest<'a>,
+        timeout: Option<Duration>,
+        plugin_req_state: Option<&'a PluginRequestState<'a>>,
+    ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
+        (**self)
+            .execute(execution_request, timeout, plugin_req_state)
+            .await
+    }
+
+    async fn subscribe<'a>(
+        &self,
+        execution_request: SubgraphExecutionRequest<'a>,
+        timeout: Option<Duration>,
+    ) -> Result<BoxStream<'static, SubscriptionItem>, SubgraphExecutorError> {
+        (**self).subscribe(execution_request, timeout).await
+    }
+}
+
+async fn own_connection(
+    mut client: WsClient<crate::executors::websocket_client::Initialized>,
+    mut dispatcher_done: ntex::channel::oneshot::Receiver<WsClientError>,
+    mut commands: mpsc::Receiver<ConnectionCommand>,
+    executor: Arc<PooledWebSocketExecutor>,
+    id: WebSocketConnectionId,
+    entries: Arc<DashMap<WebSocketConnectionId, PoolEntry>>,
+    idle_timeout: Duration,
+) {
+    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+    let mut active = 0usize;
+    let mut idle_expired = false;
+    loop {
+        tokio::select! {
+            command = commands.recv() => match command {
+                Some(ConnectionCommand::Subscribe { payload, custom_scalar_paths, responses }) => {
+                    match client.subscribe(payload, custom_scalar_paths).await {
+                        Ok(stream) => {
+                            active += 1;
+                            let telemetry_context = executor.telemetry_context.clone();
+                            let subgraph_name = executor.subgraph_name.clone();
+                            let endpoint = executor.endpoint.to_string();
+                            let completed_tx = completed_tx.clone();
+                            rt::spawn(async move {
+                                drain_into(
+                                    stream.map(|item| item.map_err(SubgraphExecutorError::from)),
+                                    responses,
+                                    &telemetry_context,
+                                    SubscriptionTransport::WebSocket,
+                                    &subgraph_name,
+                                    &endpoint,
+                                ).await;
+                                let _ = completed_tx.send(());
+                            });
+                        }
+                        Err(error) => {
+                            try_send_or_drop(
+                                &responses,
+                                Err(error.into()),
+                                &executor.telemetry_context,
+                                SubscriptionTransport::WebSocket,
+                                &executor.subgraph_name,
+                                &executor.endpoint.to_string(),
+                            );
+                        }
+                    }
+                }
+                None => break,
+            },
+            Some(()) = completed_rx.recv(), if active > 0 => active -= 1,
+            dispatcher = &mut dispatcher_done => {
+                let error = dispatcher.unwrap_or(WsClientError::MessageDispatcherClosed);
+                while let Ok(ConnectionCommand::Subscribe { responses, .. }) = commands.try_recv() {
+                    let _ = responses.try_send(Err(error.clone().into()));
+                }
+                break;
+            }
+            _ = tokio::time::sleep(idle_timeout), if active == 0 => {
+                idle_expired = true;
+                break;
+            },
+        }
+    }
+
+    if idle_expired {
+        executor
+            .telemetry_context
+            .metrics
+            .subscriptions
+            .record_websocket_pool_idle_expiration();
+    }
+    entries.remove_if(&id, |_, entry| {
+        matches!(
+            entry,
+            PoolEntry::Initialized(current)
+                if current.commands.same_channel(&executor.commands)
+        )
+    });
+}

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -645,13 +645,14 @@ impl ConnectionOwner {
                         break ConnectionShutdown::CommandsClosed;
                     };
 
+                    if responses.is_closed() {
+                        continue;
+                    }
+
                     if active_operations == 0 {
                         idle_timer
                             .as_mut()
                             .reset(Instant::now() + self.idle_timeout);
-                    }
-                    if responses.is_closed() {
-                        continue;
                     }
 
                     // writes stay serialized because WsClient mutates one subscription registry

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -15,9 +15,7 @@ use crate::{
     executors::{
         common::{ConnectionFingerprint, SubgraphExecutionRequest, SubgraphExecutor},
         error::SubgraphExecutorError,
-        graphql_transport_ws::{
-            build_connection_init_payload, build_subscribe_payload, SubscribePayload,
-        },
+        graphql_transport_ws::SubscribePayload,
         subscription_buffer::{drain_into, try_send_or_drop},
         websocket_client::{self, WsClient, WsClientError},
     },
@@ -177,8 +175,9 @@ async fn initialize_connection(
         .await
         .map_err(|error| PoolInitError::Connect(error.to_string()))?;
     let client = WsClient::new(wsconn);
+    let headers = init.headers;
     let mut client = client
-        .init(build_connection_init_payload(init.headers))
+        .init((!headers.is_empty()).then(|| headers.into()))
         .await
         .map_err(|error| PoolInitError::Handshake(error.to_string()))?;
     let dispatcher_done = client.take_dispatcher_done();
@@ -244,7 +243,7 @@ impl PooledWebSocketExecutor {
         response_capacity: usize,
     ) -> Result<mpsc::Receiver<SubscriptionItem>, SubgraphExecutorError> {
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
-        let payload = build_subscribe_payload(execution_request);
+        let payload = execution_request.into();
         let (responses, receiver) = mpsc::channel(response_capacity);
         if self
             .commands

--- a/lib/executor/src/executors/websocket_pool.rs
+++ b/lib/executor/src/executors/websocket_pool.rs
@@ -1,22 +1,28 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use async_trait::async_trait;
-use dashmap::DashMap;
-use futures::{channel::oneshot, stream::BoxStream, StreamExt};
+use dashmap::{mapref::entry::Entry, DashMap};
+use futures::{stream::BoxStream, StreamExt};
 use hive_router_internal::{
     telemetry::metrics::subscription_metrics::SubscriptionTransport, telemetry::TelemetryContext,
 };
 use hive_router_query_planner::planner::plan_nodes::CustomScalarPaths;
-use http::Uri;
+use http::{HeaderMap, Uri};
 use ntex::rt;
-use tokio::sync::mpsc;
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
 
 use crate::{
     executors::{
         common::{ConnectionFingerprint, SubgraphExecutionRequest, SubgraphExecutor},
         error::SubgraphExecutorError,
         graphql_transport_ws::SubscribePayload,
-        subscription_buffer::{drain_into, try_send_or_drop},
+        subscription_buffer::drain_into,
         websocket_client::{self, WsClient, WsClientError},
     },
     plugin_context::PluginRequestState,
@@ -25,17 +31,30 @@ use crate::{
 
 type SubscriptionItem = Result<SubgraphResponse<'static>, SubgraphExecutorError>;
 type InitResult = Result<Arc<PooledWebSocketExecutor>, PoolInitError>;
+type PoolEntries = DashMap<WebSocketConnectionId, PoolEntry>;
 
+/// Identifies one reusable, initialized subgraph WebSocket connection.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WebSocketConnectionId {
-    pub endpoint: Uri,
-    pub fingerprint: ConnectionFingerprint,
+    subgraph_name: Arc<str>,
+    fingerprint: ConnectionFingerprint,
+}
+
+impl WebSocketConnectionId {
+    pub fn new(subgraph_name: impl Into<Arc<str>>, fingerprint: ConnectionFingerprint) -> Self {
+        Self {
+            subgraph_name: subgraph_name.into(),
+            fingerprint,
+        }
+    }
 }
 
 // TODO: use thiserror and transparent and whatever to inherit errors #[from]
-#[derive(Clone)]
+#[derive(Clone, Debug, thiserror::Error)]
 enum PoolInitError {
+    #[error("WebSocket connection failed: {0}")]
     Connect(String),
+    #[error("WebSocket handshake failed: {0}")]
     Handshake(String),
 }
 
@@ -53,33 +72,35 @@ impl PoolInitError {
 }
 
 struct ConnectingEntry {
+    // each initialization attempt gets a unique token. an attempt can be canceled and replaced
+    // while its future or drop guard is still alive, so late cleanup must not remove the newer
+    // connecting entry and late success must not overwrite it. Arc::ptr_eq checks exact ownership.
+    generation: Arc<()>,
     waiters: Vec<oneshot::Sender<InitResult>>,
 }
 
+/// State for one connection identity.
+///
+/// A successful initialization replaces its exact `Connecting` generation with `Initialized`
+/// while the DashMap entry remains occupied. Failed or canceled attempts remove only their own
+/// generation, so stale work can never remove or overwrite a successor.
 enum PoolEntry {
     Connecting(ConnectingEntry),
     Initialized(Arc<PooledWebSocketExecutor>),
 }
 
 pub struct WebSocketInit {
-    pub headers: http::HeaderMap,
+    pub endpoint: Uri,
+    pub headers: HeaderMap,
     pub tls_config: Option<Arc<rustls::ClientConfig>>,
-    pub subgraph_name: String,
     pub buffer_capacity: usize,
     pub idle_timeout: Duration,
     pub telemetry_context: Arc<TelemetryContext>,
 }
 
+#[derive(Default)]
 pub struct WebSocketPool {
-    entries: Arc<DashMap<WebSocketConnectionId, PoolEntry>>,
-}
-
-impl Default for WebSocketPool {
-    fn default() -> Self {
-        Self {
-            entries: Arc::new(DashMap::new()),
-        }
-    }
+    entries: Arc<PoolEntries>,
 }
 
 impl WebSocketPool {
@@ -88,8 +109,10 @@ impl WebSocketPool {
         id: &WebSocketConnectionId,
     ) -> Option<Arc<PooledWebSocketExecutor>> {
         self.entries.get(id).and_then(|entry| match entry.value() {
-            PoolEntry::Initialized(executor) => Some(executor.clone()),
-            PoolEntry::Connecting(_) => None,
+            PoolEntry::Initialized(executor) if !executor.commands.is_closed() => {
+                Some(executor.clone())
+            }
+            PoolEntry::Connecting(_) | PoolEntry::Initialized(_) => None,
         })
     }
 
@@ -98,175 +121,273 @@ impl WebSocketPool {
         id: WebSocketConnectionId,
         init: WebSocketInit,
     ) -> Result<Arc<PooledWebSocketExecutor>, SubgraphExecutorError> {
-        let (wait_tx, wait_rx) = oneshot::channel();
-        let initialize = match self.entries.entry(id.clone()) {
-            dashmap::mapref::entry::Entry::Occupied(mut entry) => match entry.get_mut() {
-                PoolEntry::Initialized(executor) => return Ok(executor.clone()),
+        let endpoint = init.endpoint.clone();
+        let (wait_rx, generation) = match self.entries.entry(id.clone()) {
+            Entry::Occupied(mut entry) => match entry.get_mut() {
+                PoolEntry::Initialized(executor) if !executor.commands.is_closed() => {
+                    return Ok(executor.clone());
+                }
                 PoolEntry::Connecting(connecting) => {
-                    init.telemetry_context
-                        .metrics
-                        .subscriptions
-                        .record_websocket_pool_initialization_joined();
+                    connecting.waiters.retain(|waiter| !waiter.is_closed());
+                    let (wait_tx, wait_rx) = oneshot::channel();
                     connecting.waiters.push(wait_tx);
-                    false
+                    (wait_rx, None)
+                }
+                PoolEntry::Initialized(_) => {
+                    // the owner closes commands before eviction. replace a closed entry in place
+                    // so callers never join an executor that can no longer accept work.
+                    let generation = Arc::new(());
+                    let (wait_tx, wait_rx) = oneshot::channel();
+                    entry.insert(PoolEntry::Connecting(ConnectingEntry {
+                        generation: generation.clone(),
+                        waiters: vec![wait_tx],
+                    }));
+                    (wait_rx, Some(generation))
                 }
             },
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                init.telemetry_context
-                    .metrics
-                    .subscriptions
-                    .record_websocket_pool_initialization_started();
+            Entry::Vacant(entry) => {
+                let generation = Arc::new(());
+                let (wait_tx, wait_rx) = oneshot::channel();
                 entry.insert(PoolEntry::Connecting(ConnectingEntry {
+                    generation: generation.clone(),
                     waiters: vec![wait_tx],
                 }));
-                true
+                (wait_rx, Some(generation))
             }
         };
 
-        if initialize {
-            let entries = self.entries.clone();
-            let task_id = id.clone();
+        if let Some(generation) = generation {
+            init.telemetry_context
+                .metrics
+                .subscriptions
+                .record_websocket_pool_initialization_started();
+
+            let cleanup = InitializationCleanup::new(self.entries.clone(), id.clone(), generation);
             let telemetry_context = init.telemetry_context.clone();
             rt::spawn(async move {
-                let initialized =
-                    initialize_connection(entries.clone(), task_id.clone(), init).await;
-                if initialized.is_err() {
-                    telemetry_context
-                        .metrics
-                        .subscriptions
-                        .record_websocket_pool_initialization_failed();
-                }
-                let waiters = match entries.remove(&task_id) {
-                    Some((_, PoolEntry::Connecting(connecting))) => connecting.waiters,
-                    Some((_, initialized @ PoolEntry::Initialized(_))) => {
-                        entries.insert(task_id.clone(), initialized);
-                        Vec::new()
-                    }
-                    None => Vec::new(),
-                };
+                let mut cleanup = cleanup;
+                match initialize_connection(&cleanup.entries, &cleanup.id, init).await {
+                    Ok(connection) => {
+                        let executor = connection.executor.clone();
+                        let Some(waiters) = cleanup.publish(executor.clone()) else {
+                            return;
+                        };
 
-                let result = match initialized {
-                    Ok((executor, start_owner)) => {
-                        entries.insert(task_id, PoolEntry::Initialized(executor.clone()));
-                        let _ = start_owner.send(());
-                        Ok(executor)
+                        // publication happens first, so even an immediately exiting owner can only
+                        // evict the initialized generation it actually owns.
+                        rt::spawn(connection.owner.run());
+                        notify_waiters(waiters, Ok(executor));
                     }
-                    Err(error) => Err(error),
-                };
-                for waiter in waiters {
-                    let _ = waiter.send(result.clone());
+                    Err(error) => {
+                        telemetry_context
+                            .metrics
+                            .subscriptions
+                            .record_websocket_pool_initialization_failed();
+                        let waiters = cleanup.remove();
+                        notify_waiters(waiters, Err(error));
+                    }
                 }
             });
+        } else {
+            init.telemetry_context
+                .metrics
+                .subscriptions
+                .record_websocket_pool_initialization_joined();
         }
 
         wait_rx
             .await
             .map_err(|_| SubgraphExecutorError::WebSocketArbiterChannelClosed)?
-            .map_err(|error| error.into_executor_error(&id.endpoint))
+            .map_err(|error| error.into_executor_error(&endpoint))
     }
 }
 
-async fn initialize_connection(
-    entries: Arc<DashMap<WebSocketConnectionId, PoolEntry>>,
+fn notify_waiters(waiters: Vec<oneshot::Sender<InitResult>>, result: InitResult) {
+    for waiter in waiters {
+        let _ = waiter.send(result.clone());
+    }
+}
+
+struct InitializationCleanup {
+    entries: Arc<PoolEntries>,
     id: WebSocketConnectionId,
+    generation: Arc<()>,
+    armed: bool,
+}
+
+impl InitializationCleanup {
+    fn new(entries: Arc<PoolEntries>, id: WebSocketConnectionId, generation: Arc<()>) -> Self {
+        Self {
+            entries,
+            id,
+            generation,
+            armed: true,
+        }
+    }
+
+    fn publish(
+        &mut self,
+        executor: Arc<PooledWebSocketExecutor>,
+    ) -> Option<Vec<oneshot::Sender<InitResult>>> {
+        let waiters = match self.entries.entry(self.id.clone()) {
+            Entry::Occupied(mut entry) => {
+                let PoolEntry::Connecting(connecting) = entry.get_mut() else {
+                    return None;
+                };
+                if !Arc::ptr_eq(&connecting.generation, &self.generation) {
+                    return None;
+                }
+
+                let waiters = std::mem::take(&mut connecting.waiters);
+                entry.insert(PoolEntry::Initialized(executor));
+                waiters
+            }
+            Entry::Vacant(_) => return None,
+        };
+
+        self.armed = false;
+        Some(waiters)
+    }
+
+    fn remove(&mut self) -> Vec<oneshot::Sender<InitResult>> {
+        let removed = self.entries.remove_if(&self.id, |_, entry| {
+            matches!(
+                entry,
+                PoolEntry::Connecting(connecting)
+                    if Arc::ptr_eq(&connecting.generation, &self.generation)
+            )
+        });
+        self.armed = false;
+
+        match removed {
+            Some((_, PoolEntry::Connecting(connecting))) => connecting.waiters,
+            Some((_, PoolEntry::Initialized(_))) | None => Vec::new(),
+        }
+    }
+}
+
+impl Drop for InitializationCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            // dropping the stored senders wakes every waiter with a channel-closed error. this
+            // also handles task cancellation and unwinding without leaving a zombie entry.
+            let _ = self.entries.remove_if(&self.id, |_, entry| {
+                matches!(
+                    entry,
+                    PoolEntry::Connecting(connecting)
+                        if Arc::ptr_eq(&connecting.generation, &self.generation)
+                )
+            });
+        }
+    }
+}
+
+struct InitializedConnection {
+    executor: Arc<PooledWebSocketExecutor>,
+    owner: ConnectionOwner,
+}
+
+async fn initialize_connection(
+    entries: &Arc<PoolEntries>,
+    id: &WebSocketConnectionId,
     init: WebSocketInit,
-) -> Result<(Arc<PooledWebSocketExecutor>, oneshot::Sender<()>), PoolInitError> {
-    let wsconn = websocket_client::connect(&id.endpoint, init.tls_config)
+) -> Result<InitializedConnection, PoolInitError> {
+    let wsconn = websocket_client::connect(&init.endpoint, init.tls_config)
         .await
         .map_err(|error| PoolInitError::Connect(error.to_string()))?;
     let client = WsClient::new(wsconn);
-    let headers = init.headers;
+    let init_payload = (!init.headers.is_empty()).then(|| init.headers.into());
     let mut client = client
-        .init((!headers.is_empty()).then(|| headers.into()))
+        .init(init_payload)
         .await
         .map_err(|error| PoolInitError::Handshake(error.to_string()))?;
     let dispatcher_done = client.take_dispatcher_done();
     let (commands, task_commands) = mpsc::channel(init.buffer_capacity);
+    let endpoint = Arc::<str>::from(init.endpoint.to_string());
     let executor = Arc::new(PooledWebSocketExecutor {
-        endpoint: id.endpoint.clone(),
         commands,
         telemetry_context: init.telemetry_context.clone(),
-        subgraph_name: init.subgraph_name.clone(),
         buffer_capacity: init.buffer_capacity,
-        entries: Arc::downgrade(&entries),
+        entries: Arc::downgrade(entries),
         id: id.clone(),
+        endpoint_uri: init.endpoint,
+        endpoint: endpoint.clone(),
     });
+    let owner = ConnectionOwner {
+        client,
+        dispatcher_done,
+        commands: task_commands,
+        executor: Arc::downgrade(&executor),
+        telemetry_context: init.telemetry_context,
+        subgraph_name: id.subgraph_name.clone(),
+        endpoint,
+        idle_timeout: init.idle_timeout,
+    };
 
-    let task_executor = executor.clone();
-    let (start_owner, start_owner_rx) = oneshot::channel();
-    rt::spawn(async move {
-        if start_owner_rx.await.is_err() {
-            return;
-        }
-        let _connection_guard = init
-            .telemetry_context
-            .metrics
-            .subscriptions
-            .active_subgraph_connection(&init.subgraph_name, SubscriptionTransport::WebSocket);
-        own_connection(
-            client,
-            dispatcher_done,
-            task_commands,
-            task_executor,
-            id,
-            entries,
-            init.idle_timeout,
-        )
-        .await;
-    });
-
-    Ok((executor, start_owner))
+    Ok(InitializedConnection { executor, owner })
 }
 
-enum ConnectionCommand {
-    Subscribe {
-        payload: SubscribePayload,
-        custom_scalar_paths: Option<CustomScalarPaths>,
-        responses: mpsc::Sender<SubscriptionItem>,
-    },
+struct ConnectionCommand {
+    payload: SubscribePayload,
+    custom_scalar_paths: Option<CustomScalarPaths>,
+    responses: mpsc::Sender<SubscriptionItem>,
+    ready: oneshot::Sender<Result<(), WsClientError>>,
 }
 
 pub struct PooledWebSocketExecutor {
-    endpoint: Uri,
     commands: mpsc::Sender<ConnectionCommand>,
     telemetry_context: Arc<TelemetryContext>,
-    subgraph_name: String,
     buffer_capacity: usize,
-    entries: std::sync::Weak<DashMap<WebSocketConnectionId, PoolEntry>>,
+    entries: Weak<PoolEntries>,
     id: WebSocketConnectionId,
+    endpoint_uri: Uri,
+    endpoint: Arc<str>,
 }
 
 impl PooledWebSocketExecutor {
+    fn evict_if_current(&self) {
+        if let Some(entries) = self.entries.upgrade() {
+            entries.remove_if(&self.id, |_, entry| {
+                matches!(
+                    entry,
+                    PoolEntry::Initialized(current)
+                        if current.commands.same_channel(&self.commands)
+                )
+            });
+        }
+    }
+
     async fn submit(
         &self,
         execution_request: SubgraphExecutionRequest<'_>,
         response_capacity: usize,
     ) -> Result<mpsc::Receiver<SubscriptionItem>, SubgraphExecutorError> {
+        // reserve first so canceled callers do not build payloads or occupy response buffers while
+        // waiting behind a full shared command queue.
+        let permit = self.commands.reserve().await.map_err(|_| {
+            self.evict_if_current();
+            SubgraphExecutorError::WebSocketArbiterChannelClosed
+        })?;
+
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
         let payload = execution_request.into();
         let (responses, receiver) = mpsc::channel(response_capacity);
-        if self
-            .commands
-            .send(ConnectionCommand::Subscribe {
-                payload,
-                custom_scalar_paths,
-                responses,
-            })
-            .await
-            .is_err()
-        {
-            if let Some(entries) = self.entries.upgrade() {
-                entries.remove_if(&self.id, |_, entry| {
-                    matches!(
-                        entry,
-                        PoolEntry::Initialized(current)
-                            if current.commands.same_channel(&self.commands)
-                    )
-                });
+        let (ready, ready_rx) = oneshot::channel();
+        permit.send(ConnectionCommand {
+            payload,
+            custom_scalar_paths,
+            responses,
+            ready,
+        });
+
+        match ready_rx.await {
+            Ok(Ok(())) => Ok(receiver),
+            Ok(Err(error)) => Err(error.into()),
+            Err(_) => {
+                self.evict_if_current();
+                Err(SubgraphExecutorError::WebSocketArbiterChannelClosed)
             }
-            return Err(SubgraphExecutorError::WebSocketArbiterChannelClosed);
         }
-        Ok(receiver)
     }
 }
 
@@ -277,7 +398,7 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
     }
 
     fn endpoint(&self) -> &Uri {
-        &self.endpoint
+        &self.endpoint_uri
     }
 
     async fn execute<'a>(
@@ -286,18 +407,16 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
         timeout: Option<Duration>,
         _plugin_req_state: Option<&'a PluginRequestState<'a>>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
-        let endpoint = self.endpoint.to_string();
         let _operation_guard = self
             .telemetry_context
             .metrics
             .subscriptions
-            .active_subgraph_operation(&self.subgraph_name);
+            .active_subgraph_operation(&self.id.subgraph_name);
         let operation = async {
             let mut responses = self.submit(execution_request, 1).await?;
-            responses
-                .recv()
-                .await
-                .ok_or(SubgraphExecutorError::WebSocketStreamClosedEmpty(endpoint))?
+            responses.recv().await.ok_or_else(|| {
+                SubgraphExecutorError::WebSocketStreamClosedEmpty(self.endpoint.to_string())
+            })?
         };
         match timeout {
             Some(timeout) => tokio::time::timeout(timeout, operation).await?,
@@ -310,12 +429,13 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
         execution_request: SubgraphExecutionRequest<'a>,
         _timeout: Option<Duration>,
     ) -> Result<BoxStream<'static, SubscriptionItem>, SubgraphExecutorError> {
+        // timeout covers queueing and the subscribe write, not the lifetime of the returned stream.
         let mut responses = self.submit(execution_request, self.buffer_capacity).await?;
         let operation_guard = self
             .telemetry_context
             .metrics
             .subscriptions
-            .active_subgraph_operation(&self.subgraph_name);
+            .active_subgraph_operation(&self.id.subgraph_name);
         Ok(Box::pin(async_stream::stream! {
             let _operation_guard = operation_guard;
             while let Some(item) = responses.recv().await {
@@ -328,11 +448,11 @@ impl SubgraphExecutor for PooledWebSocketExecutor {
 #[async_trait]
 impl SubgraphExecutor for Arc<PooledWebSocketExecutor> {
     fn executor_name(&self) -> &str {
-        (**self).executor_name()
+        self.as_ref().executor_name()
     }
 
     fn endpoint(&self) -> &Uri {
-        (**self).endpoint()
+        self.as_ref().endpoint()
     }
 
     async fn execute<'a>(
@@ -341,7 +461,7 @@ impl SubgraphExecutor for Arc<PooledWebSocketExecutor> {
         timeout: Option<Duration>,
         plugin_req_state: Option<&'a PluginRequestState<'a>>,
     ) -> Result<SubgraphResponse<'static>, SubgraphExecutorError> {
-        (**self)
+        self.as_ref()
             .execute(execution_request, timeout, plugin_req_state)
             .await
     }
@@ -351,34 +471,128 @@ impl SubgraphExecutor for Arc<PooledWebSocketExecutor> {
         execution_request: SubgraphExecutionRequest<'a>,
         timeout: Option<Duration>,
     ) -> Result<BoxStream<'static, SubscriptionItem>, SubgraphExecutorError> {
-        (**self).subscribe(execution_request, timeout).await
+        self.as_ref().subscribe(execution_request, timeout).await
     }
 }
 
-async fn own_connection(
-    mut client: WsClient<crate::executors::websocket_client::Initialized>,
-    mut dispatcher_done: ntex::channel::oneshot::Receiver<WsClientError>,
-    mut commands: mpsc::Receiver<ConnectionCommand>,
-    executor: Arc<PooledWebSocketExecutor>,
-    id: WebSocketConnectionId,
-    entries: Arc<DashMap<WebSocketConnectionId, PoolEntry>>,
+struct OperationCompletionGuard(mpsc::UnboundedSender<()>);
+
+impl Drop for OperationCompletionGuard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+enum ConnectionShutdown {
+    Idle,
+    Dispatcher(WsClientError),
+    CommandsClosed,
+}
+
+impl ConnectionShutdown {
+    fn command_error(&self) -> WsClientError {
+        match self {
+            Self::Idle => WsClientError::ConnectionClosed,
+            Self::Dispatcher(error) => error.clone(),
+            Self::CommandsClosed => WsClientError::MessageDispatcherClosed,
+        }
+    }
+}
+
+/// Owns the non-`Send` WebSocket client and serializes all writes to its protocol state.
+///
+/// The owner closes command intake before eviction and drains every command accepted before the
+/// close. This gives each submitter either a started operation or an explicit error, including when
+/// idle expiration races with command submission.
+struct ConnectionOwner {
+    client: WsClient<crate::executors::websocket_client::Initialized>,
+    dispatcher_done: ntex::channel::oneshot::Receiver<WsClientError>,
+    commands: mpsc::Receiver<ConnectionCommand>,
+    executor: Weak<PooledWebSocketExecutor>,
+    telemetry_context: Arc<TelemetryContext>,
+    subgraph_name: Arc<str>,
+    endpoint: Arc<str>,
     idle_timeout: Duration,
-) {
-    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
-    let mut active = 0usize;
-    let mut idle_expired = false;
-    loop {
-        tokio::select! {
-            command = commands.recv() => match command {
-                Some(ConnectionCommand::Subscribe { payload, custom_scalar_paths, responses }) => {
-                    match client.subscribe(payload, custom_scalar_paths).await {
+}
+
+impl ConnectionOwner {
+    fn evict(&self) {
+        if let Some(executor) = self.executor.upgrade() {
+            executor.evict_if_current();
+        }
+    }
+
+    async fn run(mut self) {
+        let telemetry_context = self.telemetry_context.clone();
+        let subgraph_name = self.subgraph_name.clone();
+        let _connection_guard = telemetry_context
+            .metrics
+            .subscriptions
+            .active_subgraph_connection(&subgraph_name, SubscriptionTransport::WebSocket);
+        let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+        let mut active_operations = 0usize;
+        let idle_timer = tokio::time::sleep(self.idle_timeout);
+        tokio::pin!(idle_timer);
+
+        let shutdown = 'connection: loop {
+            tokio::select! {
+                command = self.commands.recv() => {
+                    let Some(ConnectionCommand {
+                        payload,
+                        custom_scalar_paths,
+                        responses,
+                        ready,
+                    }) = command else {
+                        break ConnectionShutdown::CommandsClosed;
+                    };
+
+                    if active_operations == 0 {
+                        idle_timer
+                            .as_mut()
+                            .reset(Instant::now() + self.idle_timeout);
+                    }
+                    if responses.is_closed() {
+                        continue;
+                    }
+
+                    // writes stay serialized because WsClient mutates one subscription registry
+                    // and one sink. the cancellation branch is safe because WsClient removes a
+                    // partially registered operation with its own drop guard.
+                    let subscribe_result = {
+                        let subscribe = self.client.subscribe(payload, custom_scalar_paths);
+                        tokio::pin!(subscribe);
+                        tokio::select! {
+                            result = &mut subscribe => Some(result),
+                            _ = responses.closed() => None,
+                            dispatcher = &mut self.dispatcher_done => {
+                                let error = dispatcher
+                                    .unwrap_or(WsClientError::MessageDispatcherClosed);
+                                let _ = ready.send(Err(error.clone()));
+                                break 'connection ConnectionShutdown::Dispatcher(error);
+                            }
+                        }
+                    };
+
+                    let Some(subscribe_result) = subscribe_result else {
+                        continue;
+                    };
+                    match subscribe_result {
                         Ok(stream) => {
-                            active += 1;
-                            let telemetry_context = executor.telemetry_context.clone();
-                            let subgraph_name = executor.subgraph_name.clone();
-                            let endpoint = executor.endpoint.to_string();
-                            let completed_tx = completed_tx.clone();
+                            // if the caller timed out after the write, dropping the stream sends
+                            // complete immediately instead of starting work nobody can consume.
+                            if ready.send(Ok(())).is_err() {
+                                drop(stream);
+                                continue;
+                            }
+
+                            active_operations += 1;
+                            let completion_guard =
+                                OperationCompletionGuard(completed_tx.clone());
+                            let telemetry_context = self.telemetry_context.clone();
+                            let subgraph_name = self.subgraph_name.clone();
+                            let endpoint = self.endpoint.clone();
                             rt::spawn(async move {
+                                let _completion_guard = completion_guard;
                                 drain_into(
                                     stream.map(|item| item.map_err(SubgraphExecutorError::from)),
                                     responses,
@@ -386,51 +600,55 @@ async fn own_connection(
                                     SubscriptionTransport::WebSocket,
                                     &subgraph_name,
                                     &endpoint,
-                                ).await;
-                                let _ = completed_tx.send(());
+                                )
+                                .await;
                             });
                         }
                         Err(error) => {
-                            try_send_or_drop(
-                                &responses,
-                                Err(error.into()),
-                                &executor.telemetry_context,
-                                SubscriptionTransport::WebSocket,
-                                &executor.subgraph_name,
-                                &executor.endpoint.to_string(),
-                            );
+                            let _ = ready.send(Err(error));
                         }
                     }
                 }
-                None => break,
-            },
-            Some(()) = completed_rx.recv(), if active > 0 => active -= 1,
-            dispatcher = &mut dispatcher_done => {
-                let error = dispatcher.unwrap_or(WsClientError::MessageDispatcherClosed);
-                while let Ok(ConnectionCommand::Subscribe { responses, .. }) = commands.try_recv() {
-                    let _ = responses.try_send(Err(error.clone().into()));
+                Some(()) = completed_rx.recv(), if active_operations > 0 => {
+                    active_operations -= 1;
+                    if active_operations == 0 {
+                        idle_timer
+                            .as_mut()
+                            .reset(Instant::now() + self.idle_timeout);
+                    }
                 }
-                break;
+                dispatcher = &mut self.dispatcher_done => {
+                    break ConnectionShutdown::Dispatcher(
+                        dispatcher.unwrap_or(WsClientError::MessageDispatcherClosed),
+                    );
+                }
+                _ = &mut idle_timer, if active_operations == 0 => {
+                    break ConnectionShutdown::Idle;
+                }
             }
-            _ = tokio::time::sleep(idle_timeout), if active == 0 => {
-                idle_expired = true;
-                break;
-            },
+        };
+
+        // close first so new reservations fail, evict next so lookups miss, then wait for any
+        // reservation acquired before close and reject every command it committed.
+        self.commands.close();
+        self.evict();
+        while let Some(command) = self.commands.recv().await {
+            let _ = command.ready.send(Err(shutdown.command_error()));
+        }
+
+        if matches!(shutdown, ConnectionShutdown::Idle) {
+            self.telemetry_context
+                .metrics
+                .subscriptions
+                .record_websocket_pool_idle_expiration();
         }
     }
+}
 
-    if idle_expired {
-        executor
-            .telemetry_context
-            .metrics
-            .subscriptions
-            .record_websocket_pool_idle_expiration();
+impl Drop for ConnectionOwner {
+    fn drop(&mut self) {
+        // this is the unwind/cancellation path; normal shutdown already performed both operations.
+        self.commands.close();
+        self.evict();
     }
-    entries.remove_if(&id, |_, entry| {
-        matches!(
-            entry,
-            PoolEntry::Initialized(current)
-                if current.commands.same_channel(&executor.commands)
-        )
-    });
 }

--- a/lib/internal/src/telemetry/logging/targets.rs
+++ b/lib/internal/src/telemetry/logging/targets.rs
@@ -18,6 +18,7 @@ pub const EXECUTOR: &str = "router::executor";
 pub const HIVE_USAGE_REPORTING: &str = "router::usage_reporting";
 pub const WEBSOCKET_SERVER: &str = "router::websocket_server";
 pub const WEBSOCKET_CLIENT: &str = "router::websocket_client";
+pub const WEBSOCKET_POOL: &str = "router::websocket_pool";
 pub const HTTP_CALLBACK: &str = "router::http_callback";
 pub const PLUGIN_SYSTEM: &str = "router::plugin_system";
 pub const SUPERGRAPH: &str = "router::supergraph";

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -213,9 +213,30 @@ pub mod names {
         "hive.router.subscriptions.clients.lagged_messages_total";
     pub const SUBSCRIPTIONS_CLIENTS_SENT_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.sent_messages_total";
+    pub const WEBSOCKET_POOL_INITIALIZATION_STARTED_TOTAL: &str =
+        "hive.router.websocket_pool.initialization_started_total";
+    pub const WEBSOCKET_POOL_INITIALIZATION_JOINED_TOTAL: &str =
+        "hive.router.websocket_pool.initialization_joined_total";
+    pub const WEBSOCKET_POOL_INITIALIZATION_FAILED_TOTAL: &str =
+        "hive.router.websocket_pool.initialization_failed_total";
+    pub const WEBSOCKET_POOL_SUBSCRIPTION_HITS_TOTAL: &str =
+        "hive.router.websocket_pool.subscription_hits_total";
+    pub const WEBSOCKET_POOL_EXECUTE_HITS_TOTAL: &str =
+        "hive.router.websocket_pool.execute_hits_total";
+    pub const WEBSOCKET_POOL_EXECUTE_MISSES_TOTAL: &str =
+        "hive.router.websocket_pool.execute_misses_total";
+    pub const WEBSOCKET_POOL_IDLE_EXPIRATIONS_TOTAL: &str =
+        "hive.router.websocket_pool.idle_expirations_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
+    (names::WEBSOCKET_POOL_INITIALIZATION_STARTED_TOTAL, &[]),
+    (names::WEBSOCKET_POOL_INITIALIZATION_JOINED_TOTAL, &[]),
+    (names::WEBSOCKET_POOL_INITIALIZATION_FAILED_TOTAL, &[]),
+    (names::WEBSOCKET_POOL_SUBSCRIPTION_HITS_TOTAL, &[]),
+    (names::WEBSOCKET_POOL_EXECUTE_HITS_TOTAL, &[]),
+    (names::WEBSOCKET_POOL_EXECUTE_MISSES_TOTAL, &[]),
+    (names::WEBSOCKET_POOL_IDLE_EXPIRATIONS_TOTAL, &[]),
     (
         names::SUBSCRIPTIONS_SUBGRAPHS_ACTIVE,
         &[labels::SUBGRAPH_NAME],

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -141,6 +141,9 @@ pub mod labels {
     pub const COPROCESSOR_STAGE: &str = "coprocessor.stage";
     pub const CIRCUIT_BREAKER_FROM_STATE: &str = "circuit_breaker.from_state";
     pub const CIRCUIT_BREAKER_TO_STATE: &str = "circuit_breaker.to_state";
+    pub const WEBSOCKET_POOL_OPERATION_TYPE: &str = "websocket_pool.operation.type";
+    pub const WEBSOCKET_POOL_CONNECTION_CLOSE_REASON: &str =
+        "websocket_pool.connection.close_reason";
 }
 
 pub mod units {
@@ -213,30 +216,54 @@ pub mod names {
         "hive.router.subscriptions.clients.lagged_messages_total";
     pub const SUBSCRIPTIONS_CLIENTS_SENT_MESSAGES_TOTAL: &str =
         "hive.router.subscriptions.clients.sent_messages_total";
-    pub const WEBSOCKET_POOL_INITIALIZATION_STARTED_TOTAL: &str =
-        "hive.router.websocket_pool.initialization_started_total";
-    pub const WEBSOCKET_POOL_INITIALIZATION_JOINED_TOTAL: &str =
-        "hive.router.websocket_pool.initialization_joined_total";
-    pub const WEBSOCKET_POOL_INITIALIZATION_FAILED_TOTAL: &str =
-        "hive.router.websocket_pool.initialization_failed_total";
-    pub const WEBSOCKET_POOL_SUBSCRIPTION_HITS_TOTAL: &str =
-        "hive.router.websocket_pool.subscription_hits_total";
-    pub const WEBSOCKET_POOL_EXECUTE_HITS_TOTAL: &str =
-        "hive.router.websocket_pool.execute_hits_total";
-    pub const WEBSOCKET_POOL_EXECUTE_MISSES_TOTAL: &str =
-        "hive.router.websocket_pool.execute_misses_total";
-    pub const WEBSOCKET_POOL_IDLE_EXPIRATIONS_TOTAL: &str =
-        "hive.router.websocket_pool.idle_expirations_total";
+    pub const WEBSOCKET_POOL_CONNECTIONS_ACTIVE: &str =
+        "hive.router.websocket_pool.connections.active";
+    pub const WEBSOCKET_POOL_CONNECTION_INITIALIZATIONS_TOTAL: &str =
+        "hive.router.websocket_pool.connections.initializations_total";
+    pub const WEBSOCKET_POOL_CONNECTION_INITIALIZATION_WAITERS_TOTAL: &str =
+        "hive.router.websocket_pool.connections.initialization_waiters_total";
+    pub const WEBSOCKET_POOL_CONNECTION_LOOKUPS_TOTAL: &str =
+        "hive.router.websocket_pool.connections.lookups_total";
+    pub const WEBSOCKET_POOL_CONNECTIONS_CLOSED_TOTAL: &str =
+        "hive.router.websocket_pool.connections.closed_total";
+    pub const WEBSOCKET_POOL_OPERATIONS_ACTIVE: &str =
+        "hive.router.websocket_pool.operations.active";
+    pub const WEBSOCKET_POOL_OPERATIONS_STARTED_TOTAL: &str =
+        "hive.router.websocket_pool.operations.started_total";
 }
 
 pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
-    (names::WEBSOCKET_POOL_INITIALIZATION_STARTED_TOTAL, &[]),
-    (names::WEBSOCKET_POOL_INITIALIZATION_JOINED_TOTAL, &[]),
-    (names::WEBSOCKET_POOL_INITIALIZATION_FAILED_TOTAL, &[]),
-    (names::WEBSOCKET_POOL_SUBSCRIPTION_HITS_TOTAL, &[]),
-    (names::WEBSOCKET_POOL_EXECUTE_HITS_TOTAL, &[]),
-    (names::WEBSOCKET_POOL_EXECUTE_MISSES_TOTAL, &[]),
-    (names::WEBSOCKET_POOL_IDLE_EXPIRATIONS_TOTAL, &[]),
+    (
+        names::WEBSOCKET_POOL_CONNECTIONS_ACTIVE,
+        &[labels::SUBGRAPH_NAME],
+    ),
+    (
+        names::WEBSOCKET_POOL_CONNECTION_INITIALIZATIONS_TOTAL,
+        &[labels::SUBGRAPH_NAME, labels::RESULT],
+    ),
+    (
+        names::WEBSOCKET_POOL_CONNECTION_INITIALIZATION_WAITERS_TOTAL,
+        &[labels::SUBGRAPH_NAME],
+    ),
+    (
+        names::WEBSOCKET_POOL_CONNECTION_LOOKUPS_TOTAL,
+        &[labels::SUBGRAPH_NAME, labels::RESULT],
+    ),
+    (
+        names::WEBSOCKET_POOL_CONNECTIONS_CLOSED_TOTAL,
+        &[
+            labels::SUBGRAPH_NAME,
+            labels::WEBSOCKET_POOL_CONNECTION_CLOSE_REASON,
+        ],
+    ),
+    (
+        names::WEBSOCKET_POOL_OPERATIONS_ACTIVE,
+        &[labels::SUBGRAPH_NAME, labels::WEBSOCKET_POOL_OPERATION_TYPE],
+    ),
+    (
+        names::WEBSOCKET_POOL_OPERATIONS_STARTED_TOTAL,
+        &[labels::SUBGRAPH_NAME, labels::WEBSOCKET_POOL_OPERATION_TYPE],
+    ),
     (
         names::SUBSCRIPTIONS_SUBGRAPHS_ACTIVE,
         &[labels::SUBGRAPH_NAME],

--- a/lib/internal/src/telemetry/metrics/mod.rs
+++ b/lib/internal/src/telemetry/metrics/mod.rs
@@ -11,6 +11,7 @@ pub mod persisted_documents_metrics;
 pub mod setup;
 pub mod subscription_metrics;
 pub mod supergraph_metrics;
+pub mod websocket_pool_metrics;
 pub use opentelemetry::metrics::ObservableGauge;
 pub use setup::{build_meter_provider_from_config, MetricsSetup, PrometheusRuntimeConfig};
 
@@ -26,6 +27,7 @@ use crate::telemetry::metrics::http_server_metrics::HttpServerMetrics;
 use crate::telemetry::metrics::persisted_documents_metrics::PersistedDocumentsMetrics;
 use crate::telemetry::metrics::subscription_metrics::SubscriptionMetrics;
 use crate::telemetry::metrics::supergraph_metrics::SupergraphMetrics;
+use crate::telemetry::metrics::websocket_pool_metrics::WebSocketPoolMetrics;
 
 pub struct Metrics {
     pub http_server: HttpServerMetrics,
@@ -38,6 +40,7 @@ pub struct Metrics {
     pub persisted_documents: PersistedDocumentsMetrics,
     pub coprocessor: CoprocessorMetrics,
     pub subscriptions: SubscriptionMetrics,
+    pub websocket_pool: WebSocketPoolMetrics,
 }
 
 impl Metrics {
@@ -53,6 +56,7 @@ impl Metrics {
             persisted_documents: PersistedDocumentsMetrics::new(meter),
             coprocessor: CoprocessorMetrics::new(meter),
             subscriptions: SubscriptionMetrics::new(meter),
+            websocket_pool: WebSocketPoolMetrics::new(meter),
         }
     }
 }

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -38,13 +38,6 @@ pub struct SubscriptionMetrics {
     clients_ended_total: Option<Counter<u64>>,
     clients_lagged_messages_total: Option<Counter<u64>>,
     clients_sent_messages_total: Option<Counter<u64>>,
-    websocket_pool_initialization_started_total: Option<Counter<u64>>,
-    websocket_pool_initialization_joined_total: Option<Counter<u64>>,
-    websocket_pool_initialization_failed_total: Option<Counter<u64>>,
-    websocket_pool_subscription_hits_total: Option<Counter<u64>>,
-    websocket_pool_execute_hits_total: Option<Counter<u64>>,
-    websocket_pool_execute_misses_total: Option<Counter<u64>>,
-    websocket_pool_idle_expirations_total: Option<Counter<u64>>,
 }
 
 impl SubscriptionMetrics {
@@ -119,37 +112,6 @@ impl SubscriptionMetrics {
                 .with_unit(units::MESSAGES)
                 .build()
         });
-        let counter = |name, description| {
-            meter.map(|m| m.u64_counter(name).with_description(description).build())
-        };
-        let websocket_pool_initialization_started_total = counter(
-            names::WEBSOCKET_POOL_INITIALIZATION_STARTED_TOTAL,
-            "Pooled WebSocket connection initializations started.",
-        );
-        let websocket_pool_initialization_joined_total = counter(
-            names::WEBSOCKET_POOL_INITIALIZATION_JOINED_TOTAL,
-            "Pooled WebSocket connection initializations joined.",
-        );
-        let websocket_pool_initialization_failed_total = counter(
-            names::WEBSOCKET_POOL_INITIALIZATION_FAILED_TOTAL,
-            "Pooled WebSocket connection initializations failed.",
-        );
-        let websocket_pool_subscription_hits_total = counter(
-            names::WEBSOCKET_POOL_SUBSCRIPTION_HITS_TOTAL,
-            "Subscriptions routed through pooled WebSocket connections.",
-        );
-        let websocket_pool_execute_hits_total = counter(
-            names::WEBSOCKET_POOL_EXECUTE_HITS_TOTAL,
-            "Executions routed through pooled WebSocket connections.",
-        );
-        let websocket_pool_execute_misses_total = counter(
-            names::WEBSOCKET_POOL_EXECUTE_MISSES_TOTAL,
-            "Executions without a matching pooled WebSocket connection.",
-        );
-        let websocket_pool_idle_expirations_total = counter(
-            names::WEBSOCKET_POOL_IDLE_EXPIRATIONS_TOTAL,
-            "Pooled WebSocket connections closed after becoming idle.",
-        );
         Self {
             subgraphs_active,
             subgraphs_connections,
@@ -162,13 +124,6 @@ impl SubscriptionMetrics {
             clients_ended_total,
             clients_lagged_messages_total,
             clients_sent_messages_total,
-            websocket_pool_initialization_started_total,
-            websocket_pool_initialization_joined_total,
-            websocket_pool_initialization_failed_total,
-            websocket_pool_subscription_hits_total,
-            websocket_pool_execute_hits_total,
-            websocket_pool_execute_misses_total,
-            websocket_pool_idle_expirations_total,
         }
     }
 
@@ -256,34 +211,6 @@ impl SubscriptionMetrics {
         }
     }
 
-    pub fn record_websocket_pool_initialization_started(&self) {
-        record_counter(&self.websocket_pool_initialization_started_total);
-    }
-
-    pub fn record_websocket_pool_initialization_joined(&self) {
-        record_counter(&self.websocket_pool_initialization_joined_total);
-    }
-
-    pub fn record_websocket_pool_initialization_failed(&self) {
-        record_counter(&self.websocket_pool_initialization_failed_total);
-    }
-
-    pub fn record_websocket_pool_subscription_hit(&self) {
-        record_counter(&self.websocket_pool_subscription_hits_total);
-    }
-
-    pub fn record_websocket_pool_execute_hit(&self) {
-        record_counter(&self.websocket_pool_execute_hits_total);
-    }
-
-    pub fn record_websocket_pool_execute_miss(&self) {
-        record_counter(&self.websocket_pool_execute_misses_total);
-    }
-
-    pub fn record_websocket_pool_idle_expiration(&self) {
-        record_counter(&self.websocket_pool_idle_expirations_total);
-    }
-
     /// Records a single subgraph message dropped because of a slow consumer.
     pub fn record_message_dropped(&self, transport: SubscriptionTransport) {
         let attrs = [KeyValue::new(
@@ -324,12 +251,6 @@ impl SubscriptionMetrics {
         if let Some(c) = &self.clients_sent_messages_total {
             c.add(1, &attrs);
         }
-    }
-}
-
-fn record_counter(counter: &Option<Counter<u64>>) {
-    if let Some(counter) = counter {
-        counter.add(1, &[]);
     }
 }
 

--- a/lib/internal/src/telemetry/metrics/subscription_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/subscription_metrics.rs
@@ -38,6 +38,13 @@ pub struct SubscriptionMetrics {
     clients_ended_total: Option<Counter<u64>>,
     clients_lagged_messages_total: Option<Counter<u64>>,
     clients_sent_messages_total: Option<Counter<u64>>,
+    websocket_pool_initialization_started_total: Option<Counter<u64>>,
+    websocket_pool_initialization_joined_total: Option<Counter<u64>>,
+    websocket_pool_initialization_failed_total: Option<Counter<u64>>,
+    websocket_pool_subscription_hits_total: Option<Counter<u64>>,
+    websocket_pool_execute_hits_total: Option<Counter<u64>>,
+    websocket_pool_execute_misses_total: Option<Counter<u64>>,
+    websocket_pool_idle_expirations_total: Option<Counter<u64>>,
 }
 
 impl SubscriptionMetrics {
@@ -112,6 +119,37 @@ impl SubscriptionMetrics {
                 .with_unit(units::MESSAGES)
                 .build()
         });
+        let counter = |name, description| {
+            meter.map(|m| m.u64_counter(name).with_description(description).build())
+        };
+        let websocket_pool_initialization_started_total = counter(
+            names::WEBSOCKET_POOL_INITIALIZATION_STARTED_TOTAL,
+            "Pooled WebSocket connection initializations started.",
+        );
+        let websocket_pool_initialization_joined_total = counter(
+            names::WEBSOCKET_POOL_INITIALIZATION_JOINED_TOTAL,
+            "Pooled WebSocket connection initializations joined.",
+        );
+        let websocket_pool_initialization_failed_total = counter(
+            names::WEBSOCKET_POOL_INITIALIZATION_FAILED_TOTAL,
+            "Pooled WebSocket connection initializations failed.",
+        );
+        let websocket_pool_subscription_hits_total = counter(
+            names::WEBSOCKET_POOL_SUBSCRIPTION_HITS_TOTAL,
+            "Subscriptions routed through pooled WebSocket connections.",
+        );
+        let websocket_pool_execute_hits_total = counter(
+            names::WEBSOCKET_POOL_EXECUTE_HITS_TOTAL,
+            "Executions routed through pooled WebSocket connections.",
+        );
+        let websocket_pool_execute_misses_total = counter(
+            names::WEBSOCKET_POOL_EXECUTE_MISSES_TOTAL,
+            "Executions without a matching pooled WebSocket connection.",
+        );
+        let websocket_pool_idle_expirations_total = counter(
+            names::WEBSOCKET_POOL_IDLE_EXPIRATIONS_TOTAL,
+            "Pooled WebSocket connections closed after becoming idle.",
+        );
         Self {
             subgraphs_active,
             subgraphs_connections,
@@ -124,6 +162,13 @@ impl SubscriptionMetrics {
             clients_ended_total,
             clients_lagged_messages_total,
             clients_sent_messages_total,
+            websocket_pool_initialization_started_total,
+            websocket_pool_initialization_joined_total,
+            websocket_pool_initialization_failed_total,
+            websocket_pool_subscription_hits_total,
+            websocket_pool_execute_hits_total,
+            websocket_pool_execute_misses_total,
+            websocket_pool_idle_expirations_total,
         }
     }
 
@@ -211,6 +256,34 @@ impl SubscriptionMetrics {
         }
     }
 
+    pub fn record_websocket_pool_initialization_started(&self) {
+        record_counter(&self.websocket_pool_initialization_started_total);
+    }
+
+    pub fn record_websocket_pool_initialization_joined(&self) {
+        record_counter(&self.websocket_pool_initialization_joined_total);
+    }
+
+    pub fn record_websocket_pool_initialization_failed(&self) {
+        record_counter(&self.websocket_pool_initialization_failed_total);
+    }
+
+    pub fn record_websocket_pool_subscription_hit(&self) {
+        record_counter(&self.websocket_pool_subscription_hits_total);
+    }
+
+    pub fn record_websocket_pool_execute_hit(&self) {
+        record_counter(&self.websocket_pool_execute_hits_total);
+    }
+
+    pub fn record_websocket_pool_execute_miss(&self) {
+        record_counter(&self.websocket_pool_execute_misses_total);
+    }
+
+    pub fn record_websocket_pool_idle_expiration(&self) {
+        record_counter(&self.websocket_pool_idle_expirations_total);
+    }
+
     /// Records a single subgraph message dropped because of a slow consumer.
     pub fn record_message_dropped(&self, transport: SubscriptionTransport) {
         let attrs = [KeyValue::new(
@@ -251,6 +324,12 @@ impl SubscriptionMetrics {
         if let Some(c) = &self.clients_sent_messages_total {
             c.add(1, &attrs);
         }
+    }
+}
+
+fn record_counter(counter: &Option<Counter<u64>>) {
+    if let Some(counter) = counter {
+        counter.add(1, &[]);
     }
 }
 

--- a/lib/internal/src/telemetry/metrics/websocket_pool_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/websocket_pool_metrics.rs
@@ -1,0 +1,259 @@
+use opentelemetry::{
+    metrics::{Counter, Meter, UpDownCounter},
+    KeyValue,
+};
+
+#[cfg(debug_assertions)]
+use crate::telemetry::metrics::catalog::debug_assert_attrs;
+use crate::telemetry::metrics::catalog::{labels, names, units};
+
+#[derive(Clone, Copy, strum::IntoStaticStr)]
+pub enum WebSocketPoolOperationType {
+    #[strum(serialize = "execute")]
+    Execute,
+    #[strum(serialize = "subscribe")]
+    Subscribe,
+}
+
+impl WebSocketPoolOperationType {
+    fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+
+#[derive(Clone, Copy, strum::IntoStaticStr)]
+pub enum WebSocketPoolConnectionCloseReason {
+    #[strum(serialize = "idle")]
+    Idle,
+    #[strum(serialize = "dispatcher")]
+    Dispatcher,
+    #[strum(serialize = "pool_dropped")]
+    PoolDropped,
+}
+
+impl WebSocketPoolConnectionCloseReason {
+    fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+
+pub struct WebSocketPoolMetrics {
+    connections_active: Option<UpDownCounter<i64>>,
+    connection_initializations_total: Option<Counter<u64>>,
+    connection_initialization_waiters_total: Option<Counter<u64>>,
+    connection_lookups_total: Option<Counter<u64>>,
+    connections_closed_total: Option<Counter<u64>>,
+    operations_active: Option<UpDownCounter<i64>>,
+    operations_started_total: Option<Counter<u64>>,
+}
+
+impl WebSocketPoolMetrics {
+    pub fn new(meter: Option<&Meter>) -> Self {
+        let connections_active = meter.map(|meter| {
+            meter
+                .i64_up_down_counter(names::WEBSOCKET_POOL_CONNECTIONS_ACTIVE)
+                .with_description("Active connections in the WebSocket pool.")
+                .with_unit(units::CONNECTIONS)
+                .build()
+        });
+        let connection_initializations_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::WEBSOCKET_POOL_CONNECTION_INITIALIZATIONS_TOTAL)
+                .with_description("Completed WebSocket pool connection initialization attempts.")
+                .with_unit(units::CONNECTIONS)
+                .build()
+        });
+        let connection_initialization_waiters_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::WEBSOCKET_POOL_CONNECTION_INITIALIZATION_WAITERS_TOTAL)
+                .with_description(
+                    "Requests that waited for an in-progress connection initialization.",
+                )
+                .build()
+        });
+        let connection_lookups_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::WEBSOCKET_POOL_CONNECTION_LOOKUPS_TOTAL)
+                .with_description("Attempts to reuse an existing WebSocket pool connection.")
+                .build()
+        });
+        let connections_closed_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::WEBSOCKET_POOL_CONNECTIONS_CLOSED_TOTAL)
+                .with_description("WebSocket pool connections closed.")
+                .with_unit(units::CONNECTIONS)
+                .build()
+        });
+        let operations_active = meter.map(|meter| {
+            meter
+                .i64_up_down_counter(names::WEBSOCKET_POOL_OPERATIONS_ACTIVE)
+                .with_description("Active operations using WebSocket pool connections.")
+                .build()
+        });
+        let operations_started_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::WEBSOCKET_POOL_OPERATIONS_STARTED_TOTAL)
+                .with_description("Operations started through the WebSocket pool.")
+                .build()
+        });
+
+        Self {
+            connections_active,
+            connection_initializations_total,
+            connection_initialization_waiters_total,
+            connection_lookups_total,
+            connections_closed_total,
+            operations_active,
+            operations_started_total,
+        }
+    }
+
+    pub fn record_connection_initialization(&self, subgraph_name: &str, succeeded: bool) {
+        let attrs = [
+            KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+            KeyValue::new(labels::RESULT, if succeeded { "success" } else { "error" }),
+        ];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(
+            names::WEBSOCKET_POOL_CONNECTION_INITIALIZATIONS_TOTAL,
+            &attrs,
+        );
+        if let Some(counter) = &self.connection_initializations_total {
+            counter.add(1, &attrs);
+        }
+    }
+
+    pub fn record_connection_initialization_waiter(&self, subgraph_name: &str) {
+        let attrs = [KeyValue::new(
+            labels::SUBGRAPH_NAME,
+            subgraph_name.to_string(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(
+            names::WEBSOCKET_POOL_CONNECTION_INITIALIZATION_WAITERS_TOTAL,
+            &attrs,
+        );
+        if let Some(counter) = &self.connection_initialization_waiters_total {
+            counter.add(1, &attrs);
+        }
+    }
+
+    pub fn record_connection_lookup(&self, subgraph_name: &str, found: bool) {
+        let attrs = [
+            KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+            KeyValue::new(labels::RESULT, if found { "hit" } else { "miss" }),
+        ];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::WEBSOCKET_POOL_CONNECTION_LOOKUPS_TOTAL, &attrs);
+        if let Some(counter) = &self.connection_lookups_total {
+            counter.add(1, &attrs);
+        }
+    }
+
+    pub fn active_connection(&self, subgraph_name: &str) -> ActiveConnectionGuard {
+        let attrs = [KeyValue::new(
+            labels::SUBGRAPH_NAME,
+            subgraph_name.to_string(),
+        )];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::WEBSOCKET_POOL_CONNECTIONS_ACTIVE, &attrs);
+        if let Some(counter) = &self.connections_active {
+            counter.add(1, &attrs);
+        }
+        ActiveConnectionGuard {
+            counter: self.connections_active.clone(),
+            subgraph_name: subgraph_name.to_string(),
+        }
+    }
+
+    pub fn record_connection_closed(
+        &self,
+        subgraph_name: &str,
+        reason: WebSocketPoolConnectionCloseReason,
+    ) {
+        let attrs = [
+            KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+            KeyValue::new(
+                labels::WEBSOCKET_POOL_CONNECTION_CLOSE_REASON,
+                reason.as_str(),
+            ),
+        ];
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::WEBSOCKET_POOL_CONNECTIONS_CLOSED_TOTAL, &attrs);
+        if let Some(counter) = &self.connections_closed_total {
+            counter.add(1, &attrs);
+        }
+    }
+
+    pub fn active_operation(
+        &self,
+        subgraph_name: &str,
+        operation_type: WebSocketPoolOperationType,
+    ) -> ActiveOperationGuard {
+        let attrs = operation_attrs(subgraph_name, operation_type);
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::WEBSOCKET_POOL_OPERATIONS_ACTIVE, &attrs);
+        if let Some(counter) = &self.operations_active {
+            counter.add(1, &attrs);
+        }
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::WEBSOCKET_POOL_OPERATIONS_STARTED_TOTAL, &attrs);
+        if let Some(counter) = &self.operations_started_total {
+            counter.add(1, &attrs);
+        }
+        ActiveOperationGuard {
+            counter: self.operations_active.clone(),
+            subgraph_name: subgraph_name.to_string(),
+            operation_type,
+        }
+    }
+}
+
+fn operation_attrs(
+    subgraph_name: &str,
+    operation_type: WebSocketPoolOperationType,
+) -> [KeyValue; 2] {
+    [
+        KeyValue::new(labels::SUBGRAPH_NAME, subgraph_name.to_string()),
+        KeyValue::new(
+            labels::WEBSOCKET_POOL_OPERATION_TYPE,
+            operation_type.as_str(),
+        ),
+    ]
+}
+
+pub struct ActiveConnectionGuard {
+    counter: Option<UpDownCounter<i64>>,
+    subgraph_name: String,
+}
+
+impl Drop for ActiveConnectionGuard {
+    fn drop(&mut self) {
+        if let Some(counter) = &self.counter {
+            counter.add(
+                -1,
+                &[KeyValue::new(
+                    labels::SUBGRAPH_NAME,
+                    self.subgraph_name.clone(),
+                )],
+            );
+        }
+    }
+}
+
+pub struct ActiveOperationGuard {
+    counter: Option<UpDownCounter<i64>>,
+    subgraph_name: String,
+    operation_type: WebSocketPoolOperationType,
+}
+
+impl Drop for ActiveOperationGuard {
+    fn drop(&mut self) {
+        if let Some(counter) = &self.counter {
+            counter.add(
+                -1,
+                &operation_attrs(&self.subgraph_name, self.operation_type),
+            );
+        }
+    }
+}

--- a/lib/router-config/src/subscriptions.rs
+++ b/lib/router-config/src/subscriptions.rs
@@ -138,14 +138,6 @@ pub struct WebSocketConfig {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct WebSocketSubgraphConfig {
-    /// Controls how long an idle pooled WebSocket connection remains open.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "humantime_serde::option"
-    )]
-    #[schemars(with = "Option<String>")]
-    pub idle_timeout: Option<Duration>,
     /// Determines the URL path to use for the subscription endpoint:
     ///
     /// - For WebSocket connections, the URL will be `ws://<subgraph-url><path>`.
@@ -191,20 +183,6 @@ impl SubscriptionsConfig {
                 })
         })
     }
-
-    /// Returns the pooled WebSocket idle timeout for a subgraph.
-    /// Defaults to 30 seconds.
-    pub fn get_websocket_idle_timeout(&self, subgraph_name: &str) -> Duration {
-        self.websocket
-            .as_ref()
-            .and_then(|ws| {
-                ws.subgraphs
-                    .get(subgraph_name)
-                    .and_then(|config| config.idle_timeout)
-                    .or_else(|| ws.all.as_ref().and_then(|config| config.idle_timeout))
-            })
-            .unwrap_or(Duration::from_secs(30))
-    }
 }
 
 #[cfg(test)]
@@ -240,18 +218,6 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.path.as_str(), "/callback");
-    }
-
-    #[test]
-    fn websocket_idle_timeout_is_inherited() {
-        let config = serde_json::from_str::<SubscriptionsConfig>(
-            r#"{"websocket":{"all":{"idle_timeout":"12s"},"subgraphs":{"products":{"path":"/ws"}}}}"#,
-        )
-        .unwrap();
-        assert_eq!(
-            config.get_websocket_idle_timeout("products"),
-            Duration::from_secs(12)
-        );
     }
 }
 

--- a/lib/router-config/src/subscriptions.rs
+++ b/lib/router-config/src/subscriptions.rs
@@ -138,6 +138,14 @@ pub struct WebSocketConfig {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct WebSocketSubgraphConfig {
+    /// Controls how long an idle pooled WebSocket connection remains open.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "humantime_serde::option"
+    )]
+    #[schemars(with = "Option<String>")]
+    pub idle_timeout: Option<Duration>,
     /// Determines the URL path to use for the subscription endpoint:
     ///
     /// - For WebSocket connections, the URL will be `ws://<subgraph-url><path>`.
@@ -183,6 +191,19 @@ impl SubscriptionsConfig {
                 })
         })
     }
+
+    /// Returns the pooled WebSocket idle timeout for a subgraph.
+    pub fn get_websocket_idle_timeout(&self, subgraph_name: &str) -> Duration {
+        self.websocket
+            .as_ref()
+            .and_then(|ws| {
+                ws.subgraphs
+                    .get(subgraph_name)
+                    .and_then(|config| config.idle_timeout)
+                    .or_else(|| ws.all.as_ref().and_then(|config| config.idle_timeout))
+            })
+            .unwrap_or(Duration::from_secs(30))
+    }
 }
 
 #[cfg(test)]
@@ -218,6 +239,18 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.path.as_str(), "/callback");
+    }
+
+    #[test]
+    fn websocket_idle_timeout_is_inherited() {
+        let config = serde_json::from_str::<SubscriptionsConfig>(
+            r#"{"websocket":{"all":{"idle_timeout":"12s"},"subgraphs":{"products":{"path":"/ws"}}}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.get_websocket_idle_timeout("products"),
+            Duration::from_secs(12)
+        );
     }
 }
 

--- a/lib/router-config/src/subscriptions.rs
+++ b/lib/router-config/src/subscriptions.rs
@@ -193,6 +193,7 @@ impl SubscriptionsConfig {
     }
 
     /// Returns the pooled WebSocket idle timeout for a subgraph.
+    /// Defaults to 30 seconds.
     pub fn get_websocket_idle_timeout(&self, subgraph_name: &str) -> Duration {
         self.websocket
             .as_ref()

--- a/lib/router-config/src/traffic_shaping.rs
+++ b/lib/router-config/src/traffic_shaping.rs
@@ -38,12 +38,67 @@ impl Default for TrafficShapingConfig {
     }
 }
 
+impl TrafficShapingConfig {
+    /// Returns whether WebSocket connections should be reused for a subgraph.
+    ///
+    /// A per-subgraph value takes precedence over the value configured in `all`.
+    pub fn websocket_reuse_connections(&self, subgraph_name: &str) -> bool {
+        self.subgraphs
+            .get(subgraph_name)
+            .and_then(|config| config.websocket.as_ref())
+            .and_then(|config| config.reuse_connections)
+            .or(self.all.websocket.reuse_connections)
+            .unwrap_or(true)
+    }
+
+    /// Returns how queries and mutations should be transported to a WebSocket-enabled subgraph.
+    ///
+    /// A per-subgraph value takes precedence over the value configured in `all`.
+    pub fn websocket_execute_mode(&self, subgraph_name: &str) -> WebSocketExecuteMode {
+        self.subgraphs
+            .get(subgraph_name)
+            .and_then(|config| config.websocket.as_ref())
+            .and_then(|config| config.execute_mode)
+            .or(self.all.websocket.execute_mode)
+            .unwrap_or_default()
+    }
+
+    /// Returns the idle timeout used by HTTP and pooled WebSocket connections for a subgraph.
+    ///
+    /// A per-subgraph value takes precedence over `traffic_shaping.all.pool_idle_timeout`.
+    pub fn pool_idle_timeout(&self, subgraph_name: &str) -> Duration {
+        self.subgraphs
+            .get(subgraph_name)
+            .and_then(|config| config.pool_idle_timeout)
+            .unwrap_or(self.all.pool_idle_timeout)
+    }
+
+    /// Returns whether any configured traffic-shaping rule can reuse WebSocket connections.
+    ///
+    /// This is used to avoid connection fingerprinting when pooling is disabled globally and for
+    /// every explicit subgraph override.
+    pub fn any_websocket_connection_reuse_enabled(&self) -> bool {
+        self.all.websocket.reuse_connections.unwrap_or(true)
+            || self.subgraphs.values().any(|config| {
+                config
+                    .websocket
+                    .as_ref()
+                    .and_then(|websocket| websocket.reuse_connections)
+                    .unwrap_or(false)
+            })
+    }
+}
+
 fn default_max_connections_per_host() -> usize {
     100
 }
 
 fn default_pool_idle_timeout() -> Duration {
     Duration::from_secs(50)
+}
+
+fn default_subgraph_pool_idle_timeout() -> Option<Duration> {
+    None
 }
 
 fn default_dedupe_enabled() -> bool {
@@ -57,7 +112,13 @@ fn default_router_dedupe_enabled() -> bool {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TrafficShapingExecutorSubgraphConfig {
-    /// Timeout for idle sockets being kept-alive.
+    /// Overrides how long idle pooled connections for this subgraph remain available for reuse.
+    ///
+    /// This timeout applies to both the HTTP connection pool and pooled WebSocket connections for
+    /// this subgraph. Active WebSocket operations are never expired by this setting. Their idle
+    /// timer starts only after the last operation on the pooled connection finishes.
+    ///
+    /// When omitted, `traffic_shaping.all.pool_idle_timeout` is used.
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
         serialize_with = "humantime_serde::serialize",
@@ -116,12 +177,132 @@ pub struct TrafficShapingExecutorSubgraphConfig {
     /// This setting takes precedence over the value set in `all` section.
     #[serde(default)]
     pub forward_operation_name: Option<bool>,
+
+    /// Overrides WebSocket connection reuse and execution behavior for this subgraph.
+    ///
+    /// Omitted fields inherit their values from `traffic_shaping.all.websocket`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket: Option<TrafficShapingWebSocketConfig>,
+}
+
+/// Controls which transport queries and mutations use for WebSocket-enabled subgraphs.
+///
+/// This setting does not select the subscription protocol. WebSocket support and endpoint paths
+/// are declared under `subscriptions.websocket`. It only controls whether ordinary query and
+/// mutation fetches may use those declared WebSocket endpoints.
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSocketExecuteMode {
+    /// Always executes queries and mutations over HTTP.
+    ///
+    /// WebSocket subscriptions are unaffected and may still reuse connections when
+    /// `reuse_connections` is enabled.
+    #[default]
+    Http,
+    /// Uses an already initialized matching WebSocket connection when one exists.
+    ///
+    /// A missing or still-connecting pool entry immediately falls back to HTTP. Queries and
+    /// mutations never create or wait for a WebSocket in this mode.
+    ReuseExisting,
+    /// Executes queries and mutations over WebSocket.
+    ///
+    /// With `reuse_connections` enabled, a missing connection is initialized lazily and
+    /// concurrent operations wait for the same initialization. With reuse disabled, every
+    /// operation creates its own WebSocket connection.
+    Websocket,
+}
+
+/// WebSocket traffic-shaping behavior used by both `all` and per-subgraph configuration.
+///
+/// Fields are optional so a subgraph can override one behavior while inheriting the other from
+/// `traffic_shaping.all.websocket`. Fields omitted from `all` use their documented defaults.
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TrafficShapingWebSocketConfig {
+    /// Enables multiplexing operations over matching initialized WebSocket connections.
+    ///
+    /// When enabled, subscriptions retain initialized connections in a pool and can share one
+    /// physical connection. Queries and mutations use that pool according to `execute_mode`.
+    /// When disabled, each WebSocket operation owns a dedicated connection.
+    ///
+    /// A pooled connection is discovered using two values:
+    ///
+    /// 1. The resolved WebSocket endpoint. Endpoint overrides and expressions are evaluated first,
+    ///    then the configured WebSocket path is applied. Connections to different resolved
+    ///    endpoints are never considered a match.
+    /// 2. The inbound connection fingerprint. This fingerprint contains the inbound HTTP method,
+    ///    request path, selected inbound headers, and schema checksum. It deliberately excludes the
+    ///    GraphQL operation, variables, and extensions, allowing different operations from the
+    ///    same connection identity to share one physical WebSocket.
+    ///
+    /// Header selection uses `traffic_shaping.router.dedupe.headers`, even when router request
+    /// deduplication itself is disabled. The default is `all`. If a custom header selection is
+    /// configured, it must include every inbound header that can change the authentication,
+    /// authorization, cookie, or tenant identity sent in `connection_init`. Excluding such a
+    /// header can make requests with different identities appear to match and reuse the same
+    /// authenticated connection.
+    ///
+    /// A subscription can create the matching pool entry. With `execute_mode: reuse_existing`, a
+    /// query or mutation uses the connection only after it is fully initialized. A missing entry
+    /// or one still waiting for `connection_ack` falls back to HTTP. With
+    /// `execute_mode: websocket`, queries and mutations may create a missing entry or join an
+    /// initialization already in progress.
+    ///
+    /// For example, the following configuration lets subscriptions create shared connections and
+    /// lets queries and mutations reuse them when available:
+    ///
+    /// ```yaml
+    /// traffic_shaping:
+    ///   all:
+    ///     websocket:
+    ///       reuse_connections: true
+    ///       execute_mode: reuse_existing
+    ///   router:
+    ///     dedupe:
+    ///       headers:
+    ///         include: [authorization, cookie, x-tenant]
+    /// ```
+    ///
+    /// The following keeps reuse enabled globally but gives one subgraph a dedicated connection
+    /// for every WebSocket operation:
+    ///
+    /// ```yaml
+    /// traffic_shaping:
+    ///   all:
+    ///     websocket:
+    ///       reuse_connections: true
+    ///   subgraphs:
+    ///     payments:
+    ///       websocket:
+    ///         reuse_connections: false
+    /// ```
+    ///
+    /// Idle pooled connections use the effective `pool_idle_timeout` from traffic shaping. At the
+    /// `all` level `reuse_connections` defaults to `true`. At the per-subgraph level omission
+    /// inherits the `all` value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reuse_connections: Option<bool>,
+
+    /// Controls whether queries and mutations use WebSocket-enabled subgraphs.
+    ///
+    /// The default is `http`, preserving HTTP execution unless WebSocket execution is explicitly
+    /// enabled. Subscriptions continue to use the protocol selected under `subscriptions`.
+    /// At the per-subgraph level omission inherits the `all` value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execute_mode: Option<WebSocketExecuteMode>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TrafficShapingExecutorGlobalConfig {
-    /// Timeout for idle sockets being kept-alive.
+    /// Controls how long idle pooled connections remain available for reuse by default.
+    ///
+    /// This timeout applies to both HTTP connection pools and pooled WebSocket connections for
+    /// every subgraph that does not provide an override. Active WebSocket operations are never
+    /// expired by this setting. Their idle timer starts only after the last operation on the
+    /// pooled connection finishes.
+    ///
+    /// Defaults to 50 seconds.
     #[serde(
         default = "default_pool_idle_timeout",
         deserialize_with = "humantime_serde::deserialize",
@@ -181,10 +362,12 @@ pub struct TrafficShapingExecutorGlobalConfig {
     /// Format: <Client Operation Name>__<Fetch Node ID>
     #[serde(default)]
     pub forward_operation_name: bool,
-}
 
-fn default_subgraph_pool_idle_timeout() -> Option<Duration> {
-    None
+    /// Default WebSocket connection reuse and execution behavior for subgraphs.
+    ///
+    /// Per-subgraph values under `traffic_shaping.subgraphs.<name>.websocket` take precedence.
+    #[serde(default)]
+    pub websocket: TrafficShapingWebSocketConfig,
 }
 
 fn default_request_timeout() -> DurationOrExpression {
@@ -215,6 +398,7 @@ impl Default for TrafficShapingExecutorGlobalConfig {
             tls: None,
             allow_only_http2: false,
             forward_operation_name: false,
+            websocket: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Closes #1236

Subgraph `graphql-transport-ws` operations can share an initialized connection when they have the same subgraph, resolved WebSocket endpoint, and inbound connection identity. This replaces one physical WebSocket per operation with one multiplexed connection while preserving independent GraphQL operation streams.

The implementation also adds explicit traffic-shaping controls for whether connections are reused and how queries and mutations are transported.

# Configuration

WebSocket behavior is configured under `traffic_shaping.all.websocket` or overridden per subgraph:

```yaml
subscriptions:
  websocket:
    subgraphs:
      reviews:
        path: /reviews/ws

traffic_shaping:
  all:
    pool_idle_timeout: 50s # is default
    websocket:
      reuse_connections: true # is default
      execute_mode: reuse_existing # default is "http"
```

`reuse_connections` defaults to `true` and controls whether WebSocket operations multiplex over matching pooled connections. Setting it to `false` preserves one connection per WebSocket operation.

`execute_mode` controls queries and mutations:

- `http` is the default and always uses HTTP
- `reuse_existing` prefers a matching initialized WebSocket and immediately uses HTTP when none exists or initialization is still in progress
- `websocket` executes over WebSocket, initializing or joining a pooled connection when reuse is enabled, or opening a dedicated connection when reuse is disabled

Per-subgraph WebSocket fields inherit omitted values from `traffic_shaping.all.websocket`.

Pooled WebSockets use the existing effective `pool_idle_timeout`. A per-subgraph timeout overrides `traffic_shaping.all.pool_idle_timeout` for both HTTP and WebSocket pools. Active WebSocket operations prevent idle expiry.

## Configuration examples and routing behavior

### Preserve HTTP execution and pool subscriptions

```yaml
subscriptions:
  enabled: true
  websocket:
    subgraphs:
      reviews:
        path: /reviews/ws

traffic_shaping:
  all:
    websocket:
      reuse_connections: true
      execute_mode: http
```

What happens:

- subscriptions to `reviews` use WebSocket
- subscriptions with the same resolved WebSocket endpoint and connection identity share one initialized connection
- queries and mutations always use HTTP, even when a matching WebSocket is open
- this is the default execute behavior; both WebSocket fields can be omitted because `reuse_connections` defaults to `true` and `execute_mode` defaults to `http`

### Opportunistically reuse a subscription connection

```yaml
subscriptions:
  enabled: true
  websocket:
    subgraphs:
      reviews:
        path: /reviews/ws

traffic_shaping:
  all:
    pool_idle_timeout: 50s
    websocket:
      reuse_connections: true
      execute_mode: reuse_existing
  router:
    dedupe:
      headers:
        include: [authorization, cookie, x-tenant]
```

What happens:

- a subscription may initialize the pooled WebSocket
- later queries and mutations with the same subgraph, resolved WebSocket endpoint, and connection fingerprint use that connection
- queries and mutations use HTTP when the connection is absent, closed, expired, or still waiting for `connection_ack`
- a query or mutation never creates or waits for a WebSocket in this mode
- once an initialized connection is selected, execution stays on WebSocket and failures are not retried over HTTP

### Send every operation over WebSocket

```yaml
subscriptions:
  enabled: true
  websocket:
    subgraphs:
      reviews:
        path: /reviews/ws

traffic_shaping:
  all:
    websocket:
      reuse_connections: true
      execute_mode: websocket
```

What happens:

- subscriptions, queries, and mutations use WebSocket for WebSocket-enabled subgraphs
- the first operation initializes a pooled connection
- concurrent operations for the same resolved WebSocket endpoint and identity join that initialization
- later matching operations multiplex over the initialized connection
- subgraphs without WebSocket subscription configuration continue using their configured transport

### Force a dedicated WebSocket per operation

```yaml
subscriptions:
  enabled: true
  websocket:
    subgraphs:
      reviews:
        path: /reviews/ws

traffic_shaping:
  all:
    websocket:
      reuse_connections: false
      execute_mode: websocket
```

What happens:

- subscriptions, queries, and mutations use WebSocket
- every operation opens and owns a separate WebSocket
- no connection is inserted into the shared pool
- connection fingerprinting is avoided when reuse is disabled globally and no subgraph override enables it

### Override one subgraph

```yaml
traffic_shaping:
  all:
    pool_idle_timeout: 50s
    websocket:
      reuse_connections: true
      execute_mode: reuse_existing
  subgraphs:
    payments:
      pool_idle_timeout: 5s
      websocket:
        reuse_connections: false
        execute_mode: websocket
```

What happens:

- other WebSocket-enabled subgraphs opportunistically reuse initialized connections and inherit the 50 second idle timeout
- `payments` sends queries, mutations, and subscriptions over dedicated WebSockets
- `payments` inherits nothing for the two explicitly overridden WebSocket fields
- its 5 second `pool_idle_timeout` also remains the effective timeout for its HTTP connection pool

# Connection identity

Request identity is now split into two typed fingerprints:

- `ConnectionFingerprint` covers the inbound method, path, selected headers, and supergraph identity
- `InboundRequestFingerprint` extends it with the normalized operation, variables, and extensions for request deduplication

This keeps request deduplication separate from connection reuse. Different operations are not treated as the same request, but they can still multiplex over the same connection.

Header selection follows `traffic_shaping.router.dedupe.headers`, including when request deduplication is disabled. Operators using a custom header policy must include every inbound header that can affect connection-scoped authentication, authorization, cookies, or tenant identity.

The router avoids computing a connection fingerprint when neither request deduplication nor WebSocket reuse needs one. Inbound client WebSockets compute it once and reuse it across operations.

# WebSocket pool

The shared pool coordinates connections per subgraph, resolved WebSocket endpoint, and connection fingerprint.

Concurrent operations that are allowed to initialize a matching connection join one initialization attempt. The executor becomes available only after `connection_ack`. Failed or canceled attempts wake their waiters and remove only their own pool generation.

The underlying ntex WebSocket client remains on its local runtime because it is not `Send`. Shared executors communicate with that owner through a bounded command channel. Operations are registered serially and their response streams drain concurrently through the existing subscription buffer.

Pool removal checks exact command-channel ownership, so an expired or failed connection cannot remove a newer replacement.

# Query and mutation routing

Plugin executor decisions continue to win. Pool routing happens only when hooks did not return a response or replace the original HTTP executor.

For `execute_mode: reuse_existing`, the router resolves the endpoint once and uses the corresponding cached subscription executor's parsed WebSocket endpoint to look up an initialized matching connection. This keeps endpoint expressions and overrides isolated without parsing the endpoint again. A missing subscription executor or connecting pool entry is an immediate miss, and execution stays on HTTP.

For `execute_mode: websocket`, the configured WebSocket executor handles queries and mutations. With reuse enabled it can initialize or join the pool. With reuse disabled it opens a dedicated connection for the operation.

After WebSocket execution is selected, command, timeout, transport, dispatcher, and empty-stream failures are returned to the client. The router does not retry the operation over HTTP, avoiding mutation replay after an uncertain WebSocket send.

# WebSocket client lifecycle

`WsClient` now has explicit connected and initialized states. Only a connected client can run protocol initialization, and only an initialized client can start operations.

The client now:

- propagates initialization and subscribe send failures
- removes partially registered operations when a send is canceled or fails
- rejects subscription ID exhaustion instead of wrapping
- exposes dispatcher completion to the pool owner
- forwards transport failures as typed operation errors
- preserves GraphQL protocol `error` messages as GraphQL responses
- accepts frames up to 16 MiB instead of ntex's 64 KiB default

Execute timeout now covers WebSocket execution, including connection initialization where applicable, command submission, and the first response.

# Buffering and cancellation

Pooled operations preserve the existing bounded buffering and drop-on-backpressure behavior.

The drainer now also waits for the downstream channel to close. This immediately drops a silent upstream stream when its consumer disappears.

For pooled execute, dropping the receiver after the first response sends protocol `complete`, ends only that logical operation, and allows the physical connection to become idle without waiting for another subgraph message.

# Telemetry

The pool exposes the following low-cardinality metrics:

| Metric                                                                | Type            | Attributes                                                                               | What it shows                                                             |
| --------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| `hive.router.websocket_pool.connections.active`                       | up-down counter | `subgraph.name`                                                                          | currently initialized physical pooled connections                         |
| `hive.router.websocket_pool.connections.initializations_total`        | counter         | `subgraph.name`, `result=success\|error`                                                 | completed connection initialization attempts                              |
| `hive.router.websocket_pool.connections.initialization_waiters_total` | counter         | `subgraph.name`                                                                          | operations that joined an initialization already in progress              |
| `hive.router.websocket_pool.connections.lookups_total`                | counter         | `subgraph.name`, `result=hit\|miss`                                                      | `reuse_existing` attempts and whether an initialized connection was found |
| `hive.router.websocket_pool.connections.closed_total`                 | counter         | `subgraph.name`, `websocket_pool.connection.close_reason=idle\|dispatcher\|pool_dropped` | why pooled physical connections ended                                     |
| `hive.router.websocket_pool.operations.active`                        | up-down counter | `subgraph.name`, `websocket_pool.operation.type=execute\|subscribe`                      | currently active logical operations multiplexed over the pool             |
| `hive.router.websocket_pool.operations.started_total`                 | counter         | `subgraph.name`, `websocket_pool.operation.type=execute\|subscribe`                      | logical operations started through pooled connections                     |

These metrics distinguish physical connection lifetime from logical operation lifetime. That makes it possible to derive and monitor:

- **lookup hit ratio**: `hit lookups / all lookups`. A low ratio in `reuse_existing` mode means most queries and mutations still use HTTP. This can indicate that subscriptions rarely overlap with those requests, connection fingerprints are too fragmented, or the idle timeout is too short.
- **initialization failure ratio**: `error initializations / all initializations`. This surfaces DNS, TCP, TLS, WebSocket upgrade, `connection_init`, and acknowledgement problems before they are hidden among ordinary operation failures.
- **single-flight effectiveness**: initialization waiters compared with successful initializations. More waiters per initialization means concurrent operations are sharing handshake work instead of opening duplicate connections. A sustained spike can also show initialization latency or a burst of cold identities.
- **multiplexing factor**: active logical operations divided by active physical connections, or the same comparison over rates of started operations and successful initializations. Values above one demonstrate concurrent multiplexing and quantify how many operation sockets are being avoided.
- **connection churn**: the rate of successful initializations compared with the rate of closed connections. High churn with mostly `idle` closures suggests increasing `pool_idle_timeout` may improve reuse. High `dispatcher` closure rates point to subgraph or network instability instead.
- **pool utilization by operation type**: execute versus subscribe values from `operations.active` and `operations.started_total`. This shows whether the pool is serving only its original subscription workload or is also carrying queries and mutations.
- **pool footprint by subgraph**: `connections.active` grouped by `subgraph.name`. This identifies subgraphs or identity fragmentation that create unexpectedly many physical connections.
- **cold-start pressure**: the rate of initializations plus initialization waiters. This helps correlate request latency with WebSocket handshakes and distinguish a traffic burst from connection instability.

Metrics are labeled by subgraph and bounded status values only. Fingerprints, headers, and endpoints are intentionally excluded to avoid leaking identity data and creating unbounded cardinality.

Pool initialization, reuse, lookup, eviction, idle closure, dispatcher failure, and stale initialization events also use the dedicated `router::websocket_pool` logging target. Logs provide the endpoint and event context needed to investigate a metric anomaly without turning endpoint or connection identity into metric dimensions.

# Should we move the `websocket` subgraph config?

WebSocket endpoint paths still live at `subscriptions.websocket.subgraphs.<name>.path`. WebSocket is now also a transport for queries and mutations, so that hierarchy may no longer describe the full feature accurately.

Consider moving the path to a transport-level location such as `websocket.subgraphs.<name>.path`.

```diff
+websocket:
+  subgraphs:
+    reviews:
+      path: /reviews/ws
subscriptions:
  enabled: true
- websocket:
-   subgraphs:
-     reviews:
-       path: /reviews/ws
```

# TODO

- [ ] docs
- [ ] product update
