### PR TITLE
fix(router): expose correlations to plugin system

### DIFF
--- a/.changeset/expose-correlations-to-plugin-system.md
+++ b/.changeset/expose-correlations-to-plugin-system.md
@@ -1,0 +1,11 @@
+---
+hive-router: patch
+---
+
+# Expose request correlation IDs to plugins and middlewares
+
+Request/trace correlation IDs are now extracted and scoped by a dedicated middleware that wraps the entire request pipeline, instead of only inside the GraphQL handler. 
+
+This means plugins, the coprocessor runtime, and any other middleware can now log with the same `request_id`/`trace_id` as the rest of the request.
+
+Fixes https://github.com/graphql-hive/router/issues/1351

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -1,5 +1,4 @@
-// Needed because of ntex's way of defining middlewares. When we have more than ~5, we need this
-// set.
+// Needed because of ntex's way of defining middlewares
 #![recursion_limit = "256"]
 
 mod cache_state;

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -1,3 +1,7 @@
+// Needed because of ntex's way of defining middlewares. When we have more than ~5, we need this
+// set.
+#![recursion_limit = "256"]
+
 mod cache_state;
 mod consts;
 pub mod error;
@@ -41,6 +45,7 @@ use crate::{
             read_graphql_operation_metric_identity, read_graphql_response_metric_status,
             write_graphql_response_metric_status,
         },
+        request_identifiers::RequestIdentifiersService,
         timeout::handle_timeout,
         usage_reporting::init_hive_usage_agent,
         validation::{
@@ -68,7 +73,6 @@ pub use hive_router_internal::background_tasks;
 use hive_router_internal::background_tasks::{BackgroundTask, CancellationToken};
 use hive_router_internal::telemetry::{
     logging::{
-        request_id::WithRequestIdentifiers,
         summary::{self, WithRequestSummary},
         targets,
     },
@@ -151,12 +155,6 @@ async fn graphql_endpoint_handler(
     let parent_ctx = app_state
         .telemetry_context
         .extract_context(&HeaderExtractor(request.headers()));
-    let request_identifiers = Arc::new(
-        app_state
-            .telemetry_context
-            .logging_correlation_extractor
-            .extract(&request, &parent_ctx),
-    );
 
     let http_request_capture = app_state
         .telemetry_context
@@ -210,7 +208,6 @@ async fn graphql_endpoint_handler(
 
         (response_mode, inner_res, summary_guard)
     }
-    .with_request_id(request_identifiers)
     .with_request_summary()
     .await;
 
@@ -428,6 +425,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 paths_for_plugin,
                 prometheus.as_ref().map(|p| p.endpoint.clone()),
             ))
+            .middleware(RequestIdentifiersService)
             .state(shared_state.clone())
             .state(schema_state.clone())
             .state(shared_state.telemetry_context.clone())

--- a/bin/router/src/main.rs
+++ b/bin/router/src/main.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 use hive_router::{
     configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider,
     router_entrypoint, PluginRegistry, RouterGlobalAllocator,

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -103,6 +103,7 @@ pub mod persisted_documents;
 pub mod progressive_override;
 pub mod query_plan;
 pub mod request_extensions;
+pub mod request_identifiers;
 pub mod sse;
 pub mod timeout;
 pub(crate) mod trie;

--- a/bin/router/src/pipeline/request_identifiers.rs
+++ b/bin/router/src/pipeline/request_identifiers.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use hive_router_internal::telemetry::logging::request_id::WithRequestIdentifiers;
+use ntex::{
+    service::{Service, ServiceCtx},
+    web::{self, DefaultError},
+    Middleware, SharedCfg,
+};
+
+use crate::{telemetry::HeaderExtractor, RouterSharedState};
+
+/// Extracts the request/trace correlation identifiers and scopes them as a task-local
+/// for the rest of the request, so every downstream middleware (`PluginService`,
+/// the coprocessor, etc.) can log with the same correlation ids as the handler -
+/// not just the handler itself, which is where this used to happen.
+#[derive(Clone, Default)]
+pub struct RequestIdentifiersService;
+
+impl<S> Middleware<S, SharedCfg> for RequestIdentifiersService {
+    type Service = RequestIdentifiersMiddleware<S>;
+
+    fn create(&self, service: S, _cfg: SharedCfg) -> Self::Service {
+        RequestIdentifiersMiddleware { service }
+    }
+}
+
+pub struct RequestIdentifiersMiddleware<S> {
+    service: S,
+}
+
+impl<S> Service<web::WebRequest<DefaultError>> for RequestIdentifiersMiddleware<S>
+where
+    S: Service<web::WebRequest<DefaultError>, Response = web::WebResponse, Error = web::Error>,
+{
+    type Response = web::WebResponse;
+    type Error = S::Error;
+
+    ntex::forward_ready!(service);
+
+    async fn call(
+        &self,
+        req: web::WebRequest<DefaultError>,
+        ctx: ServiceCtx<'_, Self>,
+    ) -> Result<Self::Response, Self::Error> {
+        let Some(shared_state) = req.app_state::<Arc<RouterSharedState>>().cloned() else {
+            return ctx.call(&self.service, req).await;
+        };
+
+        let parent_ctx = shared_state
+            .telemetry_context
+            .extract_context(&HeaderExtractor(req.headers()));
+
+        let identifiers = Arc::new(
+            shared_state
+                .telemetry_context
+                .logging_correlation_extractor
+                .extract(req.headers(), &parent_ctx),
+        );
+
+        ctx.call(&self.service, req)
+            .with_request_id(identifiers)
+            .await
+    }
+}

--- a/bin/router/src/pipeline/request_identifiers.rs
+++ b/bin/router/src/pipeline/request_identifiers.rs
@@ -42,7 +42,7 @@ where
         req: web::WebRequest<DefaultError>,
         ctx: ServiceCtx<'_, Self>,
     ) -> Result<Self::Response, Self::Error> {
-        let Some(shared_state) = req.app_state::<Arc<RouterSharedState>>().cloned() else {
+        let Some(shared_state) = req.app_state::<Arc<RouterSharedState>>() else {
             return ctx.call(&self.service, req).await;
         };
 

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,3 +1,7 @@
+// mirrors the recursion_limit bump in bin/router/src/lib.rs: the test harness builds
+// the same nested ntex middleware stack, which needs the same higher layout-recursion budget.
+#![recursion_limit = "256"]
+
 #[cfg(test)]
 mod authorization_directives_filter;
 #[cfg(test)]

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -6,11 +6,18 @@ use crate::{
         Started, TestRouter, TestRouterBuilder, TestSubgraphs,
     },
 };
+use hive_router::{
+    async_trait,
+    plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+    plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+    plugins::plugin_trait::{RouterPlugin, StartHookPayload},
+};
 use hive_router_internal::telemetry::logging::targets;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use insta::assert_json_snapshot;
 use serde_json::{Map, Value};
 use sonic_rs::json;
+use tracing::debug;
 
 const TEST_QUERY: &str = "{ users { id } }";
 const TRACEPARENT_VALUE: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
@@ -660,4 +667,56 @@ log:
         .await;
     let http_start = log_line(&stdout_log, LOG_HTTP_REQUEST_START);
     assert!(find_attr(http_start, "trace_id").is_none());
+}
+
+#[derive(Default)]
+struct TestDebugLogPlugin;
+
+#[async_trait]
+impl RouterPlugin for TestDebugLogPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "test_debug_log"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin_with_defaults()
+    }
+
+    fn on_http_request<'req>(
+        &self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
+        debug!("i'm just a test");
+        payload.proceed()
+    }
+}
+
+#[ntex::test]
+async fn plugin_log_lines_are_correlated_with_request_id() {
+    let (_subgraphs, router) = setup_router(
+        router_with_telemetry(
+            "\
+log:
+  level: debug
+  format: json
+plugins:
+  test_debug_log:
+    enabled: true
+",
+        )
+        .register_plugin::<TestDebugLogPlugin>(),
+    )
+    .await;
+
+    let stdout_log = router
+        .send_graphql_request(TEST_QUERY, None, None)
+        .capture_stdout_json()
+        .await;
+
+    let http_start = log_line(&stdout_log, LOG_HTTP_REQUEST_START);
+    let plugin_log = log_line(&stdout_log, "i'm just a test");
+
+    assert_eq!(req_id_of(http_start), req_id_of(plugin_log));
 }

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -41,6 +41,7 @@ use hive_router::{
     add_callback_handler, background_tasks::BackgroundTasksManager, configure_app_from_config,
     configure_ntex_app, init_rustls_crypto_provider, invoke_shutdown_hooks,
     pipeline::long_lived_client_limit::LongLivedClientLimitService,
+    pipeline::request_identifiers::RequestIdentifiersService,
     plugins::plugins_service::PluginService, telemetry::Telemetry, PluginRegistry, RouterPaths,
     RouterSharedState, SchemaState,
 };
@@ -922,6 +923,7 @@ impl TestRouter<Built> {
                         paths.clone(),
                         prometheus.as_ref().map(|p| p.endpoint.clone()),
                     ))
+                    .middleware(RequestIdentifiersService)
                     .state(shared_state.clone())
                     .state(schema_state)
                     .state(callback_subs)

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.0.85"
+version = "0.0.86"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-config"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "config",
  "envconfig",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-internal"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2821,7 +2821,6 @@ dependencies = [
  "prometheus",
  "serde",
  "sonic-rs",
- "sonyflake",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
@@ -2831,12 +2830,13 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uuid",
  "vrl",
 ]
 
 [[package]]
 name = "hive-router-plan-executor"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "ahash",
  "async-stream",
@@ -3394,15 +3394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -4107,12 +4098,6 @@ checksum = "9f79c902b31ceac6856e262af5dbaffef75390cf4647c9fef7b55da69a4b912e"
 dependencies = [
  "cidr",
 ]
-
-[[package]]
-name = "no-std-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nom"
@@ -5247,38 +5232,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "pnet_base"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
-dependencies = [
- "no-std-net",
-]
-
-[[package]]
-name = "pnet_datalink"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
-dependencies = [
- "ipnetwork",
- "libc",
- "pnet_base",
- "pnet_sys",
- "winapi",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "poly1305"
@@ -7115,17 +7068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sonyflake"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bcd9b6dfb17bf52cefb3db84a111267d8f2db88087d9cd1a46aa57de3cfcc1"
-dependencies = [
- "chrono",
- "pnet_datalink",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8130,9 +8072,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/plugin_examples/apollo_sandbox/src/lib.rs
+++ b/plugin_examples/apollo_sandbox/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/apq/src/lib.rs
+++ b/plugin_examples/apq/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/async_auth/src/lib.rs
+++ b/plugin_examples/async_auth/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/context_data/src/lib.rs
+++ b/plugin_examples/context_data/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/error_mapping/src/lib.rs
+++ b/plugin_examples/error_mapping/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/feature_flags/src/lib.rs
+++ b/plugin_examples/feature_flags/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/field_nulling/src/lib.rs
+++ b/plugin_examples/field_nulling/src/lib.rs
@@ -1,1 +1,4 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;

--- a/plugin_examples/forbid_anonymous_operations/src/lib.rs
+++ b/plugin_examples/forbid_anonymous_operations/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/incoming_request_deduplication/src/lib.rs
+++ b/plugin_examples/incoming_request_deduplication/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/jwt_cookie/src/lib.rs
+++ b/plugin_examples/jwt_cookie/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/multipart/src/lib.rs
+++ b/plugin_examples/multipart/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/non_standard_request/src/lib.rs
+++ b/plugin_examples/non_standard_request/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/non_standard_request/src/main.rs
+++ b/plugin_examples/non_standard_request/src/main.rs
@@ -1,3 +1,4 @@
+
 use hive_router::{
     configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
     router_entrypoint, PluginRegistry, RouterGlobalAllocator,

--- a/plugin_examples/one_of/src/lib.rs
+++ b/plugin_examples/one_of/src/lib.rs
@@ -45,6 +45,9 @@
     }
 */
 
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 use std::sync::Arc;
 
 use hive_router::graphql_tools::ast::{OperationVisitor, OperationVisitorContext};

--- a/plugin_examples/plugin_template/src/main.rs
+++ b/plugin_examples/plugin_template/src/main.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 use hive_router::{
     configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
     router_entrypoint, PluginRegistry, RouterGlobalAllocator,

--- a/plugin_examples/progressive_override_launchdarkly/src/lib.rs
+++ b/plugin_examples/progressive_override_launchdarkly/src/lib.rs
@@ -1,1 +1,4 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;

--- a/plugin_examples/propagate_status_code/src/lib.rs
+++ b/plugin_examples/propagate_status_code/src/lib.rs
@@ -1,5 +1,9 @@
 // From https://github.com/apollographql/router/blob/dev/examples/status-code-propagation/rust/src/propagate_status_code.rs
 
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
+
 use hive_router::http::StatusCode;
 use serde::Deserialize;
 

--- a/plugin_examples/replace_schema/src/lib.rs
+++ b/plugin_examples/replace_schema/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;

--- a/plugin_examples/response_cache/src/lib.rs
+++ b/plugin_examples/response_cache/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 use std::collections::HashMap;
 
 use hive_router::http::HeaderMap;

--- a/plugin_examples/root_field_limit/src/lib.rs
+++ b/plugin_examples/root_field_limit/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 use hive_router::http::StatusCode;
 use hive_router::query_planner::ast::selection_item::SelectionItem;
 use hive_router::{

--- a/plugin_examples/subgraph_response_cache/src/lib.rs
+++ b/plugin_examples/subgraph_response_cache/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 use hive_router::plugins::{
     hooks::{
         on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},

--- a/plugin_examples/usage_reporting/src/lib.rs
+++ b/plugin_examples/usage_reporting/src/lib.rs
@@ -1,3 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
 pub mod plugin;
 #[cfg(test)]
 pub mod test;


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1351 

The proposed fix moves the request correlation extraction higher (to ntex's middleware) so other middlewares and other aspects of the execution can access it fully. 

By moving it up the hirerchy, we allow `on_http_req` hook to also be fully correlated, so plugin developers can benefit from using the logger without the needs to deal with correlation manually. 