### PR TITLE
feat(router): enrich OTEL traces with logging request-id correlations

### DIFF
--- a/.changeset/attach_request_id_to_root_span.md
+++ b/.changeset/attach_request_id_to_root_span.md
@@ -1,0 +1,10 @@
+---
+hive-router-internal: minor
+hive-router: minor
+---
+
+# Attach the correlation request-id to the root HTTP server span
+
+The root `http.server` OpenTelemetry span now carries a `router.request_id` attribute, set to the same request-id used for log correlation (either the incoming correlation header, e.g. `x-request-id`, or an auto-generated one). This makes it possible to join a trace directly to its logs without cross-referencing trace IDs.
+
+Fixes https://github.com/graphql-hive/router/pull/1353

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -69,7 +69,6 @@ use graphql_tools::validation::rules::default_rules_validation_plan;
 pub use hive_router_config::humantime_serde;
 use hive_router_config::{load_config, subscriptions::CallbackConfig, HiveRouterConfig};
 pub use hive_router_internal::background_tasks;
-use hive_router_internal::background_tasks::{BackgroundTask, CancellationToken};
 use hive_router_internal::telemetry::{
     logging::{
         summary::{self, WithRequestSummary},
@@ -80,6 +79,10 @@ use hive_router_internal::telemetry::{
     TelemetryContext,
 };
 pub use hive_router_internal::BoxError;
+use hive_router_internal::{
+    background_tasks::{BackgroundTask, CancellationToken},
+    telemetry::logging::request_id::REQUEST_IDENTIFIERS,
+};
 use hive_router_internal::{
     http::read_request_body_size, telemetry::metrics::catalog::values::GraphQLResponseStatus,
 };
@@ -181,7 +184,6 @@ async fn graphql_endpoint_handler(
             schema_state,
             app_state.clone(),
             parent_ctx,
-            &request_identifiers,
         )
         .await;
 
@@ -245,7 +247,6 @@ async fn graphql_endpoint_dispatch(
     schema_state: web::types::State<Arc<SchemaState>>,
     app_state: web::types::State<Arc<RouterSharedState>>,
     parent_ctx: opentelemetry::Context,
-    request_identifiers: &RequestIdentifiers,
 ) -> (ResponseMode, web::HttpResponse) {
     let root_http_request_span = HttpServerRequestSpan::from_request(
         request,
@@ -256,7 +257,11 @@ async fn graphql_endpoint_dispatch(
             .ip_header,
     );
     let _ = root_http_request_span.set_parent(parent_ctx);
-    root_http_request_span.record_request_id(request_identifiers.req_id());
+
+    #[allow(unused_must_use)]
+    REQUEST_IDENTIFIERS.try_with(|request_identifiers| {
+        root_http_request_span.record_request_id(request_identifiers.req_id());
+    });
 
     let response_header_sink = ResponseHeaderSink::default();
 

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -181,6 +181,7 @@ async fn graphql_endpoint_handler(
             schema_state,
             app_state.clone(),
             parent_ctx,
+            &request_identifiers,
         )
         .await;
 
@@ -244,6 +245,7 @@ async fn graphql_endpoint_dispatch(
     schema_state: web::types::State<Arc<SchemaState>>,
     app_state: web::types::State<Arc<RouterSharedState>>,
     parent_ctx: opentelemetry::Context,
+    request_identifiers: &RequestIdentifiers,
 ) -> (ResponseMode, web::HttpResponse) {
     let root_http_request_span = HttpServerRequestSpan::from_request(
         request,
@@ -254,6 +256,7 @@ async fn graphql_endpoint_dispatch(
             .ip_header,
     );
     let _ = root_http_request_span.set_parent(parent_ctx);
+    root_http_request_span.record_request_id(request_identifiers.req_id());
 
     let response_header_sink = ResponseHeaderSink::default();
 

--- a/e2e/src/telemetry/tracing/otlp_attributes.rs
+++ b/e2e/src/telemetry/tracing/otlp_attributes.rs
@@ -62,7 +62,7 @@ async fn test_deprecated_span_attributes() {
 
     insta::assert_snapshot!(
       http_server_span,
-      @r"
+      @"
     Span: http.server
       Kind: Server
       Status: message='' code='1'
@@ -82,6 +82,7 @@ async fn test_deprecated_span_attributes() {
         http.url: /graphql
         network.peer.address: [address]
         network.peer.port: [port]
+        router.request_id: [request_id]
         server.port: [port]
         target: hive-router
     "
@@ -196,7 +197,7 @@ async fn test_spec_and_deprecated_span_attributes() {
 
     insta::assert_snapshot!(
       http_server_span,
-      @r"
+      @"
     Span: http.server
       Kind: Server
       Status: message='' code='1'
@@ -221,6 +222,7 @@ async fn test_spec_and_deprecated_span_attributes() {
         network.peer.address: [address]
         network.peer.port: [port]
         network.protocol.version: 1.1
+        router.request_id: [request_id]
         server.address: localhost
         server.port: [port]
         target: hive-router

--- a/e2e/src/telemetry/tracing/otlp_attributes.rs
+++ b/e2e/src/telemetry/tracing/otlp_attributes.rs
@@ -450,6 +450,124 @@ async fn test_custom_client_identification() {
     );
 }
 
+#[ntex::test]
+async fn request_id_span_attribute_from_logging_header_correlation() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_traces_endpoint();
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {supergraph_path}
+
+          telemetry:
+            tracing:
+              exporters:
+                - kind: otlp
+                  endpoint: {otlp_endpoint}
+                  protocol: http
+                  batch_processor:
+                    scheduled_delay: 50ms
+                    max_export_timeout: 2s
+      "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    let res = router
+        .send_graphql_request(
+            "{ users { id } }",
+            None,
+            some_header_map!(
+                http::header::HeaderName::from_static("x-request-id") => "e2e-test-request-id"
+            ),
+        )
+        .await;
+
+    assert!(res.status().is_success());
+
+    let http_server_span = otlp_collector
+        .wait_for_span_by_hive_kind_one("http.server")
+        .await;
+
+    assert_eq!(
+        http_server_span.attributes.get("router.request_id"),
+        Some(&"e2e-test-request-id".to_string()),
+        "Expected the 'router.request_id' span attribute to match the incoming 'x-request-id' header"
+    );
+}
+
+/// Verify a request-id is generated and attached to the root HTTP server span
+/// even when the client does not send a correlation header
+#[ntex::test]
+async fn request_id_span_attribute_auto_generated_from_logging_header_correlation() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_traces_endpoint();
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {supergraph_path}
+
+          telemetry:
+            tracing:
+              exporters:
+                - kind: otlp
+                  endpoint: {otlp_endpoint}
+                  protocol: http
+                  batch_processor:
+                    scheduled_delay: 50ms
+                    max_export_timeout: 2s
+      "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    let res = router
+        .send_graphql_request("{ users { id } }", None, None)
+        .await;
+
+    assert!(res.status().is_success());
+
+    let http_server_span = otlp_collector
+        .wait_for_span_by_hive_kind_one("http.server")
+        .await;
+
+    let request_id = http_server_span
+        .attributes
+        .get("router.request_id")
+        .expect("Expected a 'router.request_id' span attribute to be set");
+
+    assert!(
+        !request_id.is_empty(),
+        "Expected a non-empty auto-generated request id"
+    );
+}
+
 /// Verify default resource attributes
 #[ntex::test]
 async fn test_default_resource_attributes() {

--- a/e2e/src/telemetry/tracing/otlp_basic.rs
+++ b/e2e/src/telemetry/tracing/otlp_basic.rs
@@ -86,7 +86,7 @@ async fn test_otlp_http_export_with_graphql_request() {
 
     insta::assert_snapshot!(
       http_server_span,
-      @r"
+      @"
     Span: http.server
       Kind: Server
       Status: message='' code='1'
@@ -102,6 +102,7 @@ async fn test_otlp_http_export_with_graphql_request() {
         network.peer.address: [address]
         network.peer.port: [port]
         network.protocol.version: 1.1
+        router.request_id: [request_id]
         server.address: localhost
         server.port: [port]
         target: hive-router
@@ -347,7 +348,7 @@ async fn test_otlp_grpc_export_with_graphql_request() {
 
     insta::assert_snapshot!(
       http_server_span,
-      @r"
+      @"
     Span: http.server
       Kind: Server
       Status: message='' code='1'
@@ -363,6 +364,7 @@ async fn test_otlp_grpc_export_with_graphql_request() {
         network.peer.address: [address]
         network.peer.port: [port]
         network.protocol.version: 1.1
+        router.request_id: [request_id]
         server.address: localhost
         server.port: [port]
         target: hive-router

--- a/e2e/src/testkit/otel.rs
+++ b/e2e/src/testkit/otel.rs
@@ -784,10 +784,12 @@ impl OtlpCollector {
 
         // keys
         settings.add_filter(r"(hive\.inflight\.key:\s+)\d+", "$1[random]");
+        settings.add_filter(r"(hive\.inflight\.key:\s+)\d+", "$1[random]");
 
         // addresses and ports
         settings.add_filter(r"(server\.address:\s+)[\d.]+", "$1[address]");
         settings.add_filter(r"(server\.port:\s+)\d+", "$1[port]");
+        settings.add_filter(r"(router\.request_id:\s+)[0-9a-f-]+", "$1[request_id]");
         settings.add_filter(r"(client\.address:\s+)[\d.]+", "$1[address]");
         settings.add_filter(r"(client\.port:\s+)\d+", "$1[port]");
         settings.add_filter(r"(network\.peer\.address:\s+)[\d.]+", "$1[address]");

--- a/lib/internal/src/telemetry/logging/summary.rs
+++ b/lib/internal/src/telemetry/logging/summary.rs
@@ -186,7 +186,7 @@ impl<F: Future> WithRequestSummary for F {}
 pub struct SummaryOnDrop {
     started_at: std::time::Instant,
     summary: Option<Arc<RequestSummary>>,
-    request_ids: Option<Arc<RequestIdentifiers>>,
+    pub request_ids: Option<Arc<RequestIdentifiers>>,
 }
 
 impl SummaryOnDrop {

--- a/lib/internal/src/telemetry/traces/spans/attributes.rs
+++ b/lib/internal/src/telemetry/traces/spans/attributes.rs
@@ -44,6 +44,7 @@ pub const HIVE_CLIENT_NAME: &str = "hive.client.name";
 pub const HIVE_CLIENT_VERSION: &str = "hive.client.version";
 pub const HIVE_GRAPHQL_OPERATION_HASH: &str = "hive.graphql.operation.hash";
 pub const HIVE_GRAPHQL_SUBGRAPH_NAME: &str = "hive.graphql.subgraph.name";
+
 /// Hive-specific attributes for errors
 pub const HIVE_ERROR_AFFECTED_PATH: &str = "hive.error.affected_path";
 pub const HIVE_ERROR_SUBGRAPH_NAME: &str = "hive.error.subgraph_name";
@@ -70,3 +71,6 @@ pub const DEPRECATED_HTTP_RESPONSE_CONTENT_LENGTH: &str = "http.response_content
 pub const DEPRECATED_NET_PEER_NAME: &str = "net.peer.name";
 pub const DEPRECATED_NET_PEER_PORT: &str = "net.peer.port";
 pub const DEPRECATED_GRAPHQL_DOCUMENT: &str = "graphql.document";
+
+// Custom Router attributes
+pub const ROUTER_REQUEST_ID: &str = "router.request_id";

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -117,6 +117,7 @@ impl HttpServerRequestSpan {
             target: TARGET_NAME,
             "http.server",
             "hive.kind" = kind,
+            "router.request_id" = Empty,
             "otel.status_code" = Empty,
             "otel.kind" = "Server",
             "error.type" = Empty,
@@ -147,6 +148,10 @@ impl HttpServerRequestSpan {
     pub fn record_body_size(&self, body_size: usize) {
         self.span
             .record(attributes::HTTP_REQUEST_BODY_SIZE, body_size);
+    }
+
+    pub fn record_request_id(&self, req_id: &str) {
+        self.span.record(attributes::ROUTER_REQUEST_ID, req_id);
     }
 
     pub fn record_response(&self, response: &ntex::web::HttpResponse) {

--- a/lib/internal/src/telemetry/traces/spans/tests.rs
+++ b/lib/internal/src/telemetry/traces/spans/tests.rs
@@ -240,6 +240,7 @@ fn test_http_server_request_span() {
                 attributes::CLIENT_PORT,
                 attributes::NETWORK_PEER_ADDRESS,
                 attributes::NETWORK_PEER_PORT,
+                attributes::ROUTER_REQUEST_ID,
             ],
         );
 


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1349 

This PR rolls the request-id extracted in the logger, and passes it to the root trace produced by OTEL logging. This is useful because now users can correlate logs and traces easily. 

The semantic attributes of OTEL doesn't declare a attribute key, and it seems like each solution picks their own. I used `router.request_id`. 

Ideally, this should go in after https://github.com/graphql-hive/router/pull/1352 , and it will require some rebasing and adjustments for the req-id extraction (it should come from the task-local context, and not from the local variable, as it moved) 