### PR TITLE
feat(router): added new `apollo_graphos` supergraph source

### DIFF
--- a/.changeset/add_apollo_graphos_supergraph_source.md
+++ b/.changeset/add_apollo_graphos_supergraph_source.md
@@ -1,0 +1,14 @@
+---
+hive-router-config: minor
+hive-router: minor
+hive-router-internal: patch
+hive-router-plan-executor: patch
+---
+
+# Add `apollo_graphos` supergraph source
+
+Adds a new `apollo_graphos` supergraph source that fetches the supergraph schema from Apollo GraphOS's managed federation Uplink, for routers migrating from Apollo Router/Gateway without needing a separate schema-delivery pipeline.
+
+Configure it with `graph_ref` and `key` (or the `APOLLO_GRAPH_REF`/`APOLLO_KEY` environment variables), and optionally `endpoint` (defaults to Apollo's GCP and AWS Uplink endpoints, tried in order), `timeout` and `accept_invalid_certs`.
+
+Closes https://github.com/graphql-hive/router/issues/505

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -586,7 +586,7 @@ impl BackgroundTask for SupergraphBackgroundLoaderTask {
             if let Some(interval) = self.0.loader.reload_interval() {
                 debug!(target: targets::SUPERGRAPH, interval_ms = interval.as_millis(), "waiting before checking again for supergraph changes");
 
-                ntex::time::sleep(*interval).await;
+                ntex::time::sleep(interval).await;
             } else {
                 debug!(target: targets::SUPERGRAPH, "poll interval not configured for supergraph changes, skipping");
 

--- a/bin/router/src/supergraph/apollo_graphos.rs
+++ b/bin/router/src/supergraph/apollo_graphos.rs
@@ -1,0 +1,225 @@
+use std::sync::RwLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hive_router_internal::telemetry::logging::targets;
+use serde::Deserialize;
+use tracing::{debug, error, trace};
+
+use crate::supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApolloGraphOSSupergraphError {
+    #[error("Apollo GraphOS graph ref is missing. Please provide it via 'APOLLO_GRAPH_REF' environment variable or under 'supergraph.graph_ref' in the configuration.")]
+    MissingApolloGraphRef,
+    #[error("Apollo GraphOS key is missing. Please provide it via 'APOLLO_KEY' environment variable or under 'supergraph.key' in the configuration.")]
+    MissingApolloKey,
+    #[error("Failed to initialize the loader: {0}")]
+    InitializationError(String),
+    #[error("Apollo Uplink reported a fetch error: code={code} message={message}")]
+    ApolloUplinkFetchError { code: String, message: String },
+    #[error("Failed to fetch from Apollo Uplink: no endpoint succeeded")]
+    ApolloUplinkAllEndpointsFailed,
+}
+
+const UPLINK_QUERY: &str = r#"
+query($apiKey: String!, $graphRef: String!, $ifAfterId: ID) {
+  routerConfig(ref: $graphRef, apiKey: $apiKey, ifAfterId: $ifAfterId) {
+    __typename
+    ... on RouterConfigResult {
+      id
+      supergraphSDL
+      minDelaySeconds
+    }
+    ... on Unchanged {
+      id
+      minDelaySeconds
+    }
+    ... on FetchError {
+      code
+      message
+    }
+  }
+}
+"#;
+
+const INITIAL_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Deserialize)]
+struct UplinkGraphQLResponse {
+    data: Option<UplinkData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UplinkData {
+    #[serde(rename = "routerConfig")]
+    router_config: RouterConfigResponse,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "__typename")]
+enum RouterConfigResponse {
+    RouterConfigResult {
+        id: String,
+        #[serde(rename = "supergraphSDL")]
+        supergraph_sdl: String,
+        #[serde(rename = "minDelaySeconds")]
+        min_delay_seconds: f64,
+    },
+    Unchanged {
+        id: String,
+        #[serde(rename = "minDelaySeconds")]
+        min_delay_seconds: f64,
+    },
+    FetchError {
+        code: String,
+        message: String,
+    },
+}
+
+pub struct SupergraphApolloGraphOSLoader {
+    client: reqwest::Client,
+    endpoints: Vec<String>,
+    graph_ref: String,
+    key: String,
+    last_id: RwLock<Option<String>>,
+    current_interval: RwLock<Duration>,
+}
+
+impl SupergraphApolloGraphOSLoader {
+    pub fn try_new(
+        endpoints: Vec<String>,
+        graph_ref: &str,
+        key: &str,
+        timeout: Duration,
+        accept_invalid_certs: bool,
+    ) -> Result<Box<Self>, ApolloGraphOSSupergraphError> {
+        debug!(
+          target: targets::SUPERGRAPH,
+          endpoints = ?endpoints,
+          graph_ref,
+          "Creating supergraph source from Apollo GraphOS Uplink",
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .danger_accept_invalid_certs(accept_invalid_certs)
+            .build()
+            .map_err(|e| ApolloGraphOSSupergraphError::InitializationError(e.to_string()))?;
+
+        Ok(Box::new(Self {
+            client,
+            endpoints,
+            graph_ref: graph_ref.to_string(),
+            key: key.to_string(),
+            last_id: RwLock::new(None),
+            current_interval: RwLock::new(INITIAL_POLL_INTERVAL),
+        }))
+    }
+
+    // Tries each configured endpoint in order, a failed/unparseable response just
+    // falls through to the next endpoint, and the next scheduled poll is the real retry mechanism.
+    async fn fetch(&self) -> Result<RouterConfigResponse, ApolloGraphOSSupergraphError> {
+        let last_id = self.last_id.read().unwrap().clone();
+
+        let body = serde_json::json!({
+            "query": UPLINK_QUERY,
+            "variables": {
+                "apiKey": &self.key,
+                "graphRef": &self.graph_ref,
+                "ifAfterId": last_id,
+            },
+        });
+
+        for endpoint in &self.endpoints {
+            let response = match self.client.post(endpoint).json(&body).send().await {
+                Ok(response) => response,
+                Err(err) => {
+                    debug!(
+                      target: targets::SUPERGRAPH,
+                      endpoint,
+                      error = ?err,
+                      "failed to fetch from Apollo Uplink endpoint, trying next endpoint",
+                    );
+
+                    continue;
+                }
+            };
+
+            match response.json::<UplinkGraphQLResponse>().await {
+                Ok(UplinkGraphQLResponse { data: Some(data) }) => {
+                    return Ok(data.router_config);
+                }
+                Ok(UplinkGraphQLResponse { data: None }) => {
+                    debug!(
+                      target: targets::SUPERGRAPH,
+                      endpoint,
+                      "empty response from Apollo Uplink endpoint, trying next endpoint",
+                    );
+                }
+                Err(err) => {
+                    debug!(
+                      target: targets::SUPERGRAPH,
+                      endpoint,
+                      error = ?err,
+                      "failed to parse response from Apollo Uplink endpoint, trying next endpoint",
+                    );
+                }
+            }
+        }
+
+        Err(ApolloGraphOSSupergraphError::ApolloUplinkAllEndpointsFailed)
+    }
+}
+
+#[async_trait]
+impl SupergraphLoader for SupergraphApolloGraphOSLoader {
+    async fn load(&self) -> Result<ReloadSupergraphResult, LoadSupergraphError> {
+        let router_config = self.fetch().await?;
+
+        match router_config {
+            RouterConfigResponse::RouterConfigResult {
+                id,
+                supergraph_sdl,
+                min_delay_seconds,
+            } => {
+                *self.last_id.write().unwrap() = Some(id);
+                *self.current_interval.write().unwrap() =
+                    Duration::from_secs_f64(min_delay_seconds.max(0.0));
+
+                trace!(
+                  target: targets::SUPERGRAPH,
+                  "supergraph loaded from Apollo Uplink with changes",
+                );
+
+                Ok(ReloadSupergraphResult::Changed {
+                    new_sdl: supergraph_sdl,
+                })
+            }
+            RouterConfigResponse::Unchanged {
+                id,
+                min_delay_seconds,
+            } => {
+                *self.last_id.write().unwrap() = Some(id);
+                *self.current_interval.write().unwrap() =
+                    Duration::from_secs_f64(min_delay_seconds.max(0.0));
+
+                Ok(ReloadSupergraphResult::Unchanged)
+            }
+            RouterConfigResponse::FetchError { code, message } => {
+                error!(
+                  target: targets::SUPERGRAPH,
+                  code = %code,
+                  message = %message,
+                  "Apollo Uplink reported a fetch error",
+                );
+
+                Err(ApolloGraphOSSupergraphError::ApolloUplinkFetchError { code, message }.into())
+            }
+        }
+    }
+
+    fn reload_interval(&self) -> Option<Duration> {
+        Some(*self.current_interval.read().unwrap())
+    }
+}

--- a/bin/router/src/supergraph/apollo_graphos.rs
+++ b/bin/router/src/supergraph/apollo_graphos.rs
@@ -1,0 +1,225 @@
+use std::sync::RwLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hive_router_internal::telemetry::logging::targets;
+use serde::Deserialize;
+use tracing::{debug, error, trace};
+
+use crate::supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApolloGraphOSSupergraphError {
+    #[error("Apollo GraphOS graph ref is missing. Please provide it via 'APOLLO_GRAPH_REF' environment variable or under 'supergraph.graph_ref' in the configuration.")]
+    MissingApolloGraphRef,
+    #[error("Apollo GraphOS key is missing. Please provide it via 'APOLLO_KEY' environment variable or under 'supergraph.key' in the configuration.")]
+    MissingApolloKey,
+    #[error("Failed to initialize the loader: {0}")]
+    InitializationError(String),
+    #[error("Apollo Uplink reported a fetch error: code={code} message={message}")]
+    ApolloUplinkFetchError { code: String, message: String },
+    #[error("Failed to fetch from Apollo Uplink: no endpoint succeeded")]
+    ApolloUplinkAllEndpointsFailed,
+}
+
+const UPLINK_QUERY: &str = r#"
+query($apiKey: String!, $graphRef: String!, $ifAfterId: ID) {
+  routerConfig(ref: $graphRef, apiKey: $apiKey, ifAfterId: $ifAfterId) {
+    __typename
+    ... on RouterConfigResult {
+      id
+      supergraphSDL
+      minDelaySeconds
+    }
+    ... on Unchanged {
+      id
+      minDelaySeconds
+    }
+    ... on FetchError {
+      code
+      message
+    }
+  }
+}
+"#;
+
+const INITIAL_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Deserialize)]
+struct UplinkGraphQLResponse {
+    data: Option<UplinkData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UplinkData {
+    #[serde(rename = "routerConfig")]
+    router_config: RouterConfigResponse,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "__typename")]
+enum RouterConfigResponse {
+    RouterConfigResult {
+        id: String,
+        #[serde(rename = "supergraphSDL")]
+        supergraph_sdl: String,
+        #[serde(rename = "minDelaySeconds")]
+        min_delay_seconds: f64,
+    },
+    Unchanged {
+        id: String,
+        #[serde(rename = "minDelaySeconds")]
+        min_delay_seconds: f64,
+    },
+    FetchError {
+        code: String,
+        message: String,
+    },
+}
+
+pub struct SupergraphApolloGraphOSLoader {
+    client: reqwest::Client,
+    endpoints: Vec<String>,
+    graph_ref: String,
+    key: String,
+    last_id: RwLock<Option<String>>,
+    current_interval: RwLock<Duration>,
+}
+
+impl SupergraphApolloGraphOSLoader {
+    pub fn try_new(
+        endpoints: Vec<String>,
+        graph_ref: &str,
+        key: &str,
+        timeout: Duration,
+        accept_invalid_certs: bool,
+    ) -> Result<Box<Self>, ApolloGraphOSSupergraphError> {
+        debug!(
+          target: targets::SUPERGRAPH,
+          endpoints = ?endpoints,
+          graph_ref,
+          "Creating supergraph source from Apollo GraphOS Uplink",
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .danger_accept_invalid_certs(accept_invalid_certs)
+            .build()
+            .map_err(|e| ApolloGraphOSSupergraphError::InitializationError(e.to_string()))?;
+
+        Ok(Box::new(Self {
+            client,
+            endpoints,
+            graph_ref: graph_ref.to_string(),
+            key: key.to_string(),
+            last_id: RwLock::new(None),
+            current_interval: RwLock::new(INITIAL_POLL_INTERVAL),
+        }))
+    }
+
+    // Tries each configured endpoint in order, a failed/unparseable response just
+    // falls through to the next endpoint, and the next scheduled poll is the real retry mechanism.
+    async fn fetch(&self) -> Result<RouterConfigResponse, ApolloGraphOSSupergraphError> {
+        let last_id = self.last_id.read().unwrap().clone();
+
+        let body = serde_json::json!({
+            "query": UPLINK_QUERY,
+            "variables": {
+                "apiKey": self.key,
+                "graphRef": self.graph_ref,
+                "ifAfterId": last_id,
+            },
+        });
+
+        for endpoint in &self.endpoints {
+            let response = match self.client.post(endpoint).json(&body).send().await {
+                Ok(response) => response,
+                Err(err) => {
+                    debug!(
+                      target: targets::SUPERGRAPH,
+                      endpoint,
+                      error = ?err,
+                      "failed to fetch from Apollo Uplink endpoint, trying next endpoint",
+                    );
+
+                    continue;
+                }
+            };
+
+            match response.json::<UplinkGraphQLResponse>().await {
+                Ok(UplinkGraphQLResponse { data: Some(data) }) => {
+                    return Ok(data.router_config);
+                }
+                Ok(UplinkGraphQLResponse { data: None }) => {
+                    debug!(
+                      target: targets::SUPERGRAPH,
+                      endpoint,
+                      "empty response from Apollo Uplink endpoint, trying next endpoint",
+                    );
+                }
+                Err(err) => {
+                    debug!(
+                      target: targets::SUPERGRAPH,
+                      endpoint,
+                      error = ?err,
+                      "failed to parse response from Apollo Uplink endpoint, trying next endpoint",
+                    );
+                }
+            }
+        }
+
+        Err(ApolloGraphOSSupergraphError::ApolloUplinkAllEndpointsFailed)
+    }
+}
+
+#[async_trait]
+impl SupergraphLoader for SupergraphApolloGraphOSLoader {
+    async fn load(&self) -> Result<ReloadSupergraphResult, LoadSupergraphError> {
+        let router_config = self.fetch().await?;
+
+        match router_config {
+            RouterConfigResponse::RouterConfigResult {
+                id,
+                supergraph_sdl,
+                min_delay_seconds,
+            } => {
+                *self.last_id.write().unwrap() = Some(id);
+                *self.current_interval.write().unwrap() =
+                    Duration::from_secs_f64(min_delay_seconds.max(0.0));
+
+                trace!(
+                  target: targets::SUPERGRAPH,
+                  "supergraph loaded from Apollo Uplink with changes",
+                );
+
+                Ok(ReloadSupergraphResult::Changed {
+                    new_sdl: supergraph_sdl,
+                })
+            }
+            RouterConfigResponse::Unchanged {
+                id,
+                min_delay_seconds,
+            } => {
+                *self.last_id.write().unwrap() = Some(id);
+                *self.current_interval.write().unwrap() =
+                    Duration::from_secs_f64(min_delay_seconds.max(0.0));
+
+                Ok(ReloadSupergraphResult::Unchanged)
+            }
+            RouterConfigResponse::FetchError { code, message } => {
+                error!(
+                  target: targets::SUPERGRAPH,
+                  code = %code,
+                  message = %message,
+                  "Apollo Uplink reported a fetch error",
+                );
+
+                Err(ApolloGraphOSSupergraphError::ApolloUplinkFetchError { code, message }.into())
+            }
+        }
+    }
+
+    fn reload_interval(&self) -> Option<Duration> {
+        Some(*self.current_interval.read().unwrap())
+    }
+}

--- a/bin/router/src/supergraph/apollo_graphos.rs
+++ b/bin/router/src/supergraph/apollo_graphos.rs
@@ -125,8 +125,8 @@ impl SupergraphApolloGraphOSLoader {
         let body = serde_json::json!({
             "query": UPLINK_QUERY,
             "variables": {
-                "apiKey": self.key,
-                "graphRef": self.graph_ref,
+                "apiKey": &self.key,
+                "graphRef": &self.graph_ref,
                 "ifAfterId": last_id,
             },
         });

--- a/bin/router/src/supergraph/base.rs
+++ b/bin/router/src/supergraph/base.rs
@@ -1,32 +1,20 @@
 use async_trait::async_trait;
 
-use crate::storage::error::StorageError;
+use crate::supergraph::{
+    apollo_graphos::ApolloGraphOSSupergraphError, file::FileSupergraphError,
+    hive::HiveConsoleSupergraphError, storage::StorageSupergraphError,
+};
 
 #[derive(Debug, thiserror::Error)]
-#[allow(clippy::enum_variant_names)]
 pub enum LoadSupergraphError {
-    #[error("Failed to read supergraph file: {0}")]
-    ReadFileError(#[from] std::io::Error),
-    #[error("Failed to read supergraph from network: {0}")]
-    NetworkError(#[from] reqwest_middleware::Error),
-    #[error("Failed to read supergraph from network: {0}")]
-    NetworkResponseError(#[from] reqwest::Error),
-    #[error("Failed to lock supergraph: {0}")]
-    LockError(String),
-    #[error("Failed to initialize the loader: {0}")]
-    InitializationError(String),
-    #[error("Invalid configuration: {0}")]
-    InvalidConfiguration(String),
-    #[error("Supergraph file path is missing. Please provide it via 'SUPERGRAPH_FILE_PATH' environment variable or under 'supergraph.path' in the configuration.")]
-    MissingSupergraphFilePath,
-    #[error("Hive CDN endpoint is missing. Please provide it via 'HIVE_CDN_ENDPOINT' environment variable or under 'supergraph.endpoint' in the configuration.")]
-    MissingHiveCDNEndpoint,
-    #[error("Hive CDN key is missing. Please provide it via 'HIVE_CDN_KEY' environment variable or under 'supergraph.key' in the configuration.")]
-    MissingHiveCDNKey,
-    #[error("Storage ID {0} is not defined in the Router configuration")]
-    StorageIdNotFound(String),
-    #[error("Storage error: {0}")]
-    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    File(#[from] FileSupergraphError),
+    #[error(transparent)]
+    HiveConsole(#[from] HiveConsoleSupergraphError),
+    #[error(transparent)]
+    ApolloGraphOS(#[from] ApolloGraphOSSupergraphError),
+    #[error(transparent)]
+    Storage(#[from] StorageSupergraphError),
     #[error("'supergraph.source: plugin' has no loader - a plugin must select a supergraph for every request")]
     NoLoaderForPluginSource,
 }
@@ -40,7 +28,7 @@ pub enum ReloadSupergraphResult {
 #[async_trait]
 pub trait SupergraphLoader {
     async fn load(&self) -> Result<ReloadSupergraphResult, LoadSupergraphError>;
-    fn reload_interval(&self) -> Option<&std::time::Duration> {
+    fn reload_interval(&self) -> Option<std::time::Duration> {
         None
     }
 }

--- a/bin/router/src/supergraph/file.rs
+++ b/bin/router/src/supergraph/file.rs
@@ -8,6 +8,14 @@ use tracing::{debug, trace};
 
 use crate::supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader};
 
+#[derive(Debug, thiserror::Error)]
+pub enum FileSupergraphError {
+    #[error("Failed to read supergraph file: {0}")]
+    ReadFileError(#[from] std::io::Error),
+    #[error("Supergraph file path is missing. Please provide it via 'SUPERGRAPH_FILE_PATH' environment variable or under 'supergraph.path' in the configuration.")]
+    MissingSupergraphFilePath,
+}
+
 pub struct SupergraphFileLoader {
     file_path: FilePath,
     poll_interval: Option<Duration>,
@@ -15,7 +23,7 @@ pub struct SupergraphFileLoader {
 }
 
 impl SupergraphFileLoader {
-    async fn load_with_polling(&self) -> Result<ReloadSupergraphResult, LoadSupergraphError> {
+    async fn load_with_polling(&self) -> Result<ReloadSupergraphResult, FileSupergraphError> {
         let file_metadata = fs::metadata(&self.file_path.absolute).await?;
         let current_time = file_metadata.modified()?;
         let mut modified_time = self.modified_time.write().await;
@@ -30,7 +38,7 @@ impl SupergraphFileLoader {
         }
     }
 
-    async fn load_without_polling(&self) -> Result<ReloadSupergraphResult, LoadSupergraphError> {
+    async fn load_without_polling(&self) -> Result<ReloadSupergraphResult, FileSupergraphError> {
         let content = fs::read_to_string(&self.file_path.absolute).await?;
 
         Ok(ReloadSupergraphResult::Changed { new_sdl: content })
@@ -66,11 +74,11 @@ impl SupergraphLoader for SupergraphFileLoader {
           "Supergraph loaded from file",
         );
 
-        result
+        Ok(result?)
     }
 
-    fn reload_interval(&self) -> Option<&std::time::Duration> {
-        self.poll_interval.as_ref()
+    fn reload_interval(&self) -> Option<std::time::Duration> {
+        self.poll_interval
     }
 }
 
@@ -78,7 +86,7 @@ impl SupergraphFileLoader {
     pub fn new(
         file_path: &FilePath,
         poll_interval: Option<Duration>,
-    ) -> Result<Box<Self>, LoadSupergraphError> {
+    ) -> Result<Box<Self>, FileSupergraphError> {
         debug!(
           target: targets::SUPERGRAPH,
           path = ?file_path.absolute,

--- a/bin/router/src/supergraph/hive.rs
+++ b/bin/router/src/supergraph/hive.rs
@@ -11,40 +11,59 @@ use crate::{
     supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader},
 };
 
+#[derive(Debug, thiserror::Error)]
+#[allow(clippy::enum_variant_names)]
+pub enum HiveConsoleSupergraphError {
+    #[error("Failed to read supergraph from network: {0}")]
+    NetworkError(#[from] reqwest_middleware::Error),
+    #[error("Failed to read supergraph from network: {0}")]
+    NetworkResponseError(#[from] reqwest::Error),
+    #[error("Failed to lock supergraph: {0}")]
+    LockError(String),
+    #[error("Failed to initialize the loader: {0}")]
+    InitializationError(String),
+    #[error("Invalid configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("Hive CDN endpoint is missing. Please provide it via 'HIVE_CDN_ENDPOINT' environment variable or under 'supergraph.endpoint' in the configuration.")]
+    MissingHiveCDNEndpoint,
+    #[error("Hive CDN key is missing. Please provide it via 'HIVE_CDN_KEY' environment variable or under 'supergraph.key' in the configuration.")]
+    MissingHiveCDNKey,
+}
+
 pub struct SupergraphHiveConsoleLoader {
     fetcher: SupergraphFetcher<SupergraphFetcherAsyncState>,
     poll_interval: Duration,
 }
 
-impl From<SupergraphFetcherError> for LoadSupergraphError {
+impl From<SupergraphFetcherError> for HiveConsoleSupergraphError {
     fn from(err: SupergraphFetcherError) -> Self {
         match err {
-            SupergraphFetcherError::Network(e) => LoadSupergraphError::NetworkError(e),
+            SupergraphFetcherError::Network(e) => HiveConsoleSupergraphError::NetworkError(e),
             SupergraphFetcherError::ResponseParse(e) => {
-                LoadSupergraphError::NetworkResponseError(e)
+                HiveConsoleSupergraphError::NetworkResponseError(e)
             }
             SupergraphFetcherError::ETagRead(e) => {
-                LoadSupergraphError::LockError(format!("Failed to read etag: {:?}", e))
+                HiveConsoleSupergraphError::LockError(format!("Failed to read etag: {:?}", e))
             }
             SupergraphFetcherError::ETagWrite(e) => {
-                LoadSupergraphError::LockError(format!("Failed to write etag: {:?}", e))
+                HiveConsoleSupergraphError::LockError(format!("Failed to write etag: {:?}", e))
             }
             SupergraphFetcherError::HTTPClientCreation(e) => {
-                LoadSupergraphError::InitializationError(e.to_string())
+                HiveConsoleSupergraphError::InitializationError(e.to_string())
             }
             SupergraphFetcherError::InvalidKey(e) => {
-                LoadSupergraphError::InvalidConfiguration(format!("Invalid CDN key: {}", e))
+                HiveConsoleSupergraphError::InvalidConfiguration(format!("Invalid CDN key: {}", e))
             }
             SupergraphFetcherError::MissingConfigurationOption(msg) => {
-                LoadSupergraphError::InvalidConfiguration(msg)
+                HiveConsoleSupergraphError::InvalidConfiguration(msg)
             }
             SupergraphFetcherError::RejectedByCircuitBreaker => {
-                LoadSupergraphError::NetworkError(reqwest_middleware::Error::Middleware(
+                HiveConsoleSupergraphError::NetworkError(reqwest_middleware::Error::Middleware(
                     anyhow::anyhow!("Request rejected by circuit breaker"),
                 ))
             }
             SupergraphFetcherError::CircuitBreakerCreation(e) => {
-                LoadSupergraphError::InitializationError(format!(
+                HiveConsoleSupergraphError::InitializationError(format!(
                     "Circuit breaker creation failed: {}",
                     e
                 ))
@@ -65,7 +84,7 @@ impl SupergraphLoader for SupergraphHiveConsoleLoader {
                   error = ?err,
                   "Error fetching supergraph from Hive Console",
                 );
-                Err(LoadSupergraphError::from(err))
+                Err(HiveConsoleSupergraphError::from(err).into())
             }
             // If the supergraph has not changed, return Unchanged
             Ok(None) => Ok(ReloadSupergraphResult::Unchanged),
@@ -74,8 +93,8 @@ impl SupergraphLoader for SupergraphHiveConsoleLoader {
         }
     }
 
-    fn reload_interval(&self) -> Option<&std::time::Duration> {
-        Some(&self.poll_interval)
+    fn reload_interval(&self) -> Option<std::time::Duration> {
+        Some(self.poll_interval)
     }
 }
 
@@ -88,7 +107,7 @@ impl SupergraphHiveConsoleLoader {
         request_timeout: Duration,
         accept_invalid_certs: bool,
         retry_count: u32,
-    ) -> Result<Box<Self>, LoadSupergraphError> {
+    ) -> Result<Box<Self>, HiveConsoleSupergraphError> {
         debug!(
           target: targets::SUPERGRAPH,
           endpoints = ?endpoints,

--- a/bin/router/src/supergraph/mod.rs
+++ b/bin/router/src/supergraph/mod.rs
@@ -6,14 +6,16 @@ use hive_router_internal::telemetry::logging::targets;
 use crate::{
     storage::{utils::resolve_value_or_expression, StorageManager},
     supergraph::{
+        apollo_graphos::{ApolloGraphOSSupergraphError, SupergraphApolloGraphOSLoader},
         base::{LoadSupergraphError, SupergraphLoader},
-        file::SupergraphFileLoader,
-        hive::SupergraphHiveConsoleLoader,
-        storage::SupergraphStorageLoader,
+        file::{FileSupergraphError, SupergraphFileLoader},
+        hive::{HiveConsoleSupergraphError, SupergraphHiveConsoleLoader},
+        storage::{StorageSupergraphError, SupergraphStorageLoader},
     },
 };
 use tracing::debug;
 
+pub mod apollo_graphos;
 pub mod base;
 pub mod file;
 pub mod hive;
@@ -36,7 +38,7 @@ pub fn resolve_from_config(
         } => {
             let path = path
                 .as_ref()
-                .ok_or(LoadSupergraphError::MissingSupergraphFilePath)?;
+                .ok_or(FileSupergraphError::MissingSupergraphFilePath)?;
             Ok(SupergraphFileLoader::new(path, *poll_interval)?)
         }
         SupergraphSource::HiveConsole {
@@ -50,8 +52,10 @@ pub fn resolve_from_config(
         } => {
             let endpoint = endpoint
                 .as_ref()
-                .ok_or(LoadSupergraphError::MissingHiveCDNEndpoint)?;
-            let key = key.as_ref().ok_or(LoadSupergraphError::MissingHiveCDNKey)?;
+                .ok_or(HiveConsoleSupergraphError::MissingHiveCDNEndpoint)?;
+            let key = key
+                .as_ref()
+                .ok_or(HiveConsoleSupergraphError::MissingHiveCDNKey)?;
 
             Ok(SupergraphHiveConsoleLoader::try_new(
                 endpoint.clone().into(),
@@ -63,36 +67,45 @@ pub fn resolve_from_config(
                 retry_policy.max_retries,
             )?)
         }
+        SupergraphSource::ApolloGraphOS {
+            graph_ref,
+            key,
+            endpoint,
+            timeout,
+            accept_invalid_certs,
+        } => {
+            let graph_ref = graph_ref
+                .as_ref()
+                .ok_or(ApolloGraphOSSupergraphError::MissingApolloGraphRef)?;
+            let key = key
+                .as_ref()
+                .ok_or(ApolloGraphOSSupergraphError::MissingApolloKey)?;
+
+            Ok(SupergraphApolloGraphOSLoader::try_new(
+                endpoint.clone().into(),
+                graph_ref,
+                key,
+                *timeout,
+                *accept_invalid_certs,
+            )?)
+        }
         SupergraphSource::Storage {
             storage_id,
             location,
             poll_interval,
-        } => {
-            match storage_manager.get_storage_runtime(storage_id) {
-                None => Err(LoadSupergraphError::StorageIdNotFound(
-                    storage_id.to_string(),
-                )),
-                Some(runtime) => {
-                    let location = resolve_value_or_expression(location, "supergraph.storage.key")?;
+        } => match storage_manager.get_storage_runtime(storage_id) {
+            None => Err(StorageSupergraphError::StorageIdNotFound(storage_id.to_string()).into()),
+            Some(runtime) => {
+                let location = resolve_value_or_expression(location, "supergraph.storage.key")
+                    .map_err(StorageSupergraphError::from)?;
 
-                    Ok(SupergraphStorageLoader::try_new(
-                        runtime.clone(),
-                        location,
-                        *poll_interval,
-                    )?)
-                }
+                Ok(SupergraphStorageLoader::try_new(
+                    runtime.clone(),
+                    location,
+                    *poll_interval,
+                )?)
             }
-
-            // Ok(SupergraphHiveConsoleLoader::try_new(
-            //     endpoint.clone().into(),
-            //     key,
-            //     *poll_interval,
-            //     *connect_timeout,
-            //     *request_timeout,
-            //     *accept_invalid_certs,
-            //     retry_policy.max_retries,
-            // )?)
-        }
+        },
         // there is no loader for a source that's entirely plugin-provided, this should never
         // be called in when the `supergraph.source = plugin`
         SupergraphSource::Plugin => Err(LoadSupergraphError::NoLoaderForPluginSource),

--- a/bin/router/src/supergraph/storage.rs
+++ b/bin/router/src/supergraph/storage.rs
@@ -7,9 +7,17 @@ use tokio::sync::RwLock;
 use tracing::error;
 
 use crate::{
-    storage::{StorageGetResult, StorageRuntime},
+    storage::{error::StorageError, StorageGetResult, StorageRuntime},
     supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader},
 };
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageSupergraphError {
+    #[error("Storage error: {0}")]
+    StorageError(#[from] StorageError),
+    #[error("Storage ID {0} is not defined in the Router configuration")]
+    StorageIdNotFound(String),
+}
 
 pub struct SupergraphStorageLoader {
     fetcher: SupergraphStorageFetcher,
@@ -23,7 +31,7 @@ struct SupergraphStorageFetcher {
 }
 
 impl SupergraphStorageFetcher {
-    async fn fetch_supergraph(&self) -> Result<Option<String>, LoadSupergraphError> {
+    async fn fetch_supergraph(&self) -> Result<Option<String>, StorageSupergraphError> {
         let etag = {
             let read_guard = self.last_etag.read().await;
 
@@ -51,7 +59,7 @@ impl SupergraphStorageLoader {
         fetcher: Arc<Box<dyn StorageRuntime>>,
         location: String,
         poll_interval: Option<Duration>,
-    ) -> Result<Box<Self>, LoadSupergraphError> {
+    ) -> Result<Box<Self>, StorageSupergraphError> {
         Ok(Box::new(Self {
             fetcher: SupergraphStorageFetcher {
                 storage: fetcher,
@@ -77,7 +85,7 @@ impl SupergraphLoader for SupergraphStorageLoader {
                     "Error fetching supergraph from storage",
                 );
 
-                Err(err)
+                Err(err.into())
             }
             // If the supergraph has not changed, return Unchanged
             Ok(None) => Ok(ReloadSupergraphResult::Unchanged),
@@ -86,7 +94,7 @@ impl SupergraphLoader for SupergraphStorageLoader {
         }
     }
 
-    fn reload_interval(&self) -> Option<&std::time::Duration> {
-        self.poll_interval.as_ref()
+    fn reload_interval(&self) -> Option<std::time::Duration> {
+        self.poll_interval
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -3259,6 +3259,35 @@ retry_policy:
 
    
 **Option 3 (alternative):** 
+Loads a supergraph from Apollo GraphOS Uplink.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**accept\_invalid\_certs**|`boolean`|Whether to accept invalid TLS certificates when connecting to Apollo Uplink.<br/>Default: `false`<br/>|no|
+|**endpoint**||The Apollo Uplink endpoint(s) to poll, tried in order on each poll.<br/><br/>Can also be set using the `APOLLO_UPLINK_ENDPOINTS` environment variable<br/>(comma-separated).<br/>Default: `"https://uplink.api.apollographql.com/"`, `"https://aws.uplink.api.apollographql.com/"`<br/>|no|
+|**graph\_ref**|`string`, `null`|The graph ref of the managed federation graph (`<GRAPH_ID>@<VARIANT>`).<br/><br/>Can also be set using the `APOLLO_GRAPH_REF` environment variable.<br/>|no|
+|**key**|`string`, `null`|The Apollo API key, with at least the `service:read` permission.<br/><br/>Can also be set using the `APOLLO_KEY` environment variable.<br/>|no|
+|**source**|`string`|Constant Value: `"apollo_graphos"`<br/>|yes|
+|**timeout**|`string`|The timeout for a single HTTP call to Apollo Uplink.<br/>Default: `"30s"`<br/>|no|
+
+**Additional Properties:** not allowed   
+**Example**
+
+```yaml
+accept_invalid_certs: false
+endpoint:
+  - https://uplink.api.apollographql.com/
+  - https://aws.uplink.api.apollographql.com/
+timeout: 30s
+
+```
+
+
+   
+**Option 4 (alternative):** 
 **Properties**
 
 |Name|Type|Description|Required|
@@ -3278,7 +3307,7 @@ poll_interval: null
 
 
    
-**Option 4 (alternative):** 
+**Option 5 (alternative):** 
 No configured supergraph source. A plugin must select a supergraph for every GraphQL
 request and WebSocket upgrade that needs one, via `set_supergraph` in
 `on_http_request`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3270,7 +3270,7 @@ Loads a supergraph from Apollo GraphOS Uplink.
 |**graph\_ref**|`string`, `null`|The graph ref of the managed federation graph (`<GRAPH_ID>@<VARIANT>`).<br/><br/>Can also be set using the `APOLLO_GRAPH_REF` environment variable.<br/>|no|
 |**key**|`string`, `null`|The Apollo API key, with at least the `service:read` permission.<br/><br/>Can also be set using the `APOLLO_KEY` environment variable.<br/>|no|
 |**source**|`string`|Constant Value: `"apollo_graphos"`<br/>|yes|
-|**timeout**|`string`|The timeout for a single HTTP call to Apollo Uplink.<br/><br/>Can also be set using the `APOLLO_UPLINK_TIMEOUT` environment variable.<br/>Default: `"30s"`<br/>|no|
+|**timeout**|`string`|The timeout for a single HTTP call to Apollo Uplink.<br/>Default: `"30s"`<br/>|no|
 
 **Additional Properties:** not allowed   
 **Example**

--- a/docs/README.md
+++ b/docs/README.md
@@ -3258,6 +3258,35 @@ retry_policy:
 
    
 **Option 3 (alternative):** 
+Loads a supergraph from Apollo GraphOS Uplink.
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**accept\_invalid\_certs**|`boolean`|Whether to accept invalid TLS certificates when connecting to Apollo Uplink.<br/>Default: `false`<br/>|no|
+|**endpoint**||The Apollo Uplink endpoint(s) to poll, tried in order on each poll.<br/><br/>Can also be set using the `APOLLO_UPLINK_ENDPOINTS` environment variable<br/>(comma-separated).<br/>Default: `"https://uplink.api.apollographql.com/"`, `"https://aws.uplink.api.apollographql.com/"`<br/>|no|
+|**graph\_ref**|`string`, `null`|The graph ref of the managed federation graph (`<GRAPH_ID>@<VARIANT>`).<br/><br/>Can also be set using the `APOLLO_GRAPH_REF` environment variable.<br/>|no|
+|**key**|`string`, `null`|The Apollo API key, with at least the `service:read` permission.<br/><br/>Can also be set using the `APOLLO_KEY` environment variable.<br/>|no|
+|**source**|`string`|Constant Value: `"apollo_graphos"`<br/>|yes|
+|**timeout**|`string`|The timeout for a single HTTP call to Apollo Uplink.<br/><br/>Can also be set using the `APOLLO_UPLINK_TIMEOUT` environment variable.<br/>Default: `"30s"`<br/>|no|
+
+**Additional Properties:** not allowed   
+**Example**
+
+```yaml
+accept_invalid_certs: false
+endpoint:
+  - https://uplink.api.apollographql.com/
+  - https://aws.uplink.api.apollographql.com/
+timeout: 30s
+
+```
+
+
+   
+**Option 4 (alternative):** 
 **Properties**
 
 |Name|Type|Description|Required|
@@ -3277,7 +3306,7 @@ poll_interval: null
 
 
    
-**Option 4 (alternative):** 
+**Option 5 (alternative):** 
 No configured supergraph source. A plugin must select a supergraph for every GraphQL
 request and WebSocket upgrade that needs one, via `set_supergraph` in
 `on_http_request`.

--- a/e2e/src/storage/mod.rs
+++ b/e2e/src/storage/mod.rs
@@ -8,7 +8,7 @@ mod storage_e2e_tests {
     /// This is needed in order to ensure config is checked statically and validated at startup
     #[ntex::test]
     #[should_panic(
-        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(StorageIdNotFound(\"missing\")))"
+        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(Storage(StorageIdNotFound(\"missing\"))))"
     )]
     async fn should_throw_when_storage_is_missing_in_supergraph() {
         TestRouter::builder()

--- a/e2e/src/storage/mod.rs
+++ b/e2e/src/storage/mod.rs
@@ -27,7 +27,7 @@ mod storage_e2e_tests {
 
     #[ntex::test]
     #[should_panic(
-        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(Storage(StorageIdNotFound(\"missing\"))))"
+        expected = "failed to configure hive router from config: SharedStateError(PersistedDocuments(StorageNotFound(\"missing\")))"
     )]
     async fn should_throw_when_storage_is_missing_in_persisted_docs() {
         TestRouter::builder()

--- a/e2e/src/storage/mod.rs
+++ b/e2e/src/storage/mod.rs
@@ -8,7 +8,7 @@ mod storage_e2e_tests {
     /// This is needed in order to ensure config is checked statically and validated at startup
     #[ntex::test]
     #[should_panic(
-        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(StorageIdNotFound(\"missing\")))"
+        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(Storage(StorageIdNotFound(\"missing\"))))"
     )]
     async fn should_throw_when_storage_is_missing_in_supergraph() {
         TestRouter::builder()
@@ -27,7 +27,7 @@ mod storage_e2e_tests {
 
     #[ntex::test]
     #[should_panic(
-        expected = "failed to configure hive router from config: SharedStateError(PersistedDocuments(StorageNotFound(\"missing\")))"
+        expected = "failed to configure hive router from config: SupergraphManagerError(LoadSupergraphError(Storage(StorageIdNotFound(\"missing\"))))"
     )]
     async fn should_throw_when_storage_is_missing_in_persisted_docs() {
         TestRouter::builder()

--- a/lib/router-config/src/env_overrides.rs
+++ b/lib/router-config/src/env_overrides.rs
@@ -45,6 +45,12 @@ pub struct EnvVarOverrides {
     pub hive_console_cdn_key: Option<String>,
     #[envconfig(from = "HIVE_CDN_POLL_INTERVAL")]
     pub hive_console_cdn_poll_interval: Option<String>,
+    #[envconfig(from = "APOLLO_KEY")]
+    pub apollo_key: Option<String>,
+    #[envconfig(from = "APOLLO_GRAPH_REF")]
+    pub apollo_graph_ref: Option<String>,
+    #[envconfig(from = "APOLLO_UPLINK_ENDPOINTS")]
+    pub apollo_uplink_endpoints: Option<String>,
     #[envconfig(from = "HIVE_ACCESS_TOKEN")]
     pub hive_access_token: Option<String>,
     #[envconfig(from = "HIVE_TARGET")]
@@ -71,7 +77,7 @@ pub struct EnvVarOverrides {
 pub enum EnvVarOverridesError {
     #[error("Failed to override configuration: {0}")]
     FailedToOverrideConfig(#[from] ConfigError),
-    #[error("Cannot override supergraph source due to conflict: SUPERGRAPH_FILE_PATH and HIVE_CDN_ENDPOINT cannot be used together")]
+    #[error("Cannot override supergraph source due to conflict: SUPERGRAPH_FILE_PATH, HIVE_CDN_ENDPOINT and APOLLO_KEY cannot be used together")]
     ConflictingSupergraphSource,
     #[error("Missing required environment variable: {0}")]
     MissingRequiredEnvVar(&'static str),
@@ -118,7 +124,15 @@ impl EnvVarOverrides {
             config = config.set_override("http.workers", http_workers as u64)?;
         }
 
-        if self.supergraph_file_path.is_some() && self.hive_console_cdn_endpoint.is_some() {
+        let configured_supergraph_sources = [
+            self.supergraph_file_path.is_some(),
+            self.hive_console_cdn_endpoint.is_some(),
+            self.apollo_key.is_some(),
+        ]
+        .into_iter()
+        .filter(|configured| *configured)
+        .count();
+        if configured_supergraph_sources > 1 {
             return Err(EnvVarOverridesError::ConflictingSupergraphSource);
         }
 
@@ -154,6 +168,30 @@ impl EnvVarOverrides {
                 debug!(target: CONFIG_LOGGING_TARGET, value = hive_console_cdn_poll_interval, "overriding 'hive_console_cdn_poll_interval'");
                 config = config
                     .set_override("supergraph.poll_interval", hive_console_cdn_poll_interval)?;
+            }
+        }
+
+        if let Some(apollo_key) = self.apollo_key.take() {
+            debug!(target: CONFIG_LOGGING_TARGET, "overriding 'apollo_key'");
+            config = config.set_override("supergraph.source", "apollo_graphos")?;
+            config = config.set_override("supergraph.key", apollo_key)?;
+
+            if let Some(apollo_graph_ref) = self.apollo_graph_ref.take() {
+                debug!(target: CONFIG_LOGGING_TARGET, value = apollo_graph_ref, "overriding 'apollo_graph_ref'");
+                config = config.set_override("supergraph.graph_ref", apollo_graph_ref)?;
+            } else {
+                return Err(EnvVarOverridesError::MissingRequiredEnvVar(
+                    "APOLLO_GRAPH_REF",
+                ));
+            }
+
+            if let Some(apollo_uplink_endpoints) = self.apollo_uplink_endpoints.take() {
+                debug!(target: CONFIG_LOGGING_TARGET, value = apollo_uplink_endpoints, "overriding 'apollo_uplink_endpoints'");
+                let endpoints: Vec<String> = apollo_uplink_endpoints
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .collect();
+                config = config.set_override("supergraph.endpoint", endpoints)?;
             }
         }
 

--- a/lib/router-config/src/supergraph.rs
+++ b/lib/router-config/src/supergraph.rs
@@ -75,6 +75,35 @@ pub enum SupergraphSource {
         #[serde(default = "default_hive_retry_policy")]
         retry_policy: RetryPolicyConfig,
     },
+    /// Loads a supergraph from Apollo GraphOS Uplink.
+    #[serde(rename = "apollo_graphos")]
+    ApolloGraphOS {
+        /// The graph ref of the managed federation graph (`<GRAPH_ID>@<VARIANT>`).
+        ///
+        /// Can also be set using the `APOLLO_GRAPH_REF` environment variable.
+        graph_ref: Option<String>,
+        /// The Apollo API key, with at least the `service:read` permission.
+        ///
+        /// Can also be set using the `APOLLO_KEY` environment variable.
+        key: Option<String>,
+        /// The Apollo Uplink endpoint(s) to poll, tried in order on each poll.
+        ///
+        /// Can also be set using the `APOLLO_UPLINK_ENDPOINTS` environment variable
+        /// (comma-separated).
+        #[serde(default = "default_apollo_uplink_endpoints")]
+        endpoint: SingleOrMultiple<String>,
+        /// The timeout for a single HTTP call to Apollo Uplink.
+        #[serde(
+            default = "default_apollo_uplink_timeout",
+            deserialize_with = "humantime_serde::deserialize",
+            serialize_with = "humantime_serde::serialize"
+        )]
+        #[schemars(with = "String")]
+        timeout: Duration,
+        /// Whether to accept invalid TLS certificates when connecting to Apollo Uplink.
+        #[serde(default = "default_accept_invalid_certs")]
+        accept_invalid_certs: bool,
+    },
     #[serde(rename = "storage")]
     Storage {
         /// The storage id as it was defined in the config file, under `storages:` field.
@@ -118,11 +147,25 @@ fn default_hive_retry_policy() -> RetryPolicyConfig {
     RetryPolicyConfig { max_retries: 10 }
 }
 
+/// Apollo's managed federation Uplink endpoints: GCP first, AWS as fallback.
+/// Matches the default order used by Apollo Router itself.
+fn default_apollo_uplink_endpoints() -> SingleOrMultiple<String> {
+    SingleOrMultiple::Multiple(vec![
+        "https://uplink.api.apollographql.com/".to_string(),
+        "https://aws.uplink.api.apollographql.com/".to_string(),
+    ])
+}
+
+fn default_apollo_uplink_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
 impl SupergraphSource {
     pub fn source_name(&self) -> &str {
         match self {
             SupergraphSource::File { .. } => "file",
             SupergraphSource::HiveConsole { .. } => "hive",
+            SupergraphSource::ApolloGraphOS { .. } => "apollo_graphos",
             SupergraphSource::Storage { storage_id, .. } => storage_id.as_str(),
             SupergraphSource::Plugin => "plugin",
         }

--- a/lib/router-config/src/supergraph.rs
+++ b/lib/router-config/src/supergraph.rs
@@ -93,8 +93,6 @@ pub enum SupergraphSource {
         #[serde(default = "default_apollo_uplink_endpoints")]
         endpoint: SingleOrMultiple<String>,
         /// The timeout for a single HTTP call to Apollo Uplink.
-        ///
-        /// Can also be set using the `APOLLO_UPLINK_TIMEOUT` environment variable.
         #[serde(
             default = "default_apollo_uplink_timeout",
             deserialize_with = "humantime_serde::deserialize",

--- a/lib/router-config/src/supergraph.rs
+++ b/lib/router-config/src/supergraph.rs
@@ -75,6 +75,37 @@ pub enum SupergraphSource {
         #[serde(default = "default_hive_retry_policy")]
         retry_policy: RetryPolicyConfig,
     },
+    /// Loads a supergraph from Apollo GraphOS Uplink.
+    #[serde(rename = "apollo_graphos")]
+    ApolloGraphOS {
+        /// The graph ref of the managed federation graph (`<GRAPH_ID>@<VARIANT>`).
+        ///
+        /// Can also be set using the `APOLLO_GRAPH_REF` environment variable.
+        graph_ref: Option<String>,
+        /// The Apollo API key, with at least the `service:read` permission.
+        ///
+        /// Can also be set using the `APOLLO_KEY` environment variable.
+        key: Option<String>,
+        /// The Apollo Uplink endpoint(s) to poll, tried in order on each poll.
+        ///
+        /// Can also be set using the `APOLLO_UPLINK_ENDPOINTS` environment variable
+        /// (comma-separated).
+        #[serde(default = "default_apollo_uplink_endpoints")]
+        endpoint: SingleOrMultiple<String>,
+        /// The timeout for a single HTTP call to Apollo Uplink.
+        ///
+        /// Can also be set using the `APOLLO_UPLINK_TIMEOUT` environment variable.
+        #[serde(
+            default = "default_apollo_uplink_timeout",
+            deserialize_with = "humantime_serde::deserialize",
+            serialize_with = "humantime_serde::serialize"
+        )]
+        #[schemars(with = "String")]
+        timeout: Duration,
+        /// Whether to accept invalid TLS certificates when connecting to Apollo Uplink.
+        #[serde(default = "default_accept_invalid_certs")]
+        accept_invalid_certs: bool,
+    },
     #[serde(rename = "storage")]
     Storage {
         /// The storage id as it was defined in the config file, under `storages:` field.
@@ -118,11 +149,25 @@ fn default_hive_retry_policy() -> RetryPolicyConfig {
     RetryPolicyConfig { max_retries: 10 }
 }
 
+/// Apollo's managed federation Uplink endpoints: GCP first, AWS as fallback.
+/// Matches the default order used by Apollo Router itself.
+fn default_apollo_uplink_endpoints() -> SingleOrMultiple<String> {
+    SingleOrMultiple::Multiple(vec![
+        "https://uplink.api.apollographql.com/".to_string(),
+        "https://aws.uplink.api.apollographql.com/".to_string(),
+    ])
+}
+
+fn default_apollo_uplink_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
 impl SupergraphSource {
     pub fn source_name(&self) -> &str {
         match self {
             SupergraphSource::File { .. } => "file",
             SupergraphSource::HiveConsole { .. } => "hive",
+            SupergraphSource::ApolloGraphOS { .. } => "apollo_graphos",
             SupergraphSource::Storage { storage_id, .. } => storage_id.as_str(),
             SupergraphSource::Plugin => "plugin",
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,6 +1048,7 @@
       "version": "7.0.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1217,6 +1218,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,6 +1063,7 @@
       "version": "7.0.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1232,6 +1233,7 @@
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }


### PR DESCRIPTION
Docs PR: https://github.com/graphql-hive/docs/pull/152 

Adds a new `apollo_graphos` supergraph source that fetches the supergraph schema from Apollo GraphOS's managed federation Uplink, for routers migrating from Apollo Router/Gateway without needing a separate schema-delivery pipeline.

Configure it with `graph_ref` and `key` (or the `APOLLO_GRAPH_REF`/`APOLLO_KEY` environment variables), and optionally `endpoint` (defaults to Apollo's GCP and AWS Uplink endpoints, tried in order), `timeout` and `accept_invalid_certs`.

Polling is based on the `min_delay_seconds` value returned from Apollo GraphOS API, and not based on a fixed/configurable value. 

Both Apollo Uplink are supported and used by default in order (like apollo-router does), and env-var keys are also supported. 

In addition, I cleaned `SupergraohError` struct a bit and made the errors encapsulated next to each source. 

Closes https://github.com/graphql-hive/router/issues/505