### PR TITLE
feat(router): authorize `@requiresScopes` from a configurable JWT claim (`jwt.scopes_claim`)

### DIFF
--- a/.changeset/jwt_scopes_claim_config.md
+++ b/.changeset/jwt_scopes_claim_config.md
@@ -1,0 +1,10 @@
+---
+hive-router-config: minor
+hive-router: minor
+---
+
+# Add `jwt.scopes_claim`
+
+Adds a new `jwt.scopes_claim` configuration option that lets you specify which JWT claim the `@requiresScopes` directive should read authorization data from, instead of the hardcoded `scope`/`scopes` claim.
+
+This is useful for identity providers that grant authorization data under a different claim name — for example, Microsoft Entra ID, which issues app roles under a `roles` claim rather than `scope`. Setting `jwt.scopes_claim: roles` allows `@requiresScopes` to authorize requests using Entra app roles without requiring any changes to how the claim is issued.

--- a/bin/router/src/jwt/context.rs
+++ b/bin/router/src/jwt/context.rs
@@ -11,6 +11,8 @@ pub struct JwtRequestContext {
     pub token_prefix: Option<String>,
     pub token_raw: String,
     pub token_payload: Arc<JwtTokenPayload>,
+    /// The name of the claim to read authorization scopes from. Defaults to "scope"/"scopes" when `None`.
+    pub scopes_claim: Option<String>,
 }
 
 impl JwtRequestContext {
@@ -18,11 +20,15 @@ impl JwtRequestContext {
         Ok(sonic_rs::to_value(&self.token_payload.claims)?)
     }
 
-    /// Extracts an optional "scope"/"scopes" field form the token's payload.
+    /// Extracts an optional scopes field from the token's payload, read from the claim named by
+    /// `scopes_claim`, or from "scope" (falling back to "scopes") when `scopes_claim` is `None`.
     /// Supports both space-delimited and array formats.
     pub fn extract_scopes(&self) -> Option<Vec<String>> {
         let map = &self.token_payload.claims.additional_claims;
-        let maybe_scopes = map.get("scope").or_else(|| map.get("scopes"));
+        let maybe_scopes = match &self.scopes_claim {
+            Some(claim_name) => map.get(claim_name.as_str()),
+            None => map.get("scope").or_else(|| map.get("scopes")),
+        };
 
         if let Some(serde_json::Value::String(scopes_str)) = maybe_scopes {
             return Some(scopes_str.split(' ').map(String::from).collect());
@@ -77,4 +83,66 @@ pub struct JwtClaims {
     // because the jsonwebtoken crate is using `serde_json` internally, and the `sonic_rs::Value` is not recognized as valid type
     #[serde(flatten)]
     pub additional_claims: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonwebtoken::Header;
+    use serde_json::json;
+
+    use super::*;
+
+    fn context_with_claims(
+        additional_claims: HashMap<String, serde_json::Value>,
+        scopes_claim: Option<String>,
+    ) -> JwtRequestContext {
+        JwtRequestContext {
+            token_prefix: None,
+            token_raw: "token".to_string(),
+            scopes_claim,
+            token_payload: Arc::new(TokenData {
+                header: Header::default(),
+                claims: JwtClaims {
+                    iss: None,
+                    sub: None,
+                    aud: None,
+                    exp: None,
+                    nbf: None,
+                    iat: None,
+                    jti: None,
+                    additional_claims,
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn extracts_default_scope_claim_when_scopes_claim_not_configured() {
+        let claims = HashMap::from([("scope".to_string(), json!("read:foo write:bar"))]);
+        let ctx = context_with_claims(claims, None);
+
+        assert_eq!(
+            ctx.extract_scopes(),
+            Some(vec!["read:foo".to_string(), "write:bar".to_string()])
+        );
+    }
+
+    #[test]
+    fn extracts_configured_claim_name() {
+        let claims = HashMap::from([("roles".to_string(), json!(["Admin", "Reader"]))]);
+        let ctx = context_with_claims(claims, Some("roles".to_string()));
+
+        assert_eq!(
+            ctx.extract_scopes(),
+            Some(vec!["Admin".to_string(), "Reader".to_string()])
+        );
+    }
+
+    #[test]
+    fn ignores_default_scope_claim_when_a_different_claim_is_configured() {
+        let claims = HashMap::from([("scope".to_string(), json!("read:foo"))]);
+        let ctx = context_with_claims(claims, Some("roles".to_string()));
+
+        assert_eq!(ctx.extract_scopes(), None);
+    }
 }

--- a/bin/router/src/jwt/mod.rs
+++ b/bin/router/src/jwt/mod.rs
@@ -306,6 +306,7 @@ impl JwtAuthRuntime {
                 token_payload,
                 token_raw: token,
                 token_prefix: maybe_prefix,
+                scopes_claim: self.config.scopes_claim.clone(),
             })),
             Err(err) => {
                 warn!(target: targets::JWT, error = ?err, "jwt token error");

--- a/docs/README.md
+++ b/docs/README.md
@@ -2172,6 +2172,7 @@ Configuration for JWT authentication plugin.
 |[**jwks\_providers**](#jwtjwks_providers)|`array`|A list of JWKS providers to use for verifying the JWT signature.<br/>|yes|
 |[**lookup\_locations**](#jwtlookup_locations)|`array`|A list of locations to look up for the JWT token in the incoming HTTP request.<br/>Default: `{"name":"authorization","prefix":"Bearer","source":"header"}`<br/>|no|
 |**require\_authentication**|`boolean`, `null`|If set to `true`, the entire request will be rejected if the JWT token is not present in the request.<br/>|no|
+|**scopes\_claim**|`string`, `null`|The name of the JWT claim to read authorization scopes from, used to evaluate the `@requiresScopes` directive.<br/>If not specified, the `scope` claim is used (falling back to `scopes` if `scope` is not present), each holding<br/>either a space-delimited string or an array of strings.<br/><br/>This is useful for identity providers that grant authorization data under a different claim name, such as<br/>Microsoft Entra ID, which issues app roles under a `roles` claim.<br/>|no|
 
 **Additional Properties:** not allowed   
 **Example**

--- a/e2e/configs/jwt_auth_custom_scopes_claim.router.yaml
+++ b/e2e/configs/jwt_auth_custom_scopes_claim.router.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../supergraph-authz.graphql
+jwt:
+  enabled: true
+  require_authentication: false
+  jwks_providers:
+    - source: file
+      path: ../jwks.rsa512.json
+  scopes_claim: roles

--- a/e2e/src/authorization_directives_filter.rs
+++ b/e2e/src/authorization_directives_filter.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod authorization_directives_in_filter_mode_e2e_tests {
     use jsonwebtoken::{encode, EncodingKey};
-    use sonic_rs::{json, Value};
+    use sonic_rs::{json, JsonValueMutTrait, Value};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::testkit::{some_header_map, ClientResponseExt, TestRouter, TestSubgraphs};
@@ -22,20 +22,26 @@ mod authorization_directives_in_filter_mode_e2e_tests {
     }
 
     fn authorization_header_with_scopes(scopes: &str) -> http::HeaderMap {
+        authorization_header_with_claim("scope", scopes)
+    }
+
+    fn authorization_header_with_claim(claim_name: &str, value: &str) -> http::HeaderMap {
+        let mut payload = json!({
+            "sub": "user2",
+            "iat": 1516239022,
+            "exp": SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 3600,
+        });
+        payload
+            .as_object_mut()
+            .expect("payload should be an object")
+            .insert(claim_name, json!(value));
+
         some_header_map! {
-            http::header::AUTHORIZATION => format!(
-                "Bearer {}",
-                generate_jwt(&json!({
-                    "sub": "user2",
-                    "iat": 1516239022,
-                    "exp": SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs()
-                        + 3600,
-                    "scope": scopes,
-                }))
-            )
+            http::header::AUTHORIZATION => format!("Bearer {}", generate_jwt(&payload))
         }
         .unwrap()
     }
@@ -209,6 +215,86 @@ mod authorization_directives_in_filter_mode_e2e_tests {
               "birthday": 1234567890
             }
           }
+        }
+        "#);
+    }
+
+    /// Verifies that when `jwt.scopes_claim` is configured to a custom claim name (e.g. `roles`,
+    /// as used for Microsoft Entra ID app roles), `@requiresScopes` is evaluated against that
+    /// claim instead of the default `scope`/`scopes` claim.
+    #[ntex::test]
+    async fn authenticated_access_to_scoped_field_with_custom_scopes_claim() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("configs/jwt_auth_custom_scopes_claim.router.yaml")
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                "{ me { birthday } }",
+                None,
+                Some(authorization_header_with_claim("roles", "read:birthday")),
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        let subgraph_requests = subgraphs.get_requests_log("accounts").unwrap_or_default();
+        assert_eq!(
+            subgraph_requests.len(),
+            1,
+            "expected 1 request to accounts subgraph"
+        );
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "me": {
+              "birthday": 1234567890
+            }
+          }
+        }
+        "#);
+    }
+
+    /// Verifies that when `jwt.scopes_claim` is configured to a custom claim name, the default
+    /// `scope` claim is no longer consulted, so a token granting the required scope only via
+    /// `scope` (and not the configured claim) is treated as unauthorized.
+    #[ntex::test]
+    async fn default_scope_claim_is_ignored_when_custom_scopes_claim_is_configured() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("configs/jwt_auth_custom_scopes_claim.router.yaml")
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request(
+                "{ me { birthday } }",
+                None,
+                Some(authorization_header_with_claim("scope", "read:birthday")),
+            )
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "me": null
+          },
+          "errors": [
+            {
+              "message": "Unauthorized field or type",
+              "extensions": {
+                "code": "UNAUTHORIZED_FIELD_OR_TYPE",
+                "affectedPath": "me.birthday"
+              }
+            }
+          ]
         }
         "#);
     }

--- a/lib/router-config/src/jwt_auth.rs
+++ b/lib/router-config/src/jwt_auth.rs
@@ -43,6 +43,14 @@ pub struct JwtAuthConfig {
     #[serde(default = "default_forward_claims_to_upstream_extensions")]
     /// Forward the JWT claims to the upstream service using GraphQL's `.extensions`.
     pub forward_claims_to_upstream_extensions: JwtClaimsForwardingConfig,
+    /// The name of the JWT claim to read authorization scopes from, used to evaluate the `@requiresScopes` directive.
+    /// If not specified, the `scope` claim is used (falling back to `scopes` if `scope` is not present), each holding
+    /// either a space-delimited string or an array of strings.
+    ///
+    /// This is useful for identity providers that grant authorization data under a different claim name, such as
+    /// Microsoft Entra ID, which issues app roles under a `roles` claim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes_claim: Option<String>,
 }
 
 impl JwtAuthConfig {
@@ -74,6 +82,7 @@ impl Default for JwtAuthConfig {
             audiences: None,
             issuers: None,
             allowed_algorithms: None,
+            scopes_claim: None,
         }
     }
 }
@@ -165,4 +174,31 @@ pub enum JwtAuthPluginLookupLocation {
     #[serde(rename = "cookies")]
     #[schemars(title = "cookies")]
     Cookie { name: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JwtAuthConfig;
+
+    #[test]
+    fn scopes_claim_defaults_to_none() {
+        let config = JwtAuthConfig::default();
+        assert_eq!(config.scopes_claim, None);
+    }
+
+    #[test]
+    fn scopes_claim_is_none_when_not_specified_in_config() {
+        let config = serde_json::from_str::<JwtAuthConfig>(r#"{"jwks_providers":[]}"#)
+            .expect("config should parse");
+        assert_eq!(config.scopes_claim, None);
+    }
+
+    #[test]
+    fn scopes_claim_parses_configured_claim_name() {
+        let config = serde_json::from_str::<JwtAuthConfig>(
+            r#"{"jwks_providers":[],"scopes_claim":"roles"}"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.scopes_claim, Some("roles".to_string()));
+    }
 }


### PR DESCRIPTION
Closes #1361

## Summary

- Adds an optional `jwt.scopes_claim` config option. When set, the `@requiresScopes` directive reads authorization data from that JWT claim instead of the hardcoded `scope`/`scopes` claim.
- Motivation: identity providers such as Microsoft Entra ID grant authorization data via application roles issued under a `roles` claim, not `scope`. This lets `@requiresScopes` work with such providers without requiring the IdP to be reconfigured to emit a `scope` claim.
- When `jwt.scopes_claim` is unset, behavior is unchanged (still reads `scope`, falling back to `scopes`). When set, only the configured claim is consulted — the default `scope`/`scopes` claim is no longer read, so there's no ambiguity about which claim authorizes the request.

## Changes

- `lib/router-config/src/jwt_auth.rs`: new `scopes_claim: Option<String>` field on `JwtAuthConfig`.
- `bin/router/src/jwt/context.rs`: `JwtRequestContext::extract_scopes()` reads the configured claim name when present.
- `bin/router/src/jwt/mod.rs`: threads the configured claim name into `JwtRequestContext` at construction.
- `docs/README.md`: regenerated from the config schema to document the new field.
- `.changeset/jwt_scopes_claim_config.md`: minor version bump for `hive-router-config` and `hive-router`.

## Test plan

- [x] Unit tests in `lib/router-config/src/jwt_auth.rs` covering default (`None`), omitted-field, and explicit `scopes_claim` deserialization.
- [x] Unit tests in `bin/router/src/jwt/context.rs` covering default claim extraction, custom claim extraction, and that the default claim is ignored once a custom claim is configured.
- [x] New e2e tests in `e2e/src/authorization_directives_filter.rs` (new fixture `e2e/configs/jwt_auth_custom_scopes_claim.router.yaml` with `jwt.scopes_claim: roles`):
  - a token with a `roles` claim satisfies `@requiresScopes(["read:birthday"])`
  - a token with the default `scope` claim (but not `roles`) is unauthorized once `scopes_claim` is configured, confirming there's no silent fallback
- [x] Full workspace build, `cargo fmt`/`cargo clippy` clean on touched files, all existing authorization (45) and JWT (12) e2e tests still pass, no regressions.
