### PR TITLE
fix(router): register the state the subscription callback handler extracts

### DIFF
--- a/.changeset/register_callback_subscription_state.md
+++ b/.changeset/register_callback_subscription_state.md
@@ -1,0 +1,23 @@
+---
+hive-router: patch
+---
+
+# Register the state the subscription callback handler extracts
+
+The subscription callback handler could not serve a single request: every call failed the `ntex` `State` extractor with `App state is not configured, to configure use App::state()`, returning a 500 to the subgraph. Because callbacks are how the subgraph delivers events back to the router, any subscription using the callback transport silently stopped producing messages.
+
+`handle_callback` extracts two pieces of state:
+
+```rust
+callback_subscriptions: web::types::State<CallbackSubscriptionsMap>,
+telemetry_context:      web::types::State<std::sync::Arc<TelemetryContext>>,
+```
+
+Neither listener registered a matching pair:
+
+- the **dedicated** callback server (`subscriptions.callback.listen` set) registered the map, but passed `telemetry.context` — a bare `TelemetryContext`, since `Telemetry::context` is not an `Arc` — where the handler asks for `State<Arc<TelemetryContext>>`;
+- the **main** server (no `listen`, callback mounted on the main app) registered `Arc<TelemetryContext>` via `shared_state.telemetry_context`, but never registered `CallbackSubscriptionsMap` at all.
+
+`State<T>` is generic, so both mismatches compile; they only fail when the extractor runs. That makes the callback protocol broken in **both** configurations, with no config-level workaround.
+
+This registers an `Arc` on the dedicated server and adds the missing map on the main one.

--- a/.changeset/register_callback_subscription_state.md
+++ b/.changeset/register_callback_subscription_state.md
@@ -20,4 +20,6 @@ Neither listener registered a matching pair:
 
 `State<T>` is generic, so both mismatches compile; they only fail when the extractor runs. That makes the callback protocol broken in **both** configurations, with no config-level workaround.
 
-This registers an `Arc` on the dedicated server and adds the missing map on the main one.
+The dedicated server now takes its telemetry context from `shared_state.telemetry_context`, the same `Arc` the main server already registers, and the main server gains the missing map.
+
+The e2e suite does not catch this: `TestRouter` builds its own `ntex` `App` rather than reusing the one `run_router` assembles, and its copy happens to register both states correctly — it reads the telemetry context from `shared_state` (already an `Arc`) and registers `callback_subscriptions` on the main app. `listen_on_different_port` therefore passes against a build whose callback endpoint 500s on every request.

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -374,7 +374,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             let cb_path = path.to_string();
             let cb_addr = listen.to_string();
             let cb_subs = callback_subscriptions_for_handler.clone();
-            let cb_telemetry_context = std::sync::Arc::new(telemetry.context.clone());
+            let cb_telemetry_context = shared_state.telemetry_context.clone();
             let mut cb_server_builder = web::HttpServer::new(async move || {
                 let cb_subs = cb_subs.clone();
                 let cb_path = cb_path.clone();

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -374,7 +374,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             let cb_path = path.to_string();
             let cb_addr = listen.to_string();
             let cb_subs = callback_subscriptions_for_handler.clone();
-            let cb_telemetry_context = telemetry.context.clone();
+            let cb_telemetry_context = std::sync::Arc::new(telemetry.context.clone());
             let mut cb_server_builder = web::HttpServer::new(async move || {
                 let cb_subs = cb_subs.clone();
                 let cb_path = cb_path.clone();
@@ -428,6 +428,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             .state(shared_state.clone())
             .state(schema_state.clone())
             .state(shared_state.telemetry_context.clone())
+            .state(callback_subscriptions_for_handler.clone())
             .configure(|m| configure_ntex_app(m, &paths, prometheus))
             .configure(|m| {
                 if let Some(ref callback) = paths.callback {


### PR DESCRIPTION
## Summary

The subscription callback handler cannot serve any request. Every call fails the `ntex` `State` extractor with:

```
App state is not configured, to configure use App::state()
```

and returns 500 to the subgraph. Since callbacks are how a subgraph delivers events back to the router, subscriptions using the callback transport silently stop producing messages.

Introduced in #1261 (subscription metrics, released in `0.0.83`) and still present on `main` (`ae2d2d2`).

## Cause

`handle_callback` (`bin/router/src/pipeline/http_callback.rs`) extracts two pieces of state:

```rust
callback_subscriptions: web::types::State<CallbackSubscriptionsMap>,
telemetry_context:      web::types::State<std::sync::Arc<TelemetryContext>>,
```

Neither listener in `bin/router/src/lib.rs` registers a matching pair:

| Listener | `CallbackSubscriptionsMap` | `Arc<TelemetryContext>` |
| --- | --- | --- |
| Dedicated (`subscriptions.callback.listen` set) | ✅ `.state(cb_subs)` | ❌ `.state(telemetry.context.clone())` — `Telemetry::context` is a bare `TelemetryContext` (`bin/router/src/telemetry.rs`), not an `Arc` |
| Main (no `listen`; callback mounted on the main app) | ❌ never registered | ✅ `shared_state.telemetry_context` |

`State<T>` is generic, so both mismatches compile cleanly and only fail when the extractor runs. The result is that the callback protocol is broken in **both** supported configurations, and there is no config-level workaround.

## Fix

```rust
// dedicated listener
- let cb_telemetry_context = telemetry.context.clone();
+ let cb_telemetry_context = std::sync::Arc::new(telemetry.context.clone());

// main listener
  .state(shared_state.telemetry_context.clone())
+ .state(callback_subscriptions_for_handler.clone())
```

## Reproducing

With `subscriptions.callback.listen` configured, any callback request — including a `check` for an id that does not exist, which should be a 404 — returns the state error instead:

```
curl -X POST http://<router>:4001/callback \
  -H 'content-type: application/json' \
  -d '{"kind":"subscription","action":"check","id":"<any>","verifier":"<any>"}'
```

We hit this in production after upgrading `0.0.49 → 0.0.85`: callback checks went to 100% 500s across both environments, and we rolled back. `0.0.49` is unaffected — it has a single extractor, correctly registered.

## Notes for reviewers

- Changeset added as `hive-router: patch`.
- I have **not** been able to run the repo's own test suite against this change; the fix is derived from reading the handler signature against both registration sites. If there is an integration test that drives a real callback, it would be worth pointing it at both listener configurations — the two code paths fail for different reasons, so a test covering only one would still pass with the other broken.
- Happy to adjust the approach if you would rather change `Telemetry::context` to hold an `Arc` directly, or narrow the handler to `State<TelemetryContext>` — this keeps the handler signature untouched as the smaller change.
