### PR TITLE
feat(router): expose logging summary and log correlations to plugin system

### DIFF
--- a/.changeset/expose-log-correlation-to-plugin-system.md
+++ b/.changeset/expose-log-correlation-to-plugin-system.md
@@ -1,0 +1,11 @@
+---
+hive-router-internal: minor
+hive-router: minor
+hive-router-plan-executor: patch
+---
+
+# Expose log correlation to the plugin system
+
+Plugins can now attach a custom correlation (e.g. a tenant or project ID) to every log line of the current request via `hive_router::set_log_correlation(key, value)`, callable from any hook, alongside the built-in `request_id` and `trace_id`.
+
+Fixes https://github.com/graphql-hive/router/issues/1350

--- a/.changeset/expose-request-summary-to-plugin-system.md
+++ b/.changeset/expose-request-summary-to-plugin-system.md
@@ -1,0 +1,11 @@
+---
+hive-router-internal: minor
+hive-router: minor
+hive-router-plan-executor: patch
+---
+
+# Expose the request summary to the plugin system
+
+Plugins can now enrich the request summary log line with custom attributes via `hive_router::set_summary_attribute(key, value)`, callable from any hook (e.g. `on_http_request`, `on_graphql_analysis`).
+
+Fixes https://github.com/graphql-hive/router/issues/1368

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -45,6 +45,7 @@ use crate::{
             write_graphql_response_metric_status,
         },
         request_identifiers::RequestIdentifiersService,
+        request_summary::RequestSummaryService,
         timeout::handle_timeout,
         usage_reporting::init_hive_usage_agent,
         validation::{
@@ -70,10 +71,7 @@ pub use hive_router_config::humantime_serde;
 use hive_router_config::{load_config, subscriptions::CallbackConfig, HiveRouterConfig};
 pub use hive_router_internal::background_tasks;
 use hive_router_internal::telemetry::{
-    logging::{
-        summary::{self, WithRequestSummary},
-        targets,
-    },
+    logging::{summary, targets},
     otel::{opentelemetry, tracing_opentelemetry::OpenTelemetrySpanExt},
     traces::spans::http_request::HttpServerRequestSpan,
     TelemetryContext,
@@ -81,7 +79,7 @@ use hive_router_internal::telemetry::{
 pub use hive_router_internal::BoxError;
 use hive_router_internal::{
     background_tasks::{BackgroundTask, CancellationToken},
-    telemetry::logging::request_id::REQUEST_IDENTIFIERS,
+    telemetry::logging::request_id::{self, REQUEST_IDENTIFIERS},
 };
 use hive_router_internal::{
     http::read_request_body_size, telemetry::metrics::catalog::values::GraphQLResponseStatus,
@@ -135,6 +133,21 @@ impl BackgroundTask for CallbackServer {
             server.stop(true).await;
         }
     }
+}
+
+/// Lets plugins enrich the current request's summary log line with a custom attribute.
+/// Setting the same key again overwrites the previous value.
+///
+/// A no-op outside a request (e.g. during `on_plugin_init`) or when the summary log target is filtered off.
+pub fn set_summary_attribute(key: impl Into<String>, value: impl Into<sonic_rs::Value>) {
+    summary::record(|s| s.set_custom(key, value));
+}
+
+/// Lets plugins attach a custom correlation to every log line of the current request (not
+/// just the summary), e.g. a tenant or project id extracted from the URL. Setting the same
+/// key again overwrites the previous value. A no-op outside a request.
+pub fn set_log_correlation(key: impl Into<String>, value: impl std::fmt::Display) {
+    request_id::set_correlation(key, value);
 }
 
 #[inline]
@@ -210,7 +223,6 @@ async fn graphql_endpoint_handler(
 
         (response_mode, inner_res, summary_guard)
     }
-    .with_request_summary()
     .await;
 
     // for streamed responses the summary must be emitted when the stream ends, not now
@@ -433,6 +445,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 prometheus.as_ref().map(|p| p.endpoint.clone()),
             ))
             .middleware(RequestIdentifiersService)
+            .middleware(RequestSummaryService)
             .state(shared_state.clone())
             .state(schema_state.clone())
             .state(shared_state.telemetry_context.clone())

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -104,6 +104,7 @@ pub mod progressive_override;
 pub mod query_plan;
 pub mod request_extensions;
 pub mod request_identifiers;
+pub mod request_summary;
 pub mod sse;
 pub mod timeout;
 pub(crate) mod trie;

--- a/bin/router/src/pipeline/request_summary.rs
+++ b/bin/router/src/pipeline/request_summary.rs
@@ -1,0 +1,42 @@
+use hive_router_internal::telemetry::logging::summary::WithRequestSummary;
+use ntex::{
+    service::{Service, ServiceCtx},
+    web::{self, DefaultError},
+    Middleware, SharedCfg,
+};
+
+/// Scopes the request summary as a task-local for the rest of the request, so every
+/// downstream middleware (`PluginService`, the coprocessor, etc.) can enrich it - not
+/// just the handler itself, which is where this used to happen.
+#[derive(Clone, Default)]
+pub struct RequestSummaryService;
+
+impl<S> Middleware<S, SharedCfg> for RequestSummaryService {
+    type Service = RequestSummaryMiddleware<S>;
+
+    fn create(&self, service: S, _cfg: SharedCfg) -> Self::Service {
+        RequestSummaryMiddleware { service }
+    }
+}
+
+pub struct RequestSummaryMiddleware<S> {
+    service: S,
+}
+
+impl<S> Service<web::WebRequest<DefaultError>> for RequestSummaryMiddleware<S>
+where
+    S: Service<web::WebRequest<DefaultError>, Response = web::WebResponse, Error = web::Error>,
+{
+    type Response = web::WebResponse;
+    type Error = S::Error;
+
+    ntex::forward_ready!(service);
+
+    async fn call(
+        &self,
+        req: web::WebRequest<DefaultError>,
+        ctx: ServiceCtx<'_, Self>,
+    ) -> Result<Self::Response, Self::Error> {
+        ctx.call(&self.service, req).with_request_summary().await
+    }
+}

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -11,6 +11,7 @@ use hive_router::{
     plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
     plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
     plugins::plugin_trait::{RouterPlugin, StartHookPayload},
+    set_summary_attribute,
 };
 use hive_router_internal::telemetry::logging::targets;
 use http::{HeaderMap, HeaderName, HeaderValue};
@@ -689,6 +690,15 @@ impl RouterPlugin for TestDebugLogPlugin {
         payload: OnHttpRequestHookPayload<'req>,
     ) -> OnHttpRequestHookResult<'req> {
         debug!("i'm just a test");
+        set_summary_attribute("test_debug_log.simple", "hello-from-plugin");
+        set_summary_attribute(
+            "test_debug_log.nested",
+            json!({
+                "flag": true,
+                "count": 3,
+                "tags": ["a", "b"],
+            }),
+        );
         payload.proceed()
     }
 }
@@ -719,4 +729,70 @@ plugins:
     let plugin_log = log_line(&stdout_log, "i'm just a test");
 
     assert_eq!(req_id_of(http_start), req_id_of(plugin_log));
+}
+
+#[ntex::test]
+async fn plugin_can_record_a_simple_custom_summary_field() {
+    let (_subgraphs, router) = setup_router(
+        router_with_telemetry(
+            "\
+log:
+  level: info
+  format: json
+plugins:
+  test_debug_log:
+    enabled: true
+",
+        )
+        .register_plugin::<TestDebugLogPlugin>(),
+    )
+    .await;
+
+    let stdout_log = router
+        .send_graphql_request(TEST_QUERY, None, None)
+        .capture_stdout_json()
+        .await;
+
+    let req_summary = log_line_by_target(&stdout_log, targets::SUMMARY);
+    assert_eq!(
+        find_attr(req_summary, "test_debug_log.simple"),
+        Some("hello-from-plugin".to_string())
+    );
+}
+
+#[ntex::test]
+async fn plugin_can_record_a_nested_custom_summary_field() {
+    let (_subgraphs, router) = setup_router(
+        router_with_telemetry(
+            "\
+log:
+  level: info
+  format: json
+plugins:
+  test_debug_log:
+    enabled: true
+",
+        )
+        .register_plugin::<TestDebugLogPlugin>(),
+    )
+    .await;
+
+    let stdout_log = router
+        .send_graphql_request(TEST_QUERY, None, None)
+        .capture_stdout_json()
+        .await;
+
+    let req_summary = log_line_by_target(&stdout_log, targets::SUMMARY);
+    let nested = req_summary
+        .get("test_debug_log.nested")
+        .expect("missing nested custom summary field");
+
+    assert_eq!(
+        nested,
+        &serde_json::json!({
+            "flag": true,
+            "count": 3,
+            "tags": ["a", "b"],
+        })
+    );
 }

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -42,8 +42,8 @@ use hive_router::{
     configure_ntex_app, init_rustls_crypto_provider, invoke_shutdown_hooks,
     pipeline::long_lived_client_limit::LongLivedClientLimitService,
     pipeline::request_identifiers::RequestIdentifiersService,
-    plugins::plugins_service::PluginService, telemetry::Telemetry, PluginRegistry, RouterPaths,
-    RouterSharedState, SchemaState,
+    pipeline::request_summary::RequestSummaryService, plugins::plugins_service::PluginService,
+    telemetry::Telemetry, PluginRegistry, RouterPaths, RouterSharedState, SchemaState,
 };
 use hive_router_config::{
     load_config, parse_yaml_config, subscriptions::CallbackConfig, HiveRouterConfig,
@@ -924,6 +924,7 @@ impl TestRouter<Built> {
                         prometheus.as_ref().map(|p| p.endpoint.clone()),
                     ))
                     .middleware(RequestIdentifiersService)
+                    .middleware(RequestSummaryService)
                     .state(shared_state.clone())
                     .state(schema_state)
                     .state(callback_subs)

--- a/lib/internal/src/telemetry/logging/format_json.rs
+++ b/lib/internal/src/telemetry/logging/format_json.rs
@@ -10,6 +10,8 @@ use tracing_subscriber::{
 };
 
 use crate::telemetry::logging::request_id::REQUEST_IDENTIFIERS;
+use crate::telemetry::logging::summary::REQUEST_SUMMARY;
+use crate::telemetry::logging::targets;
 
 #[inline]
 fn write_json_body<W: std::fmt::Write>(w: &mut W, s: &str) -> std::fmt::Result {
@@ -146,10 +148,32 @@ where
                     buf.push_str(",\"trace_id\":");
                     write_json_str(&mut *buf, trace_id)?;
                 }
+                if let Ok(correlations) = ids.correlations.lock() {
+                    for (key, value) in correlations.iter() {
+                        buf.push(',');
+                        write_json_str(&mut *buf, key)?;
+                        buf.push(':');
+                        write_json_str(&mut *buf, value)?;
+                    }
+                }
                 Ok(())
             });
 
             event.record(&mut JsonVisitor { buf: &mut buf });
+
+            if meta.target() == targets::SUMMARY {
+                let _ = REQUEST_SUMMARY.try_with(|summary| -> std::fmt::Result {
+                    if let Ok(custom) = summary.custom.lock() {
+                        for (key, value) in custom.iter() {
+                            buf.push(',');
+                            write_json_str(&mut *buf, key)?;
+                            buf.push(':');
+                            let _ = write!(buf, "{value}");
+                        }
+                    }
+                    Ok(())
+                });
+            }
 
             buf.push_str("}\n");
             writer.write_str(&buf)

--- a/lib/internal/src/telemetry/logging/format_text.rs
+++ b/lib/internal/src/telemetry/logging/format_text.rs
@@ -7,6 +7,8 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 
 use crate::telemetry::logging::request_id::REQUEST_IDENTIFIERS;
+use crate::telemetry::logging::summary::REQUEST_SUMMARY;
+use crate::telemetry::logging::targets;
 
 pub struct RouterTextFormat<T>(pub Format<Compact, T>);
 
@@ -40,8 +42,24 @@ where
                 if let Some(trace_id) = ids.trace_id() {
                     write!(writer, " trace_id={:?}", trace_id)?;
                 }
+                if let Ok(correlations) = ids.correlations.lock() {
+                    for (key, value) in correlations.iter() {
+                        write!(writer, " {key}={value:?}")?;
+                    }
+                }
                 Ok(())
             });
+
+            if event.metadata().target() == targets::SUMMARY {
+                let _ = REQUEST_SUMMARY.try_with(|summary| -> std::fmt::Result {
+                    if let Ok(custom) = summary.custom.lock() {
+                        for (key, value) in custom.iter() {
+                            write!(writer, " {key}={value}")?;
+                        }
+                    }
+                    Ok(())
+                });
+            }
 
             writer.write_char('\n')
         })

--- a/lib/internal/src/telemetry/logging/request_id.rs
+++ b/lib/internal/src/telemetry/logging/request_id.rs
@@ -1,4 +1,8 @@
-use std::{future::Future, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    sync::{Arc, Mutex},
+};
 
 use hive_router_config::log::CorrelationConfig;
 use http::{HeaderMap, HeaderName};
@@ -23,6 +27,7 @@ impl Default for RequestIdentifierExtractor {
 pub struct RequestIdentifiers {
     req_id: String,
     trace_id: Option<String>,
+    pub correlations: Mutex<BTreeMap<String, String>>,
 }
 
 impl RequestIdentifiers {
@@ -32,6 +37,15 @@ impl RequestIdentifiers {
 
     pub fn trace_id(&self) -> Option<&str> {
         self.trace_id.as_deref()
+    }
+
+    /// Records a plugin-contributed correlation, so it's added to every log
+    /// line of the request (not just the summary). Setting the same key again overwrites
+    /// the previous value.
+    pub fn set_correlation(&self, key: impl Into<String>, value: impl std::fmt::Display) {
+        if let Ok(mut correlations) = self.correlations.lock() {
+            correlations.insert(key.into(), value.to_string());
+        }
     }
 }
 
@@ -51,6 +65,7 @@ impl RequestIdentifierExtractor {
         RequestIdentifiers {
             req_id,
             trace_id: trace_id.map(|id| id.to_string()),
+            correlations: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -124,6 +139,10 @@ impl HeaderLookup for HttpRequest {
 
 tokio::task_local! {
     pub static REQUEST_IDENTIFIERS: Arc<RequestIdentifiers>;
+}
+
+pub fn set_correlation(key: impl Into<String>, value: impl std::fmt::Display) {
+    let _ = REQUEST_IDENTIFIERS.try_with(|ids| ids.set_correlation(key, value));
 }
 
 pub trait WithRequestIdentifiers: Future + Sized {

--- a/lib/internal/src/telemetry/logging/summary.rs
+++ b/lib/internal/src/telemetry/logging/summary.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::error::Error;
 use std::future::Future;
 use std::rc::Rc;
@@ -36,6 +36,7 @@ pub struct RequestSummary {
     pub payload_bytes: AtomicI64,
     pub duration_ms: AtomicU64,
     pub supergraph_identifier: AtomicU64,
+    pub custom: Mutex<BTreeMap<String, sonic_rs::Value>>,
 }
 
 impl RequestSummary {
@@ -83,6 +84,14 @@ impl RequestSummary {
 
     pub fn set_supergraph_identifier(&self, identifier: u64) {
         self.supergraph_identifier.store(identifier, Relaxed);
+    }
+
+    /// Records a plugin-contributed attribute, so it's included when the summary is emitted.
+    /// Setting the same key again overwrites the previous value.
+    pub fn set_custom(&self, key: impl Into<String>, value: impl Into<sonic_rs::Value>) {
+        if let Ok(mut custom) = self.custom.lock() {
+            custom.insert(key.into(), value.into());
+        }
     }
 
     pub fn record_subgraph(&self, name: &str) {

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -1518,6 +1518,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom-logger-correlation-plugin-example"
+version = "0.0.1"
+dependencies = [
+ "e2e",
+ "hive-router",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/plugin_examples/Cargo.toml
+++ b/plugin_examples/Cargo.toml
@@ -20,7 +20,8 @@ members = [
   "incoming_request_deduplication",
   "error_mapping",
   "replace_schema",
-  "field_nulling"
+  "field_nulling",
+  "custom_logger_correlation"
 ]
 
 [workspace.dependencies]

--- a/plugin_examples/custom_logger_correlation/Cargo.toml
+++ b/plugin_examples/custom_logger_correlation/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "custom-logger-correlation-plugin-example"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+authors = ["The Guild"]
+repository = "https://github.com/graphql-hive/router"
+homepage = "https://github.com/graphql-hive/router"
+publish = false
+
+[lib]
+
+[[bin]]
+name = "hive_router_with_custom_logger_correlation"
+path = "src/main.rs"
+
+[dependencies]
+hive-router = { version = "*", path = "../../bin/router" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+e2e = { version = "*", path = "../../e2e" }

--- a/plugin_examples/custom_logger_correlation/router.config.yaml
+++ b/plugin_examples/custom_logger_correlation/router.config.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../../e2e/supergraph.graphql
+plugins:
+  custom_logger_correlation:
+    enabled: true
+http:
+  graphql_endpoint: "/{project_id}/graphql"
+log:
+  format: json
+  level: debug

--- a/plugin_examples/custom_logger_correlation/src/lib.rs
+++ b/plugin_examples/custom_logger_correlation/src/lib.rs
@@ -1,0 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
+pub mod plugin;
+#[cfg(test)]
+pub mod test;

--- a/plugin_examples/custom_logger_correlation/src/main.rs
+++ b/plugin_examples/custom_logger_correlation/src/main.rs
@@ -1,0 +1,17 @@
+use hive_router::{
+    configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
+    router_entrypoint, PluginRegistry, RouterGlobalAllocator,
+};
+
+configure_global_allocator!();
+
+#[hive_router::main]
+async fn main() -> Result<(), RouterInitError> {
+    init_rustls_crypto_provider();
+
+    router_entrypoint(
+        PluginRegistry::new()
+            .register::<custom_logger_correlation_plugin_example::plugin::CustomLoggerCorrelationPlugin>(),
+    )
+    .await
+}

--- a/plugin_examples/custom_logger_correlation/src/plugin.rs
+++ b/plugin_examples/custom_logger_correlation/src/plugin.rs
@@ -1,0 +1,44 @@
+use hive_router::plugins::hooks::on_http_request::{
+    OnHttpRequestHookPayload, OnHttpRequestHookResult,
+};
+use hive_router::plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult};
+use hive_router::plugins::plugin_trait::{RouterPlugin, StartHookPayload};
+use hive_router::{set_log_correlation, tracing};
+
+pub struct CustomLoggerCorrelationPlugin;
+
+const PROJECT_ID_KEY: &str = "project_id";
+
+impl RouterPlugin for CustomLoggerCorrelationPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "custom_logger_correlation"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin(Self)
+    }
+
+    fn on_http_request<'req>(
+        &'req self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookResult<'req> {
+        let project_id = payload
+            .router_http_request
+            .path()
+            .split('/')
+            .nth(1)
+            .filter(|segment| !segment.is_empty())
+            .unwrap_or("unknown_project")
+            .to_string();
+
+        // Attach it as soon as we know it, so every log line for the rest of this
+        // request - including this plugin's own - carries the same correlation.
+        set_log_correlation(PROJECT_ID_KEY, project_id);
+
+        tracing::debug!(target: "custom_logger_correlation", "on_http_request called");
+
+        payload.proceed()
+    }
+}

--- a/plugin_examples/custom_logger_correlation/src/test.rs
+++ b/plugin_examples/custom_logger_correlation/src/test.rs
@@ -1,0 +1,53 @@
+#[cfg(test)]
+mod custom_logger_correlation_tests {
+    use e2e::testkit::stdout::CaptureStdoutExt;
+    use e2e::testkit::{TestRouter, TestSubgraphs};
+    use hive_router::{ntex, sonic_rs};
+
+    #[ntex::test]
+    async fn correlates_log_lines_correctly() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .file_config("../plugin_examples/custom_logger_correlation/router.config.yaml")
+            .register_plugin::<crate::plugin::CustomLoggerCorrelationPlugin>()
+            .with_subgraphs(&subgraphs)
+            .build()
+            .start()
+            .await;
+
+        let stdout_log = router
+            .send_post_request(
+                "/test/graphql",
+                sonic_rs::json!({
+                  "query": "{ __typename }",
+                }),
+                None,
+            )
+            .capture_stdout_json()
+            .await;
+
+        // The plugin's own log line, emitted right after it sets the correlation, already
+        // carries it - unlike the callback-based approach this replaces, which could only
+        // correlate log lines emitted after the whole request-identifiers extraction step.
+        let plugin_log_line = stdout_log
+            .by_message("on_http_request called")
+            .expect("missing on_http_request log line");
+        assert_eq!(
+            plugin_log_line
+                .get("project_id")
+                .and_then(serde_json::Value::as_str),
+            Some("test")
+        );
+
+        // Every log line emitted afterwards for the same request carries it too.
+        let http_req_start_line = stdout_log
+            .by_message("http request started")
+            .expect("missing http request started line");
+        assert_eq!(
+            http_req_start_line
+                .get("project_id")
+                .and_then(serde_json::Value::as_str),
+            Some("test")
+        );
+    }
+}


### PR DESCRIPTION
Replaces https://github.com/graphql-hive/router/pull/1348
Fixes https://github.com/graphql-hive/router/issues/1368
Fixes https://github.com/graphql-hive/router/issues/1350

Plugins can now enrich request logging in two ways, both callable from any hook (not just `on_plugin_init`, and with no callback/registration step):

## Summary attributes

```rs
fn on_http_request<'req>(
    &self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookResult<'req> {
    set_summary_attribute("i_am_custom", "hello-from-plugin");
    payload.proceed()
}
```

Adds `i_am_custom` to the request summary log line. The value can be anything `impl Into<sonic_rs::Value>`, including a nested object. Setting the same key again overwrites the previous value.

## Log correlations

```rs
fn on_http_request<'req>(
    &self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookResult<'req> {
    set_log_correlation("project_id", "abc123");
    payload.proceed()
}
```

Adds `project_id` to **every** log line of the request from that point on (not just the summary) - same treatment as the built-in `request_id`/`trace_id`. The value is anything `impl Display`, kept as a plain string since it repeats on every line. See the `custom_logger_correlation` plugin example.

## Why not a callback in `on_plugin_init`?

#1348 registered a correlation extractor callback during `on_plugin_init` because at the time, request identifiers were only extracted deep inside the GraphQL handler, too late for `on_http_request` to contribute anything. That's no longer true: request summary/identifiers are now scoped by a dedicated middleware that wraps the *entire* request pipeline, including the plugin chain - so a plugin can just call these functions directly, whenever it has the value, and it's already visible in the same log line and every one after it.

## Public API

Both are single, narrow functions - `set_summary_attribute(key, value)` and `set_log_correlation(key, value)`. Neither leaks the underlying `RequestSummary`/`RequestIdentifiers` internals; everything else is handled by the task-local state.
