### PR TITLE
Accept multipart streaming types with boundary parameters

### DIFF
--- a/.changeset/relax_accept_header_streaming_type_params.md
+++ b/.changeset/relax_accept_header_streaming_type_params.md
@@ -1,0 +1,7 @@
+---
+hive-router: patch
+---
+
+# Accept multipart streaming types with boundary parameters
+
+Hive Router now accepts `boundary` parameters on `multipart/mixed` values in the `Accept` header. This prevents Apollo Client's default Accept header from returning `415 Unsupported Media Type` while leaving response boundary selection to the router.

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -351,7 +351,7 @@ mod tests {
             ),
             (
                 Method::GET,
-                // unqouredquoted boundary param
+                // unquoted boundary param
                 "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
                 true,
                 ResponseMode::Dual(

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -268,16 +268,26 @@ impl RequestAccepts for HttpRequest {
         // strip multipart/mixed boundaries before negotiation since the server chooses the response boundary
         // as per the spec. furthermore, the incremental delivery and apollo multipart specs already have
         // their boundaries defined in the spec and we use those boundaries when generating the response
-        let accept = accept
-            .media_types()
-            .map(|media_type| {
-                let mut media_type = media_type.to_ref();
-                if media_type.ty.as_str() == "multipart" && media_type.subty.as_str() == "mixed" {
-                    media_type.remove_params(Name::new_unchecked("boundary"));
-                }
-                media_type
-            })
-            .collect::<Accept>();
+        let boundary = Name::new_unchecked("boundary");
+        let accept = if accept.media_types().any(|media_type| {
+            media_type.ty().as_str() == "multipart"
+                && media_type.subty().as_str() == "mixed"
+                && media_type.get_param(boundary).is_some()
+        }) {
+            accept
+                .media_types()
+                .map(|media_type| {
+                    let mut media_type = media_type.to_ref();
+                    if media_type.ty.as_str() == "multipart" && media_type.subty.as_str() == "mixed"
+                    {
+                        media_type.remove_params(boundary);
+                    }
+                    media_type
+                })
+                .collect::<Accept>()
+        } else {
+            accept
+        };
 
         if laboratory_enabled && self.method() == Method::GET {
             // if the client GETs we negotiate with the all supported media type, including HTML

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -351,7 +351,18 @@ mod tests {
             ),
             (
                 Method::GET,
+                // unqouredquoted boundary param
                 "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                true,
+                ResponseMode::Dual(
+                    SingleContentType::JSON,
+                    StreamContentType::ApolloMultipartHTTP,
+                ),
+            ),
+            (
+                Method::GET,
+                // quoted boundary param
+                "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0,application/json",
                 true,
                 ResponseMode::Dual(
                     SingleContentType::JSON,

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -3,7 +3,7 @@ use hive_router_internal::telemetry::logging::targets;
 use http::{header::ACCEPT, Method};
 use mediatype::{
     names::{HTML, TEXT},
-    MediaType, Name, ReadParams,
+    MediaType, Name, ReadParams, WriteParams,
 };
 use ntex::web::HttpRequest;
 use std::str::FromStr;
@@ -265,6 +265,20 @@ impl RequestAccepts for HttpRequest {
             PipelineError::InvalidHeaderValue(ACCEPT)
         })?;
 
+        // strip multipart/mixed boundaries before negotiation since the server chooses the response boundary
+        // as per the spec. furthermore, the incremental delivery and apollo multipart specs already have
+        // their boundaries defined in the spec and we use those boundaries when generating the response
+        let accept = accept
+            .media_types()
+            .map(|media_type| {
+                let mut media_type = media_type.to_ref();
+                if media_type.ty.as_str() == "multipart" && media_type.subty.as_str() == "mixed" {
+                    media_type.remove_params(Name::new_unchecked("boundary"));
+                }
+                media_type
+            })
+            .collect::<Accept>();
+
         if laboratory_enabled && self.method() == Method::GET {
             // if the client GETs we negotiate with the all supported media type, including HTML
             // to see if the client wants Laboratory. we negotiate with everything because browsers
@@ -329,6 +343,15 @@ mod tests {
             (
                 Method::GET,
                 r#"application/json, text/event-stream, multipart/mixed;subscriptionSpec="1.0""#,
+                true,
+                ResponseMode::Dual(
+                    SingleContentType::JSON,
+                    StreamContentType::ApolloMultipartHTTP,
+                ),
+            ),
+            (
+                Method::GET,
+                "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
                 true,
                 ResponseMode::Dual(
                     SingleContentType::JSON,


### PR DESCRIPTION
Closes #1367

Strip `boundary` parameters from `multipart/mixed` media types before Accept negotiation. Other parameters, including `subscriptionSpec`, continue to participate in negotiation.

After removing the `boundary` param, the media types must be collected into a new `Accept` value. The `headers-accept` crate only lets us read the original parsed values, not change them in place, and they do not provide an option to ignore just the boundary during negotiation. Creating a new `Accept` is therefore the only supported approach...
