### PR TITLE
feat(router): Bind graph-specific configuration to selected supergraphs

### DIFF
--- a/.changeset/add_persisted_documents_support_to_websockets.md
+++ b/.changeset/add_persisted_documents_support_to_websockets.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+# Add persisted documents support to WebSocket operations
+
+WebSocket `subscribe` payloads can now omit the GraphQL query and provide a persisted document ID through their extensions. The router resolves the document before parsing, validation, and execution.
+
+Persisted-document extraction, ID enforcement, resolution, metrics, and missing-ID logging use the supergraph selected for the WebSocket connection. This prevents an operation from resolving a document from one supergraph's manifest and executing it against another supergraph.

--- a/.changeset/isolate-plugin-supergraph-options.md
+++ b/.changeset/isolate-plugin-supergraph-options.md
@@ -1,0 +1,30 @@
+---
+hive-router: minor
+---
+
+# Isolate plugin-selected supergraph configuration
+
+Plugin-selected supergraphs no longer inherit graph-bound settings from the router's configured supergraph. Requests, WebSocket connections, persisted-document resolution, subgraph execution, usage reports, and Hive traces now use the options attached to the selected `Supergraph` snapshot.
+
+Persisted-document reloaders and Hive usage agents now use separate background-task groups scoped to the selected supergraph runtime. Cancelling a runtime waits for any active Hive flush and explicitly flushes the remaining report buffer before removing its worker. Router shutdown also waits for these graceful background tasks to finish.
+
+## Migration
+
+Configured supergraphs require no YAML changes. The router continues deriving their graph-bound options from the existing configuration.
+
+Plugins that construct supergraph variants must import `SupergraphOptions`, provide the graph-bound settings each variant needs, and retain the owner while it remains selectable:
+
+```rust
+use std::sync::Arc;
+
+use hive_router::plugins::hooks::on_supergraph_load::{Supergraph, SupergraphOptions};
+
+let mut options = SupergraphOptions::default();
+options.traffic_shaping.all.forward_operation_name = true;
+options.error_masking.redacted_error_message = "Variant error".to_string();
+options.hive_target = Some("organization/project/variant".to_string());
+
+let variant = Arc::new(Supergraph::from_sdl(sdl, options)?);
+```
+
+Move any existing `QueryPlannerOptions` into `SupergraphOptions::query_planner`. Also copy every graph-specific setting the variant previously inherited from router configuration, including subgraph traffic shaping, URL overrides, headers, override labels, demand control, subscription transports, error masking, persisted documents, and its Hive target. Omitted fields use `SupergraphOptions::default()` and no longer inherit values from the configured supergraph.

--- a/.changeset/run_graphql_params_hooks_for_websockets.md
+++ b/.changeset/run_graphql_params_hooks_for_websockets.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+# Run GraphQL parameters hooks for WebSocket operations
+
+WebSocket `subscribe` payloads now run the `on_graphql_params` start hook and its registered end callbacks before parsing, validation, and execution. The start hook receives the synthetic WebSocket operation request and the already-decoded parameters in `OnGraphQLParamsStartHookPayload.graphql_params`.
+
+When a hook ends preparation with an early response, the router sends the response's GraphQL body as a WebSocket `next` message followed by `complete`. HTTP-only response metadata, including its status and headers, cannot be represented by the GraphQL over WebSocket protocol and is not forwarded.

--- a/.changeset/stop-usage-flush-cancellation-race.md
+++ b/.changeset/stop-usage-flush-cancellation-race.md
@@ -1,0 +1,7 @@
+---
+hive-console-sdk: patch
+---
+
+# Stop cancellation from interrupting an active usage flush
+
+The usage agent now observes cancellation while waiting for the next flush interval instead of checking only after the full interval has elapsed. Cancellation remains pending while an active flush completes, preventing a drained report batch from being lost when its send future is interrupted.

--- a/.changeset/supergraph-options-api.md
+++ b/.changeset/supergraph-options-api.md
@@ -1,0 +1,44 @@
+---
+hive-router-plan-executor: major
+hive-router: patch
+---
+
+# Bind graph-specific configuration to `Supergraph`
+
+`Supergraph::from_sdl` and `Supergraph::from_document` now accept `SupergraphOptions` instead of `QueryPlannerOptions`. The immutable options snapshot includes planner, executor, subgraph subscription, persisted-document, error-masking, and Hive target settings.
+
+## Migration
+
+Import `SupergraphOptions` with `Supergraph`:
+
+```rust
+use hive_router::plugins::hooks::on_supergraph_load::{Supergraph, SupergraphOptions};
+```
+
+Replace the query-planner options argument with a complete supergraph options value:
+
+```diff
+-use hive_router::plugins::hooks::on_supergraph_load::Supergraph;
++use hive_router::plugins::hooks::on_supergraph_load::{Supergraph, SupergraphOptions};
+ use hive_router::query_planner::planner::QueryPlannerOptions;
+
+ let query_planner = QueryPlannerOptions {
+     experimental_abstract_type_folding: true,
+ };
+-let supergraph = Supergraph::from_sdl(sdl, query_planner)?;
++let supergraph = Supergraph::from_sdl(
++    sdl,
++    SupergraphOptions {
++        query_planner,
++        ..SupergraphOptions::default()
++    },
++)?;
+```
+
+Callers that used `Default::default()` can migrate directly:
+
+```rust
+use hive_router::plugins::hooks::on_supergraph_load::{Supergraph, SupergraphOptions};
+
+let supergraph = Supergraph::from_sdl(sdl, SupergraphOptions::default())?;
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ dependencies = [
  "mediatype",
  "memchr",
  "mimalloc",
+ "mockito",
  "moka",
  "notify",
  "ntex",

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -103,6 +103,7 @@ object_store = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 insta = { workspace = true }
+mockito = { workspace = true }
 
 [[bench]]
 name = "persisted_documents_matcher_benches"

--- a/bin/router/src/error.rs
+++ b/bin/router/src/error.rs
@@ -2,9 +2,9 @@ use hive_router_config::RouterConfigError;
 use hive_router_plan_executor::executors::error::TlsCertificatesError;
 
 use crate::{
-    jwt::jwks_manager::JwksSourceError, pipeline::usage_reporting::UsageReportingError,
-    plugins::registry::PluginRegistryError, schema_state::SupergraphManagerError,
-    shared_state::SharedStateError, storage::error::StorageError, telemetry::TelemetryInitError,
+    jwt::jwks_manager::JwksSourceError, plugins::registry::PluginRegistryError,
+    schema_state::SupergraphManagerError, shared_state::SharedStateError,
+    storage::error::StorageError, telemetry::TelemetryInitError,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -21,16 +21,12 @@ pub enum RouterInitError {
     HttpServerStartError(std::io::Error),
     #[error(transparent)]
     JwksSourceError(#[from] JwksSourceError),
-    #[error("Usage Reporting - {0}")]
-    UsageReportingError(#[from] UsageReportingError),
     #[error(transparent)]
     SharedStateError(#[from] SharedStateError),
     #[error(transparent)]
     TelemetryInitError(#[from] TelemetryInitError),
     #[error(transparent)]
     PluginRegistryError(#[from] PluginRegistryError),
-    #[error("Persisted documents endpoint incompatible: {0}")]
-    PersistedDocumentsEndpointIncompatible(String),
     #[error("Endpoints of '{endpoint_name_one}' and '{endpoint_name_two}' cannot both use the same endpoint: {endpoint}")]
     EndpointConflict {
         endpoint_name_one: String,

--- a/bin/router/src/http_utils/probes.rs
+++ b/bin/router/src/http_utils/probes.rs
@@ -12,7 +12,7 @@ pub async fn readiness_check_handler(
     req: HttpRequest,
     schema_state: web::types::State<Arc<SchemaState>>,
 ) -> impl Responder {
-    if schema_state.is_ready(&req) {
+    if schema_state.is_ready(&req).await {
         web::HttpResponse::Ok()
     } else {
         web::HttpResponse::ServiceUnavailable()

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -39,7 +39,7 @@ use crate::{
         header::ResponseMode,
         http_callback::handler,
         long_lived_client_limit::LongLivedClientLimitService,
-        persisted_documents::PersistedDocumentsRuntime,
+        persisted_documents::PersistedDocumentsBackgroundTasks,
         request_extensions::{
             read_graphql_operation_metric_identity, read_graphql_response_metric_status,
             write_graphql_response_metric_status,
@@ -47,7 +47,7 @@ use crate::{
         request_identifiers::RequestIdentifiersService,
         request_summary::RequestSummaryService,
         timeout::handle_timeout,
-        usage_reporting::init_hive_usage_agent,
+        usage_reporting::HiveUsageReportingBackgroundTasks,
         validation::{
             max_aliases_rule::MaxAliasesRule, max_depth_rule::MaxDepthRule,
             max_directives_rule::MaxDirectivesRule,
@@ -535,7 +535,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     .map_err(RouterInitError::HttpServerStartError);
 
     info!(target: targets::CORE, "router stopped, clearing background tasks");
-    bg_tasks_manager.shutdown();
+    bg_tasks_manager.graceful_shutdown().await;
     telemetry.graceful_shutdown().await;
 
     invoke_shutdown_hooks(&shared_state_clone).await;
@@ -564,18 +564,19 @@ pub async fn configure_app_from_config(
         false => None,
     };
 
-    let hive_usage_agent = match router_config.telemetry.hive.as_ref() {
-        Some(hive_config) if hive_config.usage_reporting.enabled => {
-            Some(init_hive_usage_agent(bg_tasks_manager, hive_config)?)
-        }
-        _ => None,
-    };
     let plugins_arc = plugin_registry.initialize_plugins(router_config, bg_tasks_manager)?;
 
     let active_subscriptions =
         ActiveSubscriptions::new(router_config.subscriptions.broadcast_capacity);
     let storage_manager = Arc::new(StorageManager::new(&router_config.storages)?);
     let telemetry_context_arc = Arc::new(telemetry_context);
+
+    let (persisted_documents_background_tasks, persisted_documents_background_task) =
+        PersistedDocumentsBackgroundTasks::new();
+    bg_tasks_manager.register_graceful_task(persisted_documents_background_task);
+    let (hive_usage_reporting_background_tasks, hive_usage_reporting_background_task) =
+        HiveUsageReportingBackgroundTasks::new();
+    bg_tasks_manager.register_graceful_task(hive_usage_reporting_background_task);
 
     let schema_state = SchemaState::new_from_config(
         bg_tasks_manager,
@@ -584,6 +585,8 @@ pub async fn configure_app_from_config(
         plugins_arc.clone(),
         active_subscriptions.clone(),
         storage_manager.clone(),
+        persisted_documents_background_tasks,
+        hive_usage_reporting_background_tasks,
     )
     .await?;
     let schema_state_arc = Arc::new(schema_state);
@@ -604,31 +607,10 @@ pub async fn configure_app_from_config(
             config: max_aliases_config.clone(),
         }));
     }
-    let persisted_documents_runtime = PersistedDocumentsRuntime::init(
-        &router_config.persisted_documents,
-        &router_config.http.graphql_endpoint,
-        bg_tasks_manager,
-        &storage_manager,
-    )
-    .await
-    .map_err(|err| crate::shared_state::SharedStateError::PersistedDocuments(Box::new(err)))?;
-
-    if !persisted_documents_runtime.supports_graphql_endpoint(&router_config.http.graphql_endpoint)
-    {
-        // url_path_param extractor depends on path segments relative to graphql endpoint.
-        // Root endpoint would make all routes ambiguous for persisted-document extraction.
-        // Even /health could be treated as a graphql request with document id == "health".
-        return Err(RouterInitError::PersistedDocumentsEndpointIncompatible(
-            "http.graphql_endpoint='/' is not allowed when persisted_documents.selectors contains type=url_path_param. Use a non-root endpoint like '/graphql'.".to_string(),
-        ));
-    }
-
     let metrics_enabled = router_config.telemetry.metrics.is_enabled();
     let shared_state = Arc::new(RouterSharedState::new(
         router_config,
-        persisted_documents_runtime,
         jwt_runtime,
-        hive_usage_agent,
         validation_plan,
         telemetry_context_arc.clone(),
         plugins_arc,

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -129,7 +129,7 @@ pub async fn execute_plan<'exec>(
                 .operation_for_plan
                 .clone(),
             projection_plan: planned_request.normalized_payload.projection_plan.clone(),
-            headers_plan: app_state.headers_plan.clone(),
+            headers_plan: supergraph.runtime.headers_plan.clone(),
             extensions_plan: app_state.extensions_plan.clone(),
             variable_values: planned_request.variable_payload.clone(),
             extensions,
@@ -151,7 +151,7 @@ pub async fn execute_plan<'exec>(
                 operation_name,
             ),
             response_header_sink,
-            error_masking_runtime: app_state.error_masking.clone(),
+            error_masking_runtime: supergraph.runtime.error_masking.clone(),
             connection_fingerprint: planned_request.connection_fingerprint,
         })
         .await?;

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -28,6 +28,7 @@ use crate::pipeline::persisted_documents::extract::{
 use crate::pipeline::persisted_documents::resolve::PersistedDocumentResolveInput;
 use crate::pipeline::persisted_documents::types::{ClientIdentity, PersistedDocumentId};
 use crate::pipeline::persisted_documents::PersistedDocumentsRuntime;
+use crate::schema_state::SelectedSupergraph;
 use crate::shared_state::RouterSharedState;
 
 #[derive(serde::Deserialize, Debug)]
@@ -301,10 +302,10 @@ pub enum OperationPreparationResult {
     Operation(PreparedOperation),
 }
 
-pub struct OperationPreparation<'a> {
+pub struct OperationPreparation<'a, 'p> {
     req: &'a HttpRequest,
     persisted_documents_runtime: &'a PersistedDocumentsRuntime,
-    plugin_req_state: &'a Option<PluginRequestState<'a>>,
+    plugin_req_state: &'p Option<PluginRequestState<'a>>,
     body: Bytes,
     persisted_documents_enabled: bool,
     log_missing_id_requests: bool,
@@ -312,24 +313,26 @@ pub struct OperationPreparation<'a> {
     metrics: Arc<Metrics>,
 }
 
-impl<'a> OperationPreparation<'a> {
+impl<'a, 'p> OperationPreparation<'a, 'p> {
     #[inline]
-    pub async fn prepare(
+    pub async fn prepare_http(
         req: &'a HttpRequest,
         shared_state: &'a Arc<RouterSharedState>,
-        plugin_req_state: &'a Option<PluginRequestState<'a>>,
+        supergraph: &'a SelectedSupergraph,
+        plugin_req_state: &'p Option<PluginRequestState<'a>>,
         body: Bytes,
         client_name: Option<&'a str>,
         client_version: Option<&'a str>,
     ) -> Result<OperationPreparationResult, PipelineError> {
         Self {
             req,
-            persisted_documents_runtime: &shared_state.persisted_documents_runtime,
+            persisted_documents_runtime: &supergraph.runtime.persisted_documents,
             plugin_req_state,
             body,
-            persisted_documents_enabled: shared_state.router_config.persisted_documents.enabled,
-            log_missing_id_requests: shared_state
-                .router_config
+            persisted_documents_enabled: supergraph.snapshot.options.persisted_documents.enabled,
+            log_missing_id_requests: supergraph
+                .snapshot
+                .options
                 .persisted_documents
                 .log_missing_id,
             client_identity: ClientIdentity {
@@ -338,12 +341,46 @@ impl<'a> OperationPreparation<'a> {
             },
             metrics: shared_state.telemetry_context.metrics.clone(),
         }
-        .extract_and_resolve()
+        .extract_and_resolve(None)
         .await
     }
 
-    async fn extract_and_resolve(mut self) -> Result<OperationPreparationResult, PipelineError> {
-        let mut graphql_params_from_plugins = None;
+    pub async fn prepare_websocket(
+        req: &'a HttpRequest,
+        shared_state: &'a Arc<RouterSharedState>,
+        supergraph: &'a SelectedSupergraph,
+        plugin_req_state: &'p Option<PluginRequestState<'a>>,
+        graphql_params: GraphQLParams,
+        client_name: Option<&'a str>,
+        client_version: Option<&'a str>,
+    ) -> Result<OperationPreparationResult, PipelineError> {
+        Self {
+            req,
+            persisted_documents_runtime: &supergraph.runtime.persisted_documents,
+            plugin_req_state,
+            body: Bytes::new(),
+            persisted_documents_enabled: supergraph.snapshot.options.persisted_documents.enabled,
+            log_missing_id_requests: supergraph
+                .snapshot
+                .options
+                .persisted_documents
+                .log_missing_id,
+            client_identity: ClientIdentity {
+                name: client_name,
+                version: client_version,
+            },
+            metrics: shared_state.telemetry_context.metrics.clone(),
+        }
+        .extract_and_resolve(Some(graphql_params))
+        .await
+    }
+}
+
+impl<'a, 'p> OperationPreparation<'a, 'p> {
+    async fn extract_and_resolve(
+        mut self,
+        mut graphql_params: Option<GraphQLParams>,
+    ) -> Result<OperationPreparationResult, PipelineError> {
         let mut graphql_params_end_callbacks = Vec::new();
 
         if let Some(plugin_req_state) = self.plugin_req_state.as_ref() {
@@ -355,7 +392,7 @@ impl<'a> OperationPreparation<'a> {
                         .request_context
                         .for_plugin::<hooks::OnGraphqlParams>(),
                     body: self.body.clone(),
-                    graphql_params: None,
+                    graphql_params: graphql_params.take(),
                 };
 
             for plugin in plugin_req_state.plugins.as_ref() {
@@ -372,11 +409,11 @@ impl<'a> OperationPreparation<'a> {
                 }
             }
 
-            graphql_params_from_plugins = deserialization_payload.graphql_params;
+            graphql_params = deserialization_payload.graphql_params;
             self.body = deserialization_payload.body;
         }
 
-        let mut operation = self.decode_or_use_plugin_override(graphql_params_from_plugins)?;
+        let mut operation = self.decode_or_use_graphql_params(graphql_params)?;
 
         if self.persisted_documents_enabled && operation.resolved_document_id.is_none() {
             self.metrics.persisted_documents.record_missing_id();
@@ -434,7 +471,7 @@ impl<'a> OperationPreparation<'a> {
     }
 
     #[inline]
-    fn decode_or_use_plugin_override(
+    fn decode_or_use_graphql_params(
         &self,
         graphql_params_override: Option<GraphQLParams>,
     ) -> Result<PreparedOperation, PipelineError> {

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -220,9 +220,18 @@ pub async fn graphql_request_handler(
             });
         }
 
-        let operation_preparation_result = OperationPreparation::prepare(
+        let Some(supergraph) = schema_state.select_supergraph(req).await? else {
+            return Err(InternalPipelineError::NoSupergraphAvailable {
+                response_headers: vec![(RETRY_AFTER, HeaderValue::from_static("10"))],
+            }.into());
+        };
+        summary::record(|s| s.set_supergraph_identifier(supergraph.snapshot.cache_id));
+        operation_span.record_hive_target(supergraph.snapshot.options.hive_target.as_deref());
+
+        let operation_preparation_result = OperationPreparation::prepare_http(
             req,
             shared_state,
+            &supergraph,
             &plugin_req_state,
             body_bytes,
             client_name,
@@ -278,16 +287,6 @@ pub async fn graphql_request_handler(
             client_version,
             &parser_payload.hive_operation_hash,
         );
-
-        let Some(supergraph) = schema_state.select_supergraph(req)? else {
-            return Err(InternalPipelineError::NoSupergraphAvailable {
-                response_headers: vec![(RETRY_AFTER, HeaderValue::from_static("10"))],
-            }
-            .into());
-        };
-
-        summary::record(|s| s.set_supergraph_identifier(supergraph.snapshot.cache_id));
-
 
         if let Some(response) = validate_operation_with_cache(
             &supergraph,
@@ -430,8 +429,7 @@ pub async fn graphql_request_handler(
             .router
             .dedupe
             .enabled;
-        let websocket_reuse_enabled = shared_state
-            .router_config
+        let websocket_reuse_enabled = supergraph.snapshot.options
             .traffic_shaping
             .any_websocket_connection_reuse_enabled();
 
@@ -512,7 +510,7 @@ pub async fn graphql_request_handler(
             exec(None).await?
         };
 
-        if let Some(hive_usage_agent) = &shared_state.hive_usage_agent {
+        if let Some(hive_usage_agent) = &supergraph.runtime.hive_usage_agent {
             usage_reporting::collect_usage_report(
                 supergraph.snapshot.supergraph_schema.clone(),
                 started_at.elapsed(),
@@ -776,7 +774,7 @@ pub async fn execute_pipeline<'exec>(
     )?;
 
     let mut progressive_override_ctx = RequestOverrideContext::new(
-        &shared_state.override_labels_evaluator,
+        &supergraph.runtime.override_labels_evaluator,
         &client_request_details,
         request_context,
     )?;

--- a/bin/router/src/pipeline/persisted_documents/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/mod.rs
@@ -1,14 +1,18 @@
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use async_trait::async_trait;
+use futures::{stream::FuturesUnordered, StreamExt};
 
 use hive_console_sdk::expressions::{CompileExpression, ProgramHints};
 use hive_router_config::persisted_documents::{
     PersistedDocumentsConfig, PersistedDocumentsStorageConfig,
 };
 use hive_router_config::primitives::value_or_expression::ValueOrExpression;
-use hive_router_internal::background_tasks::BackgroundTasksManager;
+use hive_router_internal::background_tasks::{BackgroundTask, CancellationToken};
 use hive_router_internal::expressions::{ToVrlValue, ValueOrProgram};
 use hive_router_plan_executor::execution::client_request_details::ntex_header_map_to_vrl_value;
 use ntex::web::HttpRequest;
+use tokio::sync::{mpsc, Mutex};
 
 use crate::pipeline::error::{InternalPipelineError, PipelineError};
 use crate::pipeline::persisted_documents::extract::DocumentIdResolver;
@@ -19,11 +23,148 @@ use crate::pipeline::persisted_documents::resolve::{
     FileManifestReloadTask, FileManifestResolver, HiveCDNResolver, PersistedDocumentResolver,
     PersistedDocumentResolverError,
 };
-use crate::storage::StorageManager;
+use crate::storage::{StorageManager, StorageRuntime};
 
 pub mod extract;
 pub mod resolve;
 pub mod types;
+
+enum PersistedDocumentsWorkerRegistration {
+    File(FileManifestReloadTask, CancellationToken),
+    Storage(StorageManifestReloadTask, CancellationToken),
+}
+
+fn persisted_documents_worker(
+    registration: PersistedDocumentsWorkerRegistration,
+    router_shutdown: CancellationToken,
+) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    Box::pin(async move {
+        match registration {
+            PersistedDocumentsWorkerRegistration::File(task, supergraph_lifetime) => {
+                let token = CancellationToken::new();
+                let run = task.run(token.clone());
+                tokio::pin!(run);
+                tokio::select! {
+                    _ = router_shutdown.cancelled() => token.cancel(),
+                    _ = supergraph_lifetime.cancelled() => token.cancel(),
+                    _ = &mut run => return,
+                }
+                run.await;
+            }
+            PersistedDocumentsWorkerRegistration::Storage(task, supergraph_lifetime) => {
+                let token = CancellationToken::new();
+                let run = task.run(token.clone());
+                tokio::pin!(run);
+                tokio::select! {
+                    _ = router_shutdown.cancelled() => token.cancel(),
+                    _ = supergraph_lifetime.cancelled() => token.cancel(),
+                    _ = &mut run => return,
+                }
+                run.await;
+            }
+        }
+    })
+}
+
+/// Adds manifest reload workers that are scoped to one selected supergraph runtime.
+///
+/// The supplied lifetime is the cancellation token owned by that runtime. A worker remains active
+/// while the runtime is retained by its configured owner, runtime cache, request, WebSocket, or
+/// subscription. Cancelling the lifetime removes only that runtime's workers; router shutdown is
+/// handled independently by [`PersistedDocumentsBackgroundTasks`].
+#[derive(Clone)]
+pub struct PersistedDocumentsBackgroundTaskController {
+    sender: mpsc::UnboundedSender<PersistedDocumentsWorkerRegistration>,
+}
+
+impl PersistedDocumentsBackgroundTaskController {
+    fn add_file_worker(
+        &self,
+        task: FileManifestReloadTask,
+        supergraph_lifetime: CancellationToken,
+    ) {
+        self.sender
+            .send(PersistedDocumentsWorkerRegistration::File(
+                task,
+                supergraph_lifetime,
+            ))
+            .ok();
+    }
+
+    fn add_storage_worker(
+        &self,
+        task: StorageManifestReloadTask,
+        supergraph_lifetime: CancellationToken,
+    ) {
+        self.sender
+            .send(PersistedDocumentsWorkerRegistration::Storage(
+                task,
+                supergraph_lifetime,
+            ))
+            .ok();
+    }
+}
+
+/// Runs all persisted-document manifest reload workers registered after router startup.
+///
+/// Workers are removed when their selected supergraph runtime lifetime is cancelled. This is tied
+/// to the final runtime drop rather than cache eviction or owner retirement because active requests
+/// and subscriptions may still retain and use that runtime.
+pub struct PersistedDocumentsBackgroundTasks {
+    registrations: Mutex<mpsc::UnboundedReceiver<PersistedDocumentsWorkerRegistration>>,
+}
+
+impl PersistedDocumentsBackgroundTasks {
+    pub fn new() -> (PersistedDocumentsBackgroundTaskController, Self) {
+        let (sender, registrations) = mpsc::unbounded_channel();
+        (
+            PersistedDocumentsBackgroundTaskController { sender },
+            Self {
+                registrations: Mutex::new(registrations),
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl BackgroundTask for PersistedDocumentsBackgroundTasks {
+    fn id(&self) -> &str {
+        "persisted-documents-background-tasks"
+    }
+
+    async fn run(&self, router_shutdown: CancellationToken) {
+        let mut registrations = self.registrations.lock().await;
+        let mut workers: FuturesUnordered<Pin<Box<dyn Future<Output = ()> + Send>>> =
+            FuturesUnordered::new();
+
+        loop {
+            tokio::select! {
+                _ = router_shutdown.cancelled() => {
+                    registrations.close();
+                    while let Some(registration) = registrations.recv().await {
+                        workers.push(persisted_documents_worker(
+                            registration,
+                            router_shutdown.clone(),
+                        ));
+                    }
+                    while workers.next().await.is_some() {}
+                    return;
+                }
+                registration = registrations.recv() => {
+                    let Some(registration) = registration else {
+                        while workers.next().await.is_some() {}
+                        return;
+                    };
+                    workers.push(persisted_documents_worker(
+                        registration,
+                        router_shutdown.clone(),
+                    ));
+                }
+                Some(()) = workers.next(), if !workers.is_empty() => {}
+            }
+        }
+    }
+}
 
 pub struct PersistedDocumentsRuntime {
     pub document_id_resolver: Arc<DocumentIdResolver>,
@@ -32,12 +173,39 @@ pub struct PersistedDocumentsRuntime {
 }
 
 impl PersistedDocumentsRuntime {
+    /// Resolves the shared storage referenced by persisted-document configuration.
+    ///
+    /// Configured supergraphs call this before asynchronous schema loading so an invalid static
+    /// reference still fails router startup. Runtime initialization consumes the returned storage
+    /// directly, avoiding a separate validation lookup. Plugin-selected supergraphs are validated
+    /// through runtime initialization because they own their persisted-document configuration.
+    pub(crate) fn resolve_storage_runtime(
+        config: &PersistedDocumentsConfig,
+        storage_manager: &StorageManager,
+    ) -> Result<Option<Arc<Box<dyn StorageRuntime>>>, PersistedDocumentResolverError> {
+        if !config.enabled {
+            return Ok(None);
+        }
+        let Some(PersistedDocumentsStorageConfig::Storage { config }) = &config.storage else {
+            return Ok(None);
+        };
+        storage_manager
+            .get_storage_runtime(&config.storage_id)
+            .map(Some)
+            .ok_or_else(|| {
+                PersistedDocumentResolverError::StorageNotFound(config.storage_id.to_string())
+            })
+    }
+
     pub async fn init(
         config: &PersistedDocumentsConfig,
         graphql_endpoint: &str,
-        background_tasks_mgr: &mut BackgroundTasksManager,
+        background_tasks: &PersistedDocumentsBackgroundTaskController,
+        supergraph_lifetime: CancellationToken,
         storage_manager: &Arc<StorageManager>,
     ) -> Result<Self, PersistedDocumentResolverError> {
+        let storage_runtime = Self::resolve_storage_runtime(config, storage_manager)?;
+
         let document_id_resolver = Arc::new(
             DocumentIdResolver::from_config(config, graphql_endpoint).map_err(|error| {
                 PersistedDocumentResolverError::Configuration(format!(
@@ -69,8 +237,10 @@ impl PersistedDocumentsRuntime {
                     let resolver =
                         Arc::new(FileManifestResolver::from_storage_config(config).await?);
                     if resolver.has_watcher() {
-                        background_tasks_mgr
-                            .register_task(FileManifestReloadTask(resolver.clone()));
+                        background_tasks.add_file_worker(
+                            FileManifestReloadTask(resolver.clone()),
+                            supergraph_lifetime.clone(),
+                        );
                     }
                     Some(resolver as Arc<dyn PersistedDocumentResolver>)
                 }
@@ -79,27 +249,19 @@ impl PersistedDocumentsRuntime {
                     Some(resolver as Arc<dyn PersistedDocumentResolver>)
                 }
                 PersistedDocumentsStorageConfig::Storage { config } => {
-                    match storage_manager.get_storage_runtime(&config.storage_id) {
-                        Some(storage) => {
-                            let resolver = Arc::new(
-                                StorageResolver::from_storage_config(config, storage).await?,
-                            );
+                    let storage = storage_runtime
+                        .expect("storage runtime is present for storage-backed configuration");
+                    let resolver =
+                        Arc::new(StorageResolver::from_storage_config(config, storage).await?);
 
-                            if let Some(poll_interval) = &config.poll_interval {
-                                background_tasks_mgr.register_task(StorageManifestReloadTask::new(
-                                    resolver.clone(),
-                                    *poll_interval,
-                                ));
-                            }
-
-                            Some(resolver as Arc<dyn PersistedDocumentResolver>)
-                        }
-                        None => {
-                            return Err(PersistedDocumentResolverError::StorageNotFound(
-                                config.storage_id.to_string(),
-                            ));
-                        }
+                    if let Some(poll_interval) = &config.poll_interval {
+                        background_tasks.add_storage_worker(
+                            StorageManifestReloadTask::new(resolver.clone(), *poll_interval),
+                            supergraph_lifetime.clone(),
+                        );
                     }
+
+                    Some(resolver as Arc<dyn PersistedDocumentResolver>)
                 }
             }
         } else {

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -1,10 +1,13 @@
 use std::{
+    future::Future,
+    pin::Pin,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use crate::consts::ROUTER_VERSION;
 use async_trait::async_trait;
+use futures::{stream::FuturesUnordered, StreamExt};
 use graphql_tools::parser::schema::Document;
 use hive_console_sdk::agent::usage_agent::{
     AgentError, ExecutionReport, OperationType, RequestDetails, SamplingKey, UsageAgent,
@@ -12,16 +15,16 @@ use hive_console_sdk::agent::usage_agent::{
 };
 use hive_router_config::{
     headers::OneOrMany,
-    telemetry::hive::{is_slug_target_ref, is_uuid_target_ref, HiveTelemetryConfig},
+    telemetry::hive::HiveTelemetryConfig,
     usage_reporting::{UsageReportingExclude, UsageReportingSamplingKeyKind},
 };
 use hive_router_internal::telemetry::utils::resolve_value_or_expression;
 use hive_router_internal::{
-    background_tasks::{BackgroundTask, BackgroundTasksManager},
+    background_tasks::{BackgroundTask, CancellationToken},
     telemetry::logging::targets,
 };
 use hive_router_query_planner::state::supergraph_state::OperationKind;
-use tokio_util::sync::CancellationToken;
+use tokio::sync::{mpsc, Mutex};
 use tracing::error;
 
 #[derive(Debug, thiserror::Error)]
@@ -37,8 +40,10 @@ pub enum UsageReportingError {
 }
 
 pub fn init_hive_usage_agent(
-    bg_tasks_manager: &mut BackgroundTasksManager,
+    background_tasks: &HiveUsageReportingBackgroundTaskController,
+    supergraph_lifetime: CancellationToken,
     hive_config: &HiveTelemetryConfig,
+    target: Option<&str>,
 ) -> Result<UsageAgent, UsageReportingError> {
     let usage_config = &hive_config.usage_reporting;
     let user_agent = format!("hive-router/{}", ROUTER_VERSION);
@@ -47,23 +52,6 @@ pub fn init_hive_usage_agent(
             .map_err(|e| UsageReportingError::ConfigurationError(e.to_string()))?,
         None => return Err(UsageReportingError::MissingAccessToken),
     };
-
-    let target = match &hive_config.target {
-        Some(t) => Some(
-            resolve_value_or_expression(t, "Hive Telemetry target")
-                .map_err(|e| UsageReportingError::ConfigurationError(e.to_string()))?,
-        ),
-        None => None,
-    };
-
-    if let Some(target) = &target {
-        if !is_uuid_target_ref(target) && !is_slug_target_ref(target) {
-            return Err(UsageReportingError::ConfigurationError(format!(
-                "Invalid Hive Telemetry target format: '{}'. It must be either in slug format '$organizationSlug/$projectSlug/$targetSlug' or UUID format 'a0f4c605-6541-4350-8cfe-b31f21a4bf80'",
-                target
-            )));
-        }
-    }
 
     let mut agent_builder = UsageAgent::builder()
         .user_agent(user_agent)
@@ -77,7 +65,7 @@ pub fn init_hive_usage_agent(
         .flush_interval(usage_config.flush_interval);
 
     if let Some(target_id) = target {
-        agent_builder = agent_builder.target_id(target_id);
+        agent_builder = agent_builder.target_id(target_id.to_string());
     }
 
     if let Some(UsageReportingExclude::Expression { expression }) = &usage_config.exclude {
@@ -100,7 +88,7 @@ pub fn init_hive_usage_agent(
 
     let agent = agent_builder.build()?;
 
-    bg_tasks_manager.register_task(UsageAgentTask(agent.clone()));
+    background_tasks.add_worker(agent.clone(), supergraph_lifetime);
     Ok(agent)
 }
 
@@ -158,16 +146,184 @@ fn map_sampling_key_to_sdk(kind: &UsageReportingSamplingKeyKind) -> SamplingKey 
     }
 }
 
-struct UsageAgentTask(UsageAgent);
+struct HiveUsageReportingWorker {
+    agent: UsageAgent,
+    supergraph_lifetime: CancellationToken,
+}
+
+fn hive_usage_reporting_worker(
+    worker: HiveUsageReportingWorker,
+    router_shutdown: CancellationToken,
+) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    Box::pin(async move {
+        let interval_token = CancellationToken::new();
+        let interval = worker.agent.start_flush_interval(&interval_token);
+        tokio::pin!(interval);
+        let cancelled = tokio::select! {
+            _ = router_shutdown.cancelled() => true,
+            _ = worker.supergraph_lifetime.cancelled() => true,
+            _ = &mut interval => false,
+        };
+        if cancelled {
+            interval_token.cancel();
+            interval.await;
+        }
+        if let Err(err) = worker.agent.flush().await {
+            error!(target: targets::HIVE_USAGE_REPORTING, error = ?err, "failed to flush usage reports while stopping supergraph runtime");
+        }
+    })
+}
+
+/// Adds Hive usage-reporting workers that are scoped to one selected supergraph runtime.
+///
+/// The supplied lifetime is the cancellation token owned by that runtime. It is cancelled only
+/// after the final runtime reference is dropped, so reports from retained requests, WebSockets, and
+/// subscriptions are not lost after cache eviction or supergraph retirement. Cancellation removes
+/// the worker only after its buffered reports have been flushed.
+#[derive(Clone)]
+pub struct HiveUsageReportingBackgroundTaskController {
+    sender: mpsc::UnboundedSender<HiveUsageReportingWorker>,
+}
+
+impl HiveUsageReportingBackgroundTaskController {
+    fn add_worker(&self, agent: UsageAgent, supergraph_lifetime: CancellationToken) {
+        self.sender
+            .send(HiveUsageReportingWorker {
+                agent,
+                supergraph_lifetime,
+            })
+            .ok();
+    }
+}
+
+/// Runs Hive usage-reporting agents registered for selected supergraph runtimes.
+///
+/// Each worker periodically flushes one runtime's agent. When either the router or that runtime
+/// shuts down, the periodic loop is stopped and one final flush is awaited before the worker is
+/// removed. Explicitly awaiting this flush avoids relying on asynchronous drop timing.
+pub struct HiveUsageReportingBackgroundTasks {
+    registrations: Mutex<mpsc::UnboundedReceiver<HiveUsageReportingWorker>>,
+}
+
+impl HiveUsageReportingBackgroundTasks {
+    pub fn new() -> (HiveUsageReportingBackgroundTaskController, Self) {
+        let (sender, registrations) = mpsc::unbounded_channel();
+        (
+            HiveUsageReportingBackgroundTaskController { sender },
+            Self {
+                registrations: Mutex::new(registrations),
+            },
+        )
+    }
+}
 
 #[async_trait]
-impl BackgroundTask for UsageAgentTask {
+impl BackgroundTask for HiveUsageReportingBackgroundTasks {
     fn id(&self) -> &str {
-        "hive_console_usage_report_task"
+        "hive-usage-reporting-background-tasks"
     }
 
-    async fn run(&self, token: CancellationToken) {
-        self.0.start_flush_interval(&token).await
+    async fn run(&self, router_shutdown: CancellationToken) {
+        let mut registrations = self.registrations.lock().await;
+        let mut workers: FuturesUnordered<Pin<Box<dyn Future<Output = ()> + Send>>> =
+            FuturesUnordered::new();
+
+        loop {
+            tokio::select! {
+                _ = router_shutdown.cancelled() => {
+                    registrations.close();
+                    while let Some(worker) = registrations.recv().await {
+                        workers.push(hive_usage_reporting_worker(
+                            worker,
+                            router_shutdown.clone(),
+                        ));
+                    }
+                    while workers.next().await.is_some() {}
+                    return;
+                }
+                registration = registrations.recv() => {
+                    let Some(worker) = registration else {
+                        while workers.next().await.is_some() {}
+                        return;
+                    };
+                    workers.push(hive_usage_reporting_worker(
+                        worker,
+                        router_shutdown.clone(),
+                    ));
+                }
+                Some(()) = workers.next(), if !workers.is_empty() => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use graphql_tools::parser::schema::parse_schema;
+
+    // usage agent async drop uses block_in_place, which requires tokio's multi-threaded runtime
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lifetime_cancellation_flushes_before_the_worker_stops() {
+        crate::init_rustls_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        let usage_request = server
+            .mock("POST", "/usage")
+            .expect(1)
+            .with_status(200)
+            .create_async()
+            .await;
+        let agent = UsageAgent::builder()
+            .token("token".into())
+            .endpoint(format!("{}/usage", server.url()))
+            .flush_interval(Duration::from_secs(3600))
+            .build()
+            .unwrap();
+        agent
+            .add_report_with_request(
+                ExecutionReport {
+                    schema: Arc::new(
+                        parse_schema::<String>("type Query { hello: String }")
+                            .unwrap()
+                            .to_owned(),
+                    ),
+                    client_name: None,
+                    client_version: None,
+                    timestamp: 0,
+                    duration: Duration::ZERO,
+                    ok: true,
+                    errors: 0,
+                    operation_body: "query { hello }".to_string(),
+                    operation_type: Some(OperationType::Query),
+                    operation_name: None,
+                    persisted_document_hash: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let (controller, background_tasks) = HiveUsageReportingBackgroundTasks::new();
+        let router_shutdown = CancellationToken::new();
+        let supergraph_lifetime = CancellationToken::new();
+        controller.add_worker(agent, supergraph_lifetime.clone());
+        let task_shutdown = router_shutdown.clone();
+        let handle = tokio::spawn(async move {
+            background_tasks.run(task_shutdown).await;
+        });
+
+        supergraph_lifetime.cancel();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !usage_request.matched_async().await {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("usage worker should flush promptly after lifetime cancellation");
+
+        router_shutdown.cancel();
+        handle.await.unwrap();
+        usage_request.assert_async().await;
     }
 }
 

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -1,3 +1,4 @@
+use futures::StreamExt;
 use hive_console_sdk::agent::usage_agent::RequestDetails;
 use hive_router_plan_executor::headers::response::ResponseHeaderSink;
 use http::Method;
@@ -40,6 +41,7 @@ use crate::jwt::errors::JwtError;
 use crate::pipeline::active_subscriptions::SubscriptionEvent;
 use crate::pipeline::error::{ClientPipelineError, PipelineError};
 use crate::pipeline::execute_planned_request;
+use crate::pipeline::execution_request::{OperationPreparation, OperationPreparationResult};
 use crate::pipeline::header::{ResponseMode, SingleContentType, StreamContentType};
 use crate::pipeline::{
     connection_fingerprint, hash_graphql_extensions, hash_graphql_variables,
@@ -243,7 +245,7 @@ async fn handle_text_frame(
     // browsers cannot interpret a rejected HTTP Upgrade request and will show a cryptic
     // error to clients. instead, we accept the connection but close it immediately if no
     // supergraph is available, which results in a more understandable error
-    let supergraph = match schema_state.select_supergraph(req) {
+    let supergraph = match schema_state.select_supergraph(req).await {
         Ok(supergraph) => supergraph,
         Err(err) => {
             error!(target: targets::WEBSOCKET_SERVER, err = ?err, "Supergraph runtime error");
@@ -302,6 +304,9 @@ async fn handle_text_frame(
 
             let started_at = Instant::now();
             let operation_span = GraphQLOperationSpan::new();
+            operation_span.record_hive_target(
+                supergraph.and_then(|selected| selected.snapshot.options.hive_target.as_deref()),
+            );
             let span_clone = operation_span.clone();
 
             let result = async {
@@ -379,7 +384,7 @@ async fn handle_text_frame(
                   }
 
                   let payload = GraphQLParams {
-                      query: Some(payload.query),
+                      query: (!payload.query.is_empty()).then_some(payload.query),
                       operation_name: payload.operation_name,
                       variables: payload.variables.unwrap_or_default(),
                       extensions: payload.extensions,
@@ -428,6 +433,43 @@ async fn handle_text_frame(
                               .version_header.get_header_ref(),
                       )
                       .and_then(|v| v.to_str().ok());
+
+                  let payload = match OperationPreparation::prepare_websocket(
+                      req,
+                      shared_state,
+                      supergraph,
+                      &plugin_req_state,
+                      payload,
+                      client_name,
+                      client_version,
+                  )
+                  .await
+                  {
+                      Ok(OperationPreparationResult::Operation(operation)) => {
+                          summary::record(|summary| {
+                              summary.set_persisted_document_id(
+                                  operation.resolved_document_id.as_deref(),
+                              )
+                          });
+                          operation.graphql_params
+                      }
+                      Ok(OperationPreparationResult::EarlyResponse(mut response)) => {
+                          let mut response_body = response.take_body();
+                          let mut body = Vec::new();
+                          while let Some(chunk) = response_body.next().await {
+                              match chunk {
+                                  Ok(chunk) => body.extend_from_slice(&chunk),
+                                  Err(err) => {
+                                      error!(target: targets::WEBSOCKET_SERVER, error = ?err, "Failed to read GraphQL params hook response body");
+                                      return Some(CloseCode::InternalServerError(None).into());
+                                  }
+                              }
+                          }
+                          let _ = sink.send(ServerMessage::next(&id, &body)).await;
+                          return Some(ServerMessage::complete(&id));
+                      }
+                      Err(err) => return Some(err.into_server_message(&id, shared_state)),
+                  };
 
                   let parser_result =
                       match parse_operation_with_cache(shared_state, &payload, &plugin_req_state).await {
@@ -502,10 +544,8 @@ async fn handle_text_frame(
 
                   let request_dedupe_enabled =
                       shared_state.router_config.traffic_shaping.router.dedupe.enabled;
-                  let websocket_reuse_enabled = shared_state
-                      .router_config
-                      .traffic_shaping
-                      .any_websocket_connection_reuse_enabled();
+                  let websocket_reuse_enabled = supergraph.snapshot.options.traffic_shaping
+                  .any_websocket_connection_reuse_enabled();
 
                   let connection_fingerprint = (request_dedupe_enabled || websocket_reuse_enabled)
                     .then(|| connection_fingerprint(
@@ -621,7 +661,7 @@ async fn handle_text_frame(
                       }
                   };
 
-                  if let Some(hive_usage_agent) = &shared_state.hive_usage_agent {
+                  if let Some(hive_usage_agent) = &supergraph.runtime.hive_usage_agent {
                       let mut headers_vec = Vec::with_capacity(headers.len());
                       for (name, value) in headers.iter() {
                           if let Ok(val_str) = value.to_str() {

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -6,10 +6,15 @@ use dashmap::DashMap;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use graphql_tools::validation::utils::ValidationError;
+use hive_console_sdk::agent::usage_agent::UsageAgent;
+use hive_router_config::telemetry::hive::{
+    is_slug_target_ref, is_uuid_target_ref, HiveTelemetryConfig,
+};
 use hive_router_config::{supergraph::SupergraphSource, HiveRouterConfig};
 use hive_router_internal::authorization::metadata::AuthorizationMetadata;
 use hive_router_internal::background_tasks::{BackgroundTask, BackgroundTasksManager};
 use hive_router_internal::telemetry::logging::targets;
+use hive_router_internal::telemetry::utils::resolve_value_or_expression;
 use hive_router_internal::telemetry::{metrics::Metrics, TelemetryContext};
 use hive_router_plan_executor::execution::operation_name::OperationNameForwardConfig;
 use hive_router_plan_executor::executors::http_callback::{
@@ -17,10 +22,11 @@ use hive_router_plan_executor::executors::http_callback::{
 };
 use hive_router_plan_executor::response::graphql_error::GraphQLErrorExtensions;
 use hive_router_plan_executor::{
-    executors::error::SubgraphExecutorError,
+    execution::error_masking::ErrorMaskingRuntime,
+    executors::{error::SubgraphExecutorError, map::HttpCallbackRuntimeConfig},
     hooks::on_supergraph_load::{
         OnSupergraphLoadEndHookPayload, OnSupergraphLoadStartHookPayload, Supergraph,
-        SupergraphBuildError, SupergraphSnapshot,
+        SupergraphBuildError, SupergraphOptions, SupergraphSnapshot,
     },
     plugin_trait::{EndControlFlow, RouterPluginBoxed, StartControlFlow},
     response::graphql_error::GraphQLError,
@@ -29,21 +35,34 @@ use hive_router_plan_executor::{
 use hive_router_query_planner::{
     planner::plan_nodes::QueryPlan, utils::parsing::safe_parse_schema,
 };
+use http::Uri;
 use moka::future::Cache;
 use ntex::web::HttpRequest;
 use std::collections::hash_map;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
+
+use hive_router_plan_executor::headers::{
+    compile::compile_headers_plan, errors::HeaderRuleCompileError, plan::HeaderRulesPlan,
+};
 
 use crate::{
     pipeline::authorization::AuthorizationMetadataError,
     pipeline::authorization::AuthorizationMetadataExt,
     pipeline::demand_control::runtime::DemandControlRuntime,
     pipeline::normalize::GraphQLNormalizationPayload,
+    pipeline::persisted_documents::{
+        resolve::PersistedDocumentResolverError, PersistedDocumentsBackgroundTaskController,
+        PersistedDocumentsRuntime,
+    },
+    pipeline::progressive_override::{OverrideLabelsCompileError, OverrideLabelsEvaluator},
+    pipeline::usage_reporting::{
+        init_hive_usage_agent, HiveUsageReportingBackgroundTaskController, UsageReportingError,
+    },
     supergraph::{
         base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader},
         resolve_from_config,
@@ -56,6 +75,20 @@ pub enum RouterSupergraphRuntimeError {
     ExecutorInitError(#[from] SubgraphExecutorError),
     #[error(transparent)]
     AuthorizationMetadataError(#[from] AuthorizationMetadataError),
+    #[error(transparent)]
+    HeaderRuleCompileError(#[from] HeaderRuleCompileError),
+    #[error(transparent)]
+    OverrideLabelsCompileError(#[from] OverrideLabelsCompileError),
+    #[error(transparent)]
+    UsageReportingError(#[from] UsageReportingError),
+    #[error(transparent)]
+    PersistedDocumentsError(#[from] PersistedDocumentResolverError),
+    #[error("Persisted-document selectors are incompatible with GraphQL endpoint '{0}'")]
+    PersistedDocumentsEndpoint(String),
+    #[error("Hive tracing is enabled but no target was provided")]
+    HiveTargetMissing,
+    #[error("Invalid Hive Tracing target format: '{0}'. It must be either in slug format '$organizationSlug/$projectSlug/$targetSlug' or UUID format 'a0f4c605-6541-4350-8cfe-b31f21a4bf80'")]
+    InvalidHiveTargetFormat(String),
 }
 
 /// Router state derived from a supergraph and router configuration: subgraph executors,
@@ -75,46 +108,228 @@ pub enum RouterSupergraphRuntimeError {
 pub struct RouterSupergraphRuntime {
     pub subgraph_executor_map: Arc<SubgraphExecutorMap>,
     pub operation_name_forward_config: Arc<OperationNameForwardConfig>,
+    pub headers_plan: Arc<HeaderRulesPlan>,
+    pub override_labels_evaluator: OverrideLabelsEvaluator,
+    pub error_masking: Arc<Option<ErrorMaskingRuntime>>,
+    pub hive_usage_agent: Option<UsageAgent>,
+    pub persisted_documents: PersistedDocumentsRuntime,
     pub authorization: AuthorizationMetadata,
     pub validate_cache: Cache<u64, Arc<Vec<ValidationError>>>,
     pub normalize_cache: Cache<u64, Arc<GraphQLNormalizationPayload>>,
     pub plan_cache: Cache<u64, Arc<QueryPlan>>,
     pub demand_control_runtime: Option<DemandControlRuntime>,
+    /// Controls background work belonging to this selected supergraph runtime.
+    ///
+    /// Persisted-document reloaders and the Hive usage-reporting agent receive clones of this
+    /// token. It must remain active while any configured owner, runtime-cache entry, request,
+    /// WebSocket, or subscription retains this runtime, even if the supergraph snapshot has been
+    /// retired or its cache entry has been evicted. Cancelling earlier could stop manifest updates
+    /// or discard usage reports for in-flight operations still using this exact schema generation.
+    ///
+    /// The token is therefore cancelled only when runtime construction fails or the final runtime
+    /// reference is dropped. The specialized background-task groups observe cancellation, remove
+    /// this runtime's workers promptly, and explicitly flush Hive reports before its worker exits.
+    supergraph_lifetime: CancellationToken,
+}
+
+/// Warns about configuration for subgraphs absent from the selected snapshot instead of failing
+/// runtime construction.
+///
+/// The configuration and supergraph can be deployed on different schedules. An entry may be added
+/// before its subgraph appears, kept while that subgraph is temporarily removed, or shared by
+/// plugin-owned supergraph variants with different subgraph sets. The router historically accepted
+/// these dormant entries, so making them errors here would turn an otherwise valid schema reload or
+/// variant selection into an outage and would be a backwards-incompatible validation change.
+///
+/// Runtime construction is still the right place to report them because this is where the concrete
+/// selected snapshot is known. A warning catches misspellings and stale entries while preserving
+/// rolling deployment and plugin-variant use cases. The absent entry has no matching executor in
+/// this snapshot and therefore cannot affect one of its subgraphs. If strict validation is ever
+/// needed, it should be introduced as an explicit opt-in policy rather than changing this tolerant
+/// behavior for every existing configuration.
+fn warn_unknown_subgraphs<'a>(
+    setting: &str,
+    known: &HashSet<&str>,
+    names: impl IntoIterator<Item = &'a String>,
+) {
+    for name in names {
+        if !known.contains(name.as_str()) {
+            warn!(
+                target: targets::SUPERGRAPH,
+                setting,
+                subgraph = name,
+                "configuration refers to a subgraph absent from the selected supergraph"
+            );
+        }
+    }
 }
 
 impl RouterSupergraphRuntime {
-    pub fn build(
+    pub async fn build(
         snapshot: &SupergraphSnapshot,
-        router_config: &'static HiveRouterConfig,
-        telemetry_context: &Arc<TelemetryContext>,
-        callback_subscriptions: &CallbackSubscriptionsMap,
+        context: &RouterSupergraphRuntimeContext,
     ) -> Result<Self, RouterSupergraphRuntimeError> {
+        let known_subgraphs: HashSet<_> = snapshot
+            .planner
+            .supergraph
+            .subgraph_endpoint_map
+            .keys()
+            .map(String::as_str)
+            .collect();
+        warn_unknown_subgraphs(
+            "traffic_shaping.subgraphs",
+            &known_subgraphs,
+            snapshot.options.traffic_shaping.subgraphs.keys(),
+        );
+        warn_unknown_subgraphs(
+            "override_subgraph_urls.subgraphs",
+            &known_subgraphs,
+            snapshot.options.override_subgraph_urls.subgraphs.keys(),
+        );
+        if let Some(headers) = snapshot.options.headers.subgraphs.as_ref() {
+            warn_unknown_subgraphs("headers.subgraphs", &known_subgraphs, headers.keys());
+        }
+        if let Some(demand_control) = snapshot.options.demand_control.as_ref() {
+            if let Some(subgraphs) = demand_control.default_list_size.subgraphs.as_ref() {
+                warn_unknown_subgraphs(
+                    "demand_control.default_list_size.subgraphs",
+                    &known_subgraphs,
+                    subgraphs.keys(),
+                );
+            }
+            if let Some(subgraphs) = demand_control.subgraphs_budget.subgraphs.as_ref() {
+                warn_unknown_subgraphs(
+                    "demand_control.subgraphs_budget.subgraphs",
+                    &known_subgraphs,
+                    subgraphs.keys(),
+                );
+            }
+        }
+        warn_unknown_subgraphs(
+            "subscriptions.callback.subgraphs",
+            &known_subgraphs,
+            snapshot.options.subscriptions.callback_subgraphs.iter(),
+        );
+        if let Some(websocket) = snapshot.options.subscriptions.websocket.as_ref() {
+            warn_unknown_subgraphs(
+                "subscriptions.websocket.subgraphs",
+                &known_subgraphs,
+                websocket.subgraphs.keys(),
+            );
+        }
+        if let Some(error_masking) = snapshot.options.error_masking.subgraphs.as_ref() {
+            warn_unknown_subgraphs(
+                "error_masking.subgraphs",
+                &known_subgraphs,
+                error_masking.keys(),
+            );
+        }
+
         let subgraph_executor_map = Arc::new(SubgraphExecutorMap::from_http_endpoint_map(
             &snapshot.planner.supergraph.subgraph_endpoint_map,
-            router_config,
-            telemetry_context.clone(),
-            callback_subscriptions.clone(),
+            snapshot.options.traffic_shaping.clone(),
+            snapshot.options.override_subgraph_urls.clone(),
+            snapshot.options.subscriptions.clone(),
+            context.callback.clone(),
+            context.telemetry.clone(),
+            context.callback_subscriptions.clone(),
         )?);
         let operation_name_forward_config = Arc::new(OperationNameForwardConfig::new(
-            &router_config.traffic_shaping,
+            &snapshot.options.traffic_shaping,
             snapshot.planner.supergraph.known_subgraphs.values(),
         ));
         let authorization =
             AuthorizationMetadata::build(&snapshot.planner.supergraph, &snapshot.metadata)?;
         let demand_control_runtime = DemandControlRuntime::from_config(
-            router_config.demand_control.as_ref(),
-            telemetry_context.metrics.clone(),
+            snapshot.options.demand_control.as_ref(),
+            context.telemetry.metrics.clone(),
         );
-        Ok(Self {
-            subgraph_executor_map,
-            operation_name_forward_config,
-            authorization,
-            validate_cache: Cache::new(1000),
-            normalize_cache: Cache::new(1000),
-            plan_cache: Cache::new(1000),
-            demand_control_runtime,
-        })
+        if let Some(target) = snapshot.options.hive_target.as_deref() {
+            if !is_uuid_target_ref(target) && !is_slug_target_ref(target) {
+                return Err(RouterSupergraphRuntimeError::InvalidHiveTargetFormat(
+                    target.to_string(),
+                ));
+            }
+        } else if context
+            .hive
+            .as_ref()
+            .is_some_and(|hive| hive.tracing.enabled)
+        {
+            return Err(RouterSupergraphRuntimeError::HiveTargetMissing);
+        }
+        let supergraph_lifetime = CancellationToken::new();
+        let maybe_runtime: Result<Self, RouterSupergraphRuntimeError> = async {
+            let persisted_documents = PersistedDocumentsRuntime::init(
+                &snapshot.options.persisted_documents,
+                &context.graphql_endpoint,
+                &context.persisted_documents_background_tasks,
+                supergraph_lifetime.clone(),
+                &context.storage_manager,
+            )
+            .await?;
+            if !persisted_documents.supports_graphql_endpoint(&context.graphql_endpoint) {
+                return Err(RouterSupergraphRuntimeError::PersistedDocumentsEndpoint(
+                    context.graphql_endpoint.clone(),
+                ));
+            }
+            let hive_usage_agent = context
+                .hive
+                .as_ref()
+                .filter(|hive| hive.usage_reporting.enabled)
+                .map(|hive| {
+                    init_hive_usage_agent(
+                        &context.hive_usage_reporting_background_tasks,
+                        supergraph_lifetime.clone(),
+                        hive,
+                        snapshot.options.hive_target.as_deref(),
+                    )
+                })
+                .transpose()?;
+            Ok(Self {
+                subgraph_executor_map,
+                operation_name_forward_config,
+                headers_plan: Arc::new(compile_headers_plan(&snapshot.options.headers)?),
+                override_labels_evaluator: OverrideLabelsEvaluator::from_config(
+                    &snapshot.options.override_labels,
+                )?,
+                error_masking: Arc::new(ErrorMaskingRuntime::compile_from_config(
+                    &snapshot.options.error_masking,
+                )),
+                hive_usage_agent,
+                persisted_documents,
+                authorization,
+                validate_cache: Cache::new(1000),
+                normalize_cache: Cache::new(1000),
+                plan_cache: Cache::new(1000),
+                demand_control_runtime,
+                supergraph_lifetime: supergraph_lifetime.clone(),
+            })
+        }
+        .await;
+        if maybe_runtime.is_err() {
+            // cancel workers that may have been registered before runtime construction failed
+            supergraph_lifetime.cancel();
+        }
+        maybe_runtime
     }
+}
+
+impl Drop for RouterSupergraphRuntime {
+    fn drop(&mut self) {
+        // this is the final runtime reference, so no operation can add more reports or use its resolver
+        self.supergraph_lifetime.cancel();
+    }
+}
+
+pub struct RouterSupergraphRuntimeContext {
+    telemetry: Arc<TelemetryContext>,
+    callback_subscriptions: CallbackSubscriptionsMap,
+    callback: Option<HttpCallbackRuntimeConfig>,
+    persisted_documents_background_tasks: PersistedDocumentsBackgroundTaskController,
+    hive_usage_reporting_background_tasks: HiveUsageReportingBackgroundTaskController,
+    hive: Option<HiveTelemetryConfig>,
+    storage_manager: Arc<StorageManager>,
+    graphql_endpoint: String,
 }
 
 /// One selected supergraph for a request: the schema snapshot plus the router runtime built for
@@ -150,10 +365,10 @@ impl From<&ConfiguredSupergraph> for SelectedSupergraph {
 
 const RUNTIME_CACHE_MAX_SIZE: usize = 10;
 
-type RouterSupergraphRuntimeCache = Mutex<VecDeque<(u64, Arc<RouterSupergraphRuntime>)>>;
+type RouterSupergraphRuntimeCell = tokio::sync::OnceCell<Arc<RouterSupergraphRuntime>>;
+type RouterSupergraphRuntimeCache = Mutex<VecDeque<(u64, Arc<RouterSupergraphRuntimeCell>)>>;
 
 pub struct SchemaState {
-    router_config: &'static HiveRouterConfig,
     /// The supergraph configured through the router config that can be loaded (and polled)
     ///   - `Some` when the router's configured supergraph is available and has been loaded
     ///   - sometimes `None` when the supergraph is being fetched and built
@@ -169,6 +384,7 @@ pub struct SchemaState {
     runtime_cache_cleanup: Option<mpsc::UnboundedSender<RuntimeCacheCleanupMessage>>,
     pub telemetry_context: Arc<TelemetryContext>,
     pub callback_subscriptions: CallbackSubscriptionsMap,
+    runtime_context: Arc<RouterSupergraphRuntimeContext>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -186,12 +402,143 @@ pub enum SupergraphManagerError {
 
     #[error("Error from plugin: {0}")]
     PluginError(String),
+
+    #[error("Invalid supergraph configuration: {0}")]
+    Configuration(String),
+}
+
+fn supergraph_options(
+    config: &HiveRouterConfig,
+) -> Result<SupergraphOptions, SupergraphManagerError> {
+    let hive_target = config
+        .telemetry
+        .hive
+        .as_ref()
+        .and_then(|hive| hive.target.as_ref())
+        .map(|target| {
+            resolve_value_or_expression(target, "Hive Telemetry target")
+                .map_err(|error| SupergraphManagerError::Configuration(error.to_string()))
+        })
+        .transpose()?;
+
+    Ok(SupergraphOptions {
+        query_planner: hive_router_query_planner::planner::QueryPlannerOptions {
+            experimental_abstract_type_folding: config
+                .query_planner
+                .experimental_abstract_type_folding,
+        },
+        traffic_shaping: (&config.traffic_shaping).into(),
+        override_subgraph_urls: config.override_subgraph_urls.clone(),
+        headers: config.headers.clone(),
+        override_labels: config.override_labels.clone(),
+        demand_control: config.demand_control.clone(),
+        subscriptions: (&config.subscriptions).into(),
+        error_masking: config.error_masking.clone(),
+        persisted_documents: config.persisted_documents.clone(),
+        hive_target,
+    })
+}
+
+fn callback_runtime_config(
+    config: &HiveRouterConfig,
+) -> Result<Option<HttpCallbackRuntimeConfig>, SupergraphManagerError> {
+    let Some(callback) = config.subscriptions.callback.as_ref() else {
+        return Ok(None);
+    };
+    let raw = resolve_value_or_expression(&callback.public_url, "subscription callback public URL")
+        .map_err(|error| SupergraphManagerError::Configuration(error.to_string()))?;
+    let public_url = raw.parse::<Uri>().map_err(|error| {
+        SupergraphManagerError::Configuration(format!(
+            "invalid callback public URL '{raw}': {error}"
+        ))
+    })?;
+    if public_url.scheme().is_none() || public_url.authority().is_none() {
+        return Err(SupergraphManagerError::Configuration(format!(
+            "callback public URL must be absolute: '{raw}'"
+        )));
+    }
+    Ok(Some(HttpCallbackRuntimeConfig {
+        public_url,
+        heartbeat_interval: callback.heartbeat_interval,
+    }))
+}
+
+impl ConfiguredSupergraph {
+    async fn build(
+        new_sdl: String,
+        current: &ArcSwap<Option<ConfiguredSupergraph>>,
+        router_config: &'static HiveRouterConfig,
+        plugins: Option<&Arc<Vec<RouterPluginBoxed>>>,
+        runtime_context: &RouterSupergraphRuntimeContext,
+    ) -> Result<Self, SupergraphManagerError> {
+        let mut new_ast = safe_parse_schema(&new_sdl).map_err(SupergraphBuildError::from)?;
+        let mut on_end_callbacks = vec![];
+        let mut new_supergraph = None;
+
+        if let Some(plugins) = plugins {
+            let current_supergraph_data = current
+                .load()
+                .as_ref()
+                .as_ref()
+                .map(SelectedSupergraph::from)
+                .map(|selected| selected.snapshot);
+            let mut start_payload = OnSupergraphLoadStartHookPayload {
+                current_supergraph_data,
+                new_ast,
+            };
+            for plugin in plugins.as_ref() {
+                let result = plugin.on_supergraph_reload(start_payload);
+                start_payload = result.payload;
+                match result.control_flow {
+                    StartControlFlow::Proceed => {}
+                    StartControlFlow::EndWithResponse(plugin_res) => {
+                        new_supergraph = Some(
+                            plugin_res
+                                .map_err(|err| SupergraphManagerError::PluginError(err.message)),
+                        );
+                        break;
+                    }
+                    StartControlFlow::OnEnd(callback) => on_end_callbacks.push(callback),
+                }
+            }
+            new_ast = start_payload.new_ast;
+        }
+
+        let options = supergraph_options(router_config)?;
+        let mut new_supergraph = new_supergraph.unwrap_or_else(|| {
+            Supergraph::from_document(new_ast, options).map_err(SupergraphManagerError::from)
+        })?;
+
+        if !on_end_callbacks.is_empty() {
+            let mut end_payload = OnSupergraphLoadEndHookPayload { new_supergraph };
+            for callback in on_end_callbacks {
+                let result = callback(end_payload);
+                end_payload = result.payload;
+                match result.control_flow {
+                    EndControlFlow::Proceed => {}
+                    EndControlFlow::EndWithResponse(plugin_res) => match plugin_res {
+                        Ok(data) => end_payload.new_supergraph = data,
+                        Err(err) => return Err(SupergraphManagerError::PluginError(err.message)),
+                    },
+                }
+            }
+            new_supergraph = end_payload.new_supergraph;
+        }
+
+        let snapshot = new_supergraph.snapshot();
+        let runtime = RouterSupergraphRuntime::build(&snapshot, runtime_context).await?;
+        Ok(Self {
+            _owner: Arc::new(new_supergraph),
+            snapshot,
+            runtime: Arc::new(runtime),
+        })
+    }
 }
 
 impl SchemaState {
     /// Resolves the supergraph for a request, preferring a plugin-selected supergraph if present,
     /// falling back to the router's configured default if not. Returns `None` if neither is present.
-    pub fn select_supergraph(
+    pub async fn select_supergraph(
         &self,
         req: &HttpRequest,
     ) -> Result<Option<SelectedSupergraph>, RouterSupergraphRuntimeError> {
@@ -209,7 +556,7 @@ impl SchemaState {
             // a plugin selected a supergraph for this request, maybe we cached its runtime (fast)
             // and if we didnt cache the runtime, we will build a new one (slow)
 
-            let runtime = self.resolve_runtime(&plugin_supergraph)?;
+            let runtime = self.resolve_runtime(&plugin_supergraph).await?;
 
             let selected = SelectedSupergraph {
                 snapshot: plugin_supergraph,
@@ -257,74 +604,92 @@ impl SchemaState {
             f(&configured.runtime);
         }
         for (_, runtime) in self.runtime_cache.lock().unwrap().iter() {
-            f(runtime);
+            if let Some(runtime) = runtime.get() {
+                f(runtime);
+            }
         }
     }
 
-    /// Resolves the runtime for a plugin-selected snapshot from the bounded FIFO cache, building
-    /// and caching a new one on a miss. Cache hits do not refresh FIFO order.
-    fn resolve_runtime(
+    /// Resolves the runtime for a snapshot. The configured runtime is returned directly; plugin
+    /// runtimes use the bounded FIFO cache, where cache hits do not refresh FIFO order.
+    async fn resolve_runtime(
         &self,
         snapshot: &SupergraphSnapshot,
     ) -> Result<Arc<RouterSupergraphRuntime>, RouterSupergraphRuntimeError> {
         let cache_id = snapshot.cache_id;
 
-        let mut entries = self.runtime_cache.lock().unwrap();
-        if let Some((_, runtime)) = entries.iter().find(|(id, _)| *id == cache_id) {
-            return Ok(runtime.clone());
+        // skip all of the synchronisation mechanisms if the user is requesting the configured supergraph
+        let configured_runtime = self
+            .configured
+            .load()
+            .as_ref()
+            .as_ref()
+            .filter(|configured| configured.snapshot.cache_id == cache_id)
+            .map(|configured| configured.runtime.clone());
+        if let Some(runtime) = configured_runtime {
+            return Ok(runtime);
         }
 
-        // no cached runtime for the plugin-selected supergraph, build one and cache it
-
-        let runtime = Arc::new(RouterSupergraphRuntime::build(
-            snapshot,
-            self.router_config,
-            &self.telemetry_context,
-            &self.callback_subscriptions,
-        )?);
-
-        // bounded FIFO eviction protects against too many simultaneously live variants,
-        // the cleanup task below only gets entries out *sooner*, when their owner retires
-        let evicted = if entries.len() >= RUNTIME_CACHE_MAX_SIZE {
-            entries.pop_front().map(|(evicted_id, _)| evicted_id)
-        } else {
-            None
+        let (cell, evicted, inserted) = {
+            // its ok for the lock to expire in this scope - we only need to check for an existing
+            // entry and insert a new one if missing. the runtime itself is built asynchronously
+            // and cached in the `OnceCell` so that multiple requests racing to build the same runtime
+            // only build it once without sync blocking the router by using a mutex
+            let mut entries = self.runtime_cache.lock().unwrap();
+            if let Some((_, runtime)) = entries.iter().find(|(id, _)| *id == cache_id) {
+                (runtime.clone(), None, false)
+            } else {
+                let evicted = (entries.len() >= RUNTIME_CACHE_MAX_SIZE)
+                    .then(|| entries.pop_front().map(|(id, _)| id))
+                    .flatten();
+                let cell = Arc::new(RouterSupergraphRuntimeCell::new());
+                entries.push_back((cache_id, cell.clone()));
+                (cell, evicted, true)
+            }
         };
-        entries.push_back((cache_id, runtime.clone()));
 
-        // release mutex, no longer needed at this point
-        drop(entries);
-
-        if let Some(sender) = &self.runtime_cache_cleanup {
-            // evicted entry's waiter (if any) is now watching a retirement token nobody cares
-            // about anymore - cancel it so it doesn't sit dormant in the cleanup task forever.
-            if let Some(evicted_id) = evicted {
+        if inserted {
+            if let Some(sender) = &self.runtime_cache_cleanup {
+                if let Some(evicted_id) = evicted {
+                    sender
+                        .send(RuntimeCacheCleanupMessage::Evicted(evicted_id))
+                        .ok();
+                }
                 sender
-                    .send(RuntimeCacheCleanupMessage::Evicted(evicted_id))
+                    .send(RuntimeCacheCleanupMessage::Registered(
+                        cache_id,
+                        snapshot.retirement_token(),
+                    ))
                     .ok();
             }
-
-            // register this entry's retirement token with the cleanup task so the cache entry is
-            // removed promptly once its owner retires, instead of waiting for FIFO eviction. a send
-            // failure just means the cleanup task isn't running (e.g. router shutting down or a test
-            // building `SchemaState` directly) - the cache entry is still bounded by FIFO eviction.
-            sender
-                .send(RuntimeCacheCleanupMessage::Registered(
-                    cache_id,
-                    snapshot.retirement_token(),
-                ))
-                .ok();
         }
 
-        Ok(runtime)
+        match cell
+            .get_or_try_init(|| async {
+                RouterSupergraphRuntime::build(snapshot, &self.runtime_context)
+                    .await
+                    .map(Arc::new)
+            })
+            .await
+        {
+            Ok(runtime) => Ok(runtime.clone()),
+            Err(error) => {
+                self.runtime_cache
+                    .lock()
+                    .unwrap()
+                    .retain(|(id, entry)| *id != cache_id || !Arc::ptr_eq(entry, &cell));
+                Err(error)
+            }
+        }
     }
 
     /// Returns true if the router is ready to serve requests, i.e. if a supergraph is available for
     /// the request (either plugin-selected or configured default).
-    pub fn is_ready(&self, req: &HttpRequest) -> bool {
-        matches!(self.select_supergraph(req), Ok(Some(selected)) if !selected.snapshot.is_retired())
+    pub async fn is_ready(&self, req: &HttpRequest) -> bool {
+        matches!(self.select_supergraph(req).await, Ok(Some(selected)) if !selected.snapshot.is_retired())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn new_from_config(
         bg_tasks_manager: &mut BackgroundTasksManager,
         telemetry_context: Arc<TelemetryContext>,
@@ -332,6 +697,8 @@ impl SchemaState {
         plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
         active_subscriptions: ActiveSubscriptions,
         storage_manager: Arc<StorageManager>,
+        persisted_documents_background_tasks: PersistedDocumentsBackgroundTaskController,
+        hive_usage_reporting_background_tasks: HiveUsageReportingBackgroundTaskController,
     ) -> Result<Self, SupergraphManagerError> {
         let configured: Arc<ArcSwap<Option<ConfiguredSupergraph>>> =
             Arc::new(ArcSwap::from(Arc::new(None)));
@@ -341,24 +708,41 @@ impl SchemaState {
         // the heartbeat enforcer below watches it too. building a runtime with a *different* map
         // would silently break callback routing and heartbeat enforcement for it
         let callback_subscriptions: CallbackSubscriptionsMap = Arc::new(DashMap::new());
+        let runtime_context = Arc::new(RouterSupergraphRuntimeContext {
+            telemetry: telemetry_context.clone(),
+            callback_subscriptions: callback_subscriptions.clone(),
+            callback: callback_runtime_config(router_config)?,
+            persisted_documents_background_tasks,
+            hive_usage_reporting_background_tasks,
+            hive: router_config.telemetry.hive.clone(),
+            storage_manager: storage_manager.clone(),
+            graphql_endpoint: router_config.http.graphql_endpoint.clone(),
+        });
 
         // `supergraph.source: plugin` has no configured source at all... no loader, no polling
         // task, no configured-default value. a plugin must select a supergraph for every request
         // that needs one and the plugin author is responsible for maintaining the supergraphs
         if !matches!(router_config.supergraph, SupergraphSource::Plugin) {
+            // validate configured storage before async schema loading so static config errors still fail startup
+            let _ = PersistedDocumentsRuntime::resolve_storage_runtime(
+                &router_config.persisted_documents,
+                &storage_manager,
+            )
+            .map_err(RouterSupergraphRuntimeError::PersistedDocumentsError)?;
+
             let (tx, mut rx) = mpsc::channel::<String>(1);
-            let background_loader = SupergraphBackgroundLoader::new(
+            let background_loader = Arc::new(SupergraphBackgroundLoader::new(
                 &router_config.supergraph,
                 tx,
                 telemetry_context.metrics.clone(),
                 storage_manager.clone(),
-            )?;
-            bg_tasks_manager
-                .register_task(SupergraphBackgroundLoaderTask(Arc::new(background_loader)));
+            )?);
+
+            bg_tasks_manager.register_task(SupergraphBackgroundLoaderTask(background_loader));
 
             let configured_spawn_clone = configured.clone();
             let task_telemetry = telemetry_context.clone();
-            let callback_subscriptions_for_reload = callback_subscriptions.clone();
+            let runtime_context_for_reload = runtime_context.clone();
 
             bg_tasks_manager.register_handle(async move {
                 let supergraph_metrics = &task_telemetry.metrics.supergraph;
@@ -366,102 +750,15 @@ impl SchemaState {
                     let process_capture = supergraph_metrics.capture_process();
                     debug!("Received new supergraph SDL, building new supergraph state...");
 
-                    let mut new_ast = match safe_parse_schema(&new_sdl) {
-                        Ok(ast) => ast,
-                        Err(e) => {
-                            process_capture.finish_error();
-                            error!(error = %e, "Failed to parse supergraph during update");
-                            continue;
-                        }
-                    };
-
-                    let mut on_end_callbacks = vec![];
-                    let mut new_supergraph = None;
-                    if let Some(plugins) = plugins.as_ref() {
-                        let current_supergraph_data = configured_spawn_clone
-                            .load()
-                            .as_ref()
-                            .as_ref()
-                            .map(SelectedSupergraph::from)
-                            .map(|selected| selected.snapshot);
-                        let mut start_payload = OnSupergraphLoadStartHookPayload {
-                            current_supergraph_data,
-                            new_ast,
-                        };
-                        for plugin in plugins.as_ref() {
-                            let result = plugin.on_supergraph_reload(start_payload);
-                            start_payload = result.payload;
-                            match result.control_flow {
-                                StartControlFlow::Proceed => {}
-                                StartControlFlow::EndWithResponse(plugin_res) => {
-                                    new_supergraph = Some(plugin_res.map_err(|err| {
-                                        SupergraphManagerError::PluginError(err.message)
-                                    }));
-                                    break;
-                                }
-                                StartControlFlow::OnEnd(callback) => {
-                                    on_end_callbacks.push(callback);
-                                }
-                            }
-                        }
-                        new_ast = start_payload.new_ast;
-                    }
-
-                    let query_planner_options =
-                        hive_router_query_planner::planner::QueryPlannerOptions {
-                            experimental_abstract_type_folding: router_config
-                                .query_planner
-                                .experimental_abstract_type_folding,
-                        };
-
-                    let built = new_supergraph
-                        .unwrap_or_else(|| {
-                            Supergraph::from_document(new_ast, query_planner_options)
-                                .map_err(SupergraphManagerError::from)
-                        })
-                        .and_then(|mut new_supergraph| {
-                            if !on_end_callbacks.is_empty() {
-                                let mut end_payload =
-                                    OnSupergraphLoadEndHookPayload { new_supergraph };
-                                for callback in on_end_callbacks {
-                                    let result = callback(end_payload);
-                                    end_payload = result.payload;
-                                    match result.control_flow {
-                                        EndControlFlow::Proceed => {}
-                                        EndControlFlow::EndWithResponse(plugin_res) => {
-                                            match plugin_res {
-                                                Ok(data) => end_payload.new_supergraph = data,
-                                                Err(err) => {
-                                                    return Err(
-                                                        SupergraphManagerError::PluginError(
-                                                            err.message,
-                                                        ),
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                new_supergraph = end_payload.new_supergraph;
-                            }
-                            Ok(new_supergraph)
-                        })
-                        .and_then(|new_supergraph| {
-                            let snapshot = new_supergraph.snapshot();
-                            let runtime = RouterSupergraphRuntime::build(
-                                &snapshot,
-                                router_config,
-                                &task_telemetry,
-                                &callback_subscriptions_for_reload,
-                            )?;
-                            Ok(ConfiguredSupergraph {
-                                _owner: Arc::new(new_supergraph),
-                                snapshot,
-                                runtime: Arc::new(runtime),
-                            })
-                        });
-
-                    match built {
+                    match ConfiguredSupergraph::build(
+                        new_sdl,
+                        &configured_spawn_clone,
+                        router_config,
+                        plugins.as_ref(),
+                        &runtime_context_for_reload,
+                    )
+                    .await
+                    {
                         Ok(new_configured) => {
                             // swapping in the new value here is enough: the previous
                             // `ConfiguredSupergraph`'s owner `Arc<Supergraph>` is only kept alive
@@ -511,9 +808,9 @@ impl SchemaState {
             configured,
             runtime_cache,
             runtime_cache_cleanup: Some(cleanup_tx),
-            router_config,
             telemetry_context: telemetry_context.clone(),
             callback_subscriptions,
+            runtime_context,
         })
     }
 }
@@ -551,10 +848,10 @@ impl BackgroundTask for SupergraphBackgroundLoaderTask {
 
     async fn run(&self, token: CancellationToken) {
         let supergraph_metrics = &self.0.metrics.supergraph;
+        // initial load happens here so startup probes remain available while the source is fetched
         loop {
             if token.is_cancelled() {
                 trace!(target: targets::SUPERGRAPH, "background task cancelled");
-
                 break;
             }
 
@@ -584,11 +881,15 @@ impl BackgroundTask for SupergraphBackgroundLoaderTask {
 
             if let Some(interval) = self.0.loader.reload_interval() {
                 debug!(target: targets::SUPERGRAPH, interval_ms = interval.as_millis(), "waiting before checking again for supergraph changes");
-
-                ntex::time::sleep(interval).await;
+                tokio::select! {
+                    _ = token.cancelled() => {
+                        trace!(target: targets::SUPERGRAPH, "background task cancelled");
+                        break;
+                    }
+                    _ = ntex::time::sleep(interval) => {}
+                }
             } else {
                 debug!(target: targets::SUPERGRAPH, "poll interval not configured for supergraph changes, skipping");
-
                 break;
             }
         }
@@ -769,73 +1070,128 @@ mod plugin_runtime_cache_tests {
         include_str!("../../../plugin_examples/replace_schema/supergraph.graphql");
 
     fn test_schema_state() -> SchemaState {
+        let telemetry_context = Arc::new(TelemetryContext::from_propagation_config(
+            &Default::default(),
+            &Default::default(),
+        ));
+        let callback_subscriptions = Arc::new(DashMap::new());
+        let (persisted_documents_background_tasks, _) =
+            crate::pipeline::persisted_documents::PersistedDocumentsBackgroundTasks::new();
+        let (hive_usage_reporting_background_tasks, _) =
+            crate::pipeline::usage_reporting::HiveUsageReportingBackgroundTasks::new();
+        let runtime_context = Arc::new(RouterSupergraphRuntimeContext {
+            telemetry: telemetry_context.clone(),
+            callback_subscriptions: callback_subscriptions.clone(),
+            callback: None,
+            persisted_documents_background_tasks,
+            hive_usage_reporting_background_tasks,
+            hive: None,
+            storage_manager: Arc::new(StorageManager::new(&Default::default()).unwrap()),
+            graphql_endpoint: "/graphql".to_string(),
+        });
         SchemaState {
             configured: Arc::new(ArcSwap::from(Arc::new(None))),
             runtime_cache: Arc::new(Mutex::new(VecDeque::with_capacity(RUNTIME_CACHE_MAX_SIZE))),
             runtime_cache_cleanup: None,
-            router_config: HiveRouterConfig::default().into_static(),
-            telemetry_context: Arc::new(TelemetryContext::from_propagation_config(
-                &Default::default(),
-                &Default::default(),
-            )),
-            callback_subscriptions: Arc::new(DashMap::new()),
+            telemetry_context,
+            callback_subscriptions,
+            runtime_context,
         }
     }
 
     fn test_owner() -> Arc<Supergraph> {
         crate::init_rustls_crypto_provider();
         Arc::new(
-            Supergraph::from_sdl(
-                TEST_SUPERGRAPH_SDL,
-                hive_router_query_planner::planner::QueryPlannerOptions::default(),
-            )
-            .expect("valid test supergraph SDL"),
+            Supergraph::from_sdl(TEST_SUPERGRAPH_SDL, SupergraphOptions::default())
+                .expect("valid test supergraph SDL"),
         )
     }
 
-    #[test]
-    fn reusing_same_supergraph_reuses_one_runtime() {
+    #[ntex::test]
+    async fn graph_bound_options_stay_isolated_between_live_owners() {
+        crate::init_rustls_crypto_provider();
+        let state = test_schema_state();
+        let mut first_options = SupergraphOptions::default();
+        first_options.hive_target = Some("example/router/first".to_string());
+        first_options.error_masking.redacted_error_message = "first".to_string();
+        let mut second_options = SupergraphOptions::default();
+        second_options.hive_target = Some("example/router/second".to_string());
+        second_options.error_masking.redacted_error_message = "second".to_string();
+        second_options.traffic_shaping.all.forward_operation_name = true;
+
+        let first = Arc::new(Supergraph::from_sdl(TEST_SUPERGRAPH_SDL, first_options).unwrap());
+        let second = Arc::new(Supergraph::from_sdl(TEST_SUPERGRAPH_SDL, second_options).unwrap());
+        let first_runtime = state.resolve_runtime(&first.snapshot()).await.unwrap();
+        let second_runtime = state.resolve_runtime(&second.snapshot()).await.unwrap();
+
+        assert_eq!(
+            first.options.hive_target.as_deref(),
+            Some("example/router/first")
+        );
+        assert_eq!(
+            second.options.hive_target.as_deref(),
+            Some("example/router/second")
+        );
+        assert_eq!(first.options.error_masking.redacted_error_message, "first");
+        assert_eq!(
+            second.options.error_masking.redacted_error_message,
+            "second"
+        );
+        assert!(!first_runtime
+            .operation_name_forward_config
+            .should_forward("products"));
+        assert!(second_runtime
+            .operation_name_forward_config
+            .should_forward("products"));
+        assert!(!Arc::ptr_eq(&first_runtime, &second_runtime));
+    }
+
+    #[ntex::test]
+    async fn supergraph_lifetime_is_cancelled_only_after_the_final_runtime_reference_drops() {
+        let state = test_schema_state();
+        let owner = test_owner();
+        let runtime = Arc::new(
+            RouterSupergraphRuntime::build(&owner.snapshot(), &state.runtime_context)
+                .await
+                .unwrap(),
+        );
+        let lifetime = runtime.supergraph_lifetime.clone();
+        let retained_runtime = runtime.clone();
+
+        drop(runtime);
+        tokio::task::yield_now().await;
+        assert!(!lifetime.is_cancelled());
+
+        drop(retained_runtime);
+        tokio::time::timeout(Duration::from_secs(1), lifetime.cancelled())
+            .await
+            .expect("final runtime drop should cancel its background workers promptly");
+    }
+
+    #[ntex::test]
+    async fn reusing_same_supergraph_reuses_one_runtime() {
         let state = test_schema_state();
         let owner = test_owner();
         let snapshot = owner.snapshot();
 
-        let first = state.resolve_runtime(&snapshot).unwrap();
-        let second = state.resolve_runtime(&snapshot).unwrap();
+        let first = state.resolve_runtime(&snapshot).await.unwrap();
+        let second = state.resolve_runtime(&snapshot).await.unwrap();
 
         assert!(Arc::ptr_eq(&first, &second));
         assert_eq!(state.runtime_cache.lock().unwrap().len(), 1);
     }
 
-    #[test]
-    fn concurrent_resolves_build_one_runtime() {
+    #[ntex::test]
+    async fn concurrent_resolves_build_one_runtime() {
         let state = Arc::new(test_schema_state());
         let owner = test_owner();
         let snapshot = owner.snapshot();
-        // make all worker threads hit the empty runtime cache at roughly the same time
-        let barrier = Arc::new(std::sync::Barrier::new(9));
-
-        let handles: Vec<_> = (0..8)
-            .map(|_| {
-                let state = state.clone();
-                let snapshot = snapshot.clone();
-                let barrier = barrier.clone();
-
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    // every thread enters resolve_runtime, where the mutex must serialize the
-                    // cache miss, runtime build, and insertion
-                    state.resolve_runtime(&snapshot).unwrap()
-                })
-            })
-            .collect();
-
-        // release all eight workers together after they are ready
-        barrier.wait();
-
-        let runtimes: Vec<_> = handles
-            .into_iter()
-            .map(|handle| handle.join().unwrap())
-            .collect();
+        let runtimes = futures::future::join_all((0..8).map(|_| {
+            let state = state.clone();
+            let snapshot = snapshot.clone();
+            async move { state.resolve_runtime(&snapshot).await.unwrap() }
+        }))
+        .await;
 
         // the first thread builds while holding the mutex, then every other thread observes
         // its cache entry instead of building and inserting another runtime
@@ -845,8 +1201,8 @@ mod plugin_runtime_cache_tests {
         assert_eq!(state.runtime_cache.lock().unwrap().len(), 1);
     }
 
-    #[test]
-    fn distinct_supergraph_instances_get_distinct_runtimes() {
+    #[ntex::test]
+    async fn distinct_supergraph_instances_get_distinct_runtimes() {
         let state = test_schema_state();
 
         let a = test_owner();
@@ -854,38 +1210,39 @@ mod plugin_runtime_cache_tests {
         // distinct cache ids even though the content is identical.
         assert_ne!(a.cache_id, b.cache_id);
 
-        let runtime_a = state.resolve_runtime(&a.snapshot()).unwrap();
-        let runtime_b = state.resolve_runtime(&b.snapshot()).unwrap();
+        let runtime_a = state.resolve_runtime(&a.snapshot()).await.unwrap();
+        let runtime_b = state.resolve_runtime(&b.snapshot()).await.unwrap();
 
         assert!(!Arc::ptr_eq(&runtime_a, &runtime_b));
         assert_eq!(state.runtime_cache.lock().unwrap().len(), 2);
     }
 
-    #[test]
-    fn configured_selection_stays_pinned_to_the_request_after_rotation() {
+    #[ntex::test]
+    async fn configured_selection_stays_pinned_to_the_request_after_rotation() {
         let state = test_schema_state();
         let first_owner = test_owner();
         let first_snapshot = first_owner.snapshot();
         let first_id = first_snapshot.cache_id;
         let first_runtime = Arc::new(
-            RouterSupergraphRuntime::build(
-                &first_snapshot,
-                &state.router_config,
-                &state.telemetry_context,
-                &state.callback_subscriptions,
-            )
-            .unwrap(),
+            RouterSupergraphRuntime::build(&first_snapshot, &state.runtime_context)
+                .await
+                .unwrap(),
         );
         state.configured.store(Arc::new(Some(ConfiguredSupergraph {
             _owner: first_owner,
-            snapshot: first_snapshot,
-            runtime: first_runtime,
+            snapshot: first_snapshot.clone(),
+            runtime: first_runtime.clone(),
         })));
+
+        let resolved_runtime = state.resolve_runtime(&first_snapshot).await.unwrap();
+        assert!(Arc::ptr_eq(&resolved_runtime, &first_runtime));
+        assert!(state.runtime_cache.lock().unwrap().is_empty());
 
         let req = ntex::web::test::TestRequest::default().to_http_request();
         assert_eq!(
             state
                 .select_supergraph(&req)
+                .await
                 .unwrap()
                 .unwrap()
                 .snapshot
@@ -896,13 +1253,9 @@ mod plugin_runtime_cache_tests {
         let second_owner = test_owner();
         let second_snapshot = second_owner.snapshot();
         let second_runtime = Arc::new(
-            RouterSupergraphRuntime::build(
-                &second_snapshot,
-                &state.router_config,
-                &state.telemetry_context,
-                &state.callback_subscriptions,
-            )
-            .unwrap(),
+            RouterSupergraphRuntime::build(&second_snapshot, &state.runtime_context)
+                .await
+                .unwrap(),
         );
         state.configured.store(Arc::new(Some(ConfiguredSupergraph {
             _owner: second_owner,
@@ -910,25 +1263,25 @@ mod plugin_runtime_cache_tests {
             runtime: second_runtime,
         })));
 
-        let selected = state.select_supergraph(&req).unwrap().unwrap();
+        let selected = state.select_supergraph(&req).await.unwrap().unwrap();
         assert_eq!(selected.snapshot.cache_id, first_id);
         assert!(selected.snapshot.is_retired());
     }
 
-    #[test]
-    fn eleventh_unique_supergraph_evicts_the_first() {
+    #[ntex::test]
+    async fn eleventh_unique_supergraph_evicts_the_first() {
         let state = test_schema_state();
         let owners: Vec<Arc<Supergraph>> = (0..11).map(|_| test_owner()).collect();
 
         for owner in &owners[..10] {
-            state.resolve_runtime(&owner.snapshot()).unwrap();
+            state.resolve_runtime(&owner.snapshot()).await.unwrap();
         }
         assert_eq!(
             state.runtime_cache.lock().unwrap().len(),
             RUNTIME_CACHE_MAX_SIZE
         );
 
-        state.resolve_runtime(&owners[10].snapshot()).unwrap();
+        state.resolve_runtime(&owners[10].snapshot()).await.unwrap();
 
         let entries = state.runtime_cache.lock().unwrap();
         assert_eq!(entries.len(), RUNTIME_CACHE_MAX_SIZE);
@@ -936,27 +1289,27 @@ mod plugin_runtime_cache_tests {
         assert!(entries.iter().any(|(id, _)| *id == owners[10].cache_id));
     }
 
-    #[test]
-    fn cache_hits_do_not_refresh_fifo_order() {
+    #[ntex::test]
+    async fn cache_hits_do_not_refresh_fifo_order() {
         let state = test_schema_state();
         let first = test_owner();
         let second = test_owner();
 
-        state.resolve_runtime(&first.snapshot()).unwrap();
-        state.resolve_runtime(&second.snapshot()).unwrap();
-        state.resolve_runtime(&first.snapshot()).unwrap();
+        state.resolve_runtime(&first.snapshot()).await.unwrap();
+        state.resolve_runtime(&second.snapshot()).await.unwrap();
+        state.resolve_runtime(&first.snapshot()).await.unwrap();
 
         let entries = state.runtime_cache.lock().unwrap();
         assert_eq!(entries.front().unwrap().0, first.cache_id);
     }
 
-    #[test]
-    fn dropping_owner_marks_snapshot_retired_without_a_cleanup_task() {
+    #[ntex::test]
+    async fn dropping_owner_marks_snapshot_retired_without_a_cleanup_task() {
         let state = test_schema_state();
         let owner = test_owner();
         let snapshot = owner.snapshot();
 
-        state.resolve_runtime(&snapshot).unwrap();
+        state.resolve_runtime(&snapshot).await.unwrap();
 
         drop(owner);
 
@@ -985,7 +1338,7 @@ mod plugin_runtime_cache_tests {
 
         let owner = test_owner();
         let snapshot = owner.snapshot();
-        state.resolve_runtime(&snapshot).unwrap();
+        state.resolve_runtime(&snapshot).await.unwrap();
         assert_eq!(runtime_cache.lock().unwrap().len(), 1);
 
         drop(owner);
@@ -1011,22 +1364,34 @@ mod plugin_runtime_cache_tests {
     async fn evicted_message_lets_the_same_id_be_registered_again() {
         let owner = test_owner();
         let cache_id = owner.cache_id;
+        let runtime = Arc::new(
+            RouterSupergraphRuntime::build(
+                &owner.snapshot(),
+                &RouterSupergraphRuntimeContext {
+                    telemetry: Arc::new(TelemetryContext::from_propagation_config(
+                        &Default::default(),
+                        &Default::default(),
+                    )),
+                    callback_subscriptions: Arc::new(DashMap::new()),
+                    callback: None,
+                    persisted_documents_background_tasks:
+                        crate::pipeline::persisted_documents::PersistedDocumentsBackgroundTasks::new()
+                            .0,
+                    hive_usage_reporting_background_tasks:
+                        crate::pipeline::usage_reporting::HiveUsageReportingBackgroundTasks::new()
+                            .0,
+                    hive: None,
+                    storage_manager: Arc::new(StorageManager::new(&Default::default()).unwrap()),
+                    graphql_endpoint: "/graphql".to_string(),
+                },
+            )
+            .await
+            .unwrap(),
+        );
+        let cell = Arc::new(RouterSupergraphRuntimeCell::new());
+        assert!(cell.set(runtime).is_ok());
         let runtime_cache: Arc<RouterSupergraphRuntimeCache> =
-            Arc::new(Mutex::new(VecDeque::from([(
-                cache_id,
-                Arc::new(
-                    RouterSupergraphRuntime::build(
-                        &owner.snapshot(),
-                        HiveRouterConfig::default().into_static(),
-                        &Arc::new(TelemetryContext::from_propagation_config(
-                            &Default::default(),
-                            &Default::default(),
-                        )),
-                        &Arc::new(DashMap::new()),
-                    )
-                    .unwrap(),
-                ),
-            )])));
+            Arc::new(Mutex::new(VecDeque::from([(cache_id, cell)])));
 
         let (cleanup_tx, cleanup_rx) = mpsc::unbounded_channel();
         let task = RuntimeCacheCleanupTask {

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -1,6 +1,5 @@
 use futures::Stream;
 use graphql_tools::validation::validate::ValidationPlan;
-use hive_console_sdk::agent::usage_agent::{AgentError, UsageAgent};
 use hive_router_config::traffic_shaping::{
     TrafficShapingRouterDedupeHeadersConfig, TrafficShapingRouterDedupeHeadersKeyword,
 };
@@ -13,16 +12,12 @@ use hive_router_internal::telemetry::metrics::subscription_metrics::Subscription
 use hive_router_internal::telemetry::metrics::Metrics;
 use hive_router_internal::telemetry::TelemetryContext;
 use hive_router_plan_executor::coprocessor::{CoprocessorError, CoprocessorRuntime};
-use hive_router_plan_executor::execution::error_masking::ErrorMaskingRuntime;
 use hive_router_plan_executor::execution::plan::FailedExecutionResult;
 use hive_router_plan_executor::executors::common::InboundRequestFingerprint;
 use hive_router_plan_executor::extensions::{
     compile::compile_extensions_plan, plan::ExtensionsPlan,
 };
 use hive_router_plan_executor::headers::sanitizer::is_never_join_header;
-use hive_router_plan_executor::headers::{
-    compile::compile_headers_plan, errors::HeaderRuleCompileError, plan::HeaderRulesPlan,
-};
 use hive_router_plan_executor::plugin_trait::RouterPluginBoxed;
 use http::StatusCode;
 use moka::future::Cache;
@@ -48,9 +43,6 @@ use crate::pipeline::multipart_subscribe::{
     self, APOLLO_MULTIPART_HTTP_CONTENT_TYPE, INCREMENTAL_DELIVERY_CONTENT_TYPE,
 };
 use crate::pipeline::parser::ParseCacheEntry;
-use crate::pipeline::persisted_documents::resolve::PersistedDocumentResolverError;
-use crate::pipeline::persisted_documents::PersistedDocumentsRuntime;
-use crate::pipeline::progressive_override::{OverrideLabelsCompileError, OverrideLabelsEvaluator};
 use crate::pipeline::sse;
 use crate::storage::StorageManager;
 
@@ -327,11 +319,8 @@ impl Expiry<String, Arc<JwtTokenPayload>> for JwtClaimsExpiry {
 pub struct RouterSharedState {
     pub validation_plan: Arc<ValidationPlan>,
     pub parse_cache: Cache<u64, ParseCacheEntry>,
-    pub persisted_documents_runtime: PersistedDocumentsRuntime,
     pub router_config: &'static HiveRouterConfig,
-    pub headers_plan: Arc<HeaderRulesPlan>,
     pub extensions_plan: Arc<ExtensionsPlan>,
-    pub override_labels_evaluator: OverrideLabelsEvaluator,
     pub cors_runtime: Option<Cors>,
     /// Cache for validated JWT claims to avoid re-parsing on every request.
     /// The cache key is the raw JWT token string.
@@ -339,7 +328,6 @@ pub struct RouterSharedState {
     /// but no longer than `exp` date.
     pub jwt_claims_cache: JwtClaimsCache,
     pub jwt_auth_runtime: Option<JwtAuthRuntime>,
-    pub hive_usage_agent: Option<UsageAgent>,
     pub introspection_policy: BooleanOrProgram,
     pub telemetry_context: Arc<TelemetryContext>,
     pub coprocessor: Option<CoprocessorRuntime>,
@@ -355,17 +343,13 @@ pub struct RouterSharedState {
     /// The Laboratory page, with any configured seed values already injected. Rendered once
     /// because the config cannot change while the router runs.
     pub laboratory_html: Bytes,
-    /// The error masking configuration for the router.
-    pub error_masking: Arc<Option<ErrorMaskingRuntime>>,
 }
 
 impl RouterSharedState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         router_config: &'static HiveRouterConfig,
-        persisted_documents_runtime: PersistedDocumentsRuntime,
         jwt_auth_runtime: Option<JwtAuthRuntime>,
-        hive_usage_agent: Option<UsageAgent>,
         validation_plan: ValidationPlan,
         telemetry_context: Arc<TelemetryContext>,
         plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
@@ -385,18 +369,12 @@ impl RouterSharedState {
                 .map_err(Box::new)
             })
             .transpose()?;
-        let error_masking = Arc::new(ErrorMaskingRuntime::compile_from_config(
-            &router_config.error_masking,
-        ));
-
         let laboratory_html = render_laboratory_page(&router_config.laboratory)?;
 
         Ok(Self {
             validation_plan: Arc::new(validation_plan),
-            headers_plan: Arc::new(compile_headers_plan(&router_config.headers).map_err(Box::new)?),
             extensions_plan: Arc::new(compile_extensions_plan(&router_config.response_extensions)),
             parse_cache,
-            persisted_documents_runtime,
             cors_runtime: Cors::from_config(&router_config.cors).map_err(Box::new)?,
             jwt_claims_cache: Cache::builder()
                 // High capacity due to potentially high token diversity.
@@ -405,12 +383,7 @@ impl RouterSharedState {
                 .expire_after(JwtClaimsExpiry)
                 .build(),
             router_config,
-            override_labels_evaluator: OverrideLabelsEvaluator::from_config(
-                &router_config.override_labels,
-            )
-            .map_err(Box::new)?,
             jwt_auth_runtime,
-            hive_usage_agent,
             introspection_policy: compile_introspection_policy(&router_config.introspection)
                 .map_err(Box::new)?,
             telemetry_context,
@@ -427,7 +400,6 @@ impl RouterSharedState {
             active_subscriptions,
             storage_manager,
             laboratory_html,
-            error_masking,
         })
     }
 }
@@ -462,16 +434,8 @@ fn render_laboratory_page(
 
 #[derive(thiserror::Error, Debug)]
 pub enum SharedStateError {
-    #[error("invalid headers config: {0}")]
-    HeaderRuleCompile(#[from] Box<HeaderRuleCompileError>),
     #[error("invalid regex in CORS config: {0}")]
     CORSConfig(#[from] Box<CORSConfigError>),
-    #[error("invalid override labels config: {0}")]
-    OverrideLabelsCompile(#[from] Box<OverrideLabelsCompileError>),
-    #[error("error creating hive usage agent: {0}")]
-    UsageAgent(#[from] Box<AgentError>),
-    #[error("invalid persisted documents config: {0}")]
-    PersistedDocuments(#[from] Box<PersistedDocumentResolverError>),
     #[error("invalid introspection config: {0}")]
     IntrospectionPolicyCompile(#[from] Box<ExpressionCompileError>),
     #[error("invalid coprocessor config: {0}")]

--- a/e2e/src/storage/mod.rs
+++ b/e2e/src/storage/mod.rs
@@ -27,7 +27,7 @@ mod storage_e2e_tests {
 
     #[ntex::test]
     #[should_panic(
-        expected = "failed to configure hive router from config: SharedStateError(PersistedDocuments(StorageNotFound(\"missing\")))"
+        expected = "failed to configure hive router from config: SupergraphManagerError(RouterSupergraphRuntimeError(PersistedDocumentsError(StorageNotFound(\"missing\"))))"
     )]
     async fn should_throw_when_storage_is_missing_in_persisted_docs() {
         TestRouter::builder()

--- a/e2e/src/telemetry/tracing/hive.rs
+++ b/e2e/src/telemetry/tracing/hive.rs
@@ -128,6 +128,7 @@ async fn test_hive_http_export() {
         hive.graphql: true
         hive.graphql.operation.hash: e92177e49c0010d4e52929531ebe30c9
         hive.kind: graphql.operation
+        hive.target: my-org/my-project/my-target
         http.host: localhost
         http.method: POST
         http.route: /graphql

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -730,7 +730,10 @@ struct TestRouterHandle {
 
 impl Drop for TestRouterHandle {
     fn drop(&mut self) {
-        // shut down backgroun tasks
+        // this drop bg tasks synchronously. graceful_shutdown cannot be awaited here,
+        // and blocking another thread on it deadlocks because the graceful task handles
+        // still need this blocked ntex runtime to make progress immediate cancellation is intentional
+        // for generic test teardown; focused async tests cover final hive flush behavior though
         self.bg_tasks_manager.shutdown();
 
         // shutdown hooks and wait for complete (shutdown is async so yeah)

--- a/e2e/src/websocket.rs
+++ b/e2e/src/websocket.rs
@@ -5,10 +5,89 @@ mod websocket_e2e_tests {
     use std::collections::HashMap;
 
     use crate::testkit::{TestRouter, TestSubgraphs};
+    use hive_router::{
+        async_trait,
+        http::StatusCode,
+        plugins::{
+            hooks::{
+                on_graphql_params::{
+                    OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult,
+                },
+                on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+            },
+            plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
+        },
+        GraphQLError,
+    };
     use hive_router_plan_executor::executors::{
         graphql_transport_ws::{ConnectionInitPayload, SubscribePayload},
         websocket_client::WsClient,
     };
+
+    #[derive(Default)]
+    struct TestWebSocketGraphqlParamsPlugin;
+
+    #[async_trait]
+    impl RouterPlugin for TestWebSocketGraphqlParamsPlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "test_websocket_graphql_params"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_graphql_params<'exec>(
+            &'exec self,
+            mut payload: OnGraphQLParamsStartHookPayload<'exec>,
+        ) -> OnGraphQLParamsStartHookResult<'exec> {
+            assert_eq!(payload.router_http_request.method, http::Method::POST);
+            assert_eq!(payload.router_http_request.path, "/graphql");
+            let graphql_params = payload
+                .graphql_params
+                .as_mut()
+                .expect("Expected decoded WebSocket GraphQL parameters");
+            graphql_params.query = Some(
+                "query SelectedByHook { topProducts { name } } query Other { __typename }"
+                    .to_string(),
+            );
+            payload.on_end(|mut payload| {
+                payload.graphql_params.operation_name = Some("SelectedByHook".to_string());
+                payload.proceed()
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct TestWebSocketGraphqlParamsEarlyResponsePlugin;
+
+    #[async_trait]
+    impl RouterPlugin for TestWebSocketGraphqlParamsEarlyResponsePlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "test_websocket_graphql_params_early_response"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_graphql_params<'exec>(
+            &'exec self,
+            payload: OnGraphQLParamsStartHookPayload<'exec>,
+        ) -> OnGraphQLParamsStartHookResult<'exec> {
+            payload.end_with_graphql_error(
+                GraphQLError::from_message_and_code(
+                    "Rejected by GraphQL parameters hook",
+                    "GRAPHQL_PARAMS_REJECTED",
+                ),
+                StatusCode::BAD_REQUEST,
+            )
+        }
+    }
 
     #[ntex::test]
     async fn query_over_websocket() {
@@ -61,6 +140,172 @@ mod websocket_e2e_tests {
 
         let next = stream.next().await;
         assert!(next.is_none(), "Expected stream to complete after query");
+    }
+
+    #[ntex::test]
+    async fn persisted_document_over_websocket() {
+        let document_id = "sha256:abc123";
+        let manifest =
+            tempfile::NamedTempFile::new().expect("Failed to create persisted document manifest");
+        std::fs::write(
+            manifest.path(),
+            sonic_rs::to_string(&json!({
+                document_id: "{ topProducts { name } }",
+            }))
+            .expect("Failed to serialize persisted document manifest"),
+        )
+        .expect("Failed to write persisted document manifest");
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                websocket:
+                    enabled: true
+                persisted_documents:
+                    enabled: true
+                    require_id: true
+                    storage:
+                        type: file
+                        path: "{}"
+                "#,
+                manifest.path().display(),
+            ))
+            .build()
+            .start()
+            .await;
+
+        let wsconn = router.ws().await;
+        let mut client = WsClient::new(wsconn)
+            .init(None)
+            .await
+            .expect("Failed to init WsClient");
+        let mut stream = client
+            .subscribe(
+                SubscribePayload {
+                    query: String::new(),
+                    extensions: Some(HashMap::from([(
+                        "persistedQuery".to_string(),
+                        json!({ "sha256Hash": document_id }),
+                    )])),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .expect("Failed to subscribe");
+
+        let response = stream
+            .next()
+            .await
+            .map(|response| response.expect("WebSocket response failed"))
+            .expect("Expected a response");
+        assert!(response.errors.is_none(), "Expected no errors");
+        assert!(!response.data.is_null(), "Expected data");
+        assert!(stream.next().await.is_none(), "Expected stream to complete");
+    }
+
+    #[ntex::test]
+    async fn graphql_params_hooks_prepare_websocket_operation() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                websocket:
+                    enabled: true
+                plugins:
+                    test_websocket_graphql_params:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<TestWebSocketGraphqlParamsPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let wsconn = router.ws().await;
+        let mut client = WsClient::new(wsconn)
+            .init(None)
+            .await
+            .expect("Failed to init WsClient");
+        let mut stream = client
+            .subscribe(
+                SubscribePayload {
+                    query: "not valid GraphQL".to_string(),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .expect("failed to subscribe");
+
+        let response = stream
+            .next()
+            .await
+            .map(|response| response.expect("WebSocket response failed"))
+            .expect("Expected a response");
+        assert!(response.errors.is_none(), "Expected no errors");
+        assert!(!response.data.is_null(), "Expected data");
+        assert!(stream.next().await.is_none(), "Expected stream to complete");
+    }
+
+    #[ntex::test]
+    async fn graphql_params_hook_early_response_completes_websocket_operation() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                websocket:
+                    enabled: true
+                plugins:
+                    test_websocket_graphql_params_early_response:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<TestWebSocketGraphqlParamsEarlyResponsePlugin>()
+            .build()
+            .start()
+            .await;
+
+        let wsconn = router.ws().await;
+        let mut client = WsClient::new(wsconn)
+            .init(None)
+            .await
+            .expect("Failed to init WsClient");
+        let mut stream = client
+            .subscribe(
+                SubscribePayload {
+                    query: "{ __typename }".to_string(),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .expect("failed to subscribe");
+
+        let response = stream
+            .next()
+            .await
+            .map(|response| response.expect("WebSocket response failed"))
+            .expect("Expected a response");
+        let errors = response.errors.expect("Expected GraphQL errors");
+        assert_eq!(
+            errors[0].extensions.code.as_deref(),
+            Some("GRAPHQL_PARAMS_REJECTED")
+        );
+        assert!(stream.next().await.is_none(), "Expected stream to complete");
     }
 
     #[ntex::test]

--- a/lib/executor/src/execution/operation_name.rs
+++ b/lib/executor/src/execution/operation_name.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
-use hive_router_config::traffic_shaping::TrafficShapingConfig;
+use hive_router_config::traffic_shaping::SupergraphTrafficShapingConfig;
 
 #[derive(Debug, Clone, Default)]
 pub enum OperationNameForwardConfig {
@@ -11,7 +11,7 @@ pub enum OperationNameForwardConfig {
 }
 
 impl OperationNameForwardConfig {
-    pub fn new<'a, I>(config: &'a TrafficShapingConfig, known_subgraph_names: I) -> Self
+    pub fn new<'a, I>(config: &'a SupergraphTrafficShapingConfig, known_subgraph_names: I) -> Self
     where
         I: IntoIterator<Item = &'a String>,
     {

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -1758,7 +1758,6 @@ mod tests {
     use super::select_fetch_variables;
     use dashmap::DashMap;
     use graphql_tools::parser::query::{self, Definition};
-    use hive_router_config::HiveRouterConfig;
     use hive_router_internal::telemetry::TelemetryContext;
     use hive_router_query_planner::{
         ast::{document::Document, operation::SubgraphFetchOperation},
@@ -1923,7 +1922,10 @@ mod tests {
 
         let executors = SubgraphExecutorMap::from_http_endpoint_map(
             &subgraph_endpoint_map,
-            HiveRouterConfig::default().into_static(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            None,
             Arc::new(TelemetryContext::from_propagation_config(
                 &Default::default(),
                 &Default::default(),
@@ -2046,7 +2048,10 @@ mod tests {
             schema_metadata: &SchemaMetadata::default(),
             executors: &SubgraphExecutorMap::from_http_endpoint_map(
                 &subgraph_endpoint_map,
-                HiveRouterConfig::default().into_static(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
                 Arc::new(TelemetryContext::from_propagation_config(
                     &Default::default(),
                     &Default::default(),

--- a/lib/executor/src/executors/error.rs
+++ b/lib/executor/src/executors/error.rs
@@ -109,12 +109,6 @@ pub enum SubgraphExecutorError {
     #[error("Subgraph HTTP callback responded with a not-OK status code '{0}'")]
     #[strum(serialize = "SUBGRAPH_HTTP_CALLBACK_STATUS_CODE_NOT_OK")]
     HttpCallbackStatusCodeNotOk(StatusCode),
-    #[error("Failed to parse callback.public_url \"{0}\" as URI: {1}")]
-    #[strum(serialize = "SUBGRAPH_HTTP_CALLBACK_PUBLIC_URL_PARSE_FAILURE`")]
-    CallbackPublicUrlParseFailure(String, InvalidUri),
-    #[error("callback.public_url \"{0}\" must be an absolute URL with both a scheme and a host")]
-    #[strum(serialize = "SUBGRAPH_HTTP_CALLBACK_PUBLIC_URL_NOT_ABSOLUTE")]
-    CallbackPublicUrlNotAbsolute(String),
     #[error("HTTP Callback protocol does not support single-shot execution, use it only for subscriptions")]
     #[strum(serialize = "SUBGRAPH_HTTP_CALLBACK_NO_SINGLE")]
     HttpCallbackNoSingle,

--- a/lib/executor/src/executors/graphql_transport_ws.rs
+++ b/lib/executor/src/executors/graphql_transport_ws.rs
@@ -80,6 +80,7 @@ impl From<CloseCode> for ws::Message {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribePayload {
+    #[serde(default)]
     pub query: String,
     pub operation_name: Option<String>,
     pub variables: Option<HashMap<String, Value>>,

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -15,7 +15,6 @@ use crate::plugin_trait::{EndControlFlow, StartControlFlow};
 use crate::plugins::hooks;
 use crate::response::subgraph_response::SubgraphResponse;
 use futures::stream::BoxStream;
-use hive_router_config::HiveRouterConfig;
 use hive_router_internal::inflight::InFlightRole;
 use hive_router_internal::telemetry::logging::targets;
 use hive_router_internal::telemetry::metrics::catalog::values::GraphQLResponseStatus;
@@ -58,7 +57,7 @@ pub struct HTTPSubgraphExecutor {
     pub dedupe_enabled: bool,
     pub in_flight_requests: InflightRequestsMap,
     pub telemetry_context: Arc<TelemetryContext>,
-    pub config: &'static HiveRouterConfig,
+    pub subgraph_buffer_capacity: usize,
 }
 
 const FIRST_VARIABLE_STR: &[u8] = b",\"variables\":{";
@@ -167,7 +166,7 @@ impl HTTPSubgraphExecutor {
         dedupe_enabled: bool,
         in_flight_requests: InflightRequestsMap,
         telemetry_context: Arc<TelemetryContext>,
-        config: &'static HiveRouterConfig,
+        subgraph_buffer_capacity: usize,
     ) -> Self {
         let mut header_map = HeaderMap::new();
         header_map.insert(
@@ -188,7 +187,7 @@ impl HTTPSubgraphExecutor {
             dedupe_enabled,
             in_flight_requests,
             telemetry_context,
-            config,
+            subgraph_buffer_capacity,
         }
     }
 }
@@ -538,7 +537,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
         SubgraphExecutorError,
     > {
         let custom_scalar_paths = execution_request.custom_scalar_paths.cloned();
-        let buffer_capacity = self.config.subscriptions.subgraph_buffer_capacity;
+        let buffer_capacity = self.subgraph_buffer_capacity;
         let body = build_request_body(&execution_request)?;
 
         let mut req = hyper::Request::builder()

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -9,11 +9,12 @@ use futures::{stream::BoxStream, FutureExt};
 use hive_console_sdk::circuit_breaker::{CircuitBreakerBuilder, CircuitBreakerError};
 use hive_router_config::{
     demand_control::DemandControlMode,
-    override_subgraph_urls::UrlOrExpression,
-    primitives::value_or_expression::ValueOrExpression,
-    subscriptions::SubscriptionProtocol,
-    traffic_shaping::{DurationOrExpression, StatusCodeMatcher, WebSocketExecuteMode},
-    HiveRouterConfig,
+    override_subgraph_urls::{OverrideSubgraphUrlsConfig, UrlOrExpression},
+    subscriptions::{SubscriptionProtocol, SupergraphSubscriptionsConfig},
+    traffic_shaping::{
+        DurationOrExpression, StatusCodeMatcher, SupergraphTrafficShapingConfig,
+        WebSocketExecuteMode,
+    },
 };
 use hive_router_internal::{
     expressions::vrl::compiler::Program as VrlProgram, inflight::InFlightMap,
@@ -145,6 +146,19 @@ struct ResolvedSubgraphConfig<'a> {
 
 pub type InflightRequestsMap = InFlightMap<u64, (SubgraphHttpResponse, u64)>;
 
+#[derive(Clone)]
+pub struct HttpCallbackRuntimeConfig {
+    pub public_url: Uri,
+    pub heartbeat_interval: Duration,
+}
+
+struct SubgraphExecutorConfig {
+    traffic_shaping: SupergraphTrafficShapingConfig,
+    override_subgraph_urls: OverrideSubgraphUrlsConfig,
+    subscriptions: SupergraphSubscriptionsConfig,
+    callback: Option<HttpCallbackRuntimeConfig>,
+}
+
 pub struct SubgraphExecutorMap {
     http_executors_by_subgraph: ExecutorsBySubgraphMap,
     subscription_executors_by_subgraph: ExecutorsBySubgraphMap,
@@ -158,7 +172,7 @@ pub struct SubgraphExecutorMap {
     timeouts_by_subgraph: TimeoutsBySubgraph,
     circuit_breakers_by_subgraph: CircuitBreakersBySubgraph,
     global_timeout: DurationOrProgram,
-    config: &'static HiveRouterConfig,
+    config: Arc<SubgraphExecutorConfig>,
     client: Arc<HttpClient>,
     semaphores_by_origin: DashMap<String, Arc<Semaphore>>,
     max_connections_per_host: usize,
@@ -176,8 +190,8 @@ pub struct SubgraphExecutorMap {
     websocket_pool: Arc<WebSocketPool>,
 }
 impl SubgraphExecutorMap {
-    pub fn new(
-        config: &'static HiveRouterConfig,
+    fn new(
+        config: Arc<SubgraphExecutorConfig>,
         global_timeout: DurationOrProgram,
         telemetry_context: Arc<TelemetryContext>,
     ) -> Result<Self, SubgraphExecutorError> {
@@ -217,10 +231,19 @@ impl SubgraphExecutorMap {
 
     pub fn from_http_endpoint_map(
         subgraph_endpoint_map: &HashMap<SubgraphName, String>,
-        config: &'static HiveRouterConfig,
+        traffic_shaping: SupergraphTrafficShapingConfig,
+        override_subgraph_urls: OverrideSubgraphUrlsConfig,
+        subscriptions: SupergraphSubscriptionsConfig,
+        callback: Option<HttpCallbackRuntimeConfig>,
         telemetry_context: Arc<TelemetryContext>,
         active_callback_subscriptions: CallbackSubscriptionsMap,
     ) -> Result<Self, SubgraphExecutorError> {
+        let config = Arc::new(SubgraphExecutorConfig {
+            traffic_shaping,
+            override_subgraph_urls,
+            subscriptions,
+            callback,
+        });
         let global_timeout =
             compile_duration_or_expression(&config.traffic_shaping.all.request_timeout, None)
                 .map_err(|err| {
@@ -230,7 +253,7 @@ impl SubgraphExecutorMap {
                     )
                 })?;
         let mut subgraph_executor_map =
-            SubgraphExecutorMap::new(config, global_timeout, telemetry_context)?;
+            SubgraphExecutorMap::new(config.clone(), global_timeout, telemetry_context)?;
         subgraph_executor_map.callback_subscriptions = active_callback_subscriptions;
 
         // The `all` expression is configured once but evaluated against each subgraph.
@@ -839,7 +862,7 @@ impl SubgraphExecutorMap {
                     subgraph_config.dedupe_enabled,
                     self.in_flight_requests.clone(),
                     self.telemetry_context.clone(),
-                    self.config,
+                    self.config.subscriptions.subgraph_buffer_capacity,
                 )
                 .to_boxed_arc();
 
@@ -897,7 +920,6 @@ impl SubgraphExecutorMap {
             SubscriptionProtocol::HTTPCallback => {
                 let callback_config = self
                     .config
-                    .subscriptions
                     .callback
                     .as_ref()
                     .ok_or_else(|| SubgraphExecutorError::HttpCallbackNotConfigured)?;
@@ -906,13 +928,11 @@ impl SubgraphExecutorMap {
 
                 let subgraph_config = self.resolve_subgraph_config(subgraph_name)?;
 
-                let public_url = self.resolve_public_url(&callback_config.public_url)?;
-
                 let callback_executor = HttpCallbackSubgraphExecutor::new(
                     subgraph_name.to_string(),
                     endpoint_uri,
                     subgraph_config.client,
-                    public_url.to_string(),
+                    callback_config.public_url.to_string(),
                     heartbeat_interval_ms,
                     self.callback_subscriptions.clone(),
                     self.telemetry_context.clone(),
@@ -927,43 +947,6 @@ impl SubgraphExecutorMap {
                 Ok(callback_executor)
             }
         }
-    }
-
-    #[inline]
-    fn resolve_public_url(
-        &self,
-        public_url: &ValueOrExpression<String>,
-    ) -> Result<Uri, SubgraphExecutorError> {
-        let raw = match public_url {
-            ValueOrExpression::Value(url) => url.clone(),
-            ValueOrExpression::Expression { expression } => expression
-                .compile_expression(None)
-                .map_err(|err| {
-                    SubgraphExecutorError::EndpointExpressionBuild(
-                        "callback.public_url".to_string(),
-                        err.diagnostics,
-                    )
-                })?
-                .execute(VrlValue::Null)
-                .map_err(|err| {
-                    SubgraphExecutorError::EndpointExpressionResolutionFailure(err.to_string())
-                })?
-                .as_str()
-                .ok_or(SubgraphExecutorError::EndpointExpressionWrongType)
-                .map(|s| s.to_string())?,
-        };
-
-        let uri = raw.parse::<Uri>().map_err(|err| {
-            SubgraphExecutorError::CallbackPublicUrlParseFailure(raw.clone(), err)
-        })?;
-
-        // Uri accepts relative paths like "foo" without a scheme or authority, so we must reejct
-        // those here because the subgraph needs a full URL to send callbacks to
-        if uri.scheme().is_none() || uri.authority().is_none() {
-            return Err(SubgraphExecutorError::CallbackPublicUrlNotAbsolute(raw));
-        }
-
-        Ok(uri)
     }
 
     /// Resolves traffic shaping configuration for a specific subgraph, applying subgraph-specific

--- a/lib/executor/src/plugins/hooks/on_supergraph_load.rs
+++ b/lib/executor/src/plugins/hooks/on_supergraph_load.rs
@@ -3,6 +3,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use graphql_tools::static_graphql::schema::Document;
+use hive_router_config::{
+    demand_control::DemandControlConfig, error_masking::ErrorMaskingConfig, headers::HeadersConfig,
+    override_labels::OverrideLabelsConfig, override_subgraph_urls::OverrideSubgraphUrlsConfig,
+    persisted_documents::PersistedDocumentsConfig, subscriptions::SupergraphSubscriptionsConfig,
+    traffic_shaping::SupergraphTrafficShapingConfig,
+};
 use hive_router_query_planner::planner::{Planner, PlannerError, QueryPlannerOptions};
 use hive_router_query_planner::utils::parsing::safe_parse_schema;
 use tokio_util::sync::CancellationToken;
@@ -32,13 +38,30 @@ pub enum SupergraphBuildError {
 /// Monotonically increasing id allocated to each constructed supergraph.
 static NEXT_SUPERGRAPH_DATA_ID: AtomicU64 = AtomicU64::new(0);
 
-/// The schema-derived data shared by a [`Supergraph`] owner and every [`SupergraphSnapshot`]
-/// cloned from it. Never constructed directly; always reached through the owner or a snapshot.
+/// Immutable configuration whose meaning belongs to one supergraph generation.
+#[derive(Clone, Default)]
+pub struct SupergraphOptions {
+    pub query_planner: QueryPlannerOptions,
+    pub traffic_shaping: SupergraphTrafficShapingConfig,
+    pub override_subgraph_urls: OverrideSubgraphUrlsConfig,
+    pub headers: HeadersConfig,
+    pub override_labels: OverrideLabelsConfig,
+    pub demand_control: Option<DemandControlConfig>,
+    pub subscriptions: SupergraphSubscriptionsConfig,
+    pub error_masking: ErrorMaskingConfig,
+    pub persisted_documents: PersistedDocumentsConfig,
+    pub hive_target: Option<String>,
+}
+
+/// The schema and immutable graph-bound options shared by a [`Supergraph`] owner and every
+/// [`SupergraphSnapshot`] cloned from it. Never constructed directly; always reached through the
+/// owner or a snapshot.
 pub struct SupergraphData {
     /// Process-unique id allocated once per constructed supergraph. Never reused, so a later
     /// instance cannot reuse an earlier runtime or join its in-flight request deduplication,
     /// even when both have identical consumer schemas.
     pub cache_id: u64,
+    pub options: SupergraphOptions,
     pub metadata: Arc<SchemaMetadata>,
     pub planner: Planner,
     pub supergraph_schema: Arc<Document>,
@@ -89,8 +112,9 @@ impl SupergraphSnapshot {
 
 /// The owner handle for one constructed supergraph. Plugins and the router's configured source
 /// retain `Arc<Supergraph>` while a supergraph remains selectable for new requests. It contains
-/// only schema-derived data. Router runtime concerns such as subgraph executors and telemetry live
-/// in the router and are built separately from a [`SupergraphSnapshot`].
+/// schema-derived data and immutable graph-bound configuration. Live router infrastructure such as
+/// clients, caches, storage runtimes, and telemetry agents is built separately from a
+/// [`SupergraphSnapshot`].
 ///
 /// When the last `Arc<Supergraph>` reference drops, [`Drop`] publishes retirement: every
 /// [`SupergraphSnapshot`] taken from it observes this (immediately, or later via
@@ -128,9 +152,9 @@ impl Supergraph {
     /// Same as [`Self::from_sdl`], but takes an already-parsed supergraph document.
     pub fn from_document(
         document: Document,
-        options: QueryPlannerOptions,
+        options: SupergraphOptions,
     ) -> Result<Self, SupergraphBuildError> {
-        let planner = Planner::new_from_supergraph(&document, options)?;
+        let planner = Planner::new_from_supergraph(&document, options.query_planner.clone())?;
         let metadata = Arc::new(planner.consumer_schema.schema_metadata());
 
         let public_schema = PublicSchema {
@@ -143,6 +167,7 @@ impl Supergraph {
             .expect("supergraph id space exhausted");
         let data = SupergraphData {
             cache_id,
+            options,
             metadata,
             planner,
             supergraph_schema: Arc::new(document),
@@ -155,10 +180,8 @@ impl Supergraph {
         })
     }
 
-    /// Parses `sdl` into a supergraph document and builds a schema-only [`Supergraph`] from
-    /// it. `options` may only carry query-planner options - router configuration, telemetry, and
-    /// router runtime state do not belong here.
-    pub fn from_sdl(sdl: &str, options: QueryPlannerOptions) -> Result<Self, SupergraphBuildError> {
+    /// Parses `sdl` and builds a [`Supergraph`] with its immutable graph-bound options.
+    pub fn from_sdl(sdl: &str, options: SupergraphOptions) -> Result<Self, SupergraphBuildError> {
         Self::from_document(safe_parse_schema(sdl)?, options)
     }
 

--- a/lib/hive-console-sdk/src/agent/usage_agent.rs
+++ b/lib/hive-console-sdk/src/agent/usage_agent.rs
@@ -353,12 +353,12 @@ impl UsageAgentExt for UsageAgent {
 
     async fn start_flush_interval(&self, token: &CancellationToken) {
         loop {
-            tokio::time::sleep(self.inner().flush_interval).await;
-
-            if token.is_cancelled() {
-                debug!(target: USAGE_REPORTING_TARGET, "Shutting down.");
-
-                return;
+            tokio::select! {
+                _ = token.cancelled() => {
+                    debug!(target: USAGE_REPORTING_TARGET, "Shutting down.");
+                    return;
+                }
+                _ = tokio::time::sleep(self.inner().flush_interval) => {}
             }
 
             self.flush()

--- a/lib/internal/src/background_tasks/mod.rs
+++ b/lib/internal/src/background_tasks/mod.rs
@@ -15,6 +15,7 @@ pub trait BackgroundTask: Send + Sync {
 pub struct BackgroundTasksManager {
     cancellation_token: CancellationToken,
     handles: Vec<JoinHandle<()>>,
+    graceful_handles: Vec<JoinHandle<()>>,
 }
 
 impl Default for BackgroundTasksManager {
@@ -28,6 +29,7 @@ impl BackgroundTasksManager {
         Self {
             cancellation_token: CancellationToken::new(),
             handles: Vec::new(),
+            graceful_handles: Vec::new(),
         }
     }
 
@@ -48,6 +50,23 @@ impl BackgroundTasksManager {
         self.handles.push(handle);
     }
 
+    /// Registers a task whose cancellation cleanup must finish before router shutdown completes.
+    pub fn register_graceful_task<T>(&mut self, task: T)
+    where
+        T: BackgroundTask + 'static,
+    {
+        info!(
+            target: targets::CORE,
+            task_id = task.id(),
+            "registering background task"
+        );
+
+        let child_token = self.cancellation_token.clone();
+        self.graceful_handles.push(spawn(async move {
+            task.run(child_token).await;
+        }));
+    }
+
     pub fn register_handle<F>(&mut self, f: F)
     where
         F: Future<Output = ()> + Send + 'static,
@@ -61,8 +80,28 @@ impl BackgroundTasksManager {
             "shutdown triggered, stopping all background tasks..."
         );
         self.cancellation_token.cancel();
+        for handle in self
+            .handles
+            .drain(..)
+            .chain(self.graceful_handles.drain(..))
+        {
+            handle.cancel();
+        }
+        info!(target: targets::CORE, "all background tasks have been shut down.");
+    }
+
+    /// Stops ordinary tasks immediately and waits for graceful task cleanup to finish.
+    pub async fn graceful_shutdown(&mut self) {
+        debug!(
+            target: targets::CORE,
+            "shutdown triggered, stopping all background tasks..."
+        );
+        self.cancellation_token.cancel();
         for handle in self.handles.drain(..) {
             handle.cancel();
+        }
+        for handle in self.graceful_handles.drain(..) {
+            let _ = handle.await;
         }
         info!(
             target: targets::CORE,

--- a/lib/internal/src/telemetry/traces/mod.rs
+++ b/lib/internal/src/telemetry/traces/mod.rs
@@ -14,22 +14,25 @@
 //! Public helpers like `TracerLayer` and tracing control functions are re-exported here
 //! for the rest of the codebase to use.
 use hive_router_config::telemetry::{
-    hive::{is_slug_target_ref, is_uuid_target_ref, HiveTelemetryConfig},
+    hive::HiveTelemetryConfig,
     tracing::{BatchProcessorConfig, OtlpProtocol, TracingExporterConfig},
     TelemetryConfig,
 };
 use opentelemetry_otlp::{
     Protocol, SpanExporter, WithExportConfig, WithHttpConfig, WithTonicConfig,
 };
+#[cfg(not(feature = "noop_otlp_exporter"))]
+use opentelemetry_sdk::error::OTelSdkError;
 use opentelemetry_sdk::{
+    error::OTelSdkResult,
     runtime,
     trace::{
         self, span_processor_with_async_runtime, BatchConfigBuilder, IdGenerator, Sampler,
-        SdkTracerProvider, SpanProcessor, TracerProviderBuilder,
+        SdkTracerProvider, SpanData, SpanProcessor, TracerProviderBuilder,
     },
     Resource,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Mutex, time::Duration};
 use tracing_opentelemetry::OpenTelemetryLayer;
 
 #[cfg(feature = "noop_otlp_exporter")]
@@ -223,6 +226,90 @@ fn build_batched_span_processor(
     processor
 }
 
+struct TargetedHiveExporter {
+    endpoint: String,
+    token: String,
+    timeout: Duration,
+    resource: Mutex<Option<Resource>>,
+}
+
+impl std::fmt::Debug for TargetedHiveExporter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let masked: String = self.token.chars().take(5).collect::<String>() + "***";
+
+        f.debug_struct("TargetedHiveExporter")
+            .field("endpoint", &self.endpoint)
+            .field("token", &masked)
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TargetedHiveExporter {
+    fn target_by_trace(batch: &[SpanData]) -> HashMap<opentelemetry::TraceId, String> {
+        batch
+            .iter()
+            .filter_map(|span| {
+                span.attributes
+                    .iter()
+                    .find(|attribute| attribute.key.as_str() == "hive.target")
+                    .and_then(|attribute| match &attribute.value {
+                        opentelemetry::Value::String(target) => {
+                            Some((span.span_context.trace_id(), target.as_str().to_string()))
+                        }
+                        _ => None,
+                    })
+            })
+            .collect()
+    }
+}
+
+impl trace::SpanExporter for TargetedHiveExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        let targets = Self::target_by_trace(&batch);
+        let mut partitions: HashMap<String, Vec<SpanData>> = HashMap::new();
+        for span in batch {
+            if let Some(target) = targets.get(&span.span_context.trace_id()) {
+                partitions.entry(target.clone()).or_default().push(span);
+            }
+        }
+
+        for (target, spans) in partitions {
+            #[cfg(not(feature = "noop_otlp_exporter"))]
+            let exporter = SpanExporter::builder()
+                .with_http()
+                .with_endpoint(self.endpoint.clone())
+                .with_timeout(self.timeout)
+                .with_headers(HashMap::from([
+                    (
+                        "authorization".to_string(),
+                        format!("Bearer {}", self.token),
+                    ),
+                    ("x-hive-target-ref".to_string(), target),
+                ]))
+                .with_protocol(Protocol::HttpBinary)
+                .build()
+                .map_err(|error| OTelSdkError::InternalFailure(error.to_string()))?;
+            #[cfg(feature = "noop_otlp_exporter")]
+            let exporter = {
+                let _ = (&self.endpoint, &self.token, self.timeout, target);
+                NoopExporter::new()
+            };
+
+            let mut exporter = HiveConsoleExporter::new(exporter);
+            if let Some(resource) = self.resource.lock().unwrap().as_ref() {
+                trace::SpanExporter::set_resource(&mut exporter, resource);
+            }
+            trace::SpanExporter::export(&exporter, spans).await?;
+        }
+        Ok(())
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        *self.resource.lock().unwrap() = Some(resource.clone());
+    }
+}
+
 fn setup_hive_exporter(
     config: &HiveTelemetryConfig,
     resource: &Resource,
@@ -237,43 +324,12 @@ fn setup_hive_exporter(
             ))
         }
     };
-    let target = match &config.target {
-        Some(t) => resolve_value_or_expression(t, "Hive Telemetry target")?,
-        None => {
-            return Err(TelemetryError::TracesExporterSetup(
-                "Hive Tracing target is required but not provided".to_string(),
-            ))
-        }
+    let hive_exporter = TargetedHiveExporter {
+        endpoint,
+        token,
+        timeout: config.tracing.batch_processor.max_export_timeout,
+        resource: Mutex::new(None),
     };
-
-    if !is_uuid_target_ref(&target) && !is_slug_target_ref(&target) {
-        return Err(TelemetryError::TracesExporterSetup(format!(
-            "Invalid Hive Tracing target format: '{}'. It must be either in slug format '$organizationSlug/$projectSlug/$targetSlug' or UUID format 'a0f4c605-6541-4350-8cfe-b31f21a4bf80'",
-            target
-        )));
-    }
-
-    let headers: HashMap<String, String> = HashMap::from_iter(vec![
-        ("authorization".to_string(), format!("Bearer {}", token)),
-        ("x-hive-target-ref".to_string(), target.clone()),
-    ]);
-
-    let exporter = SpanExporter::builder()
-        .with_http()
-        .with_endpoint(endpoint)
-        .with_timeout(config.tracing.batch_processor.max_export_timeout)
-        .with_headers(headers)
-        .with_protocol(Protocol::HttpBinary)
-        .build()
-        .map_err(|e| TelemetryError::TracesExporterSetup(e.to_string()))?;
-
-    #[cfg(feature = "noop_otlp_exporter")]
-    let exporter = {
-        let _ = exporter;
-        NoopExporter::new()
-    };
-
-    let hive_exporter = HiveConsoleExporter::new(exporter);
     let mut trace_batching_processor =
         TraceBatchSpanProcessor::new(hive_exporter, &config.tracing.batch_processor)?;
 

--- a/lib/internal/src/telemetry/traces/spans/attributes.rs
+++ b/lib/internal/src/telemetry/traces/spans/attributes.rs
@@ -42,6 +42,7 @@ pub const HIVE_GRAPHQL_ERROR_COUNT: &str = "hive.graphql.error.count";
 pub const HIVE_GRAPHQL_ERROR_CODES: &str = "hive.graphql.error.codes";
 pub const HIVE_CLIENT_NAME: &str = "hive.client.name";
 pub const HIVE_CLIENT_VERSION: &str = "hive.client.version";
+pub const HIVE_TARGET: &str = "hive.target";
 pub const HIVE_GRAPHQL_OPERATION_HASH: &str = "hive.graphql.operation.hash";
 pub const HIVE_GRAPHQL_SUBGRAPH_NAME: &str = "hive.graphql.subgraph.name";
 

--- a/lib/internal/src/telemetry/traces/spans/graphql.rs
+++ b/lib/internal/src/telemetry/traces/spans/graphql.rs
@@ -355,9 +355,16 @@ impl GraphQLOperationSpan {
             "hive.graphql.operation.hash" = Empty,
             "hive.client.name" = Empty,
             "hive.client.version" = Empty,
+            "hive.target" = Empty,
             "cost.formula_cache_hit" = Empty,
         );
         GraphQLOperationSpan { span }
+    }
+
+    pub fn record_hive_target(&self, target: Option<&str>) {
+        if let Some(target) = target {
+            self.span.record(attributes::HIVE_TARGET, target);
+        }
     }
 
     pub fn record_error_count(&self, count: usize) {

--- a/lib/internal/src/telemetry/traces/spans/tests.rs
+++ b/lib/internal/src/telemetry/traces/spans/tests.rs
@@ -832,9 +832,13 @@ fn test_graphql_operation_span() {
                 attributes::HIVE_GRAPHQL_ERROR_CODES,
                 attributes::HIVE_CLIENT_NAME,
                 attributes::HIVE_CLIENT_VERSION,
+                attributes::HIVE_TARGET,
                 attributes::HIVE_GRAPHQL_OPERATION_HASH,
             ],
         );
+
+        span.record_hive_target(Some("example/router/test"));
+        layer.assert_recorded_value(&span, attributes::HIVE_TARGET, "example/router/test");
 
         span.record_error_count(3);
         layer.assert_recorded_value(&span, attributes::HIVE_GRAPHQL_ERROR_COUNT, "3");

--- a/lib/router-config/src/subscriptions.rs
+++ b/lib/router-config/src/subscriptions.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::primitives::absolute_path::AbsolutePath;
 use crate::primitives::value_or_expression::ValueOrExpression;
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Default)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SubscriptionsConfig {
     /// Enables/disables subscriptions. By default, the subscriptions are disabled.
@@ -152,14 +152,43 @@ pub struct WebSocketSubgraphConfig {
     pub path: Option<AbsolutePath>,
 }
 
-impl SubscriptionsConfig {
+/// Subscription settings used by subgraph executors for one supergraph.
+#[derive(Clone)]
+pub struct SupergraphSubscriptionsConfig {
+    pub callback_subgraphs: HashSet<String>,
+    pub websocket: Option<WebSocketConfig>,
+    pub subgraph_buffer_capacity: usize,
+}
+
+impl Default for SupergraphSubscriptionsConfig {
+    fn default() -> Self {
+        Self {
+            callback_subgraphs: HashSet::new(),
+            websocket: None,
+            subgraph_buffer_capacity: default_subgraph_buffer_capacity(),
+        }
+    }
+}
+
+impl From<&SubscriptionsConfig> for SupergraphSubscriptionsConfig {
+    fn from(config: &SubscriptionsConfig) -> Self {
+        Self {
+            callback_subgraphs: config
+                .callback
+                .as_ref()
+                .map(|callback| callback.subgraphs.clone())
+                .unwrap_or_default(),
+            websocket: config.websocket.clone(),
+            subgraph_buffer_capacity: config.subgraph_buffer_capacity,
+        }
+    }
+}
+
+impl SupergraphSubscriptionsConfig {
     /// Returns the subscription protocol for the given subgraph.
-    /// Returns HTTP (streaming) as the default if no specific mode is configured.
     pub fn get_protocol_for_subgraph(&self, subgraph_name: &str) -> SubscriptionProtocol {
-        if let Some(ref callback) = self.callback {
-            if callback.subgraphs.contains(subgraph_name) {
-                return SubscriptionProtocol::HTTPCallback;
-            }
+        if self.callback_subgraphs.contains(subgraph_name) {
+            return SubscriptionProtocol::HTTPCallback;
         }
         if let Some(ref websocket) = self.websocket {
             if websocket.all.is_some() || websocket.subgraphs.contains_key(subgraph_name) {
@@ -170,7 +199,6 @@ impl SubscriptionsConfig {
     }
 
     /// Returns the WebSocket path for the given subgraph, if configured.
-    /// Checks the subgraph-specific configuration first, then falls back to the `all` default.
     pub fn get_websocket_path(&self, subgraph_name: &str) -> Option<&str> {
         self.websocket.as_ref().and_then(|ws| {
             ws.subgraphs

--- a/lib/router-config/src/traffic_shaping.rs
+++ b/lib/router-config/src/traffic_shaping.rs
@@ -38,7 +38,15 @@ impl Default for TrafficShapingConfig {
     }
 }
 
-impl TrafficShapingConfig {
+/// Traffic shaping that belongs to one supergraph's subgraph executors.
+#[derive(Clone)]
+pub struct SupergraphTrafficShapingConfig {
+    pub all: TrafficShapingExecutorGlobalConfig,
+    pub subgraphs: HashMap<String, TrafficShapingExecutorSubgraphConfig>,
+    pub max_connections_per_host: usize,
+}
+
+impl SupergraphTrafficShapingConfig {
     /// Returns whether WebSocket connections should be reused for a subgraph.
     ///
     /// A per-subgraph value takes precedence over the value configured in `all`.
@@ -86,6 +94,26 @@ impl TrafficShapingConfig {
                     .and_then(|websocket| websocket.reuse_connections)
                     .unwrap_or(false)
             })
+    }
+}
+
+impl Default for SupergraphTrafficShapingConfig {
+    fn default() -> Self {
+        Self {
+            all: TrafficShapingExecutorGlobalConfig::default(),
+            subgraphs: HashMap::new(),
+            max_connections_per_host: default_max_connections_per_host(),
+        }
+    }
+}
+
+impl From<&TrafficShapingConfig> for SupergraphTrafficShapingConfig {
+    fn from(config: &TrafficShapingConfig) -> Self {
+        Self {
+            all: config.all.clone(),
+            subgraphs: config.subgraphs.clone(),
+            max_connections_per_host: config.max_connections_per_host,
+        }
     }
 }
 

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.0.88"
+version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-config"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "config",
  "envconfig",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-internal"
-version = "0.0.41"
+version = "0.1.0"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-plan-executor"
-version = "7.0.3"
+version = "8.0.0"
 dependencies = [
  "ahash",
  "async-stream",

--- a/plugin_examples/async_http_fetch/src/test.rs
+++ b/plugin_examples/async_http_fetch/src/test.rs
@@ -42,7 +42,9 @@ mod tests {
             .start()
             .await;
 
-        let res = router.send_graphql_request("{ me { name } }", None, None).await;
+        let res = router
+            .send_graphql_request("{ me { name } }", None, None)
+            .await;
 
         assert!(res.status().is_success(), "Expected 200 OK");
         assert_eq!(

--- a/plugin_examples/feature_flags/README.md
+++ b/plugin_examples/feature_flags/README.md
@@ -1,0 +1,5 @@
+# Feature flags plugin
+
+This example builds and retains one `Arc<Supergraph>` per feature-flag combination. Each variant includes a complete `SupergraphOptions` snapshot, so executor settings, error masking, and Hive target stay pinned to the same generation as its schema.
+
+Configured sources derive these options from router YAML. Plugin-owned variants must provide them explicitly and keep the owner alive while the variant remains selectable.

--- a/plugin_examples/feature_flags/src/plugin.rs
+++ b/plugin_examples/feature_flags/src/plugin.rs
@@ -17,7 +17,7 @@ use hive_router::{
         hooks::{
             on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
-            on_supergraph_load::Supergraph,
+            on_supergraph_load::{Supergraph, SupergraphOptions},
         },
         plugin_trait::{RouterPlugin, StartHookPayload},
     },
@@ -92,7 +92,27 @@ impl RouterPlugin for FeatureFlagsPlugin {
                 // (expensive) not constructed, build and cache it
                 None => {
                     let document = schema_for_features(&self.supergraph, &feature_flags);
-                    match Supergraph::from_document(document, Default::default()) {
+
+                    let mut options = SupergraphOptions::default();
+                    options.traffic_shaping.all.forward_operation_name = !feature_flags.is_empty();
+                    options.error_masking.redacted_error_message = format!(
+                        "{} variant error",
+                        if feature_flags.is_empty() {
+                            "base"
+                        } else {
+                            "flagged"
+                        }
+                    );
+                    options.hive_target = Some(
+                        if feature_flags.is_empty() {
+                            "example/router/base"
+                        } else {
+                            "example/router/flagged"
+                        }
+                        .to_string(),
+                    );
+
+                    match Supergraph::from_document(document, options) {
                         Ok(supergraph_data) => {
                             // build successful
                             let supergraph_data = Arc::new(supergraph_data);

--- a/plugin_examples/field_nulling/src/main.rs
+++ b/plugin_examples/field_nulling/src/main.rs
@@ -10,7 +10,8 @@ async fn main() -> Result<(), RouterInitError> {
     init_rustls_crypto_provider();
 
     router_entrypoint(
-        PluginRegistry::new().register::<field_nulling_plugin_example::plugin::FieldNullingPlugin>(),
+        PluginRegistry::new()
+            .register::<field_nulling_plugin_example::plugin::FieldNullingPlugin>(),
     )
     .await
 }

--- a/plugin_examples/non_standard_request/src/main.rs
+++ b/plugin_examples/non_standard_request/src/main.rs
@@ -1,4 +1,3 @@
-
 use hive_router::{
     configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
     router_entrypoint, PluginRegistry, RouterGlobalAllocator,

--- a/plugin_examples/propagate_status_code/src/lib.rs
+++ b/plugin_examples/propagate_status_code/src/lib.rs
@@ -3,7 +3,6 @@
 // Needed because of ntex's way of defining middlewares
 #![recursion_limit = "256"]
 
-
 use hive_router::http::StatusCode;
 use serde::Deserialize;
 

--- a/plugin_examples/replace_schema/README.md
+++ b/plugin_examples/replace_schema/README.md
@@ -1,0 +1,5 @@
+# Replace schema plugin
+
+This example selects a plugin-owned `Supergraph` when `x-schema-variant: basic` is present. A plugin-owned supergraph must be constructed with a complete `SupergraphOptions` value and retained in an `Arc<Supergraph>` for as long as requests may select it.
+
+The configured supergraph receives graph-bound options from the existing router YAML. The basic variant supplies its own executor traffic shaping, error masking, and Hive target. It does not inherit those values from the configured supergraph.

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -14,7 +14,7 @@ use hive_router::{
         hooks::{
             on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
-            on_supergraph_load::Supergraph,
+            on_supergraph_load::{Supergraph, SupergraphOptions},
         },
         plugin_trait::{RouterPlugin, StartHookPayload},
     },
@@ -53,7 +53,13 @@ impl RouterPlugin for ReplaceSchemaPlugin {
         let document =
             safe_parse_schema(&SUPERGRAPH_SDL.replace("http://0.0.0.0:4200", &subgraphs_url))?;
         let document = strip_disabled_features(document, &["inStock", "shippingEstimate"]);
-        let basic_variant = Arc::new(Supergraph::from_document(document, Default::default())?);
+
+        let mut options = SupergraphOptions::default();
+        options.traffic_shaping.all.forward_operation_name = true;
+        options.error_masking.redacted_error_message = "Basic variant error".to_string();
+        options.hive_target = Some("example/router/basic".to_string());
+
+        let basic_variant = Arc::new(Supergraph::from_document(document, options)?);
         payload.initialize_plugin(Self { basic_variant })
     }
 


### PR DESCRIPTION
Closes #1331

Plugin-selected supergraphs now carry the immutable graph-specific configuration needed to build and execute their own router runtime. Requests, WebSocket operations, subscriptions, persisted-document resolution, subgraph execution, usage reports, and Hive traces use one pinned schema, options, and runtime generation instead of combining a selected schema with settings from the router's configured supergraph.

This keeps plugin variants isolated while preserving the existing YAML structure for configured supergraphs.

The implementation also adds persisted-document preparation and `on_graphql_params` hooks to GraphQL over WebSocket operations, since those operations must be prepared through the selected supergraph's persisted-document runtime before parsing and execution.

# Ownership model

The implementation keeps the existing schema and runtime split, but makes graph-specific configuration part of the schema generation:

- `Supergraph` owns immutable schema data and `SupergraphOptions`
- `SupergraphSnapshot` pins one schema and options generation
- `SelectedSupergraph` pins that snapshot together with its `Arc<RouterSupergraphRuntime>`
- `RouterSupergraphRuntime` owns live and compiled state derived from the snapshot and shared router infrastructure
- `RouterSharedState` retains only process-wide policy and infrastructure

This ensures a request cannot use the schema from one plugin variant with the endpoint overrides, persisted-document manifest, error masking, or Hive target from another variant.

## `SupergraphOptions`

`Supergraph::from_sdl` and `Supergraph::from_document` now accept `SupergraphOptions` instead of `QueryPlannerOptions`:

```rust
let mut options = SupergraphOptions::default();
options.traffic_shaping.all.forward_operation_name = true;
options.error_masking.redacted_error_message = "Basic variant error".to_string();
options.hive_target = Some("organization/project/basic".to_string());

let supergraph = Supergraph::from_document(document, options)?;
```

`SupergraphOptions` contains:

- query-planner construction options
- executor-side traffic shaping
- subgraph URL overrides
- request and response header rules
- progressive override labels
- demand-control configuration
- subgraph subscription transport configuration
- error masking
- persisted-document configuration
- the Hive target

The options are immutable after construction and are stored in `SupergraphData`, so every snapshot from an owner observes the same generation.

Public `SupergraphOptions` deliberately does not contain clients, caches, telemetry agents, storage runtimes, callback maps, or background tasks. Those values are live router infrastructure and remain in `RouterSupergraphRuntime` or its router-owned construction context.

Public `SupergraphOptions` also deliberately does not derive `Debug`. The current fields are configuration values, but avoiding a blanket debug representation prevents future sensitive references or credentials from being exposed accidentally.

# Configuration ownership

## Supergraph-bound configuration

The following configuration now follows the selected supergraph:

| Configuration | Why it is supergraph-bound |
| --- | --- |
| `query_planner.experimental_abstract_type_folding` | Changes construction of that supergraph's planner |
| executor-side `traffic_shaping.all`, `traffic_shaping.subgraphs`, and `max_connections_per_host` | Builds clients and policies for named subgraphs |
| `override_subgraph_urls` | Replaces endpoints belonging to the selected schema and evaluates expressions against that schema's original endpoint |
| `headers` | Can name subgraphs and alter requests or responses for their executors |
| `override_labels` | Refers to labels in the selected supergraph and changes plan execution |
| `demand_control` | Combines graph-specific list-size and subgraph budgets with schema-derived formulas |
| subgraph-facing `subscriptions` settings | Selects callback or WebSocket transports and buffer sizes for the selected graph's executors |
| `error_masking` | Contains per-subgraph behavior applied to selected execution errors |
| `persisted_documents` | Selects a manifest and ID policy belonging to one API schema |
| `telemetry.hive.target` | Attributes usage and traces to the target that owns the selected graph |

The existing YAML paths and defaults do not change. Configured supergraphs (`ConfiguredSupergraph`) derive `SupergraphOptions` from `HiveRouterConfig` during loading.

## Router-bound configuration

The rest remain process-wide because they control things like query-planning timeout and query-plan exposure, router-side traffic shaping and inbound request deduplication, authorization enforcement policy, etc.

The Hive token remains router-owned. This change routes multiple targets under one router credential; supporting different Hive accounts per selected graph would require a separate credential-routing design.

# Configured and plugin-selected supergraphs

## Configured sources

Configured supergraphs preserve the existing YAML and environment override behavior. Loading now follows this order:

1. Load and parse the new SDL
2. Run supergraph-load start hooks
3. Derive `SupergraphOptions` from the router configuration
4. Construct the `Supergraph`
5. Run end hooks, which may replace it with another complete `Supergraph`
6. Build `RouterSupergraphRuntime` from the returned snapshot and router-owned context
7. Atomically publish the owner, snapshot, and runtime

Configured-source loading remains asynchronous, matching the existing startup behavior. The router can start healthy but unready while the initial source is fetched and built. Load or construction failures are logged and retried according to the source configuration; readiness becomes available only after a complete generation is published.

The runtime is built eagerly before each publication, so a construction failure leaves the current configured generation untouched, or leaves the router unready when no generation has been published yet.

An end hook replacement keeps its own options. The router does not reapply configured graph settings after the hook, because doing so would combine the replacement schema with configuration from a different owner.

## Plugin-selected variants

A plugin-owned variant must construct a complete `SupergraphOptions` value and retain its `Arc<Supergraph>` for as long as the variant remains selectable.

Plugin-selected supergraphs no longer inherit graph-specific settings from the configured fallback. `SupergraphOptions::default()` remains available when a variant intentionally wants the normal defaults.

If a plugin-selected runtime cannot be built, selection fails closed. The router does not retry with the configured supergraph or its settings.

The `feature_flags` and `replace_schema` examples now demonstrate explicit per-variant operation-name forwarding, error masking, and Hive targets, together with the owner-retention requirement.

# Runtime construction and caching

`RouterSupergraphRuntime::build` no longer receives the complete `HiveRouterConfig`. It receives only:

- the selected `SupergraphSnapshot`
- telemetry and metrics infrastructure
- the shared callback subscription map and resolved callback details
- the storage manager
- the router GraphQL endpoint
- persisted-document and Hive usage background-task controllers
- process-wide Hive reporting policy

The runtime builds and owns:

- the subgraph executor map and compiled URL overrides
- operation-name forwarding
- compiled header rules
- progressive override-label evaluation
- authorization metadata
- demand-control runtime and formula cache
- error masking
- persisted-document extraction and resolver state
- a Hive usage agent for the selected target
- validation, normalization, and query-plan caches

Removing the complete router config from runtime and HTTP executor constructors makes it harder for future code to accidentally read graph-specific values from global state.

Configured runtimes remain eagerly built and pinned by the configured slot. Plugin runtimes remain in the existing bounded FIFO cache with a capacity of 10 (we should either increase or make this cap configurable).

Runtime selection is now asynchronous because persisted-document storage initialization can be asynchronous. Each plugin cache entry contains a `tokio::sync::OnceCell`, so concurrent first requests for the same supergraph share one initialization without holding a synchronous mutex across an `await`.

Eviction and retirement only release cache or owner references. They do not invalidate requests, WebSocket connections, or subscriptions that already retain the runtime, this allows them to finish gracefully.

# Subgraph executors and subscriptions

`SubgraphExecutorMap` now receives only graph-specific executor configuration plus resolved router callback config.

Subscription configuration is split by ownership without changing YAML.

All configured and plugin runtimes continue sharing the same callback subscription map, so callback routing and heartbeat enforcement remain process-wide infrastructure.

# Persisted documents

Persisted-document lookup now happens after supergraph selection and through the selected runtime.

For HTTP requests, operation preparation now follows this order:

1. Run the HTTP plugin chain, allowing it to select a supergraph
2. Resolve and pin `SelectedSupergraph`
3. Extract and enforce the selected graph's document ID policy
4. Resolve the document through the selected graph's manifest or storage
5. Parse, validate, normalize, plan, and execute against the same selected snapshot

This prevents an ID from being resolved through one manifest and executed against another schema.

Persisted-document runtime initialization moved out of `RouterSharedState`. File watchers and storage pollers are registered per selected runtime, and selector compatibility with the configured GraphQL endpoint is validated while that runtime is built.

# WebSockets

Incoming GraphQL over WebSocket operations (both subscriptions and queries) now use the same GraphQL parameter preparation as HTTP requests.

This adds support for:

- an omitted query when a persisted-document ID is present in `extensions`
- persisted-document ID extraction, enforcement, metrics, logging, and resolution
- `on_graphql_params` start hooks and registered end callbacks

The WebSocket connection's already pinned `SelectedSupergraph` supplies the persisted-document runtime. An operation cannot switch manifests or supergraph generations within the connection.

If a GraphQL parameters hook returns an early response, the router sends the GraphQL body as a WebSocket `next` message followed by `complete`. HTTP status and headers cannot be represented by the GraphQL over WebSocket protocol and are intentionally not forwarded.

# Hive usage reporting

The global usage agent was removed from `RouterSharedState`. Each selected runtime now builds an agent from:

- the router's global usage-reporting endpoint, token, sampling, exclusion, timeout, TLS, buffer, and flush policy
- the selected snapshot's Hive target, when provided

HTTP and WebSocket reports are sent only through `SelectedSupergraph.runtime.hive_usage_agent`.

Hive target format is validated during runtime construction instead of per report. When Hive tracing is enabled, every usable selected runtime must have a target. A missing or invalid target makes runtime construction fail rather than attributing telemetry incorrectly.

# Hive trace routing

A single startup-time `x-hive-target-ref` header cannot route concurrent requests for different selected graphs. Mutating one exporter header per request would also race with concurrent requests and buffered export batches.

The selected target is therefore recorded on each HTTP or WebSocket GraphQL operation span. `TargetedHiveExporter` then:

1. Associates each complete trace with the target recorded on its operation span
2. Partitions mixed export batches by target
3. Builds an OTLP export request for each target partition
4. Sends each partition with its own `x-hive-target-ref` header and the global token

Traces without a selected target are omitted from the Hive exporter. Other configured exporters are unaffected.

This keeps one global tracing subscriber and batching pipeline while making target routing deterministic under concurrency.

# Runtime-scoped background work

The first implementation used one generic dynamic task registrar. It was replaced with two explicit task groups because there are only two runtime-scoped use cases and their shutdown semantics differ:

- `PersistedDocumentsBackgroundTasks` accepts only file-manifest watchers and storage-manifest pollers
- `HiveUsageReportingBackgroundTasks` accepts only Hive usage agents

Each `RouterSupergraphRuntime` owns a `supergraph_lifetime` cancellation token. The token remains active while any configured slot, runtime-cache entry, HTTP request, WebSocket connection, or subscription retains that runtime. It is cancelled only when:

- runtime construction fails, or
- the final `Arc<RouterSupergraphRuntime>` is dropped

This is intentionally later than cache eviction or `Supergraph` owner retirement. Existing work can continue using immutable schema and runtime state after the owner stops being selectable.

Persisted-document workers stop promptly when the runtime lifetime ends. Hive usage shutdown however:

1. Observes router shutdown or runtime lifetime cancellation
2. Cancels the periodic flush interval
3. Allows an in-progress interval flush to finish
4. Explicitly flushes reports still in the buffer
5. Removes the worker only after the final flush resolves

`UsageAgentExt::start_flush_interval` now observes cancellation while waiting for the next interval, but does not let cancellation interrupt an active flush. This prevents a batch that has already been drained from the buffer from being lost by cancellation.

`BackgroundTasksManager` now distinguishes ordinary tasks from graceful tasks. Production router shutdown registers the two specialized groups as graceful and awaits their cleanup before telemetry shutdown.

# Validation and failures

Runtime construction compares graph-specific subgraph maps with the selected snapshot's endpoint map. Unknown names in traffic shaping, URL overrides, headers, demand control, callback subscriptions, WebSocket subscriptions, and error masking produce warnings.

They remain warnings rather than hard errors because configuration and schemas may be deployed on different schedules, and the router historically tolerated entries for future or temporarily absent subgraphs. An absent entry cannot affect an executor in the current snapshot.

Runtime construction also validates:

- header and override-label compilation
- authorization metadata
- subgraph executor construction
- persisted-document storage and selector compatibility
- Hive usage-agent construction
- Hive target format and tracing target availability

A failed plugin runtime is not cached and does not fall back to configured graph-specific settings. A failed configured reload is not published. Any workers registered before a partial failure are cancelled through that attempted runtime's lifetime token.

# Migration

## Router configuration

No YAML paths or defaults change. Existing configured-source routers continue deriving all graph-specific options from the same configuration.

## Plugin API

This is a breaking executor API change:

```diff
-Supergraph::from_sdl(sdl, QueryPlannerOptions::default())
+Supergraph::from_sdl(sdl, SupergraphOptions::default())
```

Plugins that previously relied on a selected supergraph inheriting graph-specific router settings must now populate those fields explicitly. This is the intended semantic change: a plugin-owned supergraph is a complete schema and configuration generation.

# TODOs

- [ ] docs