### PR TITLE
chore: fix ci-only flakey telemetry tests

### DIFF
--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -108,7 +108,13 @@ async fn test_log_contents_with_just_logging_enabled() {
         .capture_stdout_lines()
         .await;
 
-    assert_eq!(stdout_log.len(), LOG_LINES_BASELINE);
+    assert_eq!(
+        stdout_log
+            .iter()
+            .filter(|line| line.contains(" router::request:"))
+            .count(),
+        LOG_LINES_BASELINE
+    );
 }
 
 #[ntex::test]
@@ -141,7 +147,13 @@ log:
         .capture_stdout_lines()
         .await;
 
-    assert_eq!(stdout_log.len(), LOG_LINES_BASELINE);
+    assert_eq!(
+        stdout_log
+            .iter()
+            .filter(|line| line.contains(" router::request:"))
+            .count(),
+        LOG_LINES_BASELINE
+    );
 }
 
 #[ntex::test]

--- a/e2e/src/testkit/stdout.rs
+++ b/e2e/src/testkit/stdout.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, io::Read};
+use std::{future::Future, io::Read, time::Duration};
 
 use gag::BufferRedirect;
 use serde_json::{Map, Value};
@@ -15,12 +15,16 @@ impl Default for StdoutLogCapture {
 
 impl StdoutLogCapture {
     pub fn new() -> Self {
+        // let the non-blocking tracing writer finish logs emitted before this capture
+        std::thread::sleep(Duration::from_millis(50));
         Self {
             buf: BufferRedirect::stdout().unwrap(),
         }
     }
 
     pub fn lines(mut self) -> Vec<String> {
+        // keep stdout redirected until the tracing writer drains this capture's logs
+        std::thread::sleep(Duration::from_millis(50));
         let mut output = String::new();
         self.buf.read_to_string(&mut output).unwrap();
 


### PR DESCRIPTION
Fixes CI-only flakes in telemetry logging E2E tests caused by the non-blocking tracing writer racing with stdout capture.

The capture helper now:

 - waits for pending logs to drain before redirecting stdout
 - keeps stdout redirected until logs emitted during the request are drained

This prevents setup logs from leaking into the capture and request logs from arriving after capture ends.

Furthermore, the text logging assertions in the telemetry now count only `router::request` lines, excluding unrelated output from the OTLP test collector that might pollute.

Fix was also tested in #1380.