### PR TITLE
fix(router): better handling of internal and pipeline errors

### DIFF
--- a/.changeset/align_variable_coercion_errors_with_graphql_js.md
+++ b/.changeset/align_variable_coercion_errors_with_graphql_js.md
@@ -1,0 +1,10 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+# Improve variable coercion error messages
+
+Variable coercion errors (invalid scalar/enum/object values, missing required fields, non-null violations) reports clear and informative error messages.
+
+This only changes error text - error codes and HTTP status codes are unchanged.

--- a/.changeset/mask_internal_pipeline_errors.md
+++ b/.changeset/mask_internal_pipeline_errors.md
@@ -1,0 +1,11 @@
+---
+hive-router: patch
+---
+
+# Mask internal error details from client responses
+
+Improve router's error handling by masking internal error details from client responses.
+
+Client-caused errors still return their real message, since it only ever reflects the client's own request. Internal errors now always return a generic `"Internal server error"` message and never the underlying error message, which previously leaked details such as subgraph URLs, storage/network errors, and other backend internals. The real error is still logged for debugging purposes.
+
+Error codes are unchanged. HTTP status codes are unchanged, except for GraphQL operation normalization and minification failures, which are now correctly treated as router-side bugs and always return `500` (previously `400`, or `200` based on `Accept` header) instead of being treated as a client mistake.

--- a/bin/router/src/pipeline/authorization/mod.rs
+++ b/bin/router/src/pipeline/authorization/mod.rs
@@ -12,7 +12,7 @@ pub mod metadata;
 
 use std::sync::Arc;
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 use crate::pipeline::normalize::GraphQLNormalizationPayload;
 use crate::pipeline::nullify::rebuilder::{
     rebuild_nulled_operation, rebuild_nulled_projection_plan,
@@ -195,7 +195,7 @@ pub fn enforce_operation_authorization(
             errors,
         ),
         AuthorizationDecision::Reject { errors } => {
-            return Err(PipelineError::AuthorizationFailed(errors));
+            return Err(ClientPipelineError::AuthorizationFailed(errors).into());
         }
     })
 }

--- a/bin/router/src/pipeline/coerce_variables.rs
+++ b/bin/router/src/pipeline/coerce_variables.rs
@@ -8,7 +8,7 @@ use hive_router_plan_executor::variables::collect_variables;
 use sonic_rs::Value;
 use tracing::{debug, warn};
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 use crate::pipeline::normalize::GraphQLNormalizationPayload;
 
 #[inline]
@@ -35,13 +35,13 @@ pub fn coerce_request_variables(
                 variables_map: values,
             })
         }
-        Err(err_msg) => {
+        Err(err) => {
             warn!(
                 target: targets::COERCE_VARIABLES,
-                error = ?err_msg,
+                error = %err,
                 "failed to collect variables from incoming request",
             );
-            Err(PipelineError::VariablesCoercionError(err_msg))
+            Err(ClientPipelineError::VariablesCoercionError(err).into())
         }
     }
 }

--- a/bin/router/src/pipeline/csrf_prevention.rs
+++ b/bin/router/src/pipeline/csrf_prevention.rs
@@ -3,7 +3,7 @@ use hive_router_internal::telemetry::logging::targets;
 use ntex::web::HttpRequest;
 use tracing::warn;
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 
 // NON_PREFLIGHTED_CONTENT_TYPES are content types that do not require a preflight
 // OPTIONS request. These are content types that are considered "simple" by the CORS
@@ -43,7 +43,7 @@ pub fn perform_csrf_prevention(
     } else {
         warn!(target: targets::HTTP_SERVER, "csrf failed: missing required header");
 
-        Err(PipelineError::CsrfPreventionFailed)
+        Err(ClientPipelineError::CsrfPreventionFailed.into())
     }
 }
 

--- a/bin/router/src/pipeline/demand_control/formula.rs
+++ b/bin/router/src/pipeline/demand_control/formula.rs
@@ -21,7 +21,7 @@ use tracing::warn;
 
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 
 /// Size overrides threaded from a parent @listSize(sizedFields:[…]) down to children.
 /// Each entry is (remaining path from the current selection, size expression).
@@ -305,10 +305,11 @@ fn eval_cost_expr(
                         "rejecting operation: expected exactly one slicing argument for @listSize"
                     );
 
-                    Err(PipelineError::CostInvalidSlicingArguments {
+                    Err(ClientPipelineError::CostInvalidSlicingArguments {
                         field_name: field_name.clone(),
                         found: resolved_count,
-                    })
+                    }
+                    .into())
                 }
             } else {
                 let mut max_value: Option<u64> = None;

--- a/bin/router/src/pipeline/demand_control/runtime.rs
+++ b/bin/router/src/pipeline/demand_control/runtime.rs
@@ -25,7 +25,7 @@ use http::{HeaderName, HeaderValue};
 use moka::future::Cache;
 use tracing::{debug, info, warn};
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 
 use super::formula::{
     compile_cost_expr_for_operation, evaluate_formula_plan, DemandControlFormulaPlan,
@@ -163,9 +163,10 @@ impl DemandControlRuntime {
                             .push((header_name.get_header_ref().to_owned(), max_cost.into()));
                     }
 
-                    return Err(PipelineError::CostEstimatedTooExpensive {
+                    return Err(ClientPipelineError::CostEstimatedTooExpensive {
                         response_headers: err_extra_headers,
-                    });
+                    }
+                    .into());
                 }
                 DemandControlMode::Measure => {
                     warn!(

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -6,7 +6,8 @@ use hive_console_sdk::expressions::{
     values::boolean::BooleanConversionError, ProgramResolutionError,
 };
 use hive_router_internal::http::ReadBodyStreamError;
-use hive_router_internal::telemetry::logging::summary;
+use hive_router_internal::telemetry::logging::{summary, targets};
+use hive_router_plan_executor::variables::VariableCoercionError;
 use hive_router_plan_executor::{
     coprocessor::CoprocessorError,
     execution::{
@@ -29,6 +30,7 @@ use ntex::{
     web::{self, error::QueryPayloadError, HttpRequest},
 };
 use strum::IntoStaticStr;
+use tracing::error;
 
 use crate::{
     jwt::errors::JwtError,
@@ -47,141 +49,115 @@ use crate::{
 
 pub type PipelineErrorAdditionalHeaders = Vec<(HeaderName, HeaderValue)>;
 
+/// Errors caused by the client's own request (bad input, unauthenticated/unauthorized,
+/// unsupported transport, etc).
+/// Their `Display` message is safe to return to the client as-is because it's derived only from client-controlled data.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
-pub enum PipelineError {
-    // HTTP-related errors
+pub enum ClientPipelineError {
     #[error("Unsupported HTTP method: {0}")]
     #[strum(serialize = "METHOD_NOT_ALLOWED")]
     UnsupportedHttpMethod(Method),
+
     #[error("Header '{0}' has invalid value")]
     #[strum(serialize = "INVALID_HEADER")]
     InvalidHeaderValue(HeaderName),
+
     #[error("Content-Type header is missing")]
     #[strum(serialize = "MISSING_CONTENT_TYPE_HEADER")]
     MissingContentTypeHeader,
+
     #[error("Content-Type header is not supported")]
     #[strum(serialize = "UNSUPPORTED_CONTENT_TYPE")]
     UnsupportedContentType,
+
     #[error("Request headers exceed the maximum allowed size")]
     #[strum(serialize = "REQUEST_HEADER_FIELDS_TOO_LARGE")]
     RequestHeadersTooLarge,
 
-    // GET Specific pipeline errors
     #[error("Missing query parameter: {0}")]
     #[strum(serialize = "MISSING_QUERY_PARAM")]
     GetMissingQueryParam(&'static str),
+
     #[error("Cannot perform mutations over GET")]
     #[strum(serialize = "MUTATION_NOT_ALLOWED_OVER_HTTP_GET")]
     MutationNotAllowedOverHttpGet,
+
     #[error("Failed to parse query parameters")]
     #[strum(serialize = "UNPROCESSABLE_QUERY_PARAMS")]
-    GetUnprocessableQueryParams(#[from] QueryPayloadError),
+    GetUnprocessableQueryParams(QueryPayloadError),
 
-    // GraphQL-specific errors
     #[error("Failed to parse GraphQL request payload")]
     #[strum(serialize = "BAD_REQUEST")]
     FailedToParseBody(sonic_rs::Error),
+
     #[error("Failed to parse GraphQL variables JSON")]
     #[strum(serialize = "BAD_REQUEST")]
     FailedToParseVariables(sonic_rs::Error),
+
     #[error("Failed to parse GraphQL extensions JSON")]
     #[strum(serialize = "BAD_REQUEST")]
     FailedToParseExtensions(sonic_rs::Error),
+
     #[error("Failed to parse GraphQL operation: {0}")]
     #[strum(serialize = "GRAPHQL_PARSE_FAILED")]
-    FailedToParseOperation(#[from] Arc<graphql_tools::parser::query::ParseError>),
+    FailedToParseOperation(Arc<graphql_tools::parser::query::ParseError>),
+
     #[error("Persisted document not found: {0}")]
     #[strum(serialize = "PERSISTED_DOCUMENT_NOT_FOUND")]
     PersistedDocumentNotFound(String),
+
     #[error("Persisted document id is required")]
     #[strum(serialize = "PERSISTED_DOCUMENT_ID_REQUIRED")]
     PersistedDocumentIdRequired,
+
     #[error("{0}")]
     #[strum(serialize = "PERSISTED_DOCUMENT_EXTRACTION_FAILED")]
     PersistedDocumentExtraction(String),
-    #[error("{0}")]
-    #[strum(serialize = "PERSISTED_DOCUMENT_RESOLUTION_FAILED")]
-    PersistedDocumentResolution(String),
-    #[error("Failed to evaluate persisted document require_id expression: {0}")]
-    #[strum(serialize = "PERSISTED_DOCUMENT_ID_EXPRESSION_EVALUATION_ERROR")]
-    PersistedDocumentIdExpressionEvaluationError(ProgramResolutionError<BooleanConversionError>),
-    #[error("Failed to minify parsed GraphQL operation: {0}")]
-    #[strum(serialize = "GRAPHQL_PARSE_MINIFY_FAILED")]
-    FailedToMinifyParsedOperation(String),
+
     #[error("Failed to normalize GraphQL operation")]
     #[strum(serialize = "OPERATION_RESOLUTION_FAILURE")]
-    NormalizationError(#[from] Arc<NormalizationError>),
-    #[error("Failed to collect GraphQL variables: {0}")]
+    NormalizationError(Arc<NormalizationError>),
+
+    #[error(transparent)]
     #[strum(serialize = "BAD_USER_INPUT")]
-    VariablesCoercionError(String),
+    VariablesCoercionError(VariableCoercionError),
+
     #[error("Validation errors")]
     #[strum(serialize = "GRAPHQL_VALIDATION_FAILED")]
     ValidationErrors(Arc<Vec<ValidationError>>),
+
     #[error("Authorization failed")]
     #[strum(serialize = "UNAUTHORIZED_OPERATION")]
     AuthorizationFailed(Vec<AuthorizationError>),
-    #[error("Failed to execute a plan: {0}")]
-    #[strum(serialize = "PLAN_EXECUTION_FAILED")]
-    PlanExecutionError(#[from] PlanExecutionError),
-    #[error("Failed to produce a plan: {0}")]
-    #[strum(serialize = "QUERY_PLAN_BUILD_FAILED")]
-    PlannerError(#[from] Arc<PlannerError>),
-    #[error(transparent)]
-    #[strum(serialize = "OVERRIDE_LABEL_EVALUATION_FAILED")]
-    LabelEvaluationError(#[from] LabelEvaluationError),
 
-    // HTTP Security-related errors
     #[error("Required CSRF header(s) not present")]
     #[strum(serialize = "CSRF_PREVENTION_FAILED")]
     CsrfPreventionFailed,
 
-    // JWT-auth plugin errors
     #[error(transparent)]
     #[strum(serialize = "JWT_ERROR")]
-    JwtError(#[from] JwtError),
-    #[error("Failed to forward jwt: {0}")]
-    #[strum(serialize = "JWT_FORWARDING_ERROR")]
-    JwtForwardingError(#[from] JwtForwardingError),
+    JwtError(JwtError),
 
-    // Introspection permission errors
-    #[error("Failed to evaluate introspection expression: {0}")]
-    #[strum(serialize = "INTROSPECTION_PERMISSION_EVALUATION_ERROR")]
-    IntrospectionPermissionEvaluationError(String),
     #[error("Introspection queries are disabled")]
     #[strum(serialize = "INTROSPECTION_DISABLED")]
     IntrospectionDisabled,
 
-    // Subscription-related errors
     #[error("Subscriptions are not supported")]
     #[strum(serialize = "SUBSCRIPTIONS_NOT_SUPPORTED")]
     SubscriptionsNotSupported,
+
     #[error("Subscriptions are not supported over accepted transport(s)")]
     #[strum(serialize = "SUBSCRIPTIONS_TRANSPORT_NOT_SUPPORTED")]
     SubscriptionsTransportNotSupported,
 
     #[error(transparent)]
     #[strum(serialize = "READ_BODY_STREAM_ERROR")]
-    ReadBodyStreamError(#[from] ReadBodyStreamError),
+    ReadBodyStreamError(ReadBodyStreamError),
 
     #[error("Request timed out")]
     #[strum(serialize = "GATEWAY_TIMEOUT")]
     TimeoutError,
 
-    #[error(transparent)]
-    #[strum(serialize = "HEADER_PROPAGATION_FAILURE")]
-    HeaderPropagation(#[from] HeaderRuleRuntimeError),
-
-    #[error("Failed to serialize the query plan: {0}")]
-    #[strum(serialize = "QUERY_PLAN_SERIALIZATION_FAILED")]
-    QueryPlanSerializationFailed(sonic_rs::Error),
-
-    #[error("No supergraph available yet, unable to process request")]
-    #[strum(serialize = "NO_SUPERGRAPH_AVAILABLE")]
-    NoSupergraphAvailable {
-        response_headers: PipelineErrorAdditionalHeaders,
-    },
-
-    // Demand Control
     #[error("Operation estimated cost exceeds max cost")]
     #[strum(serialize = "COST_ESTIMATED_TOO_EXPENSIVE")]
     CostEstimatedTooExpensive {
@@ -193,19 +169,164 @@ pub enum PipelineError {
     )]
     #[strum(serialize = "COST_INVALID_SLICING_ARGUMENTS")]
     CostInvalidSlicingArguments { field_name: String, found: usize },
+}
+
+/// Errors caused by a bug or infrastructure failure on the router's side.
+/// Their `Display` message may contain internal details (subgraph URLs, storage/network errors, VRL diagnostics) and
+/// must never reach the client - only the generic message from `graphql_error_message()`
+/// does. The real message is still logged for debugging purposes.
+#[derive(Debug, thiserror::Error, IntoStaticStr)]
+pub enum InternalPipelineError {
+    #[error("Failed to produce a plan: {0}")]
+    #[strum(serialize = "QUERY_PLAN_BUILD_FAILED")]
+    PlannerError(Arc<PlannerError>),
+
+    #[error("Failed to minify parsed GraphQL operation: {0}")]
+    #[strum(serialize = "GRAPHQL_PARSE_MINIFY_FAILED")]
+    FailedToMinifyParsedOperation(String),
+
+    #[error("No supergraph available yet, unable to process request")]
+    #[strum(serialize = "NO_SUPERGRAPH_AVAILABLE")]
+    NoSupergraphAvailable {
+        response_headers: PipelineErrorAdditionalHeaders,
+    },
+
+    #[error("Failed to execute a plan: {0}")]
+    #[strum(serialize = "PLAN_EXECUTION_FAILED")]
+    PlanExecutionError(PlanExecutionError),
 
     #[error(transparent)]
-    CoprocessorError(#[from] CoprocessorError),
+    #[strum(serialize = "OVERRIDE_LABEL_EVALUATION_FAILED")]
+    LabelEvaluationError(LabelEvaluationError),
+
+    #[error("Failed to forward jwt: {0}")]
+    #[strum(serialize = "JWT_FORWARDING_ERROR")]
+    JwtForwardingError(JwtForwardingError),
+
+    #[error("{0}")]
+    #[strum(serialize = "PERSISTED_DOCUMENT_RESOLUTION_FAILED")]
+    PersistedDocumentResolution(String),
+
+    #[error("Failed to evaluate persisted document require_id expression: {0}")]
+    #[strum(serialize = "PERSISTED_DOCUMENT_ID_EXPRESSION_EVALUATION_ERROR")]
+    PersistedDocumentIdExpressionEvaluationError(ProgramResolutionError<BooleanConversionError>),
+
+    #[error("Failed to evaluate introspection expression: {0}")]
+    #[strum(serialize = "INTROSPECTION_PERMISSION_EVALUATION_ERROR")]
+    IntrospectionPermissionEvaluationError(String),
+
+    #[error(transparent)]
+    #[strum(serialize = "HEADER_PROPAGATION_FAILURE")]
+    HeaderPropagation(HeaderRuleRuntimeError),
+
+    #[error("Failed to serialize the query plan: {0}")]
+    #[strum(serialize = "QUERY_PLAN_SERIALIZATION_FAILED")]
+    QueryPlanSerializationFailed(sonic_rs::Error),
+
+    #[error(transparent)]
+    CoprocessorError(CoprocessorError),
 
     #[error("Request context error")]
-    RequestContextError(#[from] RequestContextError),
+    RequestContextError(RequestContextError),
 
     #[error(transparent)]
-    OperationFilterFailed(#[from] OperationFilterError),
+    OperationFilterFailed(OperationFilterError),
 
     #[error("Supergraph runtime error")]
     #[strum(serialize = "SUPERGRAPH_RUNTIME_ERROR")]
-    RouterSupergraphRuntimeError(#[from] RouterSupergraphRuntimeError),
+    RouterSupergraphRuntimeError(RouterSupergraphRuntimeError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineError {
+    #[error(transparent)]
+    Client(ClientPipelineError),
+    #[error(transparent)]
+    Internal(InternalPipelineError),
+}
+
+impl From<ClientPipelineError> for PipelineError {
+    fn from(value: ClientPipelineError) -> Self {
+        PipelineError::Client(value)
+    }
+}
+
+impl From<InternalPipelineError> for PipelineError {
+    fn from(value: InternalPipelineError) -> Self {
+        PipelineError::Internal(value)
+    }
+}
+
+impl From<QueryPayloadError> for PipelineError {
+    fn from(value: QueryPayloadError) -> Self {
+        ClientPipelineError::GetUnprocessableQueryParams(value).into()
+    }
+}
+
+impl From<Arc<NormalizationError>> for PipelineError {
+    fn from(value: Arc<NormalizationError>) -> Self {
+        ClientPipelineError::NormalizationError(value).into()
+    }
+}
+
+impl From<JwtError> for PipelineError {
+    fn from(value: JwtError) -> Self {
+        ClientPipelineError::JwtError(value).into()
+    }
+}
+
+impl From<ReadBodyStreamError> for PipelineError {
+    fn from(value: ReadBodyStreamError) -> Self {
+        ClientPipelineError::ReadBodyStreamError(value).into()
+    }
+}
+
+impl From<Arc<PlannerError>> for PipelineError {
+    fn from(value: Arc<PlannerError>) -> Self {
+        InternalPipelineError::PlannerError(value).into()
+    }
+}
+
+impl From<PlanExecutionError> for PipelineError {
+    fn from(value: PlanExecutionError) -> Self {
+        InternalPipelineError::PlanExecutionError(value).into()
+    }
+}
+
+impl From<LabelEvaluationError> for PipelineError {
+    fn from(value: LabelEvaluationError) -> Self {
+        InternalPipelineError::LabelEvaluationError(value).into()
+    }
+}
+
+impl From<JwtForwardingError> for PipelineError {
+    fn from(value: JwtForwardingError) -> Self {
+        InternalPipelineError::JwtForwardingError(value).into()
+    }
+}
+
+impl From<CoprocessorError> for PipelineError {
+    fn from(value: CoprocessorError) -> Self {
+        InternalPipelineError::CoprocessorError(value).into()
+    }
+}
+
+impl From<RequestContextError> for PipelineError {
+    fn from(value: RequestContextError) -> Self {
+        InternalPipelineError::RequestContextError(value).into()
+    }
+}
+
+impl From<OperationFilterError> for PipelineError {
+    fn from(value: OperationFilterError) -> Self {
+        InternalPipelineError::OperationFilterFailed(value).into()
+    }
+}
+
+impl From<RouterSupergraphRuntimeError> for PipelineError {
+    fn from(value: RouterSupergraphRuntimeError) -> Self {
+        InternalPipelineError::RouterSupergraphRuntimeError(value).into()
+    }
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -221,50 +342,37 @@ pub enum ParserCacheError {
 impl From<Arc<ParserCacheError>> for PipelineError {
     fn from(value: Arc<ParserCacheError>) -> Self {
         match value.as_ref() {
-            ParserCacheError::ParseError(err) => PipelineError::FailedToParseOperation(err.clone()),
+            ParserCacheError::ParseError(err) => {
+                ClientPipelineError::FailedToParseOperation(err.clone()).into()
+            }
             ParserCacheError::MinifyError(err) => {
-                PipelineError::FailedToMinifyParsedOperation(err.clone())
+                InternalPipelineError::FailedToMinifyParsedOperation(err.clone()).into()
             }
             ParserCacheError::ValidationErrors(errs) => {
-                PipelineError::ValidationErrors(errs.clone())
+                ClientPipelineError::ValidationErrors(errs.clone()).into()
             }
         }
     }
 }
 
-impl PipelineError {
-    pub fn additional_response_headers(&self) -> Option<&Vec<(HeaderName, HeaderValue)>> {
+impl ClientPipelineError {
+    fn additional_response_headers(&self) -> Option<&PipelineErrorAdditionalHeaders> {
         match self {
-            PipelineError::CostEstimatedTooExpensive { response_headers } => Some(response_headers),
-            PipelineError::NoSupergraphAvailable { response_headers } => Some(response_headers),
+            Self::CostEstimatedTooExpensive { response_headers } => Some(response_headers),
             _ => None,
         }
     }
 
-    pub fn graphql_error_code(&self) -> &'static str {
+    fn graphql_error_code(&self) -> &'static str {
         match self {
             Self::JwtError(err) => err.error_code(),
-            Self::PlanExecutionError(err) => err.error_code(),
             Self::ReadBodyStreamError(err) => err.error_code(),
-            Self::CoprocessorError(err) => err.error_code(),
             _ => self.into(),
         }
     }
 
-    pub fn graphql_error_message(&self) -> String {
-        match self {
-            Self::PlannerError(_) => "Unexpected error".to_string(),
-            Self::CoprocessorError(_) => "Internal server error".to_string(),
-            _ => self.to_string(),
-        }
-    }
-
-    pub fn default_status_code(&self, prefer_ok: bool) -> StatusCode {
+    fn default_status_code(&self, prefer_ok: bool) -> StatusCode {
         match (self, prefer_ok) {
-            (Self::PlannerError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::PlanExecutionError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::LabelEvaluationError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::JwtForwardingError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
             (Self::UnsupportedHttpMethod(_), _) => StatusCode::METHOD_NOT_ALLOWED,
             (Self::InvalidHeaderValue(_), _) => StatusCode::BAD_REQUEST,
             (Self::GetUnprocessableQueryParams(_), _) => StatusCode::BAD_REQUEST,
@@ -278,14 +386,8 @@ impl PipelineError {
             (Self::PersistedDocumentIdRequired, true) => StatusCode::OK,
             (Self::PersistedDocumentExtraction(_), false) => StatusCode::BAD_REQUEST,
             (Self::PersistedDocumentExtraction(_), true) => StatusCode::OK,
-            (Self::PersistedDocumentResolution(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::PersistedDocumentIdExpressionEvaluationError(_), _) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
             (Self::FailedToParseOperation(_), false) => StatusCode::BAD_REQUEST,
             (Self::FailedToParseOperation(_), true) => StatusCode::OK,
-            (Self::FailedToMinifyParsedOperation(_), false) => StatusCode::BAD_REQUEST,
-            (Self::FailedToMinifyParsedOperation(_), true) => StatusCode::OK,
             (Self::NormalizationError(_), _) => StatusCode::BAD_REQUEST,
             (Self::VariablesCoercionError(_), false) => StatusCode::BAD_REQUEST,
             (Self::VariablesCoercionError(_), true) => StatusCode::OK,
@@ -302,23 +404,70 @@ impl PipelineError {
             (Self::RequestHeadersTooLarge, _) => StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             (Self::CsrfPreventionFailed, _) => StatusCode::FORBIDDEN,
             (Self::JwtError(err), _) => err.status_code(),
-            (Self::IntrospectionPermissionEvaluationError(_), _) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
             (Self::IntrospectionDisabled, _) => StatusCode::FORBIDDEN,
             (Self::SubscriptionsNotSupported, _) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             (Self::SubscriptionsTransportNotSupported, _) => StatusCode::NOT_ACCEPTABLE,
             (Self::ReadBodyStreamError(err), _) => err.status_code(),
             (Self::TimeoutError, _) => StatusCode::GATEWAY_TIMEOUT,
-            (Self::HeaderPropagation(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::QueryPlanSerializationFailed(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
-            (Self::NoSupergraphAvailable { .. }, _) => StatusCode::SERVICE_UNAVAILABLE,
-            (Self::CoprocessorError(err), _) => err.status_code(),
-            (Self::RequestContextError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
 
-            (Self::OperationFilterFailed(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
+impl InternalPipelineError {
+    fn additional_response_headers(&self) -> Option<&PipelineErrorAdditionalHeaders> {
+        match self {
+            Self::NoSupergraphAvailable { response_headers } => Some(response_headers),
+            _ => None,
+        }
+    }
 
-            (Self::RouterSupergraphRuntimeError(_), _) => StatusCode::INTERNAL_SERVER_ERROR,
+    fn graphql_error_code(&self) -> &'static str {
+        match self {
+            Self::PlanExecutionError(err) => err.error_code(),
+            Self::CoprocessorError(err) => err.error_code(),
+            _ => self.into(),
+        }
+    }
+
+    fn default_status_code(&self, prefer_ok: bool) -> StatusCode {
+        match self {
+            Self::NoSupergraphAvailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            _ if prefer_ok => StatusCode::OK,
+            Self::CoprocessorError(e) => e.status_code(),
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl PipelineError {
+    pub fn additional_response_headers(&self) -> Option<&PipelineErrorAdditionalHeaders> {
+        match self {
+            Self::Client(err) => err.additional_response_headers(),
+            Self::Internal(err) => err.additional_response_headers(),
+        }
+    }
+
+    pub fn graphql_error_code(&self) -> &'static str {
+        match self {
+            Self::Client(err) => err.graphql_error_code(),
+            Self::Internal(err) => err.graphql_error_code(),
+        }
+    }
+
+    /// The message returned to the client.
+    ///
+    /// Internal errors always get a generic message - their real `Display` is only ever logged, never serialized to the client.
+    pub fn graphql_error_message(&self) -> String {
+        match self {
+            Self::Client(err) => err.to_string(),
+            Self::Internal(_) => "Internal server error".to_string(),
+        }
+    }
+
+    pub fn default_status_code(&self, prefer_ok: bool) -> StatusCode {
+        match self {
+            Self::Client(err) => err.default_status_code(prefer_ok),
+            Self::Internal(err) => err.default_status_code(prefer_ok),
         }
     }
 }
@@ -330,9 +479,15 @@ pub fn handle_pipeline_error(
     shared_state: &RouterSharedState,
     response_mode: &ResponseMode,
 ) -> web::HttpResponse {
+    if let PipelineError::Internal(inner) = &err {
+        error!(target: targets::CORE, error = %inner, "internal pipeline error");
+    }
+
     let error_count = match &err {
-        PipelineError::ValidationErrors(errors) => errors.len() as u32,
-        PipelineError::AuthorizationFailed(errors) => errors.len() as u32,
+        PipelineError::Client(ClientPipelineError::ValidationErrors(errors)) => errors.len() as u32,
+        PipelineError::Client(ClientPipelineError::AuthorizationFailed(errors)) => {
+            errors.len() as u32
+        }
         _ => 1,
     };
 
@@ -358,15 +513,17 @@ pub fn handle_pipeline_error(
         }
     }
 
-    let mut errors = match err {
-        PipelineError::ValidationErrors(ref validation_errors) => {
+    let mut errors = match &err {
+        PipelineError::Client(ClientPipelineError::ValidationErrors(validation_errors)) => {
             validation_errors.iter().map(|error| error.into()).collect()
         }
-        PipelineError::AuthorizationFailed(ref authorization_errors) => authorization_errors
-            .iter()
-            .map(|error| error.into())
-            .collect(),
-        PipelineError::CostEstimatedTooExpensive { .. } => {
+        PipelineError::Client(ClientPipelineError::AuthorizationFailed(authorization_errors)) => {
+            authorization_errors
+                .iter()
+                .map(|error| error.into())
+                .collect()
+        }
+        PipelineError::Client(ClientPipelineError::CostEstimatedTooExpensive { .. }) => {
             vec![GraphQLError::from_message_and_code(
                 err.graphql_error_message(),
                 "COST_ESTIMATED_TOO_EXPENSIVE",

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -1,4 +1,4 @@
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{InternalPipelineError, PipelineError};
 use crate::pipeline::normalize::GraphQLNormalizationPayload;
 use crate::schema_state::SelectedSupergraph;
 use crate::shared_state::RouterSharedState;
@@ -94,7 +94,7 @@ pub async fn execute_plan<'exec>(
             let body = sonic_rs::to_vec(&json!({
                 "extensions": extensions,
             }))
-            .map_err(PipelineError::QueryPlanSerializationFailed)?;
+            .map_err(InternalPipelineError::QueryPlanSerializationFailed)?;
 
             return Ok(QueryPlanExecutionResult::Single(PlanExecutionOutput {
                 body,

--- a/bin/router/src/pipeline/execution_request.rs
+++ b/bin/router/src/pipeline/execution_request.rs
@@ -20,7 +20,7 @@ use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, Visitor};
 use std::sync::Arc;
 use tracing::{debug, warn};
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, InternalPipelineError, PipelineError};
 use crate::pipeline::header::SingleContentType;
 use crate::pipeline::persisted_documents::extract::{
     DocumentIdResolver, DocumentIdResolverInput, HttpRequestContext, DOCUMENT_ID_FIELD,
@@ -257,7 +257,7 @@ impl TryInto<GraphQLParams> for GraphQLGetInput {
             Some(v_str) if !v_str.is_empty() => match sonic_rs::from_str(v_str) {
                 Ok(vars) => vars,
                 Err(e) => {
-                    return Err(PipelineError::FailedToParseVariables(e));
+                    return Err(ClientPipelineError::FailedToParseVariables(e).into());
                 }
             },
             _ => HashMap::new(),
@@ -267,7 +267,7 @@ impl TryInto<GraphQLParams> for GraphQLGetInput {
             Some(e_str) if !e_str.is_empty() => match sonic_rs::from_str(e_str) {
                 Ok(exts) => Some(exts),
                 Err(e) => {
-                    return Err(PipelineError::FailedToParseExtensions(e));
+                    return Err(ClientPipelineError::FailedToParseExtensions(e).into());
                 }
             },
             _ => None,
@@ -292,7 +292,7 @@ impl GetQueryStr for GraphQLParams {
     fn get_query(&self) -> Result<&str, PipelineError> {
         self.query
             .as_deref()
-            .ok_or(PipelineError::GetMissingQueryParam("query"))
+            .ok_or(ClientPipelineError::GetMissingQueryParam("query").into())
     }
 }
 
@@ -454,9 +454,7 @@ impl<'a> OperationPreparation<'a> {
             _ => {
                 warn!(target: targets::HTTP_SERVER, method = ?self.req.method(), "unsupported HTTP method");
 
-                Err(PipelineError::UnsupportedHttpMethod(
-                    self.req.method().to_owned(),
-                ))
+                Err(ClientPipelineError::UnsupportedHttpMethod(self.req.method().to_owned()).into())
             }
         }
     }
@@ -484,7 +482,7 @@ impl<'a> OperationPreparation<'a> {
             Some(value) => {
                 let content_type_str = value
                     .to_str()
-                    .map_err(|_| PipelineError::InvalidHeaderValue(CONTENT_TYPE))?;
+                    .map_err(|_| ClientPipelineError::InvalidHeaderValue(CONTENT_TYPE))?;
                 if !content_type_str.contains(SingleContentType::JSON.as_ref()) {
                     warn!(
                         target: targets::HTTP_SERVER,
@@ -492,13 +490,13 @@ impl<'a> OperationPreparation<'a> {
                         "invalid content type on a POST request",
                     );
 
-                    return Err(PipelineError::UnsupportedContentType);
+                    return Err(ClientPipelineError::UnsupportedContentType.into());
                 }
             }
             None => {
                 warn!(target: targets::HTTP_SERVER, "POST without content type detected");
 
-                return Err(PipelineError::MissingContentTypeHeader);
+                return Err(ClientPipelineError::MissingContentTypeHeader.into());
             }
         }
 
@@ -507,7 +505,7 @@ impl<'a> OperationPreparation<'a> {
         let post_input =
             GraphQLPostBodySeed::new(&self.persisted_documents_runtime.document_id_resolver)
                 .deserialize(&mut deserializer)
-                .map_err(PipelineError::FailedToParseBody)?;
+                .map_err(ClientPipelineError::FailedToParseBody)?;
 
         // Calling end() is important to ensure there is no trailing garbage after the JSON payload.
         // Without calling it, this might be accepted:
@@ -516,7 +514,7 @@ impl<'a> OperationPreparation<'a> {
         // {"query":"{ me { id } }"}{"another":"object"}
         deserializer
             .end()
-            .map_err(PipelineError::FailedToParseBody)?;
+            .map_err(ClientPipelineError::FailedToParseBody)?;
 
         Ok(PreparedOperation::from_post(
             post_input,
@@ -557,7 +555,7 @@ impl<'a> OperationPreparation<'a> {
                 // If require_id is set, clear the query to make the document ID-based resolution mandatory.
                 prepared_operation.graphql_params.query = None;
                 if prepared_operation.resolved_document_id.is_none() {
-                    return Err(PipelineError::PersistedDocumentIdRequired);
+                    return Err(ClientPipelineError::PersistedDocumentIdRequired.into());
                 }
                 return Ok(());
             }
@@ -583,7 +581,7 @@ impl<'a> OperationPreparation<'a> {
                 .persisted_document_resolver
                 .as_ref()
                 .ok_or_else(|| {
-                    PipelineError::PersistedDocumentResolution(
+                    InternalPipelineError::PersistedDocumentResolution(
                         "Persisted documents storage is not configured".to_string(),
                     )
                 })?;
@@ -623,7 +621,7 @@ mod tests {
     use ntex::web::HttpRequest;
 
     use super::{OperationPreparation, PreparedOperation};
-    use crate::pipeline::error::PipelineError;
+    use crate::pipeline::error::{ClientPipelineError, PipelineError};
     use crate::pipeline::persisted_documents::extract::DocumentIdResolver;
     use crate::pipeline::persisted_documents::resolve::{
         PersistedDocumentResolveInput, PersistedDocumentResolver, PersistedDocumentResolverError,
@@ -767,7 +765,10 @@ mod tests {
             .enforce_require_id_policy(&mut op)
             .expect_err("missing id should fail");
 
-        assert!(matches!(err, PipelineError::PersistedDocumentIdRequired));
+        assert!(matches!(
+            err,
+            PipelineError::Client(ClientPipelineError::PersistedDocumentIdRequired)
+        ));
     }
 
     #[test]
@@ -937,6 +938,9 @@ mod tests {
             .enforce_require_id_policy(&mut op)
             .expect_err("skip_enforcement=false should still enforce require_id");
 
-        assert!(matches!(err, PipelineError::PersistedDocumentIdRequired));
+        assert!(matches!(
+            err,
+            PipelineError::Client(ClientPipelineError::PersistedDocumentIdRequired)
+        ));
     }
 }

--- a/bin/router/src/pipeline/header.rs
+++ b/bin/router/src/pipeline/header.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use strum::{AsRefStr, EnumIter, EnumString, IntoEnumIterator, IntoStaticStr};
 use tracing::warn;
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 
 /// Non-GraphQL content type, used to detect if the client can accept Laboratory responses.
 pub const TEXT_HTML_MIME: &str = "text/html";
@@ -262,7 +262,7 @@ impl RequestAccepts for HttpRequest {
         let accept = Accept::from_str(accept_header).map_err(|err| {
             warn!(target: targets::HTTP_SERVER, error = ?err, "failed to parse Accept header");
 
-            PipelineError::InvalidHeaderValue(ACCEPT)
+            ClientPipelineError::InvalidHeaderValue(ACCEPT)
         })?;
 
         // strip multipart/mixed boundaries before negotiation since the server chooses the response boundary
@@ -317,7 +317,7 @@ impl RequestAccepts for HttpRequest {
             // at this point we treat no content type as "user explicitly does not support any known types"
             // this is because only empty accept header or */* is treated as "accept everything" and we check
             // that above
-            (None, None) => Err(PipelineError::UnsupportedContentType),
+            (None, None) => Err(ClientPipelineError::UnsupportedContentType.into()),
         }
     }
 }
@@ -481,7 +481,12 @@ mod tests {
             .to_http_request();
         let result = request.negotiate(false);
         assert!(
-            matches!(result, Err(PipelineError::UnsupportedContentType)),
+            matches!(
+                result,
+                Err(PipelineError::Client(
+                    ClientPipelineError::UnsupportedContentType
+                ))
+            ),
             "expected UnsupportedContentType, got {:?}",
             result
         );

--- a/bin/router/src/pipeline/introspection_policy.rs
+++ b/bin/router/src/pipeline/introspection_policy.rs
@@ -9,7 +9,7 @@ use hive_router_plan_executor::execution::client_request_details::ClientRequestD
 use tracing::warn;
 use vrl::core::Value as VrlValue;
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, InternalPipelineError, PipelineError};
 
 pub fn compile_introspection_policy(
     introspection_policy_cfg: &Option<IntrospectionPermissionConfig>,
@@ -37,7 +37,9 @@ pub fn handle_introspection_policy(
 
             VrlValue::Object(context_map)
         })
-        .map_err(|e| PipelineError::IntrospectionPermissionEvaluationError(e.to_string()))?;
+        .map_err(|e| {
+            InternalPipelineError::IntrospectionPermissionEvaluationError(e.to_string())
+        })?;
 
     if !is_enabled {
         warn!(
@@ -45,7 +47,7 @@ pub fn handle_introspection_policy(
             "graphql request rejected because introspection is disabled"
         );
 
-        Err(PipelineError::IntrospectionDisabled)
+        Err(ClientPipelineError::IntrospectionDisabled.into())
     } else {
         Ok(())
     }

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -58,7 +58,7 @@ use crate::{
         client_identification::identify_client,
         coerce_variables::coerce_request_variables,
         csrf_prevention::perform_csrf_prevention,
-        error::PipelineError,
+        error::{ClientPipelineError, InternalPipelineError, PipelineError},
         execution::{execute_plan, PlannedRequest},
         execution_request::{GetQueryStr, OperationPreparation, OperationPreparationResult},
         header::{RequestAccepts, ResponseMode, TEXT_HTML_MIME},
@@ -169,7 +169,7 @@ pub async fn graphql_request_handler(
             // drain a small amount of the body so the connection can be closed
             // cleanly instead of being reset (see `read_body_stream`)
             drain_body_stream(&mut body_stream).await;
-            return Err(PipelineError::RequestHeadersTooLarge);
+            return Err(ClientPipelineError::RequestHeadersTooLarge.into());
         }
 
         perform_csrf_prevention(req, &shared_state.router_config.csrf)?;
@@ -280,9 +280,10 @@ pub async fn graphql_request_handler(
         );
 
         let Some(supergraph) = schema_state.select_supergraph(req)? else {
-            return Err(PipelineError::NoSupergraphAvailable {
+            return Err(InternalPipelineError::NoSupergraphAvailable {
                 response_headers: vec![(RETRY_AFTER, HeaderValue::from_static("10"))],
-            });
+            }
+            .into());
         };
 
         summary::record(|s| s.set_supergraph_identifier(supergraph.snapshot.cache_id));
@@ -384,7 +385,7 @@ pub async fn graphql_request_handler(
                     "Mutation is not allowed over GET, stopping"
                 );
 
-                return Err(PipelineError::MutationNotAllowedOverHttpGet);
+                return Err(ClientPipelineError::MutationNotAllowedOverHttpGet.into());
             }
         }
 
@@ -397,7 +398,7 @@ pub async fn graphql_request_handler(
             && (!shared_state.router_config.subscriptions.enabled || !response_mode.can_stream())
         {
             // check early, even though we check again planned execution below
-            return Err(PipelineError::SubscriptionsNotSupported);
+            return Err(ClientPipelineError::SubscriptionsNotSupported.into());
         }
 
         // subscriptions over HTTP hold a streaming response open, so they count
@@ -638,7 +639,7 @@ pub async fn execute_planned_request<'exec>(
             // might choose to not deduplicate across transport boundaries
             let stream_content_type = response_mode
                 .stream_content_type()
-                .ok_or(PipelineError::SubscriptionsTransportNotSupported)?;
+                .ok_or(ClientPipelineError::SubscriptionsTransportNotSupported)?;
 
             let (producer_handle, receiver) = shared_state.active_subscriptions.register(guard);
 
@@ -701,7 +702,7 @@ pub async fn execute_planned_request<'exec>(
             let single_content_type = response_mode.
                 single_content_type().
                 // TODO: streaming single responses
-                ok_or(PipelineError::UnsupportedContentType)?.
+                ok_or(ClientPipelineError::UnsupportedContentType)?.
                 clone();
 
             // drop the `guard` as soon as the response is ready

--- a/bin/router/src/pipeline/parser.rs
+++ b/bin/router/src/pipeline/parser.rs
@@ -24,7 +24,7 @@ use hive_router_query_planner::utils::parsing::{
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::cache_state::{CacheHitMiss, EntryResultHitMissExt};
-use crate::pipeline::error::{ParserCacheError, PipelineError};
+use crate::pipeline::error::{InternalPipelineError, ParserCacheError, PipelineError};
 use crate::pipeline::execution_request::GetQueryStr;
 use crate::shared_state::RouterSharedState;
 use tracing::{debug, error, warn, Instrument};
@@ -45,7 +45,7 @@ impl ParseCacheEntry {
         let minified_arc = {
             Arc::new(minify_query(query_str).map_err(|err| {
                 error!(target: targets::GRAPHQL_PARSING, error = ?err, "failed to minify parsed GraphQL operation");
-                PipelineError::FailedToMinifyParsedOperation(err.to_string())
+                InternalPipelineError::FailedToMinifyParsedOperation(err.to_string())
             })?)
         };
         let hive_normalized_operation = hive_sdk_normalize_operation(&parsed_arc);
@@ -56,7 +56,7 @@ impl ParseCacheEntry {
                     error = ?err,
                     "failed to minify GraphQL operation normalized for Hive SDK"
                 );
-                PipelineError::FailedToMinifyParsedOperation(err.to_string())
+                InternalPipelineError::FailedToMinifyParsedOperation(err.to_string())
             })?;
         Ok(ParseCacheEntry {
             document: parsed_arc,

--- a/bin/router/src/pipeline/persisted_documents/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/mod.rs
@@ -10,7 +10,7 @@ use hive_router_internal::expressions::{ToVrlValue, ValueOrProgram};
 use hive_router_plan_executor::execution::client_request_details::ntex_header_map_to_vrl_value;
 use ntex::web::HttpRequest;
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{InternalPipelineError, PipelineError};
 use crate::pipeline::persisted_documents::extract::DocumentIdResolver;
 use crate::pipeline::persisted_documents::resolve::storage::{
     StorageManifestReloadTask, StorageResolver,
@@ -130,7 +130,8 @@ impl PersistedDocumentsRuntime {
     }
 
     pub fn require_id(&self, request: &HttpRequest) -> Result<bool, PipelineError> {
-        self.require_id
+        let require_id = self
+            .require_id
             .resolve_with_hints(|hints| {
                 hints.context_builder(|root| {
                     root.insert_object("request", |req| {
@@ -142,6 +143,8 @@ impl PersistedDocumentsRuntime {
                     });
                 })
             })
-            .map_err(PipelineError::PersistedDocumentIdExpressionEvaluationError)
+            .map_err(InternalPipelineError::PersistedDocumentIdExpressionEvaluationError)?;
+
+        Ok(require_id)
     }
 }

--- a/bin/router/src/pipeline/persisted_documents/resolve/mod.rs
+++ b/bin/router/src/pipeline/persisted_documents/resolve/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, InternalPipelineError, PipelineError};
 use crate::pipeline::persisted_documents::resolve::shared_file_manifest::FileManifestError;
 use crate::pipeline::persisted_documents::types::{ClientIdentity, PersistedDocumentId};
 use crate::storage::error::StorageError;
@@ -46,14 +46,14 @@ impl From<PersistedDocumentResolverError> for PipelineError {
     fn from(value: PersistedDocumentResolverError) -> Self {
         match value {
             PersistedDocumentResolverError::NotFound(document_id) => {
-                PipelineError::PersistedDocumentNotFound(document_id)
+                ClientPipelineError::PersistedDocumentNotFound(document_id).into()
             }
             PersistedDocumentResolverError::Hive(HiveResolverError::InvalidDocumentIdFormat(_))
             | PersistedDocumentResolverError::Hive(HiveResolverError::ClientIdentityMissing)
             | PersistedDocumentResolverError::Hive(HiveResolverError::ClientIdentityPartial) => {
-                PipelineError::PersistedDocumentExtraction(value.to_string())
+                ClientPipelineError::PersistedDocumentExtraction(value.to_string()).into()
             }
-            other => PipelineError::PersistedDocumentResolution(other.to_string()),
+            other => InternalPipelineError::PersistedDocumentResolution(other.to_string()).into(),
         }
     }
 }

--- a/bin/router/src/pipeline/timeout.rs
+++ b/bin/router/src/pipeline/timeout.rs
@@ -6,7 +6,10 @@ use ntex::{
     web,
 };
 
-use crate::{pipeline::error::PipelineError, RouterSharedState};
+use crate::{
+    pipeline::error::{ClientPipelineError, PipelineError},
+    RouterSharedState,
+};
 
 #[inline]
 pub async fn handle_timeout<TFuture: Future<Output = Result<web::HttpResponse, PipelineError>>>(
@@ -23,7 +26,7 @@ pub async fn handle_timeout<TFuture: Future<Output = Result<web::HttpResponse, P
 
     match select(timeout, res_fut).await {
         // If the timeout future completes first, return a timeout error response.
-        Either::Left(_) => Err(PipelineError::TimeoutError),
+        Either::Left(_) => Err(ClientPipelineError::TimeoutError.into()),
         // If the request handler future completes first, return its response.
         Either::Right(res) => res,
     }

--- a/bin/router/src/pipeline/validation/mod.rs
+++ b/bin/router/src/pipeline/validation/mod.rs
@@ -2,7 +2,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::cache_state::{CacheHitMiss, EntryValueHitMissExt};
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 use crate::pipeline::parser::GraphQLParserPayload;
 use crate::schema_state::SelectedSupergraph;
 use crate::shared_state::RouterSharedState;
@@ -154,7 +154,7 @@ pub async fn validate_operation_with_cache(
             warn!(target: targets::GRAPHQL_VALIDATION, total_errors = errors.len(), "GraphQL validation failed");
             debug!(target: targets::GRAPHQL_VALIDATION, errors = ?errors, document = %validation_operation, "validation errors");
 
-            return Err(PipelineError::ValidationErrors(errors));
+            return Err(ClientPipelineError::ValidationErrors(errors).into());
         }
 
         Ok(None)

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -38,7 +38,7 @@ use hive_router_query_planner::state::supergraph_state::OperationKind;
 
 use crate::jwt::errors::JwtError;
 use crate::pipeline::active_subscriptions::SubscriptionEvent;
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 use crate::pipeline::execute_planned_request;
 use crate::pipeline::header::{ResponseMode, SingleContentType, StreamContentType};
 use crate::pipeline::{
@@ -497,7 +497,7 @@ async fn handle_text_frame(
                   );
 
                   if is_subscription && !shared_state.router_config.subscriptions.enabled {
-                      return Some(PipelineError::SubscriptionsNotSupported.into_server_message(&id, shared_state));
+                      return Some(PipelineError::from(ClientPipelineError::SubscriptionsNotSupported).into_server_message(&id, shared_state));
                   }
 
                   let request_dedupe_enabled =
@@ -599,7 +599,7 @@ async fn handle_text_frame(
                       };
                       let (shared_response, _role) = match result {
                           Ok(result) => result,
-                          Err(PipelineError::JwtError(err)) => {
+                          Err(PipelineError::Client(ClientPipelineError::JwtError(err))) => {
                               let _ = sink.send(err.clone().into_server_message(&id, shared_state)).await;
                               // we report error as graphql error, but we also close the
                               // connection since we're dealing with auth so let's be safe
@@ -611,7 +611,7 @@ async fn handle_text_frame(
                   } else {
                       match exec(None).await {
                           Ok(result) => result,
-                          Err(PipelineError::JwtError(err)) => {
+                          Err(PipelineError::Client(ClientPipelineError::JwtError(err))) => {
                               let _ = sink.send(err.clone().into_server_message(&id, shared_state)).await;
                               // we report error as graphql error, but we also close the
                               // connection since we're dealing with auth so let's be safe

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -39,7 +39,7 @@ use crate::jwt::context::JwtTokenPayload;
 use crate::jwt::JwtAuthRuntime;
 use crate::pipeline::active_subscriptions::{ActiveSubscriptions, SubscriptionEvent};
 use crate::pipeline::cors::{CORSConfigError, Cors};
-use crate::pipeline::error::PipelineError;
+use crate::pipeline::error::{ClientPipelineError, PipelineError};
 use crate::pipeline::header::{ResponseMode, StreamContentType};
 use crate::pipeline::introspection_policy::compile_introspection_policy;
 use crate::pipeline::long_lived_client_limit::LongLivedClientGuard;
@@ -128,7 +128,7 @@ impl SharedRouterResponse {
             SharedRouterResponse::Stream(stream) => {
                 let stream_content_type = response_mode
                     .stream_content_type()
-                    .ok_or(PipelineError::SubscriptionsTransportNotSupported)?;
+                    .ok_or(ClientPipelineError::SubscriptionsTransportNotSupported)?;
                 Ok(stream.into_response(stream_content_type, metrics, long_lived_client_guard))
             }
         }

--- a/e2e/src/error_handling.rs
+++ b/e2e/src/error_handling.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod error_handling_e2e_tests {
-    use crate::testkit::{ClientResponseExt, ResponseLike, TestRouter, TestSubgraphs};
+    use crate::testkit::{
+        coprocessor::TestCoprocessor, ClientResponseExt, ResponseLike, TestRouter, TestSubgraphs,
+    };
 
     #[ntex::test]
     async fn should_continue_execution_when_a_subgraph_is_down() {
@@ -665,5 +667,109 @@ mod error_handling_e2e_tests {
         }
         "#
         );
+    }
+
+    #[ntex::test]
+    async fn should_return_full_message_for_a_client_caused_error() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#
+                .to_string(),
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ i bad query", None, None)
+            .await;
+
+        assert_eq!(
+            res.status().as_u16(),
+            400,
+            "client-caused errors keep their real HTTP status"
+        );
+
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "errors": [
+            {
+              "message": "Failed to parse GraphQL operation: Parse error at 1:14\nUnexpected end of input\nExpected }\n",
+              "extensions": {
+                "code": "GRAPHQL_PARSE_FAILED"
+              }
+            }
+          ]
+        }
+        "#
+        );
+    }
+
+    #[ntex::test]
+    async fn should_return_generic_message_for_an_internal_error() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let mut coprocessor = TestCoprocessor::new().await;
+        let host = coprocessor.host_with_port();
+
+        let request_stage_mock = coprocessor
+            .mock_stage("graphql.request")
+            .with_status(500)
+            .with_body("some sensitive internal coprocessor failure detail")
+            .expect(1)
+            .create();
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: supergraph.graphql
+                  coprocessor:
+                    url: http://{host}/coprocessor
+                    protocol: http1
+                    stages:
+                      graphql:
+                        request:
+                          include:
+                            body: [query]
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ topProducts { name } }", None, None)
+            .await;
+
+        assert_eq!(res.status().as_u16(), 500, "internal errors return 500");
+
+        insta::assert_snapshot!(
+            res.json_body_string_pretty().await,
+            @r#"
+        {
+          "errors": [
+            {
+              "message": "Internal server error",
+              "extensions": {
+                "code": "COPROCESSOR_UNEXPECTED_STATUS"
+              }
+            }
+          ]
+        }
+        "#
+        );
+
+        request_stage_mock.assert_async().await;
     }
 }

--- a/lib/executor/src/coprocessor/error.rs
+++ b/lib/executor/src/coprocessor/error.rs
@@ -135,6 +135,7 @@ impl CoprocessorError {
         // This way we won't leak anything to the client.
         ntex::http::StatusCode::INTERNAL_SERVER_ERROR
     }
+
     pub fn error_code(&self) -> &'static str {
         self.into()
     }

--- a/lib/executor/src/variables/mod.rs
+++ b/lib/executor/src/variables/mod.rs
@@ -5,50 +5,87 @@ use sonic_rs::{JsonNumberTrait, Value, ValueRef};
 
 use crate::introspection::schema::SchemaMetadata;
 
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum VariableCoercionError {
+    #[error("Variable \"${name}\" of required type \"{type_name}\" was not provided.")]
+    MissingNonNullableVariable { name: String, type_name: String },
+
+    #[error("Expected value of non-null type \"{type_name}\" not to be null.")]
+    UnexpectedNull { type_name: String },
+
+    #[error("Value \"{value}\" does not exist in \"{type_name}\" enum.")]
+    InvalidEnumValue { value: String, type_name: String },
+
+    #[error("Enum \"{type_name}\" cannot represent non-string value: {value}.")]
+    ExpectedEnumString { type_name: String, value: String },
+
+    #[error("Expected value of type \"{type_name}\" to include required field \"{field_name}\".")]
+    MissingField {
+        field_name: String,
+        type_name: String,
+    },
+
+    #[error("Expected value of type \"{type_name}\" to be an object, found: {value}.")]
+    ExpectedObject { type_name: String, value: String },
+
+    #[error("String cannot represent a non string value: {value}.")]
+    ExpectedString { value: String },
+
+    #[error("ID cannot represent value: {value}.")]
+    ExpectedId { value: String },
+
+    #[error("Int cannot represent non-integer value: {value}.")]
+    ExpectedInteger { value: String },
+
+    #[error("Float cannot represent non numeric value: {value}.")]
+    ExpectedFloat { value: String },
+
+    #[error("Boolean cannot represent a non boolean value: {value}.")]
+    ExpectedBoolean { value: String },
+}
+
 #[inline]
 pub fn collect_variables(
     operation: &hive_router_query_planner::ast::operation::OperationDefinition,
     variables_map: &mut HashMap<String, Value>,
     schema_metadata: &SchemaMetadata,
-) -> Result<Option<HashMap<String, Value>>, String> {
+) -> Result<Option<HashMap<String, Value>>, VariableCoercionError> {
     if operation.variable_definitions.is_none() {
         return Ok(None);
     }
     let variable_definitions = operation.variable_definitions.as_ref().unwrap();
 
-    let collected_variables: Result<Vec<Option<(String, Value)>>, String> = variable_definitions
-        .iter()
-        .map(|variable_definition| {
-            let variable_name = variable_definition.name.as_str();
-            if let Some(variable_value) = variables_map.remove(variable_name) {
-                validate_runtime_value(
-                    variable_value.as_ref(),
-                    &variable_definition.variable_type,
-                    schema_metadata,
-                )?;
-                return Ok(Some((variable_name.to_string(), variable_value)));
-            }
-            if let Some(default_value) = &variable_definition.default_value {
-                // Assuming value_from_ast now returns Result<Value, String> or similar
-                // and needs to be adapted if it returns Option or panics.
-                // For now, let's assume it can return an Err that needs to be propagated.
-                let default_value_coerced: Value = default_value.into();
-                validate_runtime_value(
-                    default_value_coerced.as_ref(),
-                    &variable_definition.variable_type,
-                    schema_metadata,
-                )?;
-                return Ok(Some((variable_name.to_string(), default_value_coerced)));
-            }
-            if variable_definition.variable_type.is_non_null() {
-                return Err(format!(
-                    "Variable '{}' is non-nullable but no value was provided",
-                    variable_name
-                ));
-            }
-            Ok(None)
-        })
-        .collect();
+    let collected_variables: Result<Vec<Option<(String, Value)>>, VariableCoercionError> =
+        variable_definitions
+            .iter()
+            .map(|variable_definition| {
+                let variable_name = variable_definition.name.as_str();
+                if let Some(variable_value) = variables_map.remove(variable_name) {
+                    validate_runtime_value(
+                        variable_value.as_ref(),
+                        &variable_definition.variable_type,
+                        schema_metadata,
+                    )?;
+                    return Ok(Some((variable_name.to_string(), variable_value)));
+                }
+                if let Some(default_value) = &variable_definition.default_value {
+                    let default_value_coerced: Value = default_value.into();
+                    validate_runtime_value(
+                        default_value_coerced.as_ref(),
+                        &variable_definition.variable_type,
+                        schema_metadata,
+                    )?;
+                    return Ok(Some((variable_name.to_string(), default_value_coerced)));
+                }
+                if variable_definition.variable_type.is_non_null() {
+                    return Err(VariableCoercionError::MissingNonNullableVariable {
+                        name: variable_name.to_string(),
+                        type_name: variable_definition.variable_type.to_string(),
+                    });
+                }
+                Ok(None)
+            })
+            .collect();
 
     let variable_values: HashMap<String, Value> =
         collected_variables?.into_iter().flatten().collect();
@@ -65,10 +102,12 @@ fn validate_runtime_value(
     value: ValueRef,
     type_node: &TypeNode,
     schema_metadata: &SchemaMetadata,
-) -> Result<(), String> {
+) -> Result<(), VariableCoercionError> {
     if let ValueRef::Null = value {
         return if type_node.is_non_null() {
-            Err("Value cannot be null for non-nullable type".to_string())
+            Err(VariableCoercionError::UnexpectedNull {
+                type_name: type_node.to_string(),
+            })
         } else {
             Ok(())
         };
@@ -78,16 +117,16 @@ fn validate_runtime_value(
             if let Some(enum_values) = schema_metadata.enum_values.get(name) {
                 if let ValueRef::String(ref s) = value {
                     if !enum_values.contains(&s.to_string()) {
-                        return Err(format!(
-                            "Value '{}' is not a valid enum value for type '{}'",
-                            s, name
-                        ));
+                        return Err(VariableCoercionError::InvalidEnumValue {
+                            value: s.to_string(),
+                            type_name: name.clone(),
+                        });
                     }
                 } else {
-                    return Err(format!(
-                        "Expected a string for enum type '{}', got {:?}",
-                        name, value
-                    ));
+                    return Err(VariableCoercionError::ExpectedEnumString {
+                        type_name: name.clone(),
+                        value: format!("{:?}", value),
+                    });
                 }
             } else if let Some(fields) = schema_metadata.type_fields.get(name) {
                 if let ValueRef::Object(obj) = value {
@@ -99,17 +138,17 @@ fn validate_runtime_value(
                                 schema_metadata,
                             )?;
                         } else {
-                            return Err(format!(
-                                "Missing field '{}' for type '{}'",
-                                field_name, name
-                            ));
+                            return Err(VariableCoercionError::MissingField {
+                                field_name: field_name.clone(),
+                                type_name: name.clone(),
+                            });
                         }
                     }
                 } else {
-                    return Err(format!(
-                        "Expected an object for type '{}', got {:?}",
-                        name, value
-                    ));
+                    return Err(VariableCoercionError::ExpectedObject {
+                        type_name: name.clone(),
+                        value: format!("{:?}", value),
+                    });
                 }
             } else {
                 return match name.as_str() {
@@ -117,61 +156,50 @@ fn validate_runtime_value(
                         if let ValueRef::String(_) = value {
                             Ok(())
                         } else {
-                            Err(format!(
-                                "Expected a string for type '{}', got {:?}",
-                                name, value
-                            ))
-                        }
-                    }
-                    "Int" => {
-                        if let ValueRef::Number(ref num) = value {
-                            if num.is_i64() {
-                                Ok(())
-                            } else {
-                                Err(format!(
-                                    "Expected an integer for type '{}', got {:?}",
-                                    name, value
-                                ))
-                            }
-                        } else {
-                            Err(format!(
-                                "Expected a number for type '{}', got {:?}",
-                                name, value
-                            ))
-                        }
-                    }
-                    "Float" => {
-                        if let ValueRef::Number(ref num) = value {
-                            if num.is_f64() || num.is_i64() {
-                                Ok(())
-                            } else {
-                                Err(format!(
-                                    "Expected a float for type '{}', got {:?}",
-                                    name, value
-                                ))
-                            }
-                        } else {
-                            Err(format!(
-                                "Expected a number for type '{}', got {:?}",
-                                name, value
-                            ))
-                        }
-                    }
-                    "Boolean" => {
-                        if let ValueRef::Bool(_) = value {
-                            Ok(())
-                        } else {
-                            Err(format!(
-                                "Expected a boolean for type '{}', got {:?}",
-                                name, value
-                            ))
+                            Err(VariableCoercionError::ExpectedString {
+                                value: format!("{:?}", value),
+                            })
                         }
                     }
                     "ID" => {
                         if let ValueRef::String(_) = value {
                             Ok(())
                         } else {
-                            Err(format!("Expected a string for type 'ID', got {:?}", value))
+                            Err(VariableCoercionError::ExpectedId {
+                                value: format!("{:?}", value),
+                            })
+                        }
+                    }
+                    "Int" => {
+                        let is_valid = matches!(value, ValueRef::Number(ref num) if num.is_i64());
+                        if is_valid {
+                            Ok(())
+                        } else {
+                            Err(VariableCoercionError::ExpectedInteger {
+                                value: format!("{:?}", value),
+                            })
+                        }
+                    }
+                    "Float" => {
+                        let is_valid = matches!(
+                            value,
+                            ValueRef::Number(ref num) if num.is_f64() || num.is_i64()
+                        );
+                        if is_valid {
+                            Ok(())
+                        } else {
+                            Err(VariableCoercionError::ExpectedFloat {
+                                value: format!("{:?}", value),
+                            })
+                        }
+                    }
+                    "Boolean" => {
+                        if let ValueRef::Bool(_) = value {
+                            Ok(())
+                        } else {
+                            Err(VariableCoercionError::ExpectedBoolean {
+                                value: format!("{:?}", value),
+                            })
                         }
                     }
                     _ => Ok(()),

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.0.87"
+version = "0.0.88"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-config"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "config",
  "envconfig",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-internal"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-plan-executor"
-version = "7.0.2"
+version = "7.0.3"
 dependencies = [
  "ahash",
  "async-stream",

--- a/plugin_examples/feature_flags/src/test.rs
+++ b/plugin_examples/feature_flags/src/test.rs
@@ -205,18 +205,18 @@ mod tests {
             )
             .await;
 
-        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
         {
           "errors": [
             {
-              "message": "Supergraph runtime error",
+              "message": "Internal server error",
               "extensions": {
                 "code": "SUPERGRAPH_RUNTIME_ERROR"
               }
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[ntex::test]
@@ -250,17 +250,17 @@ mod tests {
             )
             .await;
 
-        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
         {
           "errors": [
             {
-              "message": "No supergraph available yet, unable to process request",
+              "message": "Internal server error",
               "extensions": {
                 "code": "NO_SUPERGRAPH_AVAILABLE"
               }
             }
           ]
         }
-        "###);
+        "#);
     }
 }

--- a/plugin_examples/replace_schema/src/test.rs
+++ b/plugin_examples/replace_schema/src/test.rs
@@ -234,17 +234,17 @@ mod tests {
                 },
             )
             .await;
-        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r###"
+        e2e::insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
         {
           "errors": [
             {
-              "message": "Supergraph runtime error",
+              "message": "Internal server error",
               "extensions": {
                 "code": "SUPERGRAPH_RUNTIME_ERROR"
               }
             }
           ]
         }
-        "###);
+        "#);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1315 

## Internal error masking and improved error handling 

Improve router's error handling by masking internal error details from client responses.

Client-caused errors still return their real message, since it only ever reflects the client's own request. Internal errors now always return a generic `"Internal server error"` message and never the underlying error message, which previously leaked details such as subgraph URLs, storage/network errors, and other backend internals. The real error is still logged for debugging purposes.

Error codes are unchanged. HTTP status codes are unchanged, except for GraphQL operation normalization and minification failures, which are now correctly treated as router-side bugs and always return `500` (previously `400`, or `200` based on `Accept` header) instead of being treated as a client mistake.
 
## Improve variable coercion error messages

Variable coercion errors (invalid scalar/enum/object values, missing required fields, non-null violations) reports clear and informative error messages.

This only changes error text - error codes and HTTP status codes are unchanged.

