### PR TITLE
feat(plugin-system): allow `on_http_request` to be `async` and return a `Future` 

### DIFF
--- a/.changeset/async_on_http_request_plugin_hook.md
+++ b/.changeset/async_on_http_request_plugin_hook.md
@@ -1,0 +1,40 @@
+---
+hive-router-plan-executor: major
+hive-router: patch
+---
+
+# Allow `async fn` in the `on_http_request` plugin hook
+
+`RouterPlugin::on_http_request` now returns `OnHttpRequestHookFuture<'req>` instead of `OnHttpRequestHookResult<'req>` directly, so plugins can `await` inside - for example calling an upstream auth or feature-flag service - before the rest of the request pipeline runs.
+
+The hook still runs on the same worker thread it started on and is never moved across threads, so the returned future does not need to be `Send`.
+
+Update any plugin that overrides `on_http_request` to return a boxed future:
+
+```rust
+// Before
+fn on_http_request<'req>(
+    &self,
+    payload: OnHttpRequestHookPayload<'req>,
+) -> OnHttpRequestHookResult<'req> {
+    self.record_request(&payload);
+    payload.proceed()
+}
+
+// After
+fn on_http_request<'req>(
+    &'req self,
+    payload: OnHttpRequestHookPayload<'req>,
+) -> OnHttpRequestHookFuture<'req> {
+    Box::pin(async move {
+        self.record_request(&payload);
+        payload.proceed()
+    })
+}
+```
+
+If the body reads `self` inside the `async move` block, `&self` needs to become `&'req self` - the future now holds that borrow for its own lifetime `'req`, so the borrow has to be able to live at least that long.
+
+Plugins that don't override `on_http_request` are unaffected.
+
+See `plugin_examples/async_http_fetch` for an example that awaits an upstream HTTP call before proceeding.

--- a/bin/router/src/plugins/plugins_service.rs
+++ b/bin/router/src/plugins/plugins_service.rs
@@ -110,7 +110,7 @@ where
             let mut on_end_callbacks = Vec::with_capacity(plugins.len());
 
             for plugin in plugins.as_ref() {
-                let result = plugin.on_http_request(start_payload);
+                let result = plugin.on_http_request(start_payload).await;
                 start_payload = result.payload;
                 match result.control_flow {
                     StartControlFlow::Proceed => {

--- a/e2e/src/persisted_documents/skip_enforcement.rs
+++ b/e2e/src/persisted_documents/skip_enforcement.rs
@@ -3,7 +3,7 @@ use hive_router::{
     plugins::hooks::on_graphql_params::{
         OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult,
     },
-    plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+    plugins::hooks::on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
     plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
     plugins::plugin_trait::{RouterPlugin, StartHookPayload},
 };
@@ -32,16 +32,18 @@ impl RouterPlugin for TestSkipEnforcementPlugin {
     }
 
     fn on_http_request<'req>(
-        &self,
+        &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        payload
-            .request_context
-            .write()
-            .unwrap()
-            .persisted_documents()
-            .set_skip_enforcement(self.skip_enforcement);
-        payload.proceed()
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            payload
+                .request_context
+                .write()
+                .unwrap()
+                .persisted_documents()
+                .set_skip_enforcement(self.skip_enforcement);
+            payload.proceed()
+        })
     }
 }
 

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use hive_router::{
     async_trait,
-    plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+    plugins::hooks::on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
     plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
     plugins::plugin_trait::{RouterPlugin, StartHookPayload},
     set_summary_attribute, set_summary_message,
@@ -700,19 +700,21 @@ impl RouterPlugin for TestDebugLogPlugin {
     fn on_http_request<'req>(
         &self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        debug!("i'm just a test");
-        set_summary_message("custom summary message from plugin");
-        set_summary_attribute("test_debug_log.simple", "hello-from-plugin");
-        set_summary_attribute(
-            "test_debug_log.nested",
-            json!({
-                "flag": true,
-                "count": 3,
-                "tags": ["a", "b"],
-            }),
-        );
-        payload.proceed()
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            debug!("i'm just a test");
+            set_summary_message("custom summary message from plugin");
+            set_summary_attribute("test_debug_log.simple", "hello-from-plugin");
+            set_summary_attribute(
+                "test_debug_log.nested",
+                json!({
+                    "flag": true,
+                    "count": 3,
+                    "tags": ["a", "b"],
+                }),
+            );
+            payload.proceed()
+        })
     }
 }
 

--- a/lib/executor/src/plugins/hooks/on_http_request.rs
+++ b/lib/executor/src/plugins/hooks/on_http_request.rs
@@ -1,3 +1,4 @@
+use futures::future::LocalBoxFuture;
 use ntex::{
     http::Response,
     web::{self, DefaultError, WebRequest},
@@ -20,13 +21,15 @@ pub struct OnHttpRequestHookPayload<'req> {
     /// Example:
     /// ```
     /// use hive_router::{
-    ///    plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+    ///    plugins::hooks::on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookFuture},
     /// };
     ///
-    /// fn on_http_request<'req>(mut payload: OnHttpRequestHookPayload<'req>) -> OnHttpRequestHookResult<'req> {
-    ///     let my_header = payload.router_http_request.headers().get("my-header");
-    ///     // do something with the header...
-    ///     payload.proceed()
+    /// fn on_http_request<'req>(mut payload: OnHttpRequestHookPayload<'req>) -> OnHttpRequestHookFuture<'req> {
+    ///     Box::pin(async move {
+    ///         let my_header = payload.router_http_request.headers().get("my-header");
+    ///         // do something with the header...
+    ///         payload.proceed()
+    ///     })
     /// }
     /// ```
     pub router_http_request: WebRequest<DefaultError>,
@@ -39,7 +42,7 @@ pub struct OnHttpRequestHookPayload<'req> {
     /// ```
     /// use hive_router::{
     ///     plugins::hooks::{
-    ///         on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+    ///         on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookFuture},
     ///         on_execute::{OnExecuteStartHookPayload, OnExecuteStartHookResult}
     ///     },
     ///     plugin_context::PluginContext,
@@ -52,14 +55,16 @@ pub struct OnHttpRequestHookPayload<'req> {
     ///
     /// #[async_trait]
     /// impl RouterPlugin for MyPlugin {
-    ///     fn on_http_request<'req>(mut payload: OnHttpRequestHookPayload<'req>) -> OnHttpRequestHookResult<'req> {
-    ///         let context_data = ContextData {
-    ///            greetings: "Hello from context!".to_string()
-    ///         };
+    ///     fn on_http_request<'req>(mut payload: OnHttpRequestHookPayload<'req>) -> OnHttpRequestHookFuture<'req> {
+    ///         Box::pin(async move {
+    ///             let context_data = ContextData {
+    ///                greetings: "Hello from context!".to_string()
+    ///             };
     ///
-    ///        payload.context.insert(context_data);
+    ///            payload.context.insert(context_data);
     ///
-    ///        payload.proceed()
+    ///            payload.proceed()
+    ///         })
     ///     }
     ///
     ///     async fn on_execute<'exec>(&'exec self, payload: OnExecuteStartHookPayload<'exec>) -> OnExecuteStartHookResult<'exec> {
@@ -111,6 +116,9 @@ pub type OnHttpRequestHookResult<'req> = StartHookResult<
     Response,
 >;
 
+/// A local (non-`Send`) boxed future - always polled on its own worker thread
+pub type OnHttpRequestHookFuture<'req> = LocalBoxFuture<'req, OnHttpRequestHookResult<'req>>;
+
 pub struct OnHttpResponseHookPayload<'req> {
     pub response: web::WebResponse,
     pub context: &'req PluginContext,
@@ -126,15 +134,17 @@ impl<'req> OnHttpResponseHookPayload<'req> {
     /// fn on_http_request<'req>(
     ///     &'req self,
     ///     payload: OnHttpRequestHookPayload<'req>,
-    /// ) -> OnHttpRequestHookResult<'req> {
-    ///     payload.on_end(|payload| {
-    ///         payload.map_response(|mut response| {
-    ///             response.response_mut().headers_mut().insert(
-    ///                 "x-served-by",
-    ///                 "hive-router".parse().unwrap(),
-    ///             );
-    ///             response
-    ///         }).proceed()
+    /// ) -> OnHttpRequestHookFuture<'req> {
+    ///     Box::pin(async move {
+    ///         payload.on_end(|payload| {
+    ///             payload.map_response(|mut response| {
+    ///                 response.response_mut().headers_mut().insert(
+    ///                     "x-served-by",
+    ///                     "hive-router".parse().unwrap(),
+    ///                 );
+    ///                 response
+    ///             }).proceed()
+    ///         })
     ///     })
     /// }
     /// ```

--- a/lib/executor/src/plugins/plugin_trait.rs
+++ b/lib/executor/src/plugins/plugin_trait.rs
@@ -8,7 +8,7 @@ use crate::{
         on_graphql_validation::{
             OnGraphQLValidationStartHookPayload, OnGraphQLValidationStartHookResult,
         },
-        on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+        on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
         on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         on_query_plan::{OnQueryPlanStartHookPayload, OnQueryPlanStartHookResult},
         on_subgraph_execute::{
@@ -84,15 +84,17 @@ where
     /// fn on_http_request<'req>(
     ///     &'req self,
     ///     payload: OnHttpRequestHookPayload<'req>,
-    /// ) -> OnHttpRequestHookResult<'req> {
-    ///     if payload.router_http_request.headers().get("authorization").is_none() {
-    ///         return payload.end_with_graphql_error(
-    ///             GraphQLError::from_message_and_code("Unauthorized", "UNAUTHORIZED"),
-    ///             StatusCode::UNAUTHORIZED,
-    ///         );
-    ///     }
+    /// ) -> OnHttpRequestHookFuture<'req> {
+    ///     Box::pin(async move {
+    ///         if payload.router_http_request.headers().get("authorization").is_none() {
+    ///             return payload.end_with_graphql_error(
+    ///                 GraphQLError::from_message_and_code("Unauthorized", "UNAUTHORIZED"),
+    ///                 StatusCode::UNAUTHORIZED,
+    ///             );
+    ///         }
     ///
-    ///     payload.proceed()
+    ///         payload.proceed()
+    ///     })
     /// }
     /// ```
     fn end_with_graphql_error<'exec>(
@@ -134,15 +136,17 @@ where
     /// fn on_http_request<'req>(
     ///     &'req self,
     ///     payload: OnHttpRequestHookPayload<'req>,
-    /// ) -> OnHttpRequestHookResult<'req> {
-    ///     payload.on_end(|payload| {
-    ///         payload.map_response(|mut response| {
-    ///             response.response_mut().headers_mut().insert(
-    ///                 "x-served-by",
-    ///                 "hive-router".parse().unwrap(),
-    ///             );
-    ///             response
-    ///         }).proceed()
+    /// ) -> OnHttpRequestHookFuture<'req> {
+    ///     Box::pin(async move {
+    ///         payload.on_end(|payload| {
+    ///             payload.map_response(|mut response| {
+    ///                 response.response_mut().headers_mut().insert(
+    ///                     "x-served-by",
+    ///                     "hive-router".parse().unwrap(),
+    ///                 );
+    ///                 response
+    ///             }).proceed()
+    ///         })
     ///     })
     /// }
     /// ```
@@ -386,8 +390,8 @@ pub trait RouterPlugin: Send + Sync + 'static {
     fn on_http_request<'req>(
         &'req self,
         start_payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        start_payload.proceed()
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move { start_payload.proceed() })
     }
     #[inline]
     async fn on_graphql_params<'exec>(
@@ -468,7 +472,7 @@ pub trait DynRouterPlugin: Send + Sync + 'static {
     fn on_http_request<'req>(
         &'req self,
         start_payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req>;
+    ) -> OnHttpRequestHookFuture<'req>;
     async fn on_graphql_params<'exec>(
         &'exec self,
         start_payload: OnGraphQLParamsStartHookPayload<'exec>,
@@ -521,7 +525,7 @@ where
     fn on_http_request<'req>(
         &'req self,
         start_payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
+    ) -> OnHttpRequestHookFuture<'req> {
         RouterPlugin::on_http_request(self, start_payload)
     }
     #[inline]

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -446,6 +446,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-http-fetch-plugin-example"
+version = "0.0.1"
+dependencies = [
+ "e2e",
+ "hive-router",
+ "reqwest 0.12.28",
+ "serde",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.0.87"
+version = "0.0.88"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2778,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-config"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "config",
  "envconfig",
@@ -2803,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-internal"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2846,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router-plan-executor"
-version = "7.0.2"
+version = "7.0.3"
 dependencies = [
  "ahash",
  "async-stream",

--- a/plugin_examples/Cargo.toml
+++ b/plugin_examples/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "apollo_sandbox",
   "apq",
   "async_auth",
+  "async_http_fetch",
   "context_data",
   "forbid_anonymous_operations",
   "multipart",

--- a/plugin_examples/apollo_sandbox/src/plugin.rs
+++ b/plugin_examples/apollo_sandbox/src/plugin.rs
@@ -5,7 +5,7 @@ use hive_router::{
     ntex::http::ResponseBuilder,
     plugins::{
         hooks::{
-            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         },
         plugin_trait::{RouterPlugin, StartHookPayload},
@@ -149,17 +149,19 @@ impl RouterPlugin for ApolloSandboxPlugin {
     fn on_http_request<'req>(
         &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        if payload.router_http_request.path() == "/apollo-sandbox" {
-            return payload.end_with_response(
-                ResponseBuilder::new(StatusCode::OK)
-                    .header(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static("text/html; charset=utf-8"),
-                    )
-                    .body(self.html.clone()),
-            );
-        }
-        payload.proceed()
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            if payload.router_http_request.path() == "/apollo-sandbox" {
+                return payload.end_with_response(
+                    ResponseBuilder::new(StatusCode::OK)
+                        .header(
+                            CONTENT_TYPE,
+                            HeaderValue::from_static("text/html; charset=utf-8"),
+                        )
+                        .body(self.html.clone()),
+                );
+            }
+            payload.proceed()
+        })
     }
 }

--- a/plugin_examples/async_http_fetch/Cargo.toml
+++ b/plugin_examples/async_http_fetch/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "async-http-fetch-plugin-example"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+authors = ["The Guild"]
+repository = "https://github.com/graphql-hive/router"
+homepage = "https://github.com/graphql-hive/router"
+publish = false
+
+[lib]
+
+[[bin]]
+name = "hive_router_with_async_http_fetch"
+path = "src/main.rs"
+
+[dependencies]
+hive-router = { version = "*", path = "../../bin/router" }
+serde = { workspace = true }
+reqwest = { workspace = true }
+
+[dev-dependencies]
+e2e = { version = "*", path = "../../e2e" }

--- a/plugin_examples/async_http_fetch/README.md
+++ b/plugin_examples/async_http_fetch/README.md
@@ -1,0 +1,21 @@
+# Async HTTP Fetch Plugin Example
+
+Demonstrates calling out to an upstream HTTP service from `on_http_request` and awaiting the
+response before the rest of the request pipeline (parsing, validation, planning, execution) runs.
+
+The fetched value is stored in the per-request `PluginContext` and surfaced back on the response
+as the `x-fetched-greeting` header via `on_end`.
+
+```yaml
+plugins:
+  async_http_fetch:
+    enabled: true
+    config:
+      upstream_url: http://0.0.0.0:9876/greeting
+```
+
+The upstream is expected to respond with:
+
+```json
+{ "greeting": "hello from upstream" }
+```

--- a/plugin_examples/async_http_fetch/router.config.yaml
+++ b/plugin_examples/async_http_fetch/router.config.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../../e2e/supergraph.graphql
+plugins:
+  async_http_fetch:
+    enabled: true
+    config:
+      upstream_url: http://0.0.0.0:9876/greeting

--- a/plugin_examples/async_http_fetch/src/lib.rs
+++ b/plugin_examples/async_http_fetch/src/lib.rs
@@ -1,0 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
+pub mod plugin;
+#[cfg(test)]
+pub mod test;

--- a/plugin_examples/async_http_fetch/src/main.rs
+++ b/plugin_examples/async_http_fetch/src/main.rs
@@ -1,0 +1,17 @@
+use hive_router::{
+    configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
+    router_entrypoint, PluginRegistry, RouterGlobalAllocator,
+};
+
+configure_global_allocator!();
+
+#[hive_router::main]
+async fn main() -> Result<(), RouterInitError> {
+    init_rustls_crypto_provider();
+
+    router_entrypoint(
+        PluginRegistry::new()
+            .register::<async_http_fetch_plugin_example::plugin::AsyncHttpFetchPlugin>(),
+    )
+    .await
+}

--- a/plugin_examples/async_http_fetch/src/plugin.rs
+++ b/plugin_examples/async_http_fetch/src/plugin.rs
@@ -1,0 +1,88 @@
+use hive_router::{
+    ntex::http::header::{HeaderName, HeaderValue},
+    plugins::{
+        hooks::{
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
+            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        },
+        plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
+    },
+};
+use serde::Deserialize;
+
+const FETCHED_GREETING_HEADER: HeaderName = HeaderName::from_static("x-fetched-greeting");
+
+#[derive(Deserialize)]
+pub struct AsyncHttpFetchConfig {
+    pub upstream_url: String,
+}
+
+pub struct AsyncHttpFetchPlugin {
+    client: reqwest::Client,
+    upstream_url: String,
+}
+
+#[derive(Deserialize)]
+struct GreetingResponse {
+    greeting: String,
+}
+
+struct FetchedGreeting(String);
+
+impl RouterPlugin for AsyncHttpFetchPlugin {
+    type Config = AsyncHttpFetchConfig;
+
+    fn plugin_name() -> &'static str {
+        "async_http_fetch"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        let config = payload.config()?;
+        payload.initialize_plugin(Self {
+            client: reqwest::Client::new(),
+            upstream_url: config.upstream_url,
+        })
+    }
+
+    // Fetches data from an upstream HTTP service and awaits it here, before the rest of the
+    // pipeline (parsing, validation, planning, execution) runs.
+    fn on_http_request<'req>(
+        &'req self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            let greeting = fetch_greeting(&self.client, &self.upstream_url).await;
+            payload.context.insert(FetchedGreeting(greeting));
+
+            payload.on_end(|payload| {
+                let greeting = payload
+                    .context
+                    .get_ref::<FetchedGreeting>()
+                    .map(|entry| entry.0.clone())
+                    .unwrap_or_default();
+                payload
+                    .map_response(move |mut response| {
+                        if let Ok(header_value) = HeaderValue::from_str(&greeting) {
+                            response
+                                .response_mut()
+                                .headers_mut()
+                                .insert(FETCHED_GREETING_HEADER, header_value);
+                        }
+                        response
+                    })
+                    .proceed()
+            })
+        })
+    }
+}
+
+async fn fetch_greeting(client: &reqwest::Client, upstream_url: &str) -> String {
+    match client.get(upstream_url).send().await {
+        Ok(response) => response
+            .json::<GreetingResponse>()
+            .await
+            .map(|body| body.greeting)
+            .unwrap_or_default(),
+        Err(_) => String::new(),
+    }
+}

--- a/plugin_examples/async_http_fetch/src/test.rs
+++ b/plugin_examples/async_http_fetch/src/test.rs
@@ -1,0 +1,55 @@
+#[cfg(test)]
+mod tests {
+    use e2e::{
+        mockito,
+        testkit::{TestRouter, TestSubgraphs},
+    };
+    use hive_router::{ntex, sonic_rs};
+
+    #[ntex::test]
+    async fn awaits_upstream_fetch_before_the_request_continues() {
+        let mut server = mockito::Server::new_async().await;
+        let greeting_mock = server
+            .mock("GET", "/greeting")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(sonic_rs::json!({ "greeting": "hello from upstream" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .skip_wait_for_healthy_on_start()
+            .skip_wait_for_ready_on_start()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: ../../e2e/supergraph.graphql
+                plugins:
+                    async_http_fetch:
+                        enabled: true
+                        config:
+                            upstream_url: "http://{}/greeting"
+                "#,
+                server.host_with_port()
+            ))
+            .register_plugin::<crate::plugin::AsyncHttpFetchPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let res = router.send_graphql_request("{ me { name } }", None, None).await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+        assert_eq!(
+            res.headers().get("x-fetched-greeting").unwrap(),
+            "hello from upstream"
+        );
+
+        greeting_mock.assert_async().await;
+    }
+}

--- a/plugin_examples/custom_logger_correlation/src/plugin.rs
+++ b/plugin_examples/custom_logger_correlation/src/plugin.rs
@@ -1,5 +1,5 @@
 use hive_router::plugins::hooks::on_http_request::{
-    OnHttpRequestHookPayload, OnHttpRequestHookResult,
+    OnHttpRequestHookFuture, OnHttpRequestHookPayload,
 };
 use hive_router::plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult};
 use hive_router::plugins::plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload};
@@ -28,47 +28,49 @@ impl RouterPlugin for CustomLoggerCorrelationPlugin {
     fn on_http_request<'req>(
         &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        let project_id = payload
-            .router_http_request
-            .path()
-            .split('/')
-            .nth(1)
-            .filter(|segment| !segment.is_empty())
-            .unwrap_or("unknown_project")
-            .to_string();
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            let project_id = payload
+                .router_http_request
+                .path()
+                .split('/')
+                .nth(1)
+                .filter(|segment| !segment.is_empty())
+                .unwrap_or("unknown_project")
+                .to_string();
 
-        let started_at = Instant::now();
+            let started_at = Instant::now();
 
-        // Attach it as soon as we know it, so every log line for the rest of this
-        // request - including this plugin's own - carries the same correlation.
-        set_log_correlation(PROJECT_ID_KEY, project_id);
+            // Attach it as soon as we know it, so every log line for the rest of this
+            // request - including this plugin's own - carries the same correlation.
+            set_log_correlation(PROJECT_ID_KEY, project_id);
 
-        tracing::debug!(target: "custom_logger_correlation", "on_http_request called");
+            tracing::debug!(target: "custom_logger_correlation", "on_http_request called");
 
-        let method = payload.router_http_request.method().to_string();
-        let path = payload.router_http_request.path().to_string();
+            let method = payload.router_http_request.method().to_string();
+            let path = payload.router_http_request.path().to_string();
 
-        payload.on_end(move |end_payload| {
-            let current_summary = if let Some(summary) = get_current_summary() {
-                summary
-            } else {
-                return end_payload.proceed();
-            };
+            payload.on_end(move |end_payload| {
+                let current_summary = if let Some(summary) = get_current_summary() {
+                    summary
+                } else {
+                    return end_payload.proceed();
+                };
 
-            let operation_name = current_summary.operation_name.get().cloned();
-            let status_code = current_summary.status_code.load(Relaxed);
+                let operation_name = current_summary.operation_name.get().cloned();
+                let status_code = current_summary.status_code.load(Relaxed);
 
-            set_summary_message(format!(
-                "[status={}] [{}ms] {} {} {}",
-                status_code,
-                started_at.elapsed().as_millis(),
-                method,
-                path,
-                operation_name.as_deref().unwrap_or("-")
-            ));
+                set_summary_message(format!(
+                    "[status={}] [{}ms] {} {} {}",
+                    status_code,
+                    started_at.elapsed().as_millis(),
+                    method,
+                    path,
+                    operation_name.as_deref().unwrap_or("-")
+                ));
 
-            end_payload.proceed()
+                end_payload.proceed()
+            })
         })
     }
 }

--- a/plugin_examples/error_mapping/src/plugin.rs
+++ b/plugin_examples/error_mapping/src/plugin.rs
@@ -10,7 +10,7 @@ use hive_router::{
     plugins::{
         hooks::{
             on_graphql_error::{OnGraphQLErrorHookPayload, OnGraphQLErrorHookResult},
-            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         },
         plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
@@ -82,22 +82,24 @@ impl RouterPlugin for ErrorMappingPlugin {
     fn on_http_request<'req>(
         &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        payload.on_end(move |payload| {
-            let mapped_errors_count = payload
-                .context
-                .get_ref::<ErrorMappingCtx>()
-                .map(|ctx| ctx.count);
-            payload
-                .map_response(move |mut response| {
-                    if let Some(count) = mapped_errors_count {
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            payload.on_end(move |payload| {
+                let mapped_errors_count = payload
+                    .context
+                    .get_ref::<ErrorMappingCtx>()
+                    .map(|ctx| ctx.count);
+                payload
+                    .map_response(move |mut response| {
+                        if let Some(count) = mapped_errors_count {
+                            response
+                                .headers_mut()
+                                .insert(MAPPED_ERRORS_COUNT_HEADER, HeaderValue::from(count));
+                        }
                         response
-                            .headers_mut()
-                            .insert(MAPPED_ERRORS_COUNT_HEADER, HeaderValue::from(count));
-                    }
-                    response
-                })
-                .proceed()
+                    })
+                    .proceed()
+            })
         })
     }
 }

--- a/plugin_examples/feature_flags/src/plugin.rs
+++ b/plugin_examples/feature_flags/src/plugin.rs
@@ -15,7 +15,7 @@ use hive_router::{
     },
     plugins::{
         hooks::{
-            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
             on_supergraph_load::Supergraph,
         },
@@ -61,53 +61,55 @@ impl RouterPlugin for FeatureFlagsPlugin {
     fn on_http_request<'req>(
         &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        let feature_flags_header = payload
-            .router_http_request
-            .headers()
-            .get("x-feature-flags")
-            .and_then(|header_value| header_value.to_str().ok())
-            .unwrap_or_default();
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            let feature_flags_header = payload
+                .router_http_request
+                .headers()
+                .get("x-feature-flags")
+                .and_then(|header_value| header_value.to_str().ok())
+                .unwrap_or_default();
 
-        if feature_flags_header == "skip" {
-            // skip setting the supergraph to test NO_SUPERGRAPH_AVAILABLE
-            return payload.proceed();
-        }
+            if feature_flags_header == "skip" {
+                // skip setting the supergraph to test NO_SUPERGRAPH_AVAILABLE
+                return payload.proceed();
+            }
 
-        let mut feature_flags: Vec<String> = feature_flags_header
-            .split(',')
-            .map(|tag| tag.trim().to_string())
-            .collect();
+            let mut feature_flags: Vec<String> = feature_flags_header
+                .split(',')
+                .map(|tag| tag.trim().to_string())
+                .collect();
 
-        // sort the feature flags so header order does not change the cache key
-        feature_flags.sort();
-        let cache_key = feature_flags.join(",");
+            // sort the feature flags so header order does not change the cache key
+            feature_flags.sort();
+            let cache_key = feature_flags.join(",");
 
-        let mut variants = self.variants.lock().unwrap();
-        let existing = variants.get(&cache_key).cloned();
-        match existing {
-            // (cheap) already constructed, serve from cache
-            Some(selected) => payload.set_supergraph(selected),
-            // (expensive) not constructed, build and cache it
-            None => {
-                let document = schema_for_features(&self.supergraph, &feature_flags);
-                match Supergraph::from_document(document, Default::default()) {
-                    Ok(supergraph_data) => {
-                        // build successful
-                        let supergraph_data = Arc::new(supergraph_data);
-                        variants.insert(cache_key, supergraph_data.clone());
-                        payload.set_supergraph(supergraph_data);
-                    }
-                    Err(_) => {
-                        // building the supergraph failed, you can optionally log, but
-                        // intentionally not set the supergraph and let the router fail the
-                        // request with an error coded NO_SUPERGRAPH_AVAILABLE
+            let mut variants = self.variants.lock().unwrap();
+            let existing = variants.get(&cache_key).cloned();
+            match existing {
+                // (cheap) already constructed, serve from cache
+                Some(selected) => payload.set_supergraph(selected),
+                // (expensive) not constructed, build and cache it
+                None => {
+                    let document = schema_for_features(&self.supergraph, &feature_flags);
+                    match Supergraph::from_document(document, Default::default()) {
+                        Ok(supergraph_data) => {
+                            // build successful
+                            let supergraph_data = Arc::new(supergraph_data);
+                            variants.insert(cache_key, supergraph_data.clone());
+                            payload.set_supergraph(supergraph_data);
+                        }
+                        Err(_) => {
+                            // building the supergraph failed, you can optionally log, but
+                            // intentionally not set the supergraph and let the router fail the
+                            // request with an error coded NO_SUPERGRAPH_AVAILABLE
+                        }
                     }
                 }
             }
-        }
 
-        payload.proceed()
+            payload.proceed()
+        })
     }
 }
 

--- a/plugin_examples/incoming_request_deduplication/src/plugin.rs
+++ b/plugin_examples/incoming_request_deduplication/src/plugin.rs
@@ -20,7 +20,7 @@ use hive_router::{
         hooks::{
             on_graphql_params::{OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult},
             on_http_request::{
-                OnHttpRequestHookPayload, OnHttpRequestHookResult, OnHttpResponseHookPayload,
+                OnHttpRequestHookFuture, OnHttpRequestHookPayload, OnHttpResponseHookPayload,
             },
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         },
@@ -144,29 +144,31 @@ impl RouterPlugin for IncomingRequestDeduplicationPlugin {
     fn on_http_request<'req>(
         &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        payload.on_end(|payload: OnHttpResponseHookPayload| {
-            if let Some(context) = payload.context.get_ref::<PluginContext>() {
-                return payload
-                    .map_response(|web_response| {
-                        // Take body, headers and status
-                        let response = web_response.response();
-                        if let ResponseBody::Body(Body::Bytes(bytes)) = response.body() {
-                            let shared_response = SharedResponse {
-                                body: bytes.clone(),
-                                headers: response.headers().clone().into(),
-                                status: response.status(),
-                            };
-                            // Send to all waiting receivers
-                            self.sender
-                                .send(context.fingerprint, shared_response)
-                                .expect("Failed to send response to waiting receivers");
-                        }
-                        web_response
-                    })
-                    .proceed();
-            }
-            payload.proceed()
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            payload.on_end(|payload: OnHttpResponseHookPayload| {
+                if let Some(context) = payload.context.get_ref::<PluginContext>() {
+                    return payload
+                        .map_response(|web_response| {
+                            // Take body, headers and status
+                            let response = web_response.response();
+                            if let ResponseBody::Body(Body::Bytes(bytes)) = response.body() {
+                                let shared_response = SharedResponse {
+                                    body: bytes.clone(),
+                                    headers: response.headers().clone().into(),
+                                    status: response.status(),
+                                };
+                                // Send to all waiting receivers
+                                self.sender
+                                    .send(context.fingerprint, shared_response)
+                                    .expect("Failed to send response to waiting receivers");
+                            }
+                            web_response
+                        })
+                        .proceed();
+                }
+                payload.proceed()
+            })
         })
     }
 }

--- a/plugin_examples/jwt_cookie/src/plugin.rs
+++ b/plugin_examples/jwt_cookie/src/plugin.rs
@@ -7,7 +7,7 @@ use hive_router::{
     plugins::{
         hooks::{
             on_graphql_params::{OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult},
-            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
             on_subgraph_execute::{
                 OnSubgraphExecuteStartHookPayload, OnSubgraphExecuteStartHookResult,
@@ -224,37 +224,39 @@ impl RouterPlugin for JwtCookiePlugin {
     fn on_http_request<'exec>(
         &'exec self,
         payload: OnHttpRequestHookPayload<'exec>,
-    ) -> OnHttpRequestHookResult<'exec> {
-        payload.on_end(|payload| {
-            if let Some(ctx) = payload.context.get_ref::<JwtCookieContext>() {
-                // If the token was refreshed or newly obtained, set the new JWT token and refresh token in the response cookies
-                if let JwtCookieContext::Refreshed {
-                    ref jwt_token,
-                    ref refresh_token,
-                    ref expired_at,
-                } = *ctx
-                {
-                    // Cookie expiry is different than JWT expiry
-                    // Set the new JWT token and refresh token in the response cookies
-                    let set_jwt_cookie = create_set_cookie(JWT_TOKEN_NAME, jwt_token);
-                    let set_refresh_cookie =
-                        create_set_cookie(JWT_REFRESH_TOKEN_NAME, refresh_token);
-                    let expired_at = create_set_cookie(
-                        JWT_EXPIRED_AT_NAME,
-                        &expired_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                    );
-                    return payload
-                        .map_response(|mut response| {
-                            let headers = response.headers_mut();
-                            headers.append(SET_COOKIE, set_jwt_cookie);
-                            headers.append(SET_COOKIE, set_refresh_cookie);
-                            headers.append(SET_COOKIE, expired_at);
-                            response
-                        })
-                        .proceed();
+    ) -> OnHttpRequestHookFuture<'exec> {
+        Box::pin(async move {
+            payload.on_end(|payload| {
+                if let Some(ctx) = payload.context.get_ref::<JwtCookieContext>() {
+                    // If the token was refreshed or newly obtained, set the new JWT token and refresh token in the response cookies
+                    if let JwtCookieContext::Refreshed {
+                        ref jwt_token,
+                        ref refresh_token,
+                        ref expired_at,
+                    } = *ctx
+                    {
+                        // Cookie expiry is different than JWT expiry
+                        // Set the new JWT token and refresh token in the response cookies
+                        let set_jwt_cookie = create_set_cookie(JWT_TOKEN_NAME, jwt_token);
+                        let set_refresh_cookie =
+                            create_set_cookie(JWT_REFRESH_TOKEN_NAME, refresh_token);
+                        let expired_at = create_set_cookie(
+                            JWT_EXPIRED_AT_NAME,
+                            &expired_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                        );
+                        return payload
+                            .map_response(|mut response| {
+                                let headers = response.headers_mut();
+                                headers.append(SET_COOKIE, set_jwt_cookie);
+                                headers.append(SET_COOKIE, set_refresh_cookie);
+                                headers.append(SET_COOKIE, expired_at);
+                                response
+                            })
+                            .proceed();
+                    }
                 }
-            }
-            payload.proceed()
+                payload.proceed()
+            })
         })
     }
 }

--- a/plugin_examples/non_standard_request/src/plugin.rs
+++ b/plugin_examples/non_standard_request/src/plugin.rs
@@ -5,7 +5,7 @@ use hive_router::{
     ntex::http::header::HeaderValue,
     plugins::{
         hooks::{
-            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         },
         plugin_trait::{RouterPlugin, StartHookPayload},
@@ -42,38 +42,40 @@ impl RouterPlugin for NonStandardRequestPlugin {
     fn on_http_request<'req>(
         &'req self,
         mut payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        let mapped_content_type = payload
-            .router_http_request
-            .headers()
-            .get(CONTENT_TYPE)
-            // If it is a valid UTF-8
-            .and_then(|header| header.to_str().ok())
-            // Lowercase the header value
-            .map(|header_str| header_str.to_lowercase())
-            // Map to the new content type if it exists in the map
-            .and_then(|lowercased_header_str| {
-                // Check for the beginning, because it can be like x/y;charset=utf-8
-                self.content_type_map
-                    .iter()
-                    .find(|(k, _)| lowercased_header_str.starts_with(k.as_str()))
-                    .map(|(found_part, mapped_content_type_str)| {
-                        // Only replace that part, keep the charset if exists
-                        lowercased_header_str.replacen(found_part, mapped_content_type_str, 1)
-                    })
-            })
-            // Convert the mapped content type to a HeaderValue
-            .and_then(|mapped_content_type_str| {
-                HeaderValue::from_str(&mapped_content_type_str).ok()
-            });
-        // If there is a mapped content type
-        if let Some(mapped_content_type) = mapped_content_type {
-            // Replace the content type header with the mapped content type
-            payload
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            let mapped_content_type = payload
                 .router_http_request
-                .headers_mut()
-                .insert(CONTENT_TYPE, mapped_content_type);
-        }
-        payload.proceed()
+                .headers()
+                .get(CONTENT_TYPE)
+                // If it is a valid UTF-8
+                .and_then(|header| header.to_str().ok())
+                // Lowercase the header value
+                .map(|header_str| header_str.to_lowercase())
+                // Map to the new content type if it exists in the map
+                .and_then(|lowercased_header_str| {
+                    // Check for the beginning, because it can be like x/y;charset=utf-8
+                    self.content_type_map
+                        .iter()
+                        .find(|(k, _)| lowercased_header_str.starts_with(k.as_str()))
+                        .map(|(found_part, mapped_content_type_str)| {
+                            // Only replace that part, keep the charset if exists
+                            lowercased_header_str.replacen(found_part, mapped_content_type_str, 1)
+                        })
+                })
+                // Convert the mapped content type to a HeaderValue
+                .and_then(|mapped_content_type_str| {
+                    HeaderValue::from_str(&mapped_content_type_str).ok()
+                });
+            // If there is a mapped content type
+            if let Some(mapped_content_type) = mapped_content_type {
+                // Replace the content type header with the mapped content type
+                payload
+                    .router_http_request
+                    .headers_mut()
+                    .insert(CONTENT_TYPE, mapped_content_type);
+            }
+            payload.proceed()
+        })
     }
 }

--- a/plugin_examples/propagate_status_code/src/lib.rs
+++ b/plugin_examples/propagate_status_code/src/lib.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use hive_router::plugins::{
     hooks::{
-        on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+        on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
         on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
         on_subgraph_http_request::{
             OnSubgraphHttpRequestHookPayload, OnSubgraphHttpRequestHookResult,
@@ -73,20 +73,22 @@ impl RouterPlugin for PropagateStatusCodePlugin {
     fn on_http_request<'exec>(
         &'exec self,
         payload: OnHttpRequestHookPayload<'exec>,
-    ) -> OnHttpRequestHookResult<'exec> {
-        payload.on_end(|payload| {
-            // Checking if there is a context entry
-            let ctx = payload.context.get_ref::<PropagateStatusCodeCtx>();
-            if let Some(ctx) = ctx {
-                // Update the HTTP response status code
-                return payload
-                    .map_response(|mut response| {
-                        *response.response_mut().status_mut() = ctx.status_code;
-                        response
-                    })
-                    .proceed();
-            }
-            payload.proceed()
+    ) -> OnHttpRequestHookFuture<'exec> {
+        Box::pin(async move {
+            payload.on_end(|payload| {
+                // Checking if there is a context entry
+                let ctx = payload.context.get_ref::<PropagateStatusCodeCtx>();
+                if let Some(ctx) = ctx {
+                    // Update the HTTP response status code
+                    return payload
+                        .map_response(|mut response| {
+                            *response.response_mut().status_mut() = ctx.status_code;
+                            response
+                        })
+                        .proceed();
+                }
+                payload.proceed()
+            })
         })
     }
 }

--- a/plugin_examples/replace_schema/src/plugin.rs
+++ b/plugin_examples/replace_schema/src/plugin.rs
@@ -12,7 +12,7 @@ use hive_router::{
     },
     plugins::{
         hooks::{
-            on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+            on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
             on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
             on_supergraph_load::Supergraph,
         },
@@ -60,18 +60,20 @@ impl RouterPlugin for ReplaceSchemaPlugin {
     fn on_http_request<'req>(
         &'req self,
         payload: OnHttpRequestHookPayload<'req>,
-    ) -> OnHttpRequestHookResult<'req> {
-        let variant = payload
-            .router_http_request
-            .headers()
-            .get("x-schema-variant")
-            .and_then(|value| value.to_str().ok());
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            let variant = payload
+                .router_http_request
+                .headers()
+                .get("x-schema-variant")
+                .and_then(|value| value.to_str().ok());
 
-        if variant == Some("basic") {
-            payload.set_supergraph(self.basic_variant.clone());
-        }
+            if variant == Some("basic") {
+                payload.set_supergraph(self.basic_variant.clone());
+            }
 
-        payload.proceed()
+            payload.proceed()
+        })
     }
 }
 

--- a/plugin_examples/replace_schema/src/test.rs
+++ b/plugin_examples/replace_schema/src/test.rs
@@ -136,7 +136,7 @@ mod tests {
             async_trait,
             plugins::{
                 hooks::{
-                    on_http_request::{OnHttpRequestHookPayload, OnHttpRequestHookResult},
+                    on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
                     on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
                     on_supergraph_load::Supergraph,
                 },
@@ -170,18 +170,20 @@ mod tests {
             fn on_http_request<'req>(
                 &'req self,
                 payload: OnHttpRequestHookPayload<'req>,
-            ) -> OnHttpRequestHookResult<'req> {
-                let variant = payload
-                    .router_http_request
-                    .headers()
-                    .get("x-schema-variant")
-                    .and_then(|value| value.to_str().ok());
+            ) -> OnHttpRequestHookFuture<'req> {
+                Box::pin(async move {
+                    let variant = payload
+                        .router_http_request
+                        .headers()
+                        .get("x-schema-variant")
+                        .and_then(|value| value.to_str().ok());
 
-                if variant == Some("basic") {
-                    payload.set_supergraph(self.broken_variant.clone());
-                }
+                    if variant == Some("basic") {
+                        payload.set_supergraph(self.broken_variant.clone());
+                    }
 
-                payload.proceed()
+                    payload.proceed()
+                })
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/graphql-hive/router/issues/1391 

`RouterPlugin::on_http_request` now returns `OnHttpRequestHookFuture<'req>` instead of `OnHttpRequestHookResult<'req>` directly, so plugins can `await` inside - for example calling an upstream/external service, before the rest of the request pipeline runs.

The hook still runs on the same worker thread it started on and is never moved across threads, so the returned future does not need to be `Send`, by using `LocalBoxFuture`. 

```rust
// Before
fn on_http_request<'req>(
    &self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookResult<'req> {
    self.record_request(&payload);
    payload.proceed()
}

// After
fn on_http_request<'req>(
    &'req self,
    payload: OnHttpRequestHookPayload<'req>,
) -> OnHttpRequestHookFuture<'req> {
    Box::pin(async move {
        self.record_request(&payload);
        payload.proceed()
    })
}
```

If the body reads `self` inside the `async move` block, `&self` needs to become `&'req self` - the future now holds that borrow for its own lifetime `'req`, so the borrow has to be able to live at least that long.

### TODO

- [x] try `async_trait` with `?Send` (update: can't, it will force change the whole trait signature and all fns) 
- [x] try `OnHttpRequestHookResult` - ok this works
- [x] update all existing examples
- [x] add example with mock test
- [x] figure out e2e failures
- [ ] docs 