### PR TITLE
fix(router): avoid additional `_total` suffix for counter metrics when Prom exporter is used

### DIFF
--- a/.changeset/fix_prometheus_counter_total_total_suffix.md
+++ b/.changeset/fix_prometheus_counter_total_total_suffix.md
@@ -1,0 +1,14 @@
+---
+hive-router: patch
+---
+
+# Fix doubled `_total` suffix on Prometheus counters
+
+The built-in Prometheus metrics exporter (`/metrics`) generated counter names with a
+doubled suffix, e.g. `hive_router_graphql_errors_total_total` instead of
+`hive_router_graphql_errors_total`.
+
+Counter names on `/metrics` now end in a single `_total`, matching standard
+Prometheus conventions.
+
+OTLP metrics exporter is not affected.

--- a/bin/router/src/telemetry.rs
+++ b/bin/router/src/telemetry.rs
@@ -218,11 +218,14 @@ impl Telemetry {
             .with(logging_layer)
             .with(otel_layer);
 
+        let prometheus_config = metrics_result.as_ref().and_then(|setup| setup.prometheus.as_ref());
+        let prometheus = create_prometheus_runtime(config, prometheus_config)?;
+
         Ok((
             Self {
                 traces_provider: tracer_provider,
                 metrics_provider: metrics_result.map(|setup| setup.provider),
-                prometheus: None,
+                prometheus,
                 context,
                 logging_writer_guard,
             },

--- a/bin/router/src/telemetry.rs
+++ b/bin/router/src/telemetry.rs
@@ -218,7 +218,9 @@ impl Telemetry {
             .with(logging_layer)
             .with(otel_layer);
 
-        let prometheus_config = metrics_result.as_ref().and_then(|setup| setup.prometheus.as_ref());
+        let prometheus_config = metrics_result
+            .as_ref()
+            .and_then(|setup| setup.prometheus.as_ref());
         let prometheus = create_prometheus_runtime(config, prometheus_config)?;
 
         Ok((

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -1148,3 +1148,106 @@ async fn test_otlp_http_client_transport_failure_sets_graphql_status_and_error_t
         labels::HTTP_RESPONSE_STATUS_CODE
     );
 }
+
+/// Ensures counters scraped via the Prometheus exporter have exactly one `_total`
+/// suffix
+#[ntex::test]
+async fn issue_1389_test_prometheus_counter_names_have_single_total_suffix() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {}
+
+          telemetry:
+            metrics:
+              exporters:
+                - kind: prometheus
+      "#,
+            supergraph_path.to_str().unwrap(),
+        ))
+        .build()
+        .start()
+        .await;
+
+    router
+        .send_graphql_request("{ users { id }", None, None)
+        .await;
+
+    let resp = router
+        .serv()
+        .get("/metrics")
+        .send()
+        .await
+        .expect("failed to scrape /metrics");
+    let body = resp.string_body().await;
+
+    assert!(
+        body.contains("hive_router_graphql_errors_total{"),
+        "Expected a single `_total` suffix on the exported counter, got:\n{body}"
+    );
+    assert!(
+        !body.contains("_total_total"),
+        "Prometheus counter names must not double the `_total` suffix, got:\n{body}"
+    );
+}
+
+/// Ensures the OTLP metrics exporter ships counter instrument names as-is, without any suffix modifications
+#[ntex::test]
+async fn issue_1389_test_otlp_counter_names_have_single_total_suffix() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {}
+
+          telemetry:
+            metrics:
+              exporters:
+                - kind: otlp
+                  endpoint: {}
+                  protocol: http
+                  interval: 30ms
+                  max_export_timeout: 2s
+      "#,
+            supergraph_path.to_str().unwrap(),
+            otlp_endpoint
+        ))
+        .build()
+        .start()
+        .await;
+
+    router
+        .send_graphql_request("{ users { id }", None, None)
+        .await;
+
+    wait_for_metrics_export().await;
+
+    let metrics = otlp_collector.metrics_view().await;
+    let attrs = [(labels::CODE, "GRAPHQL_PARSE_FAILED")];
+
+    assert!(
+        metrics.has_counter(names::GRAPHQL_ERRORS_TOTAL, &attrs),
+        "Expected the OTLP instrument name to keep its single `_total` suffix ({})",
+        names::GRAPHQL_ERRORS_TOTAL
+    );
+
+    let doubled_name = format!("{}_total", names::GRAPHQL_ERRORS_TOTAL);
+    assert!(
+        !metrics.has_counter(&doubled_name, &attrs),
+        "OTLP counter names must not double the `_total` suffix, but found {doubled_name}"
+    );
+}

--- a/lib/internal/src/telemetry/metrics/setup.rs
+++ b/lib/internal/src/telemetry/metrics/setup.rs
@@ -443,7 +443,7 @@ fn setup_prometheus_reader(
     let reader = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
         .with_resource_selector(ResourceSelector::All)
-        // .without_counter_suffixes()
+        .without_counter_suffixes()
         .build()
         .map_err(|err| TelemetryError::MetricsExporterSetup(err.to_string()))?;
 

--- a/lib/internal/src/telemetry/metrics/setup.rs
+++ b/lib/internal/src/telemetry/metrics/setup.rs
@@ -443,6 +443,7 @@ fn setup_prometheus_reader(
     let reader = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
         .with_resource_selector(ResourceSelector::All)
+        // .without_counter_suffixes()
         .build()
         .map_err(|err| TelemetryError::MetricsExporterSetup(err.to_string()))?;
 


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1389 

Router counter instrument names already end in `_total`, based on OTEL convention.

The `opentelemetry-prometheus` exporter unconditionally appends its own `_total` suffix for every counter, so the built-in `/metrics` scrape endpoint generated doubled names like `hive_router_graphql_errors_total_total`.

To fix this, added `.without_counter_suffixes()` to the Prometheus exporter builder, instead of renaming any instruments — so OTLP export unaffected.

Also, added e2e tests for the metrics exporting (both prom and otlp), to confirm the fix. 