### PR TITLE
fix(router): use route template as `http.route` in metrics and traces

### DIFF
--- a/.changeset/fix_httproute_lable_value_in_metrics.md
+++ b/.changeset/fix_httproute_lable_value_in_metrics.md
@@ -1,0 +1,13 @@
+---
+hive-router-internal: patch
+hive-router: patch
+hive-router-plan-executor: patch
+---
+
+# Fix `http.route` lable value in metrics
+
+The `http.route` label value in metrics was set to the effective route path, instead of the route template.
+
+In setups with `http.graphql_endpoint` is used, or when persisted documents are used over HTTP paths, this led to high cardinality in metrics.
+
+Thanks [praguevara](https://github.com/praguevara) for contributing.

--- a/.changeset/fix_httproute_lable_value_in_traces.md
+++ b/.changeset/fix_httproute_lable_value_in_traces.md
@@ -1,0 +1,15 @@
+---
+hive-router-internal: patch
+hive-router: patch
+hive-router-plan-executor: patch
+---
+
+# Fix `http.route` lable value in traces
+
+The `http.route` span attribute was set to the effective route path, instead of the route template. 
+
+The [OTEL specification for HTTP spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server) describes the `http.router` field as:
+
+> The matched route template for the request. This MUST be low-cardinality and include all static path segments, with dynamic path segments represented with placeholders.
+
+Thanks [praguevara](https://github.com/praguevara) for contributing.

--- a/.changeset/refactor_internal_hiverouterconfig.md
+++ b/.changeset/refactor_internal_hiverouterconfig.md
@@ -1,0 +1,10 @@
+---
+hive-router-config: patch
+hive-router: patch
+hive-router-internal: patch
+hive-router-plan-executor: patch
+---
+
+# Refactor internal `HiveRouterConfig`
+
+`HiveRouterConfig` can now be treated as `'&static` (by calling `.into_static()`). This makes the work with the config struct easier, as it can be used directly without worrying about lifetimes, and without cloning.

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -188,7 +188,7 @@ async fn graphql_endpoint_handler(
         .telemetry_context
         .metrics
         .http_server
-        .capture_request(&request);
+        .capture_request(&request, app_state.router_config.graphql_path());
 
     let started_at = std::time::Instant::now();
     let (response_mode, mut response, summary_guard) = async {
@@ -283,6 +283,7 @@ async fn graphql_endpoint_dispatch(
             .telemetry
             .client_identification
             .ip_header,
+        app_state.router_config.graphql_path(),
     );
     let _ = root_http_request_span.set_parent(parent_ctx);
 

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -74,6 +74,7 @@ use hive_router_internal::telemetry::{
     logging::{summary, targets},
     otel::{opentelemetry, tracing_opentelemetry::OpenTelemetrySpanExt},
     traces::spans::http_request::HttpServerRequestSpan,
+    utils::RequestRoutePattern,
     TelemetryContext,
 };
 pub use hive_router_internal::BoxError;
@@ -180,6 +181,9 @@ async fn graphql_endpoint_handler(
     schema_state: web::types::State<Arc<SchemaState>>,
     app_state: web::types::State<Arc<RouterSharedState>>,
 ) -> web::HttpResponse {
+    request.extensions_mut().insert(RequestRoutePattern::new(
+        app_state.router_config.graphql_path(),
+    ));
     let parent_ctx = app_state
         .telemetry_context
         .extract_context(&HeaderExtractor(request.headers()));
@@ -188,7 +192,7 @@ async fn graphql_endpoint_handler(
         .telemetry_context
         .metrics
         .http_server
-        .capture_request(&request, app_state.router_config.graphql_path());
+        .capture_request(&request);
 
     let started_at = std::time::Instant::now();
     let (response_mode, mut response, summary_guard) = async {
@@ -283,7 +287,6 @@ async fn graphql_endpoint_dispatch(
             .telemetry
             .client_identification
             .ip_header,
-        app_state.router_config.graphql_path(),
     );
     let _ = root_http_request_span.set_parent(parent_ctx);
 

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -181,9 +181,9 @@ async fn graphql_endpoint_handler(
     schema_state: web::types::State<Arc<SchemaState>>,
     app_state: web::types::State<Arc<RouterSharedState>>,
 ) -> web::HttpResponse {
-    request.extensions_mut().insert(RequestRoutePattern::new(
-        app_state.router_config.graphql_path(),
-    ));
+    request
+        .extensions_mut()
+        .insert(RequestRoutePattern(app_state.router_config.graphql_path()));
     let parent_ctx = app_state
         .telemetry_context
         .extract_context(&HeaderExtractor(request.headers()));
@@ -379,8 +379,8 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     }
 
     let config_path = std::env::var("ROUTER_CONFIG_FILE_PATH").ok();
-    let router_config = load_config(config_path)?;
-    let telemetry = telemetry::Telemetry::init_global(&router_config)?;
+    let router_config = load_config(config_path)?.into_static();
+    let telemetry = telemetry::Telemetry::init_global(router_config)?;
     let prometheus = telemetry
         .prometheus
         .as_ref()
@@ -451,7 +451,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
 
     let graphql_path = graphql_path.to_string();
     let long_lived_client_limit_service =
-        LongLivedClientLimitService::new(&shared_state.router_config);
+        LongLivedClientLimitService::new(shared_state.router_config);
 
     let mut server = web::HttpServer::new(async move || {
         let landing_page_path = graphql_path.clone();
@@ -554,7 +554,7 @@ pub async fn invoke_shutdown_hooks(shared_state: &RouterSharedState) {
 }
 
 pub async fn configure_app_from_config(
-    router_config: HiveRouterConfig,
+    router_config: &'static HiveRouterConfig,
     telemetry_context: TelemetryContext,
     bg_tasks_manager: &mut background_tasks::BackgroundTasksManager,
     plugin_registry: PluginRegistry,
@@ -570,18 +570,17 @@ pub async fn configure_app_from_config(
         }
         _ => None,
     };
-    let plugins_arc = plugin_registry.initialize_plugins(&router_config, bg_tasks_manager)?;
+    let plugins_arc = plugin_registry.initialize_plugins(router_config, bg_tasks_manager)?;
 
     let active_subscriptions =
         ActiveSubscriptions::new(router_config.subscriptions.broadcast_capacity);
     let storage_manager = Arc::new(StorageManager::new(&router_config.storages)?);
-    let router_config_arc = Arc::new(router_config);
     let telemetry_context_arc = Arc::new(telemetry_context);
 
     let schema_state = SchemaState::new_from_config(
         bg_tasks_manager,
         telemetry_context_arc.clone(),
-        router_config_arc.clone(),
+        router_config,
         plugins_arc.clone(),
         active_subscriptions.clone(),
         storage_manager.clone(),
@@ -590,32 +589,31 @@ pub async fn configure_app_from_config(
     let schema_state_arc = Arc::new(schema_state);
 
     let mut validation_plan = default_rules_validation_plan();
-    if let Some(max_depth_config) = &router_config_arc.limits.max_depth {
+    if let Some(max_depth_config) = &router_config.limits.max_depth {
         validation_plan.add_rule(Box::new(MaxDepthRule {
             config: max_depth_config.clone(),
         }));
     }
-    if let Some(max_directives_config) = &router_config_arc.limits.max_directives {
+    if let Some(max_directives_config) = &router_config.limits.max_directives {
         validation_plan.add_rule(Box::new(MaxDirectivesRule {
             config: max_directives_config.clone(),
         }));
     }
-    if let Some(max_aliases_config) = &router_config_arc.limits.max_aliases {
+    if let Some(max_aliases_config) = &router_config.limits.max_aliases {
         validation_plan.add_rule(Box::new(MaxAliasesRule {
             config: max_aliases_config.clone(),
         }));
     }
     let persisted_documents_runtime = PersistedDocumentsRuntime::init(
-        &router_config_arc.persisted_documents,
-        &router_config_arc.http.graphql_endpoint,
+        &router_config.persisted_documents,
+        &router_config.http.graphql_endpoint,
         bg_tasks_manager,
         &storage_manager,
     )
     .await
     .map_err(|err| crate::shared_state::SharedStateError::PersistedDocuments(Box::new(err)))?;
 
-    if !persisted_documents_runtime
-        .supports_graphql_endpoint(&router_config_arc.http.graphql_endpoint)
+    if !persisted_documents_runtime.supports_graphql_endpoint(&router_config.http.graphql_endpoint)
     {
         // url_path_param extractor depends on path segments relative to graphql endpoint.
         // Root endpoint would make all routes ambiguous for persisted-document extraction.
@@ -625,9 +623,9 @@ pub async fn configure_app_from_config(
         ));
     }
 
-    let metrics_enabled = router_config_arc.telemetry.metrics.is_enabled();
+    let metrics_enabled = router_config.telemetry.metrics.is_enabled();
     let shared_state = Arc::new(RouterSharedState::new(
-        router_config_arc,
+        router_config,
         persisted_documents_runtime,
         jwt_runtime,
         hive_usage_agent,

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -767,7 +767,7 @@ pub async fn execute_pipeline<'exec>(
         CancellationToken::with_timeout(shared_state.router_config.query_planner.timeout);
 
     let (mut normalize_payload, authorization_errors) = enforce_operation_authorization(
-        &shared_state.router_config,
+        shared_state.router_config,
         &normalize_payload,
         &supergraph.runtime.authorization,
         &supergraph.snapshot.metadata,

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -85,13 +85,13 @@ pub struct RouterSupergraphRuntime {
 impl RouterSupergraphRuntime {
     pub fn build(
         snapshot: &SupergraphSnapshot,
-        router_config: &Arc<HiveRouterConfig>,
+        router_config: &'static HiveRouterConfig,
         telemetry_context: &Arc<TelemetryContext>,
         callback_subscriptions: &CallbackSubscriptionsMap,
     ) -> Result<Self, RouterSupergraphRuntimeError> {
         let subgraph_executor_map = Arc::new(SubgraphExecutorMap::from_http_endpoint_map(
             &snapshot.planner.supergraph.subgraph_endpoint_map,
-            router_config.clone(),
+            router_config,
             telemetry_context.clone(),
             callback_subscriptions.clone(),
         )?);
@@ -153,7 +153,7 @@ const RUNTIME_CACHE_MAX_SIZE: usize = 10;
 type RouterSupergraphRuntimeCache = Mutex<VecDeque<(u64, Arc<RouterSupergraphRuntime>)>>;
 
 pub struct SchemaState {
-    router_config: Arc<HiveRouterConfig>,
+    router_config: &'static HiveRouterConfig,
     /// The supergraph configured through the router config that can be loaded (and polled)
     ///   - `Some` when the router's configured supergraph is available and has been loaded
     ///   - sometimes `None` when the supergraph is being fetched and built
@@ -278,7 +278,7 @@ impl SchemaState {
 
         let runtime = Arc::new(RouterSupergraphRuntime::build(
             snapshot,
-            &self.router_config,
+            self.router_config,
             &self.telemetry_context,
             &self.callback_subscriptions,
         )?);
@@ -328,7 +328,7 @@ impl SchemaState {
     pub async fn new_from_config(
         bg_tasks_manager: &mut BackgroundTasksManager,
         telemetry_context: Arc<TelemetryContext>,
-        router_config: Arc<HiveRouterConfig>,
+        router_config: &'static HiveRouterConfig,
         plugins: Option<Arc<Vec<RouterPluginBoxed>>>,
         active_subscriptions: ActiveSubscriptions,
         storage_manager: Arc<StorageManager>,
@@ -357,7 +357,6 @@ impl SchemaState {
                 .register_task(SupergraphBackgroundLoaderTask(Arc::new(background_loader)));
 
             let configured_spawn_clone = configured.clone();
-            let router_config_for_task = router_config.clone();
             let task_telemetry = telemetry_context.clone();
             let callback_subscriptions_for_reload = callback_subscriptions.clone();
 
@@ -410,7 +409,7 @@ impl SchemaState {
 
                     let query_planner_options =
                         hive_router_query_planner::planner::QueryPlannerOptions {
-                            experimental_abstract_type_folding: router_config_for_task
+                            experimental_abstract_type_folding: router_config
                                 .query_planner
                                 .experimental_abstract_type_folding,
                         };
@@ -451,7 +450,7 @@ impl SchemaState {
                             let snapshot = new_supergraph.snapshot();
                             let runtime = RouterSupergraphRuntime::build(
                                 &snapshot,
-                                &router_config_for_task,
+                                router_config,
                                 &task_telemetry,
                                 &callback_subscriptions_for_reload,
                             )?;
@@ -774,7 +773,7 @@ mod plugin_runtime_cache_tests {
             configured: Arc::new(ArcSwap::from(Arc::new(None))),
             runtime_cache: Arc::new(Mutex::new(VecDeque::with_capacity(RUNTIME_CACHE_MAX_SIZE))),
             runtime_cache_cleanup: None,
-            router_config: Arc::new(HiveRouterConfig::default()),
+            router_config: HiveRouterConfig::default().into_static(),
             telemetry_context: Arc::new(TelemetryContext::from_propagation_config(
                 &Default::default(),
                 &Default::default(),
@@ -1018,7 +1017,7 @@ mod plugin_runtime_cache_tests {
                 Arc::new(
                     RouterSupergraphRuntime::build(
                         &owner.snapshot(),
-                        &Arc::new(HiveRouterConfig::default()),
+                        HiveRouterConfig::default().into_static(),
                         &Arc::new(TelemetryContext::from_propagation_config(
                             &Default::default(),
                             &Default::default(),

--- a/bin/router/src/shared_state.rs
+++ b/bin/router/src/shared_state.rs
@@ -328,7 +328,7 @@ pub struct RouterSharedState {
     pub validation_plan: Arc<ValidationPlan>,
     pub parse_cache: Cache<u64, ParseCacheEntry>,
     pub persisted_documents_runtime: PersistedDocumentsRuntime,
-    pub router_config: Arc<HiveRouterConfig>,
+    pub router_config: &'static HiveRouterConfig,
     pub headers_plan: Arc<HeaderRulesPlan>,
     pub extensions_plan: Arc<ExtensionsPlan>,
     pub override_labels_evaluator: OverrideLabelsEvaluator,
@@ -362,7 +362,7 @@ pub struct RouterSharedState {
 impl RouterSharedState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        router_config: Arc<HiveRouterConfig>,
+        router_config: &'static HiveRouterConfig,
         persisted_documents_runtime: PersistedDocumentsRuntime,
         jwt_auth_runtime: Option<JwtAuthRuntime>,
         hive_usage_agent: Option<UsageAgent>,
@@ -404,7 +404,7 @@ impl RouterSharedState {
                 .max_capacity(10_000)
                 .expire_after(JwtClaimsExpiry)
                 .build(),
-            router_config: router_config.clone(),
+            router_config,
             override_labels_evaluator: OverrideLabelsEvaluator::from_config(
                 &router_config.override_labels,
             )

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -1149,6 +1149,111 @@ async fn test_otlp_http_client_transport_failure_sets_graphql_status_and_error_t
     );
 }
 
+/// Ensures `http.route` stays low-cardinality when it comes to the HTTP path: requests that resolve to different
+/// persisted-document paths under the same registered endpoint must all be reported
+/// under a single `http.route` series, not one series per concrete path.
+#[ntex::test]
+async fn test_otlp_http_route_metric_is_low_cardinality_for_persisted_document_paths() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+    let manifest = NamedTempFile::new().expect("failed to create temp persisted manifest");
+    std::fs::write(
+        manifest.path(),
+        sonic_rs::to_string(&sonic_rs::json!({
+            "doc-a": "{ topProducts { name } }",
+            "doc-b": "{ topProducts { name } }",
+            "doc-c": "{ topProducts { name } }",
+        }))
+        .expect("failed to serialize manifest"),
+    )
+    .expect("failed to write manifest");
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {}
+
+          persisted_documents:
+            enabled: true
+            require_id: true
+            storage:
+              type: file
+              path: "{}"
+            selectors:
+              - type: url_path_param
+                template: /docs/:id
+
+          telemetry:
+            metrics:
+              exporters:
+                - kind: otlp
+                  endpoint: {}
+                  protocol: http
+                  interval: 30ms
+                  max_export_timeout: 2s
+      "#,
+            supergraph_path.to_str().unwrap(),
+            manifest.path().display(),
+            otlp_endpoint
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    // Each of these hits a distinct concrete request path (`/graphql/docs/doc-a`, etc.),
+    // but all match the same registered `/graphql` endpoint.
+    for doc_id in ["doc-a", "doc-b", "doc-c"] {
+        let response = router
+            .send_post_request(
+                &format!("/graphql/docs/{doc_id}"),
+                sonic_rs::json!({}),
+                None,
+            )
+            .await;
+        assert!(
+            response.status().is_success(),
+            "expected persisted document request to resolve successfully"
+        );
+    }
+
+    wait_for_metrics_export().await;
+
+    let metrics = otlp_collector.metrics_view().await;
+
+    // All 3 requests must have collapsed into the single, low-cardinality route template.
+    let (count, _sum) = metrics.latest_histogram_count_sum(
+        names::HTTP_SERVER_REQUEST_DURATION,
+        &[(labels::HTTP_ROUTE, "/graphql")],
+    );
+    assert_eq!(
+        count, 3,
+        "expected all 3 requests to share a single http.route=/graphql series"
+    );
+
+    // None of the concrete per-document paths must have leaked into `http.route`.
+    for doc_id in ["doc-a", "doc-b", "doc-c"] {
+        let concrete_path = format!("/graphql/docs/{doc_id}");
+        assert!(
+            !metrics.has_histogram(
+                names::HTTP_SERVER_REQUEST_DURATION,
+                &[(labels::HTTP_ROUTE, concrete_path.as_str())],
+            ),
+            "did not expect a dedicated http.route series for concrete path {concrete_path}"
+        );
+    }
+}
+
 /// Ensures counters scraped via the Prometheus exporter have exactly one `_total`
 /// suffix
 #[ntex::test]

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -12,6 +12,7 @@ use hive_router::{
     plugins::hooks::on_plugin_init::OnPluginInitResult, plugins::plugin_trait::RouterPlugin,
 };
 use hive_router_internal::telemetry::metrics::catalog::{labels, labels_for, names, values};
+use sonic_rs::json;
 use tempfile::NamedTempFile;
 
 async fn wait_for_metrics_export() {
@@ -1149,9 +1150,7 @@ async fn test_otlp_http_client_transport_failure_sets_graphql_status_and_error_t
     );
 }
 
-/// Ensures `http.route` stays low-cardinality when it comes to the HTTP path: requests that resolve to different
-/// persisted-document paths under the same registered endpoint must all be reported
-/// under a single `http.route` series, not one series per concrete path.
+/// Ensures `http.route` stays low-cardinality when it comes to the HTTP path, also when pattern matching is used.
 #[ntex::test]
 async fn test_otlp_http_route_metric_is_low_cardinality_for_persisted_document_paths() {
     let supergraph_path =
@@ -1252,6 +1251,82 @@ async fn test_otlp_http_route_metric_is_low_cardinality_for_persisted_document_p
             "did not expect a dedicated http.route series for concrete path {concrete_path}"
         );
     }
+}
+
+/// Ensures `http.route` stays low-cardinality when it comes to the HTTP path: requests that resolve to different
+/// persisted-document paths under the same registered endpoint must all be reported
+/// under a single `http.route` series, not one series per concrete path.
+#[ntex::test]
+async fn test_otlp_http_route_metric_is_low_cardinality_for_custom_graphql_paths() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {}
+
+          http:
+            graphql_endpoint: /{{tenant}}/graphql
+
+          telemetry:
+            metrics:
+              exporters:
+                - kind: otlp
+                  endpoint: {}
+                  protocol: http
+                  interval: 30ms
+                  max_export_timeout: 2s
+      "#,
+            supergraph_path.to_str().unwrap(),
+            otlp_endpoint
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    router
+        .send_post_request(
+            "/one/graphql",
+            json!({
+              "query": "{ users { id }",
+            }),
+            None,
+        )
+        .await;
+
+    router
+        .send_post_request(
+            "/two/graphql",
+            json!({
+              "query": "{ users { id }",
+            }),
+            None,
+        )
+        .await;
+    wait_for_metrics_export().await;
+
+    let metrics = otlp_collector.metrics_view().await;
+
+    // All 3 requests must have collapsed into the single, low-cardinality route template.
+    let (count, _sum) = metrics.latest_histogram_count_sum(
+        names::HTTP_SERVER_REQUEST_DURATION,
+        &[(labels::HTTP_ROUTE, "/{tenant}/graphql")],
+    );
+    assert_eq!(
+        count, 2,
+        "expected all 2 requests to share a single http.route=/{{tenant}}/graphql series"
+    );
 }
 
 /// Ensures counters scraped via the Prometheus exporter have exactly one `_total`

--- a/e2e/src/telemetry/tracing/otlp_attributes.rs
+++ b/e2e/src/telemetry/tracing/otlp_attributes.rs
@@ -1,3 +1,5 @@
+use sonic_rs::json;
+
 use crate::testkit::{otel::OtlpCollector, some_header_map, TestRouter, TestSubgraphs};
 
 /// Verify only deprecated attributes are emitted for deprecated mode
@@ -290,6 +292,107 @@ async fn test_spec_and_deprecated_span_attributes() {
         target: hive-router
         url.full: http://[address]:[port]/accounts
         url.path: /accounts
+        url.scheme: http
+    "
+    );
+}
+
+/// Verify both spec-compliant and deprecated attributes are emitted for spec_and_deprecated mode
+#[ntex::test]
+async fn test_http_route_attribute_is_low_cardinality() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+    let supergraph_path = supergraph_path.to_str().unwrap();
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let _insta_settings_guard = otlp_collector.insta_filter_settings().bind_to_scope();
+    let otlp_endpoint = otlp_collector.grpc_endpoint();
+
+    let subgraphs = TestSubgraphs::builder().build().start().await;
+
+    let router = TestRouter::builder()
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {supergraph_path}
+
+          http:
+            graphql_endpoint: /{{tenant}}/graphql
+
+          telemetry:
+            tracing:
+              instrumentation:
+                spans:
+                  mode: spec_and_deprecated
+              propagation:
+                trace_context: true
+              exporters:
+                - kind: otlp
+                  endpoint: {otlp_endpoint}
+                  protocol: grpc
+                  batch_processor:
+                    scheduled_delay: 50ms
+                    max_export_timeout: 2s
+      "#,
+        ))
+        .with_subgraphs(&subgraphs)
+        .build()
+        .start()
+        .await;
+
+    let res = router
+        .send_post_request(
+            "/test/graphql",
+            json!({
+              "query": "{ users { id } }"
+            }),
+            None,
+        )
+        .await;
+
+    assert!(res.status().is_success());
+
+    // Wait for exports to be sent
+    let http_server_span = otlp_collector
+        .wait_for_span_by_hive_kind_one("http.server")
+        .await;
+
+    insta::assert_snapshot!(
+      http_server_span,
+      @"
+    Span: http.server
+      Kind: Server
+      Status: message='' code='1'
+      Attributes:
+        client.address: [address]
+        client.port: [port]
+        hive.kind: http.server
+        http.flavor: 1.1
+        http.host: localhost
+        http.method: POST
+        http.request.body.size: 28
+        http.request.method: POST
+        http.request_content_length: 28
+        http.response.body.size: 86
+        http.response.status_code: 200
+        http.response_content_length: 86
+        http.route: /{tenant}/graphql
+        http.scheme: http
+        http.status_code: 200
+        http.target: /test/graphql
+        http.url: /test/graphql
+        network.peer.address: [address]
+        network.peer.port: [port]
+        network.protocol.version: 1.1
+        router.request_id: [request_id]
+        server.address: localhost
+        server.port: [port]
+        target: hive-router
+        url.full: /test/graphql
+        url.path: /test/graphql
         url.scheme: http
     "
     );

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -705,7 +705,7 @@ impl TestRouterBuilder {
             callback_conf: config.callback_conf().cloned(),
             port: self.port,
             listener: self.listener,
-            config: Some(config),
+            config: Some(config.into_static()),
             plugins: self.plugins,
             handle: None,
             _hold_until_drop,
@@ -796,7 +796,7 @@ pub struct TestRouter<State> {
     callback_conf: Option<CallbackConfig>,
     port: u16,
     listener: Option<std::net::TcpListener>,
-    config: Option<HiveRouterConfig>,
+    config: Option<&'static HiveRouterConfig>,
     plugins: Vec<Box<dyn Fn(PluginRegistry) -> PluginRegistry>>,
     handle: Option<TestRouterHandle>,
     _hold_until_drop: Vec<Box<dyn Any>>,
@@ -813,7 +813,7 @@ impl TestRouter<Built> {
     pub async fn start_without_healthcheck(mut self) -> TestRouter<Started> {
         init_rustls_crypto_provider();
         let config = self.config.take().unwrap();
-        let (telemetry, subscriber) = Telemetry::init_testing_subscriber(&config)
+        let (telemetry, subscriber) = Telemetry::init_testing_subscriber(config)
             .expect("failed to initialize telemetry subscriber");
         let subscription_guard = tracing::subscriber::set_default(subscriber);
         let prometheus = telemetry
@@ -901,7 +901,7 @@ impl TestRouter<Built> {
             .port();
         let serv_paths = paths.clone();
         let serv_prometheus = prometheus.clone();
-        let long_lived_limit = LongLivedClientLimitService::new(&shared_state.router_config);
+        let long_lived_limit = LongLivedClientLimitService::new(shared_state.router_config);
         let mut serv_config = test::config()
             .client_timeout(Seconds(
                 shared_state

--- a/lib/executor/src/execution/plan.rs
+++ b/lib/executor/src/execution/plan.rs
@@ -1923,7 +1923,7 @@ mod tests {
 
         let executors = SubgraphExecutorMap::from_http_endpoint_map(
             &subgraph_endpoint_map,
-            HiveRouterConfig::default().into(),
+            HiveRouterConfig::default().into_static(),
             Arc::new(TelemetryContext::from_propagation_config(
                 &Default::default(),
                 &Default::default(),
@@ -2046,7 +2046,7 @@ mod tests {
             schema_metadata: &SchemaMetadata::default(),
             executors: &SubgraphExecutorMap::from_http_endpoint_map(
                 &subgraph_endpoint_map,
-                HiveRouterConfig::default().into(),
+                HiveRouterConfig::default().into_static(),
                 Arc::new(TelemetryContext::from_propagation_config(
                     &Default::default(),
                     &Default::default(),

--- a/lib/executor/src/executors/http.rs
+++ b/lib/executor/src/executors/http.rs
@@ -58,7 +58,7 @@ pub struct HTTPSubgraphExecutor {
     pub dedupe_enabled: bool,
     pub in_flight_requests: InflightRequestsMap,
     pub telemetry_context: Arc<TelemetryContext>,
-    pub config: Arc<HiveRouterConfig>,
+    pub config: &'static HiveRouterConfig,
 }
 
 const FIRST_VARIABLE_STR: &[u8] = b",\"variables\":{";
@@ -167,7 +167,7 @@ impl HTTPSubgraphExecutor {
         dedupe_enabled: bool,
         in_flight_requests: InflightRequestsMap,
         telemetry_context: Arc<TelemetryContext>,
-        config: Arc<HiveRouterConfig>,
+        config: &'static HiveRouterConfig,
     ) -> Self {
         let mut header_map = HeaderMap::new();
         header_map.insert(

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -158,7 +158,7 @@ pub struct SubgraphExecutorMap {
     timeouts_by_subgraph: TimeoutsBySubgraph,
     circuit_breakers_by_subgraph: CircuitBreakersBySubgraph,
     global_timeout: DurationOrProgram,
-    config: Arc<HiveRouterConfig>,
+    config: &'static HiveRouterConfig,
     client: Arc<HttpClient>,
     semaphores_by_origin: DashMap<String, Arc<Semaphore>>,
     max_connections_per_host: usize,
@@ -177,7 +177,7 @@ pub struct SubgraphExecutorMap {
 }
 impl SubgraphExecutorMap {
     pub fn new(
-        config: Arc<HiveRouterConfig>,
+        config: &'static HiveRouterConfig,
         global_timeout: DurationOrProgram,
         telemetry_context: Arc<TelemetryContext>,
     ) -> Result<Self, SubgraphExecutorError> {
@@ -217,7 +217,7 @@ impl SubgraphExecutorMap {
 
     pub fn from_http_endpoint_map(
         subgraph_endpoint_map: &HashMap<SubgraphName, String>,
-        config: Arc<HiveRouterConfig>,
+        config: &'static HiveRouterConfig,
         telemetry_context: Arc<TelemetryContext>,
         active_callback_subscriptions: CallbackSubscriptionsMap,
     ) -> Result<Self, SubgraphExecutorError> {
@@ -230,7 +230,7 @@ impl SubgraphExecutorMap {
                     )
                 })?;
         let mut subgraph_executor_map =
-            SubgraphExecutorMap::new(config.clone(), global_timeout, telemetry_context)?;
+            SubgraphExecutorMap::new(config, global_timeout, telemetry_context)?;
         subgraph_executor_map.callback_subscriptions = active_callback_subscriptions;
 
         // The `all` expression is configured once but evaluated against each subgraph.
@@ -839,7 +839,7 @@ impl SubgraphExecutorMap {
                     subgraph_config.dedupe_enabled,
                     self.in_flight_requests.clone(),
                     self.telemetry_context.clone(),
-                    self.config.clone(),
+                    self.config,
                 )
                 .to_boxed_arc();
 

--- a/lib/internal/src/telemetry/metrics/http_server_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/http_server_metrics.rs
@@ -10,6 +10,7 @@ use crate::telemetry::metrics::capture::Capture;
 #[cfg(debug_assertions)]
 use crate::telemetry::metrics::catalog::debug_assert_attrs;
 use crate::telemetry::metrics::catalog::{labels, names, values};
+use crate::telemetry::utils::RequestRoutePattern;
 
 struct HttpServerInstruments {
     request_duration: Option<Histogram<f64>>,
@@ -97,7 +98,6 @@ impl HttpServerMetrics {
     pub fn capture_request<'a>(
         &'a self,
         request: &HttpRequest,
-        route: &str,
     ) -> Capture<HttpServerRequestState<'a>> {
         if !self.instruments.is_enabled() {
             return Capture::disabled();
@@ -105,6 +105,11 @@ impl HttpServerMetrics {
 
         let method = request.method().as_static_str();
         let scheme = request.uri().scheme_static_str();
+        let req_extensions = request.extensions();
+        let route = req_extensions
+            .get::<RequestRoutePattern>()
+            .map(|v| v.0.as_str())
+            .unwrap_or_default();
 
         Capture::enabled(HttpServerRequestState {
             instruments: &self.instruments,

--- a/lib/internal/src/telemetry/metrics/http_server_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/http_server_metrics.rs
@@ -33,7 +33,7 @@ pub struct HttpServerRequestState<'a> {
     _active_request_guard: HttpServerActiveRequestGuard<'a>,
     method: &'static str,
     scheme: &'static str,
-    route: String,
+    route: &'static str,
     protocol_version: &'static str,
     started_at: Instant,
 }
@@ -103,7 +103,7 @@ impl HttpServerMetrics {
         let method = request.method().as_static_str();
         let scheme = request.uri().scheme_static_str();
         let req_extensions = request.extensions();
-        let route = req_extensions
+        let route_pattern = req_extensions
             .get::<RequestRoutePattern>()
             .map(|v| v.0)
             .unwrap_or_default();
@@ -113,7 +113,7 @@ impl HttpServerMetrics {
             _active_request_guard: self.active_request_started(method, scheme),
             method,
             scheme,
-            route: route.to_string(),
+            route: route_pattern,
             protocol_version: request.version().as_static_str(),
             started_at: Instant::now(),
         })

--- a/lib/internal/src/telemetry/metrics/http_server_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/http_server_metrics.rs
@@ -92,9 +92,6 @@ impl HttpServerMetrics {
         }
     }
 
-    /// `route` is the *route template* the request matched (e.g. `/{tenant}/graphql`),
-    /// not the concrete request path: `http.route` is a metric attribute, so a
-    /// per-request value would grow the time series cardinality without bound.
     pub fn capture_request<'a>(
         &'a self,
         request: &HttpRequest,

--- a/lib/internal/src/telemetry/metrics/http_server_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/http_server_metrics.rs
@@ -108,7 +108,7 @@ impl HttpServerMetrics {
         let req_extensions = request.extensions();
         let route = req_extensions
             .get::<RequestRoutePattern>()
-            .map(|v| v.0.as_str())
+            .map(|v| v.0)
             .unwrap_or_default();
 
         Capture::enabled(HttpServerRequestState {

--- a/lib/internal/src/telemetry/metrics/http_server_metrics.rs
+++ b/lib/internal/src/telemetry/metrics/http_server_metrics.rs
@@ -91,9 +91,13 @@ impl HttpServerMetrics {
         }
     }
 
+    /// `route` is the *route template* the request matched (e.g. `/{tenant}/graphql`),
+    /// not the concrete request path: `http.route` is a metric attribute, so a
+    /// per-request value would grow the time series cardinality without bound.
     pub fn capture_request<'a>(
         &'a self,
         request: &HttpRequest,
+        route: &str,
     ) -> Capture<HttpServerRequestState<'a>> {
         if !self.instruments.is_enabled() {
             return Capture::disabled();
@@ -107,7 +111,7 @@ impl HttpServerMetrics {
             _active_request_guard: self.active_request_started(method, scheme),
             method,
             scheme,
-            route: request.path().to_string(),
+            route: route.to_string(),
             protocol_version: request.version().as_static_str(),
             started_at: Instant::now(),
         })

--- a/lib/internal/src/telemetry/traces/compatibility.rs
+++ b/lib/internal/src/telemetry/traces/compatibility.rs
@@ -279,7 +279,7 @@ impl<E: SpanExporter> SpanExporter for HttpCompatibilityExporter<E> {
 mod tests {
     use super::*;
     use crate::telemetry::traces::spans::http_request::{
-        HttpClientRequestSpan, HttpServerRequestSpan,
+        HttpClientRequestSpan, HttpServerRequestSpan, HttpServerSpanRequest,
     };
     use hive_router_config::telemetry::ClientIpHeaderConfig;
     use http::header::FORWARDED;
@@ -318,6 +318,15 @@ mod tests {
 
     fn forwarded_ip_header_config() -> Option<ClientIpHeaderConfig> {
         Some(ClientIpHeaderConfig::HeaderName(FORWARDED.as_str().into()))
+    }
+
+    /// Every HTTP server span below is built from a request to `/test`, so they all
+    /// report the same route template.
+    fn http_server_span<Req: HttpServerSpanRequest>(
+        request: &Req,
+        client_ip_header_config: &Option<ClientIpHeaderConfig>,
+    ) -> HttpServerRequestSpan {
+        HttpServerRequestSpan::from_request(request, client_ip_header_config, "/test")
     }
 
     fn setup_tracing_subscriber(provider: &SdkTracerProvider) -> impl Drop {
@@ -362,8 +371,7 @@ mod tests {
             ntex::web::HttpResponse::build(ntex::http::StatusCode::OK).body("response body");
 
         tracer.in_span("root", |_cx| {
-            let span =
-                HttpServerRequestSpan::from_request(&http_req, &forwarded_ip_header_config());
+            let span = http_server_span(&http_req, &forwarded_ip_header_config());
             span.record_body_size(body.len());
             span.record_response(&http_res);
         });
@@ -416,8 +424,7 @@ mod tests {
             ntex::web::HttpResponse::build(ntex::http::StatusCode::OK).body("response body");
 
         tracer.in_span("root", |_cx| {
-            let span =
-                HttpServerRequestSpan::from_request(&http_req, &forwarded_ip_header_config());
+            let span = http_server_span(&http_req, &forwarded_ip_header_config());
             span.record_body_size(body.len());
             span.record_response(&http_res);
         });
@@ -469,8 +476,7 @@ mod tests {
             ntex::web::HttpResponse::build(ntex::http::StatusCode::OK).body("response body");
 
         tracer.in_span("root", |_cx| {
-            let span =
-                HttpServerRequestSpan::from_request(&http_req, &forwarded_ip_header_config());
+            let span = http_server_span(&http_req, &forwarded_ip_header_config());
             span.record_body_size(body.len());
             span.record_response(&http_res);
         });

--- a/lib/internal/src/telemetry/traces/compatibility.rs
+++ b/lib/internal/src/telemetry/traces/compatibility.rs
@@ -326,7 +326,7 @@ mod tests {
         request: &Req,
         client_ip_header_config: &Option<ClientIpHeaderConfig>,
     ) -> HttpServerRequestSpan {
-        HttpServerRequestSpan::from_request(request, client_ip_header_config, "/test")
+        HttpServerRequestSpan::from_request(request, client_ip_header_config)
     }
 
     fn setup_tracing_subscriber(provider: &SdkTracerProvider) -> impl Drop {

--- a/lib/internal/src/telemetry/traces/compatibility.rs
+++ b/lib/internal/src/telemetry/traces/compatibility.rs
@@ -279,7 +279,7 @@ impl<E: SpanExporter> SpanExporter for HttpCompatibilityExporter<E> {
 mod tests {
     use super::*;
     use crate::telemetry::traces::spans::http_request::{
-        HttpClientRequestSpan, HttpServerRequestSpan, HttpServerSpanRequest,
+        HttpClientRequestSpan, HttpServerRequestSpan,
     };
     use hive_router_config::telemetry::ClientIpHeaderConfig;
     use http::header::FORWARDED;
@@ -318,15 +318,6 @@ mod tests {
 
     fn forwarded_ip_header_config() -> Option<ClientIpHeaderConfig> {
         Some(ClientIpHeaderConfig::HeaderName(FORWARDED.as_str().into()))
-    }
-
-    /// Every HTTP server span below is built from a request to `/test`, so they all
-    /// report the same route template.
-    fn http_server_span<Req: HttpServerSpanRequest>(
-        request: &Req,
-        client_ip_header_config: &Option<ClientIpHeaderConfig>,
-    ) -> HttpServerRequestSpan {
-        HttpServerRequestSpan::from_request(request, client_ip_header_config)
     }
 
     fn setup_tracing_subscriber(provider: &SdkTracerProvider) -> impl Drop {
@@ -371,7 +362,8 @@ mod tests {
             ntex::web::HttpResponse::build(ntex::http::StatusCode::OK).body("response body");
 
         tracer.in_span("root", |_cx| {
-            let span = http_server_span(&http_req, &forwarded_ip_header_config());
+            let span =
+                HttpServerRequestSpan::from_request(&http_req, &forwarded_ip_header_config());
             span.record_body_size(body.len());
             span.record_response(&http_res);
         });
@@ -424,7 +416,8 @@ mod tests {
             ntex::web::HttpResponse::build(ntex::http::StatusCode::OK).body("response body");
 
         tracer.in_span("root", |_cx| {
-            let span = http_server_span(&http_req, &forwarded_ip_header_config());
+            let span =
+                HttpServerRequestSpan::from_request(&http_req, &forwarded_ip_header_config());
             span.record_body_size(body.len());
             span.record_response(&http_res);
         });
@@ -476,7 +469,8 @@ mod tests {
             ntex::web::HttpResponse::build(ntex::http::StatusCode::OK).body("response body");
 
         tracer.in_span("root", |_cx| {
-            let span = http_server_span(&http_req, &forwarded_ip_header_config());
+            let span =
+                HttpServerRequestSpan::from_request(&http_req, &forwarded_ip_header_config());
             span.record_body_size(body.len());
             span.record_response(&http_res);
         });

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -22,6 +22,7 @@ pub trait HttpServerSpanRequest {
     fn uri(&self) -> &Uri;
     fn version(&self) -> Version;
     fn peer_addr(&self) -> Option<SocketAddr>;
+    fn route_pattern(&self) -> String;
 }
 
 impl HttpServerSpanRequest for ntex::web::HttpRequest {
@@ -31,6 +32,14 @@ impl HttpServerSpanRequest for ntex::web::HttpRequest {
 
     fn method(&self) -> &Method {
         self.method()
+    }
+
+    fn route_pattern(&self) -> String {
+        self.extensions()
+            .get::<RequestRoutePattern>()
+            .map(|v| v.0.as_str())
+            .unwrap_or_default()
+            .to_string()
     }
 
     fn uri(&self) -> &Uri {
@@ -46,7 +55,6 @@ impl HttpServerSpanRequest for ntex::web::HttpRequest {
     }
 }
 
-use crate::http::{HttpMethodAsStr, HttpUriAsStr, HttpVersionAsStr};
 use crate::telemetry::traces::{
     disabled_span, is_level_enabled,
     spans::{
@@ -54,6 +62,10 @@ use crate::telemetry::traces::{
         kind::HiveSpanKind,
         TARGET_NAME,
     },
+};
+use crate::{
+    http::{HttpMethodAsStr, HttpUriAsStr, HttpVersionAsStr},
+    telemetry::utils::RequestRoutePattern,
 };
 
 pub struct HttpServerRequestSpan {
@@ -81,7 +93,6 @@ impl HttpServerRequestSpan {
     pub fn from_request<Req: HttpServerSpanRequest>(
         request: &Req,
         client_ip_header_config: &Option<ClientIpHeaderConfig>,
-        route: &str,
     ) -> Self {
         if !is_level_enabled(Level::INFO) {
             return Self {
@@ -139,7 +150,7 @@ impl HttpServerRequestSpan {
             "user_agent.original" = header_user_agent.as_ref().and_then(|v| v.to_str().ok()),
             "http.response.status_code" = Empty,
             "http.response.body.size" = Empty,
-            "http.route" = route,
+            "http.route" = request.route_pattern(),
             // Client
             "client.address" = client_address,
             "client.port" = client_port,

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -85,10 +85,6 @@ impl Borrow<Span> for HttpServerRequestSpan {
 }
 
 impl HttpServerRequestSpan {
-    /// `route` is the *route template* the request matched (e.g. `/{tenant}/graphql`),
-    /// not the concrete request path. `http.route` MUST be low-cardinality per semconv,
-    /// as backends commonly derive span names and span metrics from it:
-    /// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server
     pub fn from_request<Req: HttpServerSpanRequest>(
         request: &Req,
         client_ip_header_config: &Option<ClientIpHeaderConfig>,

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -74,9 +74,14 @@ impl Borrow<Span> for HttpServerRequestSpan {
 }
 
 impl HttpServerRequestSpan {
+    /// `route` is the *route template* the request matched (e.g. `/{tenant}/graphql`),
+    /// not the concrete request path. `http.route` MUST be low-cardinality per semconv,
+    /// as backends commonly derive span names and span metrics from it:
+    /// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server
     pub fn from_request<Req: HttpServerSpanRequest>(
         request: &Req,
         client_ip_header_config: &Option<ClientIpHeaderConfig>,
+        route: &str,
     ) -> Self {
         if !is_level_enabled(Level::INFO) {
             return Self {
@@ -134,7 +139,7 @@ impl HttpServerRequestSpan {
             "user_agent.original" = header_user_agent.as_ref().and_then(|v| v.to_str().ok()),
             "http.response.status_code" = Empty,
             "http.response.body.size" = Empty,
-            "http.route" = url.path(),
+            "http.route" = route,
             // Client
             "client.address" = client_address,
             "client.port" = client_port,

--- a/lib/internal/src/telemetry/traces/spans/http_request.rs
+++ b/lib/internal/src/telemetry/traces/spans/http_request.rs
@@ -22,7 +22,7 @@ pub trait HttpServerSpanRequest {
     fn uri(&self) -> &Uri;
     fn version(&self) -> Version;
     fn peer_addr(&self) -> Option<SocketAddr>;
-    fn route_pattern(&self) -> String;
+    fn route_pattern(&self) -> &'static str;
 }
 
 impl HttpServerSpanRequest for ntex::web::HttpRequest {
@@ -34,12 +34,11 @@ impl HttpServerSpanRequest for ntex::web::HttpRequest {
         self.method()
     }
 
-    fn route_pattern(&self) -> String {
+    fn route_pattern(&self) -> &'static str {
         self.extensions()
             .get::<RequestRoutePattern>()
-            .map(|v| v.0.as_str())
+            .map(|v| v.0)
             .unwrap_or_default()
-            .to_string()
     }
 
     fn uri(&self) -> &Uri {

--- a/lib/internal/src/telemetry/traces/spans/tests.rs
+++ b/lib/internal/src/telemetry/traces/spans/tests.rs
@@ -185,6 +185,17 @@ fn assert_fields(span: &Span, expected_fields: &[&str]) {
     );
 }
 
+/// The route template these tests report as `http.route`. Most of them only care
+/// about client-address resolution, so they share a single fixed route.
+const TEST_ROUTE: &str = "/graphql";
+
+fn http_server_span<Req: HttpServerSpanRequest>(
+    request: &Req,
+    client_ip_header_config: &Option<ClientIpHeaderConfig>,
+) -> HttpServerRequestSpan {
+    HttpServerRequestSpan::from_request(request, client_ip_header_config, TEST_ROUTE)
+}
+
 fn ip_header_config(header: &str) -> Option<ClientIpHeaderConfig> {
     Some(ClientIpHeaderConfig::HeaderName(header.into()))
 }
@@ -215,7 +226,7 @@ fn test_http_server_request_span() {
             .to_http_request();
         let body = NtexBytes::from("test body");
 
-        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(XFF.as_str()));
+        let span = http_server_span(&req, &ip_header_config(XFF.as_str()));
         span.record_body_size(body.len());
         assert_fields(
             &span,
@@ -257,12 +268,31 @@ fn test_http_server_request_span() {
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "192.168.0.1");
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
 
-        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(XFF.as_str()));
+        let span = http_server_span(&req, &ip_header_config(XFF.as_str()));
         span.record_internal_server_error();
 
         layer.assert_recorded_value(&span, attributes::HTTP_RESPONSE_STATUS_CODE, "500");
         layer.assert_recorded_value(&span, attributes::OTEL_STATUS_CODE, "Error");
         layer.assert_recorded_value(&span, attributes::ERROR_TYPE, "500");
+    });
+}
+
+#[test]
+fn test_http_server_request_span_route_is_the_template_not_the_path() {
+    let layer = RecordingLayer::default();
+    let subscriber = Registry::default().with(layer.clone());
+
+    with_default(subscriber, || {
+        let req = TestRequest::with_uri("/acme/graphql?foo=bar")
+            .header(HOST, "localhost:8080")
+            .to_http_request();
+
+        let span = HttpServerRequestSpan::from_request(&req, &None, "/{tenant}/graphql");
+
+        // `http.route` is low-cardinality: the template, shared by every tenant.
+        layer.assert_recorded_value(&span, attributes::HTTP_ROUTE, "/{tenant}/graphql");
+        // The concrete path stays available on the high-cardinality attributes.
+        layer.assert_recorded_value(&span, attributes::URL_PATH, "/acme/graphql");
     });
 }
 
@@ -276,10 +306,7 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "10.0.0.1:1234, 172.16.1.42:443")
             .to_http_request();
-        let span = HttpServerRequestSpan::from_request(
-            &realistic_with_port,
-            &ip_header_config(XFF.as_str()),
-        );
+        let span = http_server_span(&realistic_with_port, &ip_header_config(XFF.as_str()));
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "10.0.0.1");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "1234");
 
@@ -287,20 +314,14 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "10.0.0.1, 172.16.1.42")
             .to_http_request();
-        let span = HttpServerRequestSpan::from_request(
-            &realistic_without_port,
-            &ip_header_config(XFF.as_str()),
-        );
+        let span = http_server_span(&realistic_without_port, &ip_header_config(XFF.as_str()));
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "10.0.0.1");
 
         let realistic_ipv6_with_port = TestRequest::with_uri("/graphql")
             .header(HOST, "localhost:8080")
             .header(XFF, "[2001:db8::1]:8080, [2001:db8::2]:8443")
             .to_http_request();
-        let span = HttpServerRequestSpan::from_request(
-            &realistic_ipv6_with_port,
-            &ip_header_config(XFF.as_str()),
-        );
+        let span = http_server_span(&realistic_ipv6_with_port, &ip_header_config(XFF.as_str()));
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "2001:db8::1");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "8080");
 
@@ -308,7 +329,7 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "2001:db8::1, 2001:db8::2")
             .to_http_request();
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &realistic_ipv6_without_port,
             &ip_header_config(XFF.as_str()),
         );
@@ -319,7 +340,7 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "2001:db8::2:8443")
             .to_http_request();
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &unrealistic_malformed_ipv6_with_port,
             &ip_header_config(XFF.as_str()),
         );
@@ -330,10 +351,7 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, ", ,")
             .to_http_request();
-        let span = HttpServerRequestSpan::from_request(
-            &unrealistic_empty,
-            &ip_header_config(XFF.as_str()),
-        );
+        let span = http_server_span(&unrealistic_empty, &ip_header_config(XFF.as_str()));
         layer.assert_not_recorded(&span, attributes::CLIENT_ADDRESS);
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
     });
@@ -355,7 +373,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &req,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -370,7 +388,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &all_trusted,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -385,7 +403,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &mixed_invalid,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -400,7 +418,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &non_ip_tokens,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -421,7 +439,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, "for=198.51.100.7;proto=https, for=10.0.0.2")
             .to_http_request();
 
-        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "198.51.100.7");
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
@@ -431,7 +449,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, r#"for="198.51.100.7:1234";proto=https"#)
             .to_http_request();
 
-        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "198.51.100.7");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "1234");
@@ -441,7 +459,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, r#"for="[2001:db8::1]:8080";proto=https"#)
             .to_http_request();
 
-        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "2001:db8::1");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "8080");
@@ -451,7 +469,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, "for=_hidden, proto=https")
             .to_http_request();
 
-        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_not_recorded(&span, attributes::CLIENT_ADDRESS);
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
@@ -473,7 +491,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &req,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -488,7 +506,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &all_trusted,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -503,7 +521,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &with_port,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -518,7 +536,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = HttpServerRequestSpan::from_request(
+        let span = http_server_span(
             &invalid_tokens,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );

--- a/lib/internal/src/telemetry/traces/spans/tests.rs
+++ b/lib/internal/src/telemetry/traces/spans/tests.rs
@@ -8,6 +8,7 @@ use super::http_request::{HttpClientRequestSpan, HttpInflightRequestSpan, HttpSe
 use crate::graphql::ObservedError;
 use crate::telemetry::metrics::demand_control_metrics::DemandControlResultCode;
 use crate::telemetry::traces::spans::http_request::HttpServerSpanRequest;
+use crate::telemetry::utils::RequestRoutePattern;
 use bytes::Bytes;
 use hive_router_config::telemetry::{ClientIpHeaderConfig, ClientIpHeaderTrustedProxiesConfig};
 use http::header::{FORWARDED, HOST, USER_AGENT};
@@ -54,6 +55,15 @@ impl From<TestRequest> for HttpRequestMock {
 impl HttpServerSpanRequest for HttpRequestMock {
     fn headers(&self) -> &NtexHeaderMap {
         self.req.headers()
+    }
+
+    fn route_pattern(&self) -> String {
+        self.req
+            .extensions()
+            .get::<RequestRoutePattern>()
+            .map(|v| v.0.as_str())
+            .unwrap_or_default()
+            .to_string()
     }
 
     fn method(&self) -> &Method {
@@ -185,15 +195,11 @@ fn assert_fields(span: &Span, expected_fields: &[&str]) {
     );
 }
 
-/// The route template these tests report as `http.route`. Most of them only care
-/// about client-address resolution, so they share a single fixed route.
-const TEST_ROUTE: &str = "/graphql";
-
 fn http_server_span<Req: HttpServerSpanRequest>(
     request: &Req,
     client_ip_header_config: &Option<ClientIpHeaderConfig>,
 ) -> HttpServerRequestSpan {
-    HttpServerRequestSpan::from_request(request, client_ip_header_config, TEST_ROUTE)
+    HttpServerRequestSpan::from_request(request, client_ip_header_config)
 }
 
 fn ip_header_config(header: &str) -> Option<ClientIpHeaderConfig> {
@@ -287,7 +293,10 @@ fn test_http_server_request_span_route_is_the_template_not_the_path() {
             .header(HOST, "localhost:8080")
             .to_http_request();
 
-        let span = HttpServerRequestSpan::from_request(&req, &None, "/{tenant}/graphql");
+        req.extensions_mut()
+            .insert(RequestRoutePattern::new("/{tenant}/graphql"));
+
+        let span = HttpServerRequestSpan::from_request(&req, &None);
 
         // `http.route` is low-cardinality: the template, shared by every tenant.
         layer.assert_recorded_value(&span, attributes::HTTP_ROUTE, "/{tenant}/graphql");

--- a/lib/internal/src/telemetry/traces/spans/tests.rs
+++ b/lib/internal/src/telemetry/traces/spans/tests.rs
@@ -194,13 +194,6 @@ fn assert_fields(span: &Span, expected_fields: &[&str]) {
     );
 }
 
-fn http_server_span<Req: HttpServerSpanRequest>(
-    request: &Req,
-    client_ip_header_config: &Option<ClientIpHeaderConfig>,
-) -> HttpServerRequestSpan {
-    HttpServerRequestSpan::from_request(request, client_ip_header_config)
-}
-
 fn ip_header_config(header: &str) -> Option<ClientIpHeaderConfig> {
     Some(ClientIpHeaderConfig::HeaderName(header.into()))
 }
@@ -231,7 +224,7 @@ fn test_http_server_request_span() {
             .to_http_request();
         let body = NtexBytes::from("test body");
 
-        let span = http_server_span(&req, &ip_header_config(XFF.as_str()));
+        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(XFF.as_str()));
         span.record_body_size(body.len());
         assert_fields(
             &span,
@@ -273,7 +266,7 @@ fn test_http_server_request_span() {
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "192.168.0.1");
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
 
-        let span = http_server_span(&req, &ip_header_config(XFF.as_str()));
+        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(XFF.as_str()));
         span.record_internal_server_error();
 
         layer.assert_recorded_value(&span, attributes::HTTP_RESPONSE_STATUS_CODE, "500");
@@ -314,7 +307,10 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "10.0.0.1:1234, 172.16.1.42:443")
             .to_http_request();
-        let span = http_server_span(&realistic_with_port, &ip_header_config(XFF.as_str()));
+        let span = HttpServerRequestSpan::from_request(
+            &realistic_with_port,
+            &ip_header_config(XFF.as_str()),
+        );
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "10.0.0.1");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "1234");
 
@@ -322,14 +318,20 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "10.0.0.1, 172.16.1.42")
             .to_http_request();
-        let span = http_server_span(&realistic_without_port, &ip_header_config(XFF.as_str()));
+        let span = HttpServerRequestSpan::from_request(
+            &realistic_without_port,
+            &ip_header_config(XFF.as_str()),
+        );
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "10.0.0.1");
 
         let realistic_ipv6_with_port = TestRequest::with_uri("/graphql")
             .header(HOST, "localhost:8080")
             .header(XFF, "[2001:db8::1]:8080, [2001:db8::2]:8443")
             .to_http_request();
-        let span = http_server_span(&realistic_ipv6_with_port, &ip_header_config(XFF.as_str()));
+        let span = HttpServerRequestSpan::from_request(
+            &realistic_ipv6_with_port,
+            &ip_header_config(XFF.as_str()),
+        );
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "2001:db8::1");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "8080");
 
@@ -337,7 +339,7 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "2001:db8::1, 2001:db8::2")
             .to_http_request();
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &realistic_ipv6_without_port,
             &ip_header_config(XFF.as_str()),
         );
@@ -348,7 +350,7 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, "2001:db8::2:8443")
             .to_http_request();
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &unrealistic_malformed_ipv6_with_port,
             &ip_header_config(XFF.as_str()),
         );
@@ -359,7 +361,10 @@ fn test_http_server_request_span_client_address_from_various_values() {
             .header(HOST, "localhost:8080")
             .header(XFF, ", ,")
             .to_http_request();
-        let span = http_server_span(&unrealistic_empty, &ip_header_config(XFF.as_str()));
+        let span = HttpServerRequestSpan::from_request(
+            &unrealistic_empty,
+            &ip_header_config(XFF.as_str()),
+        );
         layer.assert_not_recorded(&span, attributes::CLIENT_ADDRESS);
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
     });
@@ -381,7 +386,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &req,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -396,7 +401,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &all_trusted,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -411,7 +416,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &mixed_invalid,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -426,7 +431,7 @@ fn test_http_server_request_span_client_address_with_trusted_proxies() {
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &non_ip_tokens,
             &trusted_ip_header_config(XFF.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -447,7 +452,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, "for=198.51.100.7;proto=https, for=10.0.0.2")
             .to_http_request();
 
-        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "198.51.100.7");
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
@@ -457,7 +462,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, r#"for="198.51.100.7:1234";proto=https"#)
             .to_http_request();
 
-        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "198.51.100.7");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "1234");
@@ -467,7 +472,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, r#"for="[2001:db8::1]:8080";proto=https"#)
             .to_http_request();
 
-        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_recorded_value(&span, attributes::CLIENT_ADDRESS, "2001:db8::1");
         layer.assert_recorded_value(&span, attributes::CLIENT_PORT, "8080");
@@ -477,7 +482,7 @@ fn test_http_server_request_span_client_address_from_forwarded() {
             .header(FORWARDED, "for=_hidden, proto=https")
             .to_http_request();
 
-        let span = http_server_span(&req, &ip_header_config(FORWARDED.as_str()));
+        let span = HttpServerRequestSpan::from_request(&req, &ip_header_config(FORWARDED.as_str()));
 
         layer.assert_not_recorded(&span, attributes::CLIENT_ADDRESS);
         layer.assert_not_recorded(&span, attributes::CLIENT_PORT);
@@ -499,7 +504,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &req,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -514,7 +519,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &all_trusted,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -529,7 +534,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &with_port,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );
@@ -544,7 +549,7 @@ fn test_http_server_request_span_client_address_from_forwarded_trusted_proxies()
         )
         .with_peer_addr(peer_addr);
 
-        let span = http_server_span(
+        let span = HttpServerRequestSpan::from_request(
             &invalid_tokens,
             &trusted_ip_header_config(FORWARDED.as_str(), vec!["10.0.0.0/8"]),
         );

--- a/lib/internal/src/telemetry/traces/spans/tests.rs
+++ b/lib/internal/src/telemetry/traces/spans/tests.rs
@@ -57,13 +57,12 @@ impl HttpServerSpanRequest for HttpRequestMock {
         self.req.headers()
     }
 
-    fn route_pattern(&self) -> String {
+    fn route_pattern(&self) -> &'static str {
         self.req
             .extensions()
             .get::<RequestRoutePattern>()
-            .map(|v| v.0.as_str())
+            .map(|v| v.0)
             .unwrap_or_default()
-            .to_string()
     }
 
     fn method(&self) -> &Method {
@@ -294,7 +293,7 @@ fn test_http_server_request_span_route_is_the_template_not_the_path() {
             .to_http_request();
 
         req.extensions_mut()
-            .insert(RequestRoutePattern::new("/{tenant}/graphql"));
+            .insert(RequestRoutePattern("/{tenant}/graphql"));
 
         let span = HttpServerRequestSpan::from_request(&req, &None);
 

--- a/lib/internal/src/telemetry/utils.rs
+++ b/lib/internal/src/telemetry/utils.rs
@@ -99,3 +99,11 @@ pub fn resolve_value_or_expression(
         }
     }
 }
+
+pub struct RequestRoutePattern(pub String);
+
+impl RequestRoutePattern {
+    pub fn new(path: &str) -> Self {
+        Self(path.to_string())
+    }
+}

--- a/lib/internal/src/telemetry/utils.rs
+++ b/lib/internal/src/telemetry/utils.rs
@@ -100,10 +100,4 @@ pub fn resolve_value_or_expression(
     }
 }
 
-pub struct RequestRoutePattern(pub String);
-
-impl RequestRoutePattern {
-    pub fn new(path: &str) -> Self {
-        Self(path.to_string())
-    }
-}
+pub struct RequestRoutePattern(pub &'static str);

--- a/lib/internal/src/telemetry/utils.rs
+++ b/lib/internal/src/telemetry/utils.rs
@@ -100,4 +100,9 @@ pub fn resolve_value_or_expression(
     }
 }
 
+/// A simple identity struct inject to request's `extensions` in order to provide the
+/// route template used for /graphql.
+/// This is needed because `ntex` does not expose the template, only the final url and the matchers.
+///
+/// Used for telemetry (traces/spans) reporting.
 pub struct RequestRoutePattern(pub &'static str);

--- a/lib/router-config/src/lib.rs
+++ b/lib/router-config/src/lib.rs
@@ -205,6 +205,10 @@ pub fn default_plugin_warn_on_error() -> bool {
 }
 
 impl HiveRouterConfig {
+    pub fn into_static(self) -> &'static HiveRouterConfig {
+        Box::leak(Box::new(self))
+    }
+
     pub fn address(&self) -> String {
         format!("{}:{}", self.http.host, self.http.port)
     }


### PR DESCRIPTION
HTTP server spans and metrics set `http.route` to the concrete request path. `http.route` is required to be low-cardinality: backends commonly derive span names and span metrics from it, and it is also a metric attribute. Whenever `http.graphql_endpoint` contains path parameters, every distinct path became its own span name and its own metric time series.

Report the configured GraphQL route template instead, which is the pattern the endpoint is registered with. The concrete path stays on `url.path`/`url.full`, which are not constrained to be low-cardinality. Persisted-document subpaths (`/graphql/sha256:<hash>`) collapse to the same template rather than contributing one route value per document.

For the default `/graphql` endpoint the template equals the request path, so the reported value is unchanged.