### PR TITLE
fix(router): fix names of demand control metrics

### DIFF
--- a/.changeset/fix_demand_control_metrics.md
+++ b/.changeset/fix_demand_control_metrics.md
@@ -1,0 +1,14 @@
+---
+hive-router: major
+hive-router-internal: major
+---
+
+# Fix missing demand control metrics names
+
+Previously added metrics names were missing the `hive.router.demand_control.` prefix. This has been fixed in this change. 
+
+Here's a list of the metrics that have been fixed:
+
+- `cost.estimated` -> `hive.router.demand_control.cost.estimated`
+- `cost.actual` -> `hive.router.demand_control.cost.actual`
+- `cost.delta` -> `hive.router.demand_control.cost.delta`

--- a/e2e/src/demand_control/metrics.rs
+++ b/e2e/src/demand_control/metrics.rs
@@ -184,13 +184,13 @@ mod metrics_tests {
                               max_export_timeout: 50ms
                         instrumentation:
                             instruments:
-                                cost.estimated:
+                                hive.router.demand_control.cost.estimated:
                                     attributes:
                                         graphql.operation.name: false
-                                cost.actual:
+                                hive.router.demand_control.cost.actual:
                                     attributes:
                                         graphql.operation.name: false
-                                cost.delta:
+                                hive.router.demand_control.cost.delta:
                                     attributes:
                                         graphql.operation.name: false
                 "#,

--- a/lib/internal/src/telemetry/metrics/catalog.rs
+++ b/lib/internal/src/telemetry/metrics/catalog.rs
@@ -157,9 +157,9 @@ pub mod units {
 
 pub mod names {
     pub const GRAPHQL_ERRORS_TOTAL: &str = "hive.router.graphql.errors_total";
-    pub const COST_ESTIMATED: &str = "cost.estimated";
-    pub const COST_ACTUAL: &str = "cost.actual";
-    pub const COST_DELTA: &str = "cost.delta";
+    pub const COST_ESTIMATED: &str = "hive.router.demand_control.cost.estimated";
+    pub const COST_ACTUAL: &str = "hive.router.demand_control.cost.actual";
+    pub const COST_DELTA: &str = "hive.router.demand_control.cost.delta";
     pub const SUPERGRAPH_POLL_TOTAL: &str = "hive.router.supergraph.poll.total";
     pub const SUPERGRAPH_POLL_DURATION: &str = "hive.router.supergraph.poll.duration";
     pub const SUPERGRAPH_PROCESS_DURATION: &str = "hive.router.supergraph.process.duration";


### PR DESCRIPTION
Previously added metrics names were missing the `hive.router.demand_control.` prefix. This has been fixed in this change. 

Here's a list of the metrics that have been fixed:

- `cost.estimated` -> `hive.router.demand_control.cost.estimated`
- `cost.actual` -> `hive.router.demand_control.cost.actual`
- `cost.delta` -> `hive.router.demand_control.cost.delta`
