### PR TITLE
feat(router): track subgraph calls durations in request summary, and expose it to plugin system

### DIFF
--- a/.changeset/track-subgraph-call-durations.md
+++ b/.changeset/track-subgraph-call-durations.md
@@ -1,0 +1,9 @@
+---
+hive-router: minor
+---
+
+# Track per-subgraph call durations on the request summary
+
+The request summary now tracks `subgraph_calls_duration`, a map of subgraph name to the durations of every call made to it during the request. 
+
+This is available to custom plugins via `get_current_summary()`, alongside the existing subgraph tracking fields.

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -3,21 +3,25 @@ use crate::{
     testkit::{
         otel::OtlpCollector,
         stdout::{CaptureStdoutExt, StdOutCaptureBridge},
-        Started, TestRouter, TestRouterBuilder, TestSubgraphs,
+        ClientResponseExt, Started, TestRouter, TestRouterBuilder, TestSubgraphs,
     },
 };
 use hive_router::{
-    async_trait,
+    async_trait, get_current_summary,
+    plugins::hooks::on_execute::{
+        OnExecuteEndHookPayload, OnExecuteStartHookPayload, OnExecuteStartHookResult,
+    },
     plugins::hooks::on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
     plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
-    plugins::plugin_trait::{RouterPlugin, StartHookPayload},
+    plugins::plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
     set_summary_attribute, set_summary_message,
 };
 use hive_router_internal::telemetry::logging::targets;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use insta::assert_json_snapshot;
 use serde_json::{Map, Value};
-use sonic_rs::json;
+use sonic_rs::{json, JsonContainerTrait, JsonValueTrait};
+use std::collections::BTreeMap;
 use tracing::debug;
 
 const TEST_QUERY: &str = "{ users { id } }";
@@ -838,5 +842,86 @@ plugins:
     assert_eq!(
         find_attr(req_summary, "message"),
         Some("custom summary message from plugin".to_string())
+    );
+}
+
+#[derive(Default)]
+struct TestSubgraphDurationsPlugin;
+
+#[async_trait]
+impl RouterPlugin for TestSubgraphDurationsPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "test_subgraph_durations"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin_with_defaults()
+    }
+
+    async fn on_execute<'exec>(
+        &'exec self,
+        payload: OnExecuteStartHookPayload<'exec>,
+    ) -> OnExecuteStartHookResult<'exec> {
+        payload.on_end(|mut end_payload: OnExecuteEndHookPayload<'exec>| {
+            let subgraph_calls: BTreeMap<String, u64> = get_current_summary()
+                .and_then(|summary| {
+                    summary
+                        .subgraph_calls_duration
+                        .lock()
+                        .ok()
+                        .map(|durations| {
+                            durations
+                                .iter()
+                                .map(|(name, calls)| {
+                                    let total_ms = calls.iter().map(|d| d.as_millis() as u64).sum();
+                                    (name.clone(), total_ms)
+                                })
+                                .collect()
+                        })
+                })
+                .unwrap_or_default();
+
+            end_payload.add_extension("subgraph_calls", subgraph_calls);
+            end_payload.proceed()
+        })
+    }
+}
+
+#[ntex::test]
+async fn plugin_can_report_subgraph_calls_duration_from_summary() {
+    let (_subgraphs, router) = setup_router(
+        router_with_telemetry(
+            "\
+log:
+  level: info
+  format: json
+plugins:
+  test_subgraph_durations:
+    enabled: true
+",
+        )
+        .register_plugin::<TestSubgraphDurationsPlugin>(),
+    )
+    .await;
+
+    let res = router
+        .send_graphql_request(r#"{ topProducts(first: 1) { upc inStock } }"#, None, None)
+        .await;
+
+    assert_eq!(res.status(), 200);
+
+    let body = res.json_body().await;
+    let subgraph_calls = &body["extensions"]["subgraph_calls"];
+
+    assert_eq!(subgraph_calls.as_object().map(|o| o.len()), Some(2));
+    assert!(
+        subgraph_calls["inventory"].is_u64(),
+        "expected a recorded duration for inventory, got: {subgraph_calls:?}"
+    );
+    assert!(
+        subgraph_calls["products"].is_u64(),
+        "expected a recorded duration for products, got: {subgraph_calls:?}"
     );
 }

--- a/lib/executor/src/executors/map.rs
+++ b/lib/executor/src/executors/map.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use dashmap::DashMap;
@@ -463,6 +463,7 @@ impl SubgraphExecutorMap {
             None => {
                 debug!(target: targets::EXECUTOR, operation = execution_request.query, dedupe = execution_request.dedupe, subgraph = subgraph_name, executor = executor.executor_name(), "executing subgraph request");
                 summary::record(|s| s.record_subgraph(subgraph_name));
+                let call_started_at = Instant::now();
 
                 let exec_fut = executor.execute(execution_request, timeout, plugin_req_state);
                 // Clone the circuit breaker out of the DashMap before awaiting to avoid
@@ -471,7 +472,7 @@ impl SubgraphExecutorMap {
                     .circuit_breakers_by_subgraph
                     .get(subgraph_name)
                     .map(|r| r.value().clone());
-                match circuit_breaker {
+                let result = match circuit_breaker {
                     Some(circuit_breaker) => {
                         let SubgraphCircuitBreaker {
                             recloser,
@@ -527,7 +528,11 @@ impl SubgraphExecutorMap {
                             .await
                     }
                     None => exec_fut.await,
-                }?
+                };
+                summary::record(|s| {
+                    s.record_subgraph_call_duration(subgraph_name, call_started_at.elapsed())
+                });
+                result?
             }
         };
 
@@ -591,6 +596,7 @@ impl SubgraphExecutorMap {
         let timeout = self.resolve_subgraph_timeout(subgraph_name, client_request)?;
         debug!(target: targets::EXECUTOR, operation = execution_request.query, dedupe = execution_request.dedupe, subgraph = subgraph_name, executor = executor.executor_name(), "subscribing subgraph request");
         summary::record(|s| s.record_subgraph(subgraph_name));
+        let call_started_at = Instant::now();
 
         let subscribe_fut = executor.subscribe(execution_request, timeout);
 
@@ -605,7 +611,7 @@ impl SubgraphExecutorMap {
             .get(subgraph_name)
             .map(|r| r.value().clone());
 
-        match circuit_breaker {
+        let result = match circuit_breaker {
             Some(SubgraphCircuitBreaker { recloser, .. }) => {
                 let circuit_breaker_metrics = &self.telemetry_context.metrics.circuit_breaker;
                 recloser
@@ -627,7 +633,11 @@ impl SubgraphExecutorMap {
                     .await
             }
             None => subscribe_fut.await,
-        }
+        };
+        summary::record(|s| {
+            s.record_subgraph_call_duration(subgraph_name, call_started_at.elapsed())
+        });
+        result
     }
 
     fn resolve_subgraph_timeout(

--- a/lib/internal/src/telemetry/logging/summary.rs
+++ b/lib/internal/src/telemetry/logging/summary.rs
@@ -29,6 +29,7 @@ pub struct RequestSummary {
     pub persisted_document_id: OnceLock<String>,
     pub subgraph_requests: AtomicU32,
     pub involved_subgraphs: Mutex<HashSet<String>>,
+    pub subgraph_calls_duration: Mutex<BTreeMap<String, Vec<Duration>>>,
     pub error_count: AtomicU32,
     pub partial_response: AtomicBool,
     pub response_code: OnceLock<&'static str>,
@@ -107,6 +108,15 @@ impl RequestSummary {
             if !subgraphs.contains(name) {
                 subgraphs.insert(name.to_string());
             }
+        }
+    }
+
+    pub fn record_subgraph_call_duration(&self, name: &str, duration: Duration) {
+        if let Ok(mut durations) = self.subgraph_calls_duration.lock() {
+            durations
+                .entry(name.to_string())
+                .or_default()
+                .push(duration);
         }
     }
 


### PR DESCRIPTION
The request summary now tracks `subgraph_calls_duration`, a map of subgraph name to the durations of every call made to it during the request. 

This is available to custom plugins via `get_current_summary()`, alongside the existing subgraph tracking fields.

A plugin can do something like that, if they want to expose this in `extensions`: 

```rs
    async fn on_execute<'exec>(
        &'exec self,
        payload: OnExecuteStartHookPayload<'exec>,
    ) -> OnExecuteStartHookResult<'exec> {
        payload.on_end(|mut end_payload: OnExecuteEndHookPayload<'exec>| {
            let subgraph_calls: BTreeMap<String, u64> = get_current_summary()
                .and_then(|summary| {
                    summary.subgraph_calls_duration.lock().ok().map(|durations| {
                        durations
                            .iter()
                            .map(|(name, calls)| {
                                let total_ms = calls.iter().map(|d| d.as_millis() as u64).sum();
                                (name.clone(), total_ms)
                            })
                            .collect()
                    })
                })
                .unwrap_or_default();

            end_payload.add_extension("subgraph_calls", subgraph_calls);
            end_payload.proceed()
        })
    }
```

