### PR TITLE
fix(router): correctly handle empty `audience` field in `jwt` config

### DIFF
--- a/.changeset/fix-jwt-audience-validation.md
+++ b/.changeset/fix-jwt-audience-validation.md
@@ -1,0 +1,7 @@
+---
+hive-router: patch
+---
+
+Fix JWT audience validation rejecting tokens when `audiences` is not configured.
+
+Previously, any token containing an `aud` claim was rejected with a 403 error even though audience validation is documented to be skipped when `audiences` is left empty.

--- a/bin/router/src/jwt/mod.rs
+++ b/bin/router/src/jwt/mod.rs
@@ -230,8 +230,11 @@ impl JwtAuthRuntime {
         }
 
         // This only validates the existence of the claim, it does not validate the values, we'll do it after decoding.
-        if let Some(aud) = &self.config.audiences {
-            validation.set_audience(aud);
+        // When no audiences are configured, audience validation must be skipped entirely: `jsonwebtoken`
+        // defaults `validate_aud` to `true` and rejects any token with an `aud` claim if none is expected.
+        match &self.config.audiences {
+            Some(aud) => validation.set_audience(aud),
+            None => validation.validate_aud = false,
         }
 
         let token_data = match decode::<JwtClaims>(token, &decoding_key, &validation) {

--- a/e2e/src/jwt.rs
+++ b/e2e/src/jwt.rs
@@ -540,6 +540,46 @@ mod jwt_e2e_tests {
     }
 
     #[ntex::test]
+    async fn accepts_request_with_aud_claim_when_audiences_not_configured() {
+        // Regression test: when `audiences` is not set in the config, the docs say
+        // audience validation should be skipped entirely.
+        let router = TestRouter::builder()
+            .file_config("configs/jwt_auth.router.yaml")
+            .build()
+            .start()
+            .await;
+
+        let exp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        let claims = json!({
+            "sub": "user1",
+            "iat": 1516239022,
+            "exp": exp,
+            "aud": ["some-audience", "another-audience"],
+        });
+        let token = generate_jwt(&claims);
+
+        let res = router
+            .send_graphql_request(
+                "{ __typename }",
+                None,
+                some_header_map! {
+                    http::header::AUTHORIZATION => format!("Bearer {}", token)
+                },
+            )
+            .await;
+
+        assert!(
+            res.status().is_success(),
+            "Expected 2xx status for a token with an `aud` claim when audiences are not configured, got {}",
+            res.status()
+        );
+    }
+
+    #[ntex::test]
     async fn rejects_request_with_wrong_algorithm() {
         let router = TestRouter::builder()
             .file_config("configs/jwt_auth_jwk_with_alg.router.yaml")


### PR DESCRIPTION
Fix JWT audience validation rejecting tokens when `audiences` is not configured.

Previously, any token containing an `aud` claim was rejected with a 403 error even though audience validation is documented to be skipped when `audiences` is left empty.

