### PR TITLE
fix(authorization): properly handle `union` member scope validation rules

### DIFF
--- a/.changeset/fix-union-member-scope-combination.md
+++ b/.changeset/fix-union-member-scope-combination.md
@@ -1,0 +1,48 @@
+---
+hive-router: patch
+---
+
+Fix `@requiresScopes`/`@authenticated` on union members being combined into a single
+all-or-nothing rule for the whole union, instead of being checked independently per member.
+
+Given:
+
+```graphql
+union Media = Book | Movie
+
+type Book @requiresScopes(scopes: [["a", "b"]]) {
+  title: String
+}
+
+type Movie @requiresScopes(scopes: [["c", "d"]]) {
+  title: String
+}
+
+type Query {
+  media: Media!
+}
+```
+
+Before this fix, we required the following scopes for each field in the given query:
+
+```graphql
+{
+  media { # a + b + c +d 
+    __typename # a + b + c +d ((inherited from media's gate))
+    ... on Book { title } # a + b (but it wasn't reachable because "media" validation gated it with a+b+c+d)
+    ... on Movie { title } # c + d (but it wasn't reachable because "media" validation gated it with a+b+c+d)
+  }
+}
+```
+
+And with the fix, now: 
+
+```graphql
+{
+  media { # none
+    __typename # none
+    ... on Book { title } # a + b
+    ... on Movie { title } # c + d
+  }
+}
+```

--- a/bin/router/src/pipeline/authorization/tests.rs
+++ b/bin/router/src/pipeline/authorization/tests.rs
@@ -718,8 +718,11 @@ mod type_authorization {
           }
        "#;
 
+        /// Resolving __typename is allowed since it does not reveal any data.
+        ///
+        /// In case it's being queried by itself, we do not implement any logic to protect it.
         #[test]
-        fn disallows_typename_on_unauthorized_union_members() {
+        fn allows_bare_typename_on_a_union_field_regardless_of_member_scopes() {
             let supergraph_data = build_supergraph_data(UNION_SCHEMA);
             let query = "
               query {
@@ -730,13 +733,11 @@ mod type_authorization {
            ";
 
             let decision = supergraph_data.decide(None, query);
-            insta::assert_snapshot!(decision, @r#"
-            [Modified]
-            Operation: <empty>
-            Errors:    ["Unauthorized field or type @ media"]
-            "#);
+            insta::assert_snapshot!(decision, @"[NoChange]");
         }
 
+        /// Each fragment (and concrete type) is authorized independently against its own member's
+        /// scopes
         #[test]
         fn removes_all_unauthorized_union_member_fragments() {
             let supergraph_data = build_supergraph_data(UNION_SCHEMA);
@@ -757,21 +758,46 @@ mod type_authorization {
             insta::assert_snapshot!(decision, @r#"
             [Modified]
             Operation: <empty>
-            Errors:    ["Unauthorized field or type @ media"]
+            Errors:    ["Unauthorized field or type @ media", "Unauthorized field or type @ media"]
             "#);
         }
 
+        /// This test ensures that we apply scope validation correctly on unions.
+        /// Since we know the concrete type statically, we should be able to apply
+        /// member-specific scopes without combining them with the union's own scopes.
+        ///
+        /// Previously, the authz logic was merging the union member's scopes into one big
+        /// rule. But that's wrong since it gates all variations of the union.
+        ///
+        /// In the schema here, both rules were applied, so in order to access `media`, a token needs to ahve
+        /// ALL `a` + `b` + `c` + `d` scopes.
         #[test]
-        fn removes_union_fragments_with_partial_member_scopes() {
-            let supergraph_data = build_supergraph_data(UNION_SCHEMA);
+        fn union_members_are_authorized_independently_of_each_other() {
+            let supergraph_data = build_supergraph_data(
+                r#"
+                type Query {
+                  media: Media!
+                }
+
+                union Media = Book | Movie
+
+                type Book @requiresScopes(scopes: [["a", "b"]]) {
+                  author: String
+                }
+
+                type Movie @requiresScopes(scopes: [["c", "d"]]) {
+                  director: String
+                }
+                "#,
+            );
             let query = "
               query {
                 media {
                   ... on Book {
-                    title
+                    author
                   }
                   ... on Movie {
-                    title
+                    director
                   }
                 }
               }
@@ -780,7 +806,14 @@ mod type_authorization {
             let decision = supergraph_data.decide(Some(vec!["a", "b"]), query);
             insta::assert_snapshot!(decision, @r#"
             [Modified]
-            Operation: <empty>
+            Operation: {media{...on Book{author}}}
+            Errors:    ["Unauthorized field or type @ media"]
+            "#);
+
+            let decision = supergraph_data.decide(Some(vec!["c", "d"]), query);
+            insta::assert_snapshot!(decision, @r#"
+            [Modified]
+            Operation: {media{...on Movie{director}}}
             Errors:    ["Unauthorized field or type @ media"]
             "#);
         }

--- a/bin/router/src/pipeline/authorization/user_auth_context.rs
+++ b/bin/router/src/pipeline/authorization/user_auth_context.rs
@@ -78,9 +78,6 @@ impl AuthorizationMetadata {
             )?;
         }
 
-        // Compute authorization for union types based on their members
-        Self::compute_union_type_rules(schema_metadata, &mut type_rules);
-
         // Compute which types have any auth rules in their subtree
         let type_has_any_auth = Self::compute_type_auth_metadata(
             &supergraph.definitions,
@@ -178,86 +175,6 @@ impl AuthorizationMetadata {
         }
 
         false
-    }
-
-    /// Computes and adds authorization rules for union types based on their members.
-    /// For each union, combines the authorization requirements of all member types.
-    fn compute_union_type_rules(schema_metadata: &SchemaMetadata, type_rules: &mut TypeRulesMap) {
-        for union_name in &schema_metadata.union_types {
-            // Skip if union already has explicit authorization
-            if type_rules.contains_key(union_name) {
-                continue;
-            }
-
-            if let Some(members) = schema_metadata.get_possible_types(union_name) {
-                if let Some(rule) = Self::compute_union_authorization_rule(members, type_rules) {
-                    type_rules.insert(union_name.clone(), rule);
-                }
-            }
-        }
-    }
-
-    /// Computes the combined authorization rule for a union from its members.
-    /// Combines member requirements with AND logic (user must have access to all members).
-    fn compute_union_authorization_rule(
-        member_names: &HashSet<String>,
-        type_rules: &TypeRulesMap,
-    ) -> Option<AuthorizationRule> {
-        let mut member_scopes: Vec<&RequiredScopes> = Vec::new();
-        let mut needs_authenticated = false;
-
-        // Collect rules from all members
-        for member_name in member_names {
-            if let Some(rule) = type_rules.get(member_name) {
-                match rule {
-                    AuthorizationRule::Authenticated => {
-                        needs_authenticated = true;
-                    }
-                    AuthorizationRule::RequiresScopes(scopes) => {
-                        needs_authenticated = true; // scopes implies authenticated
-                        member_scopes.push(scopes);
-                    }
-                }
-            }
-        }
-
-        if !needs_authenticated {
-            return None;
-        }
-
-        // Some members have @authenticated but no scopes
-        if member_scopes.is_empty() {
-            return Some(AuthorizationRule::Authenticated);
-        }
-
-        Some(AuthorizationRule::RequiresScopes(
-            Self::cross_product_required_scopes(&member_scopes),
-        ))
-    }
-
-    /// Combines multiple RequiredScopes using AND logic via cross product.
-    /// Example: [["a"], ["b"]] AND [["c"], ["d"]] = [["a", "c"], ["a", "d"], ["b", "c"], ["b", "d"]]
-    fn cross_product_required_scopes(member_scopes: &[&RequiredScopes]) -> RequiredScopes {
-        let mut result: Vec<ScopeAndGroup> = vec![ScopeAndGroup(vec![])];
-
-        for member_scope in member_scopes {
-            let mut new_result = Vec::new();
-
-            for existing_and_group in &result {
-                for member_and_group in &member_scope.0 {
-                    // Combine existing AND group with member's AND group
-                    let mut combined = existing_and_group.0.clone();
-                    combined.extend(member_and_group.0.iter().copied());
-                    combined.sort();
-                    combined.dedup();
-                    new_result.push(ScopeAndGroup(combined));
-                }
-            }
-
-            result = new_result;
-        }
-
-        RequiredScopes(result)
     }
 
     /// Processes a type definition, extracting authorization rules for the type and its fields.


### PR DESCRIPTION
Fix `@requiresScopes`/`@authenticated` on union members being combined into a single
all-or-nothing rule for the whole union, instead of being checked independently per member.

Given:

```graphql
union Media = Book | Movie

type Book @requiresScopes(scopes: [["a", "b"]]) {
  title: String
}

type Movie @requiresScopes(scopes: [["c", "d"]]) {
  title: String
}

type Query {
  media: Media!
}
```

Before this fix, we required the following scopes for each field in the given query:

```graphql
{
  media { # a + b + c +d 
    __typename # a + b + c +d ((inherited from media's gate))
    ... on Book { title } # a + b (but it wasn't reachable because "media" validation gated it with a+b+c+d)
    ... on Movie { title } # c + d (but it wasn't reachable because "media" validation gated it with a+b+c+d)
  }
}
```

And with the fix, now: 

```graphql
{
  media { # none
    __typename # none
    ... on Book { title } # a + b
    ... on Movie { title } # c + d
  }
}
```

The `__typename` is the only field that can be queried directly on the `union`, it does not leak any information or data, and it considered safe to return as-is. We do not need to apply any logic to protect is. 
