### PR TITLE
fix(authorization): authorized fields being nulled out when a sibling fragment rejects a field of the same response key

### DIFF
--- a/.changeset/fix-shared-response-key-across-fragments.md
+++ b/.changeset/fix-shared-response-key-across-fragments.md
@@ -1,0 +1,48 @@
+---
+hive-router-plan-executor: patch
+hive-router: patch
+---
+
+Fix authorized fields being nulled out when a sibling fragment rejects a field of the same response key.
+
+Given:
+
+```graphql
+union Media = Book | Movie
+
+type Book @requiresScopes(scopes: [["a", "b"]]) {
+  title: String
+}
+
+type Movie @requiresScopes(scopes: [["c", "d"]]) {
+  title: String
+}
+```
+
+A token granted only `a` + `b` (fully satisfying `Book`, not `Movie`) querying:
+
+**Before:** rejected fields were tracked only by their flattened response-key path
+(`media.title`), with no notion of which fragment they came from. `Book.title` and
+`Movie.title` collapsed into the same entry, so rejecting `Movie`'s `title` nulled
+out `Book`'s too, even though it was correctly authorized on its own.
+
+```graphql
+{
+  media {
+    ... on Book { title }    # a + b - granted
+    ... on Movie { title }   # c + d - not granted
+  }
+}
+```
+
+**After:** inline fragments are also tracked as type conditions, so sibling
+fragments selecting the same field name are tracked independently:
+
+```graphql
+{
+  media {
+    ... on Book { title }    # kept
+    ... on Movie { title }   # rejected
+  }
+}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ router-config.schema.json
 node_modules
 plugin_examples/target
 failed-tests
+.idea

--- a/bin/router/src/executor/operation_filter.rs
+++ b/bin/router/src/executor/operation_filter.rs
@@ -78,11 +78,19 @@ impl NullPropagation {
     }
 }
 
+/// A single step in a rejected-path trail: either a field's response key, or the
+/// type condition of an inline fragment it was reached through
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PathSegment<'exec> {
+    Field(&'exec str),
+    Fragment(&'exec str),
+}
+
 #[derive(Default)]
 pub struct OperationFilterOutput<'exec> {
     /// Errors to report to the client, one per denied field or fragment.
     pub errors: Vec<GraphQLError>,
-    pub rejected_paths: Vec<Vec<&'exec str>>,
+    pub rejected_paths: Vec<Vec<PathSegment<'exec>>>,
 }
 
 impl<'exec> OperationFilterOutput<'exec> {
@@ -125,7 +133,7 @@ struct FilteringContext<'exec> {
     schema_metadata: &'exec SchemaMetadata,
     variable_payload: &'exec CoerceVariablesPayload,
     decisions: HashMap<(&'exec str, &'exec str), FilterDecision>,
-    path: Vec<&'exec str>,
+    path: Vec<PathSegment<'exec>>,
     result: OperationFilterOutput<'exec>,
 }
 
@@ -204,7 +212,7 @@ impl<'exec> FilteringContext<'exec> {
             }
         };
 
-        self.path.push(response_key);
+        self.path.push(PathSegment::Field(response_key));
         let rejected = match decision {
             FilterDecision::Reject { error } => {
                 self.record_rejected_path();
@@ -245,11 +253,23 @@ impl<'exec> FilteringContext<'exec> {
 
         match decision {
             FilterDecision::Keep => {
-                self.visit_selection_set(&fragment.selections, &fragment.type_condition, visitor)
+                self.path
+                    .push(PathSegment::Fragment(&fragment.type_condition));
+                let result = self.visit_selection_set(
+                    &fragment.selections,
+                    &fragment.type_condition,
+                    visitor,
+                );
+                self.path.pop();
+                result
             }
             FilterDecision::Reject { error } => {
                 self.record_error(error);
+                self.path
+                    .push(PathSegment::Fragment(&fragment.type_condition));
                 self.collect_all_field_paths(&fragment.selections);
+                self.path.pop();
+
                 Ok(NullPropagation::None)
             }
         }
@@ -261,12 +281,15 @@ impl<'exec> FilteringContext<'exec> {
                 SelectionItem::Field(field) => {
                     let response_key: &'exec str =
                         field.alias.as_deref().unwrap_or(field.name.as_str());
-                    self.path.push(response_key);
+                    self.path.push(PathSegment::Field(response_key));
                     self.record_rejected_path();
                     self.path.pop();
                 }
                 SelectionItem::InlineFragment(fragment) => {
+                    self.path
+                        .push(PathSegment::Fragment(&fragment.type_condition));
                     self.collect_all_field_paths(&fragment.selections);
+                    self.path.pop();
                 }
                 SelectionItem::FragmentSpread(_) => {}
             }
@@ -279,7 +302,16 @@ impl<'exec> FilteringContext<'exec> {
 
     fn record_error(&mut self, mut error: GraphQLError) {
         if error.extensions.affected_path.as_ref().is_none() {
-            error = error.add_affected_path(self.path.join("."));
+            let field_path = self
+                .path
+                .iter()
+                .filter_map(|segment| match segment {
+                    PathSegment::Field(name) => Some(*name),
+                    PathSegment::Fragment(_) => None,
+                })
+                .collect::<Vec<_>>()
+                .join(".");
+            error = error.add_affected_path(field_path);
         }
         self.result.errors.push(error);
     }

--- a/bin/router/src/pipeline/authorization/tests.rs
+++ b/bin/router/src/pipeline/authorization/tests.rs
@@ -818,6 +818,35 @@ mod type_authorization {
             "#);
         }
 
+        /// `Book` and `Movie` both have a `title` field with the same response key.
+        ///
+        /// Previously, having access to only one of them ended up with an empty output,
+        /// because the accessible type's field was also wiped out: rejected paths were
+        /// tracked purely by flattened response key (`media.title`).
+        #[test]
+        fn shared_field_name_across_union_members_is_authorized_independently() {
+            let supergraph_data = build_supergraph_data(UNION_SCHEMA);
+            let query = "
+              query {
+                media {
+                  ... on Book {
+                    title
+                  }
+                  ... on Movie {
+                    title
+                  }
+                }
+              }
+           ";
+
+            let decision = supergraph_data.decide(Some(vec!["a", "b"]), query);
+            insta::assert_snapshot!(decision, @r#"
+            [Modified]
+            Operation: {media{...on Book{title}}}
+            Errors:    ["Unauthorized field or type @ media"]
+            "#);
+        }
+
         #[test]
         fn allows_union_field_with_all_member_scopes() {
             let supergraph_data = build_supergraph_data(UNION_SCHEMA);

--- a/bin/router/src/pipeline/nullify/rebuilder.rs
+++ b/bin/router/src/pipeline/nullify/rebuilder.rs
@@ -1,15 +1,18 @@
 use std::sync::Arc;
 
-use crate::executor::projection::plan::{FieldProjectionPlan, ProjectionValueSource};
+use crate::executor::operation_filter::PathSegment;
+use crate::executor::projection::plan::{
+    FieldProjectionPlan, ProjectionValueSource, TypeCondition,
+};
+use crate::pipeline::trie::{PathIndex, Trie};
 use crate::query_planner::ast::{
     operation::OperationDefinition,
     selection_item::SelectionItem,
     selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet},
     value::Value,
 };
-use ahash::HashSet;
 
-use crate::pipeline::trie::{PathIndex, Trie};
+use ahash::HashSet;
 
 /// Reconstructs a GraphQL operation with nulled fields removed.
 pub(crate) fn rebuild_nulled_operation(
@@ -63,10 +66,10 @@ fn rebuild_nulled_selection_set(
     for selection in &original_selection_set.items {
         match selection {
             SelectionItem::Field(field) => {
-                let path_segment = field.alias.as_ref().unwrap_or(&field.name);
+                let path_segment = field.alias.as_deref().unwrap_or(&field.name);
 
-                let Some((child_path_position, is_nulled)) =
-                    nulled_field_trie.find_segment_at_position(path_position, path_segment)
+                let Some((child_path_position, is_nulled)) = nulled_field_trie
+                    .find_segment_at_position(path_position, PathSegment::Field(path_segment))
                 else {
                     collect_field_own_variables(field, used_variables);
                     collect_variables_recursive(&field.selections, used_variables);
@@ -94,10 +97,21 @@ fn rebuild_nulled_selection_set(
                 ));
             }
             SelectionItem::InlineFragment(fragment) => {
+                let fragment_segment = PathSegment::Fragment(&fragment.type_condition);
+
+                let Some((child_path_position, _)) =
+                    nulled_field_trie.find_segment_at_position(path_position, fragment_segment)
+                else {
+                    collect_fragment_own_variables(fragment, used_variables);
+                    collect_variables_recursive(&fragment.selections, used_variables);
+                    kept_items.push(selection.clone());
+                    continue;
+                };
+
                 let filtered_selections = rebuild_nulled_selection_set(
                     &fragment.selections,
                     nulled_field_trie,
-                    path_position,
+                    child_path_position,
                     used_variables,
                 );
 
@@ -137,9 +151,24 @@ fn rebuild_nulled_projection_plan_recursive(
     let mut kept_plans = Vec::with_capacity(original_plans.len());
 
     for plan in original_plans {
-        let path_segment = &plan.response_key;
+        let scoped_position = match &plan.parent_type_guard {
+            Some(TypeCondition::Exact(type_name)) => {
+                match nulled_field_trie
+                    .find_segment_at_position(path_position, PathSegment::Fragment(type_name))
+                {
+                    Some((child_position, _)) => child_position,
+                    None => {
+                        kept_plans.push(plan.clone());
+                        continue;
+                    }
+                }
+            }
+            _ => path_position,
+        };
+
+        let path_segment = PathSegment::Field(&plan.response_key);
         let Some((child_path_position, is_nulled)) =
-            nulled_field_trie.find_segment_at_position(path_position, path_segment)
+            nulled_field_trie.find_segment_at_position(scoped_position, path_segment)
         else {
             kept_plans.push(plan.clone());
             continue;

--- a/bin/router/src/pipeline/trie.rs
+++ b/bin/router/src/pipeline/trie.rs
@@ -1,3 +1,4 @@
+use crate::executor::operation_filter::PathSegment;
 use ahash::HashMap;
 
 /// Type-safe position in the path trie structure.
@@ -25,8 +26,9 @@ impl PathIndex {
 /// Node in the path trie for tracking "marked" field paths.
 #[derive(Debug, Default)]
 struct PathNode<'p> {
-    /// Mapping from field name to child position, hashed by content.
-    children: HashMap<&'p str, PathIndex>,
+    /// Mapping from path segment (field response key, or fragment type
+    /// condition) to child position, hashed by content.
+    children: HashMap<PathSegment<'p>, PathIndex>,
     /// If true, the field corresponding to this path is marked. What a mark
     /// means is entirely up to the caller (e.g. nulling, per `rebuilder.rs`).
     marked: bool,
@@ -41,6 +43,9 @@ struct PathNode<'p> {
 /// callers query this trie with strings from independently-allocated trees
 /// (e.g. the operation's AST vs. the projection plan's `response_key`
 /// strings) that don't share the same memory addresses even when equal.
+///
+/// A segment is either a field's response key or an inline fragment's type
+/// condition.
 ///
 /// For marked paths like `["user", "posts", "title"]` and `["user", "email"]`:
 ///
@@ -74,7 +79,7 @@ impl<'p> Trie<'p> {
     }
 
     /// Builds a trie from a list of paths, marking each one.
-    pub(crate) fn from_paths(paths: &[Vec<&'p str>]) -> Self {
+    pub(crate) fn from_paths(paths: &[Vec<PathSegment<'p>>]) -> Self {
         let segment_count: usize = paths.iter().map(|path| path.len()).sum();
         let mut trie = Self::with_capacity(segment_count);
         for path in paths {
@@ -83,13 +88,13 @@ impl<'p> Trie<'p> {
         trie
     }
 
-    pub(crate) fn add_path(&mut self, segments: impl Iterator<Item = &'p str>) {
+    pub(crate) fn add_path(&mut self, segments: impl Iterator<Item = PathSegment<'p>>) {
         let mut current = PathIndex::root();
         let mut peekable = segments.peekable();
 
         while let Some(segment) = peekable.next() {
             let is_last = peekable.peek().is_none();
-            let child = self.nodes[current.get()].children.get(segment).copied();
+            let child = self.nodes[current.get()].children.get(&segment).copied();
 
             let next = match child {
                 Some(child_idx) => child_idx,
@@ -116,10 +121,10 @@ impl<'p> Trie<'p> {
     pub(super) fn find_segment_at_position(
         &self,
         parent_path_position: PathIndex,
-        segment: &str,
+        segment: PathSegment<'_>,
     ) -> Option<(PathIndex, bool)> {
         let parent_node = &self.nodes[parent_path_position.get()];
-        let child_path_position = parent_node.children.get(segment).copied()?;
+        let child_path_position = parent_node.children.get(&segment).copied()?;
         let child_node = &self.nodes[child_path_position.get()];
         Some((child_path_position, child_node.marked))
     }


### PR DESCRIPTION
Fix authorized fields being nulled out when a sibling fragment rejects a field of the same response key.

Given:

```graphql
union Media = Book | Movie

type Book @requiresScopes(scopes: [["a", "b"]]) {
  title: String
}

type Movie @requiresScopes(scopes: [["c", "d"]]) {
  title: String
}
```

A token granted only `a` + `b` (fully satisfying `Book`, not `Movie`) querying:

**Before:** rejected fields were tracked only by their flattened response-key path
(`media.title`), with no notion of which fragment they came from. `Book.title` and
`Movie.title` collapsed into the same entry, so rejecting `Movie`'s `title` nulled
out `Book`'s too, even though it was correctly authorized on its own.

```graphql
{
  media {
    ... on Book { title }    # a + b - granted
    ... on Movie { title }   # c + d - not granted
  }
}
```

**After:** inline fragments are also tracked as type conditions, so sibling
fragments selecting the same field name are tracked independently:

```graphql
{
  media {
    ... on Book { title }    # kept
    ... on Movie { title }   # rejected
  }
}
```
