### PR TITLE
feat(node-addon): added `computeCacheKey` fn 

### DIFF
--- a/.changeset/expose_computecachekey_fn.md
+++ b/.changeset/expose_computecachekey_fn.md
@@ -1,0 +1,5 @@
+---
+node-addon: minor
+---
+
+# Expose `computeCacheKey` fn

--- a/bin/router/src/pipeline/query_plan.rs
+++ b/bin/router/src/pipeline/query_plan.rs
@@ -181,7 +181,7 @@ pub async fn plan_operation_with_cache(
 }
 
 #[inline]
-fn calculate_cache_key(operation_hash: u64, context: &StableOverrideContext) -> u64 {
+pub fn calculate_cache_key(operation_hash: u64, context: &StableOverrideContext) -> u64 {
     let mut hasher = Xxh3::new();
     operation_hash.hash(&mut hasher);
     context.hash(&mut hasher);

--- a/lib/node-addon/dist/index.d.ts
+++ b/lib/node-addon/dist/index.d.ts
@@ -5,6 +5,7 @@ export declare class QueryPlanner {
   overrideLabels: Array<string>
   overridePercentages: Array<number>
   constructor(supergraphSdl: string)
+  computeCacheKey(query: string, operationName: string | undefined | null, activeLabels: Set<string>, percentageValue: number): string
   plan(query: string, operationName: string | undefined | null, activeLabels: Set<string>, percentageValue: number, signal?: AbortSignal | undefined | null): QueryPlan
   planAsync(query: string, operationName: string | undefined | null, activeLabels: Set<string>, percentageValue: number, signal?: AbortSignal | undefined | null): Promise<QueryPlan>
 }

--- a/lib/node-addon/src/lib.rs
+++ b/lib/node-addon/src/lib.rs
@@ -59,6 +59,25 @@ impl QueryPlanner {
         })
     }
 
+    #[napi]
+    pub fn compute_cache_key<'a>(
+        &self,
+        query: String,
+        operation_name: Option<String>,
+        active_labels: HashSet<String>,
+        percentage_value: f64,
+    ) -> Result<String> {
+        let cache_key = query_plan::compute_cache_key(
+            &self.planner,
+            query.as_str(),
+            operation_name.as_deref(),
+            active_labels,
+            percentage_value,
+        )?;
+
+        Ok(cache_key)
+    }
+
     // queryplan located in query-plan.d.ts and will be merged with index.d.ts on build
     // because of napi-rs limitations, the queryplan from hive-query-planner cannot be used
     #[napi(ts_return_type = "QueryPlan")]

--- a/lib/node-addon/src/lib.rs
+++ b/lib/node-addon/src/lib.rs
@@ -60,7 +60,7 @@ impl QueryPlanner {
     }
 
     #[napi]
-    pub fn compute_cache_key<'a>(
+    pub fn compute_cache_key(
         &self,
         query: String,
         operation_name: Option<String>,

--- a/lib/node-addon/src/query_plan.rs
+++ b/lib/node-addon/src/query_plan.rs
@@ -1,11 +1,17 @@
 use std::{collections::HashSet, sync::Arc};
 
 use graphql_tools::parser::{query, schema};
-use hive_router::query_planner::{
-    ast::normalization::{error::NormalizationError, normalize_operation},
-    graph::{PlannerOverrideContext, PERCENTAGE_SCALE_FACTOR},
-    planner::{plan_nodes::QueryPlan, Planner, PlannerError},
-    utils::{cancellation::CancellationToken, parsing::safe_parse_operation},
+use hive_router::{
+    pipeline::{
+        progressive_override::{RequestOverrideContext, StableOverrideContext},
+        query_plan::calculate_cache_key,
+    },
+    query_planner::{
+        ast::normalization::{error::NormalizationError, normalize_operation},
+        graph::{PlannerOverrideContext, PERCENTAGE_SCALE_FACTOR},
+        planner::{plan_nodes::QueryPlan, Planner, PlannerError},
+        utils::{cancellation::CancellationToken, parsing::safe_parse_operation},
+    },
 };
 use napi::{Task, Unknown};
 
@@ -27,6 +33,32 @@ impl From<QueryPlanError> for napi::Error {
     }
 }
 
+pub fn compute_cache_key(
+    planner: &Planner,
+    query: &str,
+    operation_name: Option<&str>,
+    active_labels: HashSet<String>,
+    percentage_value: f64,
+) -> core::result::Result<String, QueryPlanError> {
+    let parsed_operation = safe_parse_operation(query)?;
+
+    let normalized_operation =
+        normalize_operation(&planner.supergraph, &parsed_operation, operation_name)?;
+
+    let request_override_context = RequestOverrideContext {
+        active_flags: active_labels,
+        percentage_value: (percentage_value * (PERCENTAGE_SCALE_FACTOR as f64)) as u64,
+    };
+
+    let stable_override_context =
+        StableOverrideContext::new(&planner.supergraph, &request_override_context);
+
+    let operation_hash = normalized_operation.operation.hash();
+    let cache_key = calculate_cache_key(operation_hash, &stable_override_context);
+
+    Ok(cache_key.to_string())
+}
+
 pub fn query_plan(
     planner: &Planner,
     query: &str,
@@ -36,7 +68,6 @@ pub fn query_plan(
     cancellation_token: &CancellationToken,
 ) -> core::result::Result<QueryPlan, QueryPlanError> {
     let parsed_operation = safe_parse_operation(query)?;
-
     let normalized_operation =
         normalize_operation(&planner.supergraph, &parsed_operation, operation_name)?;
 


### PR DESCRIPTION
Uses the native mechanism of the router, in order to provide cache keys to the gateway runtime. 

See https://github.com/graphql-hive/gateway/pull/2542 