### PR TITLE
feat(config): allow overriding the HTTP server graceful shutdown timeout

### DIFF
--- a/.changeset/configurable-http-shutdown-timeout.md
+++ b/.changeset/configurable-http-shutdown-timeout.md
@@ -1,0 +1,20 @@
+---
+hive-router: minor
+---
+
+Allow overriding the HTTP server graceful shutdown timeout
+
+Adds a new `http.shutdown_timeout` configuration option (and `ROUTER_HTTP_SHUTDOWN_TIMEOUT` environment variable) to control how long the HTTP server waits for in-flight requests to complete after receiving `SIGTERM`, before remaining workers are force-dropped.
+
+This was previously fixed at ntex's 30 second default, which is unrelated to `traffic_shaping.router.request_timeout`. A router configured to allow requests longer than 30 seconds would drop those requests mid-flight on every rolling deploy, even when the surrounding platform was willing to wait. The default stays at 30 seconds, so existing behaviour is unchanged.
+
+```yaml
+http:
+  shutdown_timeout: 90s
+
+traffic_shaping:
+  router:
+    request_timeout: 85s
+```
+
+Set it above `traffic_shaping.router.request_timeout` so the longest request the router accepts can still finish during a drain. In orchestrated environments the platform's own grace period (for example Kubernetes' `terminationGracePeriodSeconds`) must in turn exceed `http.shutdown_timeout`, otherwise the process is killed before the drain completes.

--- a/bin/router/src/config/env_overrides.rs
+++ b/bin/router/src/config/env_overrides.rs
@@ -37,6 +37,8 @@ pub struct EnvVarOverrides {
     pub http_workers: Option<usize>,
     #[envconfig(from = "ROUTER_HTTP_KEEP_ALIVE")]
     pub http_keep_alive: Option<String>,
+    #[envconfig(from = "ROUTER_HTTP_SHUTDOWN_TIMEOUT")]
+    pub http_shutdown_timeout: Option<String>,
 
     // Supergraph overrides
     #[envconfig(from = "SUPERGRAPH_FILE_PATH")]
@@ -129,6 +131,11 @@ impl EnvVarOverrides {
         if let Some(http_keep_alive) = self.http_keep_alive.take() {
             debug!(target: CONFIG_LOGGING_TARGET, value = http_keep_alive, "overriding 'traffic_shaping.router.keep_alive'");
             config = config.set_override("traffic_shaping.router.keep_alive", http_keep_alive)?;
+        }
+
+        if let Some(http_shutdown_timeout) = self.http_shutdown_timeout.take() {
+            debug!(target: CONFIG_LOGGING_TARGET, value = http_shutdown_timeout, "overriding 'http.shutdown_timeout'");
+            config = config.set_override("http.shutdown_timeout", http_shutdown_timeout)?;
         }
 
         let configured_supergraph_sources = [
@@ -357,6 +364,44 @@ traffic_shaping:
         assert_eq!(
             config.traffic_shaping.router.keep_alive,
             std::time::Duration::from_secs(80)
+        );
+    }
+
+    #[test]
+    fn http_shutdown_timeout_override_sets_http_shutdown_timeout() {
+        let config = config_from_overrides(EnvVarOverrides {
+            http_shutdown_timeout: Some("90s".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            config.http.shutdown_timeout,
+            std::time::Duration::from_secs(90)
+        );
+    }
+
+    #[test]
+    fn http_shutdown_timeout_override_wins_over_config_file_value() {
+        let config = EnvVarOverrides {
+            http_shutdown_timeout: Some("90s".to_string()),
+            ..Default::default()
+        }
+        .apply_overrides(Config::builder().add_source(File::from_str(
+            r#"
+http:
+  shutdown_timeout: 45s
+"#,
+            FileFormat::Yaml,
+        )))
+        .unwrap()
+        .build()
+        .unwrap()
+        .try_deserialize::<HiveRouterConfig>()
+        .unwrap();
+
+        assert_eq!(
+            config.http.shutdown_timeout,
+            std::time::Duration::from_secs(90)
         );
     }
 

--- a/bin/router/src/config/http_server.rs
+++ b/bin/router/src/config/http_server.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::time::Duration;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -36,6 +37,32 @@ pub struct HttpServerConfig {
     /// Can also be set via the `ROUTER_HTTP_WORKERS` environment variable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workers: Option<NonZeroUsize>,
+
+    /// How long the HTTP server waits for in-flight requests to complete after
+    /// receiving a termination signal (`SIGTERM`), before remaining workers are
+    /// force-dropped.
+    ///
+    /// Defaults to 30 seconds.
+    ///
+    /// Set this above `traffic_shaping.router.request_timeout` if you need the
+    /// longest requests the router accepts to also survive a shutdown. In
+    /// orchestrated environments the platform's own grace period (for example
+    /// Kubernetes' `terminationGracePeriodSeconds`) must in turn exceed this
+    /// value, otherwise the process is killed before the drain completes.
+    ///
+    /// ```yaml
+    /// http:
+    ///   shutdown_timeout: 90s
+    /// ```
+    ///
+    /// Can also be set via the `ROUTER_HTTP_SHUTDOWN_TIMEOUT` environment variable.
+    #[serde(
+        default = "http_server_shutdown_timeout_default",
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    #[schemars(with = "String")]
+    pub shutdown_timeout: Duration,
 }
 
 impl Default for HttpServerConfig {
@@ -45,6 +72,7 @@ impl Default for HttpServerConfig {
             port: http_server_port_default(),
             graphql_endpoint: graphql_endpoint_default(),
             workers: None,
+            shutdown_timeout: http_server_shutdown_timeout_default(),
         }
     }
 }
@@ -59,4 +87,48 @@ fn graphql_endpoint_default() -> String {
 
 fn http_server_port_default() -> u16 {
     4000
+}
+
+/// Matches ntex's own default graceful shutdown timeout, so configurations that
+/// omit `shutdown_timeout` keep their existing behaviour.
+fn http_server_shutdown_timeout_default() -> Duration {
+    Duration::from_secs(30)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::HttpServerConfig;
+
+    #[test]
+    fn shutdown_timeout_defaults_to_thirty_seconds() {
+        let config: HttpServerConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+
+        assert_eq!(config.shutdown_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn shutdown_timeout_accepts_human_readable_durations() {
+        let config: HttpServerConfig = serde_json::from_str(r#"{ "shutdown_timeout": "1m30s" }"#)
+            .expect("human readable duration should deserialize");
+
+        assert_eq!(config.shutdown_timeout, Duration::from_secs(90));
+    }
+
+    #[test]
+    fn shutdown_timeout_serializes_back_to_a_duration_string() {
+        let config = HttpServerConfig {
+            shutdown_timeout: Duration::from_secs(90),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_value(&config)
+            .expect("config should serialize")
+            .get("shutdown_timeout")
+            .cloned();
+
+        assert_eq!(serialized, Some(serde_json::json!("1m 30s")));
+    }
 }

--- a/bin/router/src/config/mod.rs
+++ b/bin/router/src/config/mod.rs
@@ -31,6 +31,7 @@ pub mod websocket;
 use config_rs::{Config, File, FileFormat, FileSourceFile};
 use envconfig::Envconfig;
 pub use humantime_serde;
+use ntex::time::Seconds;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -244,6 +245,13 @@ impl HiveRouterConfig {
 
     pub fn keep_alive(&self) -> std::time::Duration {
         self.traffic_shaping.router.keep_alive
+    }
+
+    pub fn shutdown_timeout(&self) -> Seconds {
+        let secs = self.http.shutdown_timeout.as_secs()
+            + u64::from(self.http.shutdown_timeout.subsec_nanos() > 0);
+
+        Seconds(u16::try_from(secs).unwrap_or(u16::MAX))
     }
 
     pub fn graphql_path(&self) -> &str {

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -436,7 +436,6 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     let websocket_path = router_config.websocket_path().map(|p| p.to_string());
     let callback_conf = router_config.callback_conf().cloned();
     let workers = router_config.workers();
-    let keep_alive = to_ntex_keep_alive(router_config.keep_alive());
     let mut bg_tasks_manager = background_tasks::BackgroundTasksManager::new();
     let (shared_state, schema_state) = configure_app_from_config(
         router_config,
@@ -482,6 +481,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 .add(build_http_service_config(router_config));
             let cb_server = cb_server_builder
                 .config(cb_cfg)
+                .shutdown_timeout(router_config.shutdown_timeout())
                 .bind(&cb_addr)
                 .map_err(|err| RouterInitError::HttpCallbackServerBindError(cb_addr, err))?
                 .run();
@@ -537,11 +537,11 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
         server = server.workers(workers.get());
     }
 
-    info!(target: targets::CORE, keep_alive = ?keep_alive, "configuring HTTP server keep-alive");
-
     let cfg = SharedCfg::new("HIVE_ROUTER").add(build_http_service_config(router_config));
 
-    server = server.config(cfg);
+    server = server
+        .config(cfg)
+        .shutdown_timeout(router_config.shutdown_timeout());
 
     let tls_config = shared_state_clone
         .router_config
@@ -809,11 +809,9 @@ macro_rules! configure_global_allocator {
 
 #[cfg(test)]
 mod to_ntex_keep_alive_tests {
-    use std::time::Duration;
-
-    use ntex::{http::KeepAlive, time::Seconds};
-
     use super::to_ntex_keep_alive;
+    use ntex::{http::KeepAlive, time::Seconds};
+    use std::time::Duration;
 
     #[test]
     fn keeps_whole_seconds() {

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -874,6 +874,7 @@ impl TestRouter<Built> {
                         .configure(move |m| add_callback_handler(m, &cb_path))
                 })
                 .config(cb_cfg)
+                .shutdown_timeout(config.shutdown_timeout())
                 .bind(&cb_addr)
                 .expect("failed to bind callback server")
                 .run();


### PR DESCRIPTION
## Problem

The router never calls ntex's `shutdown_timeout`, so the graceful drain window after `SIGTERM` is ntex's hardcoded 30 second default. That value has no relationship to `traffic_shaping.router.request_timeout`, and there is no way to change it.

The result is that any router configured to accept requests longer than 30 seconds will have those requests force-dropped mid-flight on every rolling deploy, even when the surrounding platform is willing to wait. For example, with `request_timeout: 85s` and a Kubernetes `terminationGracePeriodSeconds: 90`, requests between 30s and 85s old are killed by ntex roughly a minute before either the router or the orchestrator would have given up on them. A `preStop` hook cannot fix this, since it only delays the signal rather than extending the drain.

## Change

Adds `http.shutdown_timeout`, a human-readable duration that is passed to ntex's `shutdown_timeout` on every HTTP server the router builds:

```yaml
http:
  shutdown_timeout: 90s

traffic_shaping:
  router:
    request_timeout: 85s
```

- Defaults to 30 seconds, so behaviour is unchanged for configurations that omit it.
- Applied to both the main server and the dedicated callback server, so a separately bound subscription callback listener drains on the same terms instead of silently keeping the default.
- Overridable via `ROUTER_HTTP_SHUTDOWN_TIMEOUT`, following the existing `ROUTER_HTTP_WORKERS` pattern.
- Uses the repository's `humantime_serde` plus `schemars(with = "String")` convention, so the generated schema exposes it as a duration string.

It is kept independent of `request_timeout` rather than derived from it, since deriving would silently change the shutdown behaviour of every existing deployment. The doc comment and changeset explain the ordering an operator wants: `shutdown_timeout` above `request_timeout`, and the platform grace period above `shutdown_timeout`.

ntex takes whole seconds, so the conversion rounds partial seconds up (a configured `500ms` must not collapse into no wait at all) and clamps oversized durations rather than wrapping.

## Tests

Unit tests cover the 30 second default, parsing `1m30s`, the serialised duration-string shape, both environment override paths including precedence over a config file value, and the `Duration` to `Seconds` conversion boundaries.

```
cargo test -p hive-router --lib -- shutdown_timeout to_ntex_seconds config::
```

`cargo fmt --check` is clean and clippy reports nothing new on the touched files.

Happy to add an e2e test that drives a graceful stop with a request in flight if you would like that covered too, I just wasn't sure the existing testkit can sequence it deterministically.