### PR TITLE
feat(http): allow overriding the HTTP server keep-alive timeout, upgrade `ntex` to latest

### DIFF
--- a/.changeset/configurable-http-keep-alive.md
+++ b/.changeset/configurable-http-keep-alive.md
@@ -6,7 +6,7 @@ Allow overriding the HTTP server keep-alive timeout
 
 Adds a new `http.keep_alive` configuration option (and `ROUTER_HTTP_KEEP_ALIVE` environment variable) to control how long the HTTP server waits for a follow-up request on an idle keep-alive connection before closing it.
 
-This was previously fixed at ntex's 5 second default, with no Hive Router setting to change it. Behind a reverse proxy whose idle timeout is longer than 5 seconds, the router would close the socket first. The proxy then reused a connection the server had already dropped. The default stays at 5 seconds, so existing behaviour is unchanged.
+This was previously fixed at ntex's 5 second default, with no Hive Router setting to change it. Behind a reverse proxy whose idle timeout is longer than 5 seconds, the router would close the socket first. The proxy then reused a connection the server had already dropped.
 
 ```yaml
 http:

--- a/.changeset/configurable-http-keep-alive.md
+++ b/.changeset/configurable-http-keep-alive.md
@@ -1,0 +1,16 @@
+---
+hive-router: minor
+---
+
+Allow overriding the HTTP server keep-alive timeout
+
+Adds a new `http.keep_alive` configuration option (and `ROUTER_HTTP_KEEP_ALIVE` environment variable) to control how long the HTTP server waits for a follow-up request on an idle keep-alive connection before closing it.
+
+This was previously fixed at ntex's 5 second default, with no Hive Router setting to change it. Behind a reverse proxy whose idle timeout is longer than 5 seconds, the router would close the socket first. The proxy then reused a connection the server had already dropped. The default stays at 5 seconds, so existing behaviour is unchanged.
+
+```yaml
+http:
+  keep_alive: 80s
+```
+
+When the router sits behind a reverse proxy, set this above that proxy's idle timeout so the proxy closes first.

--- a/.changeset/configurable-http-keep-alive.md
+++ b/.changeset/configurable-http-keep-alive.md
@@ -4,13 +4,14 @@ hive-router: minor
 
 Allow overriding the HTTP server keep-alive timeout
 
-Adds a new `http.keep_alive` configuration option (and `ROUTER_HTTP_KEEP_ALIVE` environment variable) to control how long the HTTP server waits for a follow-up request on an idle keep-alive connection before closing it.
+Adds a new `traffic_shaping.router.keep_alive` configuration option (and `ROUTER_HTTP_KEEP_ALIVE` environment variable) to control how long the HTTP server waits for a follow-up request on an idle keep-alive connection before closing it.
 
 This was previously fixed at ntex's 5 second default, with no Hive Router setting to change it. Behind a reverse proxy whose idle timeout is longer than 5 seconds, the router would close the socket first. The proxy then reused a connection the server had already dropped.
 
 ```yaml
-http:
-  keep_alive: 80s
+traffic_shaping:
+  router:
+    keep_alive: 80s
 ```
 
 When the router sits behind a reverse proxy, set this above that proxy's idle timeout so the proxy closes first.

--- a/.changeset/fix-ntex-keep-alive-dispatcher-bug.md
+++ b/.changeset/fix-ntex-keep-alive-dispatcher-bug.md
@@ -1,0 +1,7 @@
+---
+hive-router: patch
+---
+
+Upgrade `ntex` dependencies
+
+Bumps `ntex` to 3.12.3 (and its `ntex-*` sibling crates to matching versions) to pick up an upstream fix (ntex-rs/ntex#933, released in ntex 3.10.1) for a dispatcher bug where an idle keep-alive connection's timer was shadowed whenever a request-header read timeout was also configured.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1609,6 +1619,12 @@ checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "der"
@@ -2671,6 +2687,7 @@ dependencies = [
  "ntex-error",
  "ntex-h2",
  "ntex-http",
+ "ntex-httparse",
  "ntex-io",
  "ntex-macros",
  "ntex-net",
@@ -3508,9 +3525,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -3866,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -3951,10 +3968,11 @@ dependencies = [
 
 [[package]]
 name = "ntex"
-version = "3.10.1"
+version = "3.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf010b0d2654465c75355a21295e6c9a66cf83719d324fccf8af1e0c941ab023"
+checksum = "0fc7d3125f1466c1c039760c0009c45d983e4a58589bbf52584ff7d421657782"
 dependencies = [
+ "atoi_simd",
  "base64",
  "bitflags 2.13.1",
  "derive_more",
@@ -3971,6 +3989,7 @@ dependencies = [
  "ntex-error",
  "ntex-h2",
  "ntex-http",
+ "ntex-httparse",
  "ntex-io",
  "ntex-macros",
  "ntex-net",
@@ -3987,7 +4006,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1 0.10.6",
  "thiserror 2.0.20",
  "uuid",
  "variadics_please",
@@ -3996,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-bytes"
-version = "1.7.6"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79595696d276a1be070159fb057e44c7b8b7c921f6690ddd3323cda71c70e92"
+checksum = "a926235646aee003de6b410c56efbfe3f8f5f6bbf8a69f1837b64f667dc03df9"
 dependencies = [
  "bytes",
  "serde",
@@ -4030,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-error"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d47e8dee801da88cca194481cb2f04a5de7cb949e3e9785086fb1b6a010884d"
+checksum = "229806c94be0c192bde46633bd044d11e3d7f3e5c5ee32aa3f430c918e99f746"
 dependencies = [
  "backtrace",
  "foldhash 0.2.0",
@@ -4042,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-h2"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462aedfed773643f8dce7b6173edcfeedc24f9dbf55a8f2c2fce3906163924f0"
+checksum = "b9169669ce11efc5ff8f14e419a982e53529c9d40e4f44be61766731ebf6590b"
 dependencies = [
  "bitflags 2.13.1",
  "foldhash 0.2.0",
@@ -4081,6 +4099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntex-httparse"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd04f3587bb190f11af135f652edff77f368d0940db134fa5a48c1f12c60b07"
+dependencies = [
+ "simdutf8",
+]
+
+[[package]]
 name = "ntex-io"
 version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4112,20 +4139,20 @@ dependencies = [
 
 [[package]]
 name = "ntex-macros"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3d0edf86b3b7168391cae05c637be4923b23968f7f65ead861d38cdfa3db1e"
+checksum = "94b2cc43bf60ff32e9d28f9b3d9bae28faa5ea5e0953a9113a8158f1e6f8dfcc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "ntex-net"
-version = "3.13.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312bd7f8090f1dee5b3f0d9eaa3a29e1642341943ee63bef3299051b27dd1e55"
+checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -4145,6 +4172,7 @@ dependencies = [
  "socket2",
  "thiserror 2.0.20",
  "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4176,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.15.4"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e619aa588c9ef95940a7fb99e45077ed261646dfc5a1754ca1712126175c9"
+checksum = "877696a0cec7fccd0813d1c075e5dbc12e3a3199e492c9bfa3dd2da63d609f35"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4191,6 +4219,7 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
+ "nix 0.31.3",
  "ntex-error",
  "ntex-service",
  "oneshot",
@@ -4203,9 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.10.4"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
+checksum = "3eecf7ebae34a050ab29978eb1fa7bf99590e46e3ab29b5526aff7790d4c9464"
 dependencies = [
  "async-channel",
  "atomic-waker",
@@ -4236,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-tls"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa8909d6cef273298d192c51345e1124200f6a655336848659464e7950de4cf"
+checksum = "ba8873e946975d18c561f700a410f4ac6739871a085341ff77f7f6469b8f0dc0"
 dependencies = [
  "log",
  "ntex-bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "ntex"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0baaa4f3df86d4f7e84b9cf7153743496360c79c689152ca9a2f1172ca5c2f"
+checksum = "bf010b0d2654465c75355a21295e6c9a66cf83719d324fccf8af1e0c941ab023"
 dependencies = [
  "base64",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,21 +49,22 @@ tokio-util = { version = "0.7.16" }
 tokio-stream = { version = "0.1.17" }
 rand = "0.10.1"
 jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
-ntex = { version = "=3.10.1", features = ["tokio", "rustls"] }
+ntex = { version = "=3.12.3", features = ["tokio", "rustls"] }
 ntex-http = { version = "=1.2.0"}
 ntex-codec = { version = "=1.2.1"}
 ntex-io = { version = "=3.13.1"}
-ntex-net = { version = "=3.13.0"}
+ntex-net = { version = "=3.15.0"}
 ntex-router = { version = "=1.0.0"}
-ntex-bytes = { version = "=1.7.6"}
+ntex-bytes = { version = "=1.9.0"}
 ntex-dispatcher = { version = "=3.2.1"}
-ntex-error = { version = "=2.3.0" }
-ntex-h2 = { version = "=3.12.0" }
-ntex-rt = { version = "=3.15.4" }
-ntex-macros = { version = "=3.3.0" }
-ntex-server = { version = "=3.10.4" }
+ntex-error = { version = "=2.4.0" }
+ntex-h2 = { version = "=3.13.0" }
+ntex-rt = { version = "=3.17.1" }
+ntex-macros = { version = "=3.5.0" }
+ntex-httparse = { version = "=2.1.0" }
+ntex-server = { version = "=3.11.1" }
 ntex-service = { version = "=4.6.0" }
-ntex-tls = { version = "=3.7.0" }
+ntex-tls = { version = "=3.8.0" }
 ntex-util = { version = "=3.6.1" }
 tonic = { version = "0.14.6", features = ["tls-aws-lc"] }
 reqwest = { version = "0.12.23", default-features = false, features = ["http2", "rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ dashmap = { version = "6.2.1" }
 async-trait = "0.1.88"
 futures = "0.3.31"
 humantime = "2.3.0"
-http = "1.4.1"
+http = "1.5.0"
 http-serde = "2.1.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.10.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio-util = { version = "0.7.16" }
 tokio-stream = { version = "0.1.17" }
 rand = "0.10.1"
 jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
-ntex = { version = "=3.10.0", features = ["tokio", "rustls"] }
+ntex = { version = "=3.10.1", features = ["tokio", "rustls"] }
 ntex-http = { version = "=1.2.0"}
 ntex-codec = { version = "=1.2.1"}
 ntex-io = { version = "=3.13.1"}

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -86,6 +86,7 @@ ntex-dispatcher = { workspace = true }
 ntex-error = { workspace = true }
 ntex-h2 = { workspace = true }
 ntex-rt = { workspace = true }
+ntex-httparse = { workspace = true }
 ntex-macros = { workspace = true }
 ntex-server = { workspace = true }
 ntex-service = { workspace = true }

--- a/bin/router/src/config/env_overrides.rs
+++ b/bin/router/src/config/env_overrides.rs
@@ -127,8 +127,8 @@ impl EnvVarOverrides {
         }
 
         if let Some(http_keep_alive) = self.http_keep_alive.take() {
-            debug!(target: CONFIG_LOGGING_TARGET, value = http_keep_alive, "overriding 'http.keep_alive'");
-            config = config.set_override("http.keep_alive", http_keep_alive)?;
+            debug!(target: CONFIG_LOGGING_TARGET, value = http_keep_alive, "overriding 'traffic_shaping.router.keep_alive'");
+            config = config.set_override("traffic_shaping.router.keep_alive", http_keep_alive)?;
         }
 
         let configured_supergraph_sources = [
@@ -328,7 +328,10 @@ telemetry:
             ..Default::default()
         });
 
-        assert_eq!(config.http.keep_alive, std::time::Duration::from_secs(80));
+        assert_eq!(
+            config.traffic_shaping.router.keep_alive,
+            std::time::Duration::from_secs(80)
+        );
     }
 
     #[test]
@@ -339,8 +342,9 @@ telemetry:
         }
         .apply_overrides(Config::builder().add_source(File::from_str(
             r#"
-http:
-  keep_alive: 5s
+traffic_shaping:
+  router:
+    keep_alive: 5s
 "#,
             FileFormat::Yaml,
         )))
@@ -350,7 +354,10 @@ http:
         .try_deserialize::<HiveRouterConfig>()
         .unwrap();
 
-        assert_eq!(config.http.keep_alive, std::time::Duration::from_secs(80));
+        assert_eq!(
+            config.traffic_shaping.router.keep_alive,
+            std::time::Duration::from_secs(80)
+        );
     }
 
     #[test]

--- a/bin/router/src/config/env_overrides.rs
+++ b/bin/router/src/config/env_overrides.rs
@@ -35,6 +35,8 @@ pub struct EnvVarOverrides {
     pub http_host: Option<String>,
     #[envconfig(from = "ROUTER_HTTP_WORKERS")]
     pub http_workers: Option<usize>,
+    #[envconfig(from = "ROUTER_HTTP_KEEP_ALIVE")]
+    pub http_keep_alive: Option<String>,
 
     // Supergraph overrides
     #[envconfig(from = "SUPERGRAPH_FILE_PATH")]
@@ -122,6 +124,11 @@ impl EnvVarOverrides {
             // cast to u64 because the `config` crate doesn't implement `Into<Value>` for `usize`;
             // the value is then deserialized into `Option<NonZeroUsize>`, which rejects `0`.
             config = config.set_override("http.workers", http_workers as u64)?;
+        }
+
+        if let Some(http_keep_alive) = self.http_keep_alive.take() {
+            debug!(target: CONFIG_LOGGING_TARGET, value = http_keep_alive, "overriding 'http.keep_alive'");
+            config = config.set_override("http.keep_alive", http_keep_alive)?;
         }
 
         let configured_supergraph_sources = [
@@ -312,6 +319,38 @@ telemetry:
         .unwrap();
 
         assert_eq!(config.telemetry.tracing.collect.sampling, 0.1);
+    }
+
+    #[test]
+    fn http_keep_alive_override_sets_http_keep_alive() {
+        let config = config_from_overrides(EnvVarOverrides {
+            http_keep_alive: Some("80s".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(config.http.keep_alive, std::time::Duration::from_secs(80));
+    }
+
+    #[test]
+    fn http_keep_alive_override_wins_over_config_file_value() {
+        let config = EnvVarOverrides {
+            http_keep_alive: Some("80s".to_string()),
+            ..Default::default()
+        }
+        .apply_overrides(Config::builder().add_source(File::from_str(
+            r#"
+http:
+  keep_alive: 5s
+"#,
+            FileFormat::Yaml,
+        )))
+        .unwrap()
+        .build()
+        .unwrap()
+        .try_deserialize::<HiveRouterConfig>()
+        .unwrap();
+
+        assert_eq!(config.http.keep_alive, std::time::Duration::from_secs(80));
     }
 
     #[test]

--- a/bin/router/src/config/http_server.rs
+++ b/bin/router/src/config/http_server.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::time::Duration;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -36,6 +37,30 @@ pub struct HttpServerConfig {
     /// Can also be set via the `ROUTER_HTTP_WORKERS` environment variable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workers: Option<NonZeroUsize>,
+
+    /// How long the HTTP server waits for a follow-up request on an idle
+    /// keep-alive connection before closing it.
+    ///
+    /// Defaults to 5 seconds, which matches ntex's own default.
+    ///
+    /// When the router sits behind a reverse proxy, set this above that proxy's
+    /// idle timeout so the proxy closes first. Closing first from the router
+    /// leaves the proxy holding a socket the server has already dropped, which
+    /// then fails the next reused request.
+    ///
+    /// ```yaml
+    /// http:
+    ///   keep_alive: 80s
+    /// ```
+    ///
+    /// Can also be set via the `ROUTER_HTTP_KEEP_ALIVE` environment variable.
+    #[serde(
+        default = "http_server_keep_alive_default",
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    #[schemars(with = "String")]
+    pub keep_alive: Duration,
 }
 
 impl Default for HttpServerConfig {
@@ -45,6 +70,7 @@ impl Default for HttpServerConfig {
             port: http_server_port_default(),
             graphql_endpoint: graphql_endpoint_default(),
             workers: None,
+            keep_alive: http_server_keep_alive_default(),
         }
     }
 }
@@ -59,4 +85,48 @@ fn graphql_endpoint_default() -> String {
 
 fn http_server_port_default() -> u16 {
     4000
+}
+
+/// Matches ntex's own default HTTP/1 keep-alive, so configurations that omit
+/// `keep_alive` keep their existing behaviour.
+fn http_server_keep_alive_default() -> Duration {
+    Duration::from_secs(5)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::HttpServerConfig;
+
+    #[test]
+    fn keep_alive_defaults_to_five_seconds() {
+        let config: HttpServerConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+
+        assert_eq!(config.keep_alive, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn keep_alive_accepts_human_readable_durations() {
+        let config: HttpServerConfig = serde_json::from_str(r#"{ "keep_alive": "80s" }"#)
+            .expect("human readable duration should deserialize");
+
+        assert_eq!(config.keep_alive, Duration::from_secs(80));
+    }
+
+    #[test]
+    fn keep_alive_serializes_back_to_a_duration_string() {
+        let config = HttpServerConfig {
+            keep_alive: Duration::from_secs(80),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_value(&config)
+            .expect("config should serialize")
+            .get("keep_alive")
+            .cloned();
+
+        assert_eq!(serialized, Some(serde_json::json!("1m 20s")));
+    }
 }

--- a/bin/router/src/config/http_server.rs
+++ b/bin/router/src/config/http_server.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroUsize;
-use std::time::Duration;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -37,30 +36,6 @@ pub struct HttpServerConfig {
     /// Can also be set via the `ROUTER_HTTP_WORKERS` environment variable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workers: Option<NonZeroUsize>,
-
-    /// How long the HTTP server waits for a follow-up request on an idle
-    /// keep-alive connection before closing it.
-    ///
-    /// Defaults to 5 seconds, which matches ntex's own default.
-    ///
-    /// When the router sits behind a reverse proxy, set this above that proxy's
-    /// idle timeout so the proxy closes first. Closing first from the router
-    /// leaves the proxy holding a socket the server has already dropped, which
-    /// then fails the next reused request.
-    ///
-    /// ```yaml
-    /// http:
-    ///   keep_alive: 80s
-    /// ```
-    ///
-    /// Can also be set via the `ROUTER_HTTP_KEEP_ALIVE` environment variable.
-    #[serde(
-        default = "http_server_keep_alive_default",
-        deserialize_with = "humantime_serde::deserialize",
-        serialize_with = "humantime_serde::serialize"
-    )]
-    #[schemars(with = "String")]
-    pub keep_alive: Duration,
 }
 
 impl Default for HttpServerConfig {
@@ -70,7 +45,6 @@ impl Default for HttpServerConfig {
             port: http_server_port_default(),
             graphql_endpoint: graphql_endpoint_default(),
             workers: None,
-            keep_alive: http_server_keep_alive_default(),
         }
     }
 }
@@ -85,48 +59,4 @@ fn graphql_endpoint_default() -> String {
 
 fn http_server_port_default() -> u16 {
     4000
-}
-
-/// Matches ntex's own default HTTP/1 keep-alive, so configurations that omit
-/// `keep_alive` keep their existing behaviour.
-fn http_server_keep_alive_default() -> Duration {
-    Duration::from_secs(5)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use super::HttpServerConfig;
-
-    #[test]
-    fn keep_alive_defaults_to_five_seconds() {
-        let config: HttpServerConfig =
-            serde_json::from_str("{}").expect("empty config should deserialize");
-
-        assert_eq!(config.keep_alive, Duration::from_secs(5));
-    }
-
-    #[test]
-    fn keep_alive_accepts_human_readable_durations() {
-        let config: HttpServerConfig = serde_json::from_str(r#"{ "keep_alive": "80s" }"#)
-            .expect("human readable duration should deserialize");
-
-        assert_eq!(config.keep_alive, Duration::from_secs(80));
-    }
-
-    #[test]
-    fn keep_alive_serializes_back_to_a_duration_string() {
-        let config = HttpServerConfig {
-            keep_alive: Duration::from_secs(80),
-            ..Default::default()
-        };
-
-        let serialized = serde_json::to_value(&config)
-            .expect("config should serialize")
-            .get("keep_alive")
-            .cloned();
-
-        assert_eq!(serialized, Some(serde_json::json!("1m 20s")));
-    }
 }

--- a/bin/router/src/config/mod.rs
+++ b/bin/router/src/config/mod.rs
@@ -242,6 +242,10 @@ impl HiveRouterConfig {
         self.http.workers
     }
 
+    pub fn keep_alive(&self) -> std::time::Duration {
+        self.http.keep_alive
+    }
+
     pub fn graphql_path(&self) -> &str {
         &self.http.graphql_endpoint
     }

--- a/bin/router/src/config/mod.rs
+++ b/bin/router/src/config/mod.rs
@@ -243,7 +243,7 @@ impl HiveRouterConfig {
     }
 
     pub fn keep_alive(&self) -> std::time::Duration {
-        self.http.keep_alive
+        self.traffic_shaping.router.keep_alive
     }
 
     pub fn graphql_path(&self) -> &str {

--- a/bin/router/src/config/traffic_shaping.rs
+++ b/bin/router/src/config/traffic_shaping.rs
@@ -449,6 +449,7 @@ pub struct TrafficShapingRouterConfig {
     #[schemars(with = "String")]
     pub request_timeout: Duration,
 
+    /// TLS configuration for the HTTP server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls: Option<ServerTLSConfig>,
 
@@ -458,6 +459,31 @@ pub struct TrafficShapingRouterConfig {
     /// If both WebSockets and Subscriptions are disabled, this setting has no effect.
     #[serde(default = "default_max_long_lived_clients")]
     pub max_long_lived_clients: usize,
+
+    /// How long the HTTP server waits for a follow-up request on an idle
+    /// keep-alive connection before closing it.
+    ///
+    /// Defaults to 5 seconds, which matches ntex's own default.
+    ///
+    /// When the router sits behind a reverse proxy, set this above that proxy's
+    /// idle timeout so the proxy closes first. Closing first from the router
+    /// leaves the proxy holding a socket the server has already dropped, which
+    /// then fails the next reused request.
+    ///
+    /// ```yaml
+    /// traffic_shaping:
+    ///   router:
+    ///     keep_alive: 80s
+    /// ```
+    ///
+    /// Can also be set via the `ROUTER_HTTP_KEEP_ALIVE` environment variable.
+    #[serde(
+        default = "http_server_keep_alive_default",
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    #[schemars(with = "String")]
+    pub keep_alive: Duration,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -558,8 +584,15 @@ impl Default for TrafficShapingRouterConfig {
             request_timeout: default_router_request_timeout(),
             tls: None,
             max_long_lived_clients: default_max_long_lived_clients(),
+            keep_alive: http_server_keep_alive_default(),
         }
     }
+}
+
+/// Matches ntex's own default HTTP/1 keep-alive, so configurations that omit
+/// `keep_alive` keep their existing behaviour.
+fn http_server_keep_alive_default() -> Duration {
+    Duration::from_secs(5)
 }
 
 fn default_circuit_breaker_config() -> Option<TrafficShapingSubgraphCircuitBreakerConfig> {
@@ -818,4 +851,42 @@ pub struct ClientTLSConfig {
 pub struct ClientAuthConfig {
     pub cert_file: SingleOrMultiple<FilePath>,
     pub key_file: FilePath,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::TrafficShapingRouterConfig;
+
+    #[test]
+    fn keep_alive_defaults_to_five_seconds() {
+        let config: TrafficShapingRouterConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+
+        assert_eq!(config.keep_alive, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn keep_alive_accepts_human_readable_durations() {
+        let config: TrafficShapingRouterConfig = serde_json::from_str(r#"{ "keep_alive": "80s" }"#)
+            .expect("human readable duration should deserialize");
+
+        assert_eq!(config.keep_alive, Duration::from_secs(80));
+    }
+
+    #[test]
+    fn keep_alive_serializes_back_to_a_duration_string() {
+        let config = TrafficShapingRouterConfig {
+            keep_alive: Duration::from_secs(80),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_value(&config)
+            .expect("config should serialize")
+            .get("keep_alive")
+            .cloned();
+
+        assert_eq!(serialized, Some(serde_json::json!("1m 20s")));
+    }
 }

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -386,6 +386,31 @@ fn to_ntex_keep_alive(duration: std::time::Duration) -> KeepAlive {
     }
 }
 
+pub fn build_http_service_config(router_config: &HiveRouterConfig) -> HttpServiceConfig {
+    let keep_alive = to_ntex_keep_alive(router_config.keep_alive());
+
+    let ntex_timeout = u16::try_from(
+        router_config
+            .traffic_shaping
+            .router
+            .request_timeout
+            .as_secs()
+            .saturating_add(1),
+    )
+    .unwrap_or(u16::MAX);
+
+    let max_request_header_size = router_config.limits.max_request_header_size.to_bytes() as usize;
+
+    HttpServiceConfig::new()
+        .set_keepalive(keep_alive)
+        // ntex HTTP timeout is set as a safe-guard on top of Hive Router's timeout
+        .set_client_timeout(Seconds(ntex_timeout))
+        // ntex's parse buffer must fit the whole request head, otherwise limits
+        // above its 64KiB default would be unreachable; the exact per-request
+        // limit is enforced in the pipeline (`graphql_request_handler`)
+        .set_max_buf_size(max_request_header_size.max(64 * 1024))
+}
+
 pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), RouterInitError> {
     if cfg!(debug_assertions) && std::env::var("CARGO").is_err() {
         eprintln!("WARNING: You are running Hive Router using a debug binary, which is not recommended for production use.");
@@ -454,7 +479,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 cb_server_builder = cb_server_builder.workers(workers.get());
             }
             let cb_cfg = SharedCfg::new("HIVE_ROUTER_CALLBACK")
-                .add(HttpServiceConfig::new().set_keepalive(keep_alive));
+                .add(build_http_service_config(router_config));
             let cb_server = cb_server_builder
                 .config(cb_cfg)
                 .bind(&cb_addr)
@@ -514,32 +539,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
 
     info!(target: targets::CORE, keep_alive = ?keep_alive, "configuring HTTP server keep-alive");
 
-    let ntex_timeout = u16::try_from(
-        shared_state_clone
-            .router_config
-            .traffic_shaping
-            .router
-            .request_timeout
-            .as_secs()
-            .saturating_add(1),
-    )
-    .unwrap_or(u16::MAX);
-
-    let max_request_header_size = shared_state_clone
-        .router_config
-        .limits
-        .max_request_header_size
-        .to_bytes() as usize;
-
-    let http_cfg = HttpServiceConfig::new()
-        .set_keepalive(keep_alive)
-        // ntex HTTP timeout is set as a safe-guard on top of Hive Router's timeout
-        .set_client_timeout(Seconds(ntex_timeout))
-        // ntex's parse buffer must fit the whole request head, otherwise limits
-        // above its 64KiB default would be unreachable; the exact per-request
-        // limit is enforced in the pipeline (`graphql_request_handler`)
-        .set_max_buf_size(max_request_header_size.max(64 * 1024));
-    let cfg = SharedCfg::new("HIVE_ROUTER").add(http_cfg);
+    let cfg = SharedCfg::new("HIVE_ROUTER").add(build_http_service_config(router_config));
 
     server = server.config(cfg);
 

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -96,7 +96,7 @@ pub use mimalloc::MiMalloc as RouterGlobalAllocator;
 pub use ntex;
 pub use ntex::main;
 use ntex::{
-    http::HttpServiceConfig,
+    http::{HttpServiceConfig, KeepAlive},
     time::Seconds,
     web::{self, HttpRequest},
     SharedCfg,
@@ -373,6 +373,19 @@ async fn graphql_endpoint_dispatch(
     .await
 }
 
+/// ntex expresses HTTP/1 keep-alive in whole seconds. Sub-second values round
+/// up so a configured timeout cannot collapse to "close immediately", and
+/// oversized values clamp instead of wrapping. Zero disables keep-alive.
+fn to_ntex_keep_alive(duration: std::time::Duration) -> KeepAlive {
+    let secs = duration.as_secs() + u64::from(duration.subsec_nanos() > 0);
+
+    match u16::try_from(secs) {
+        Ok(0) => KeepAlive::Disabled,
+        Ok(secs) => KeepAlive::Timeout(Seconds(secs)),
+        Err(_) => KeepAlive::Timeout(Seconds(u16::MAX)),
+    }
+}
+
 pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), RouterInitError> {
     if cfg!(debug_assertions) && std::env::var("CARGO").is_err() {
         eprintln!("WARNING: You are running Hive Router using a debug binary, which is not recommended for production use.");
@@ -398,6 +411,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     let websocket_path = router_config.websocket_path().map(|p| p.to_string());
     let callback_conf = router_config.callback_conf().cloned();
     let workers = router_config.workers();
+    let keep_alive = to_ntex_keep_alive(router_config.keep_alive());
     let mut bg_tasks_manager = background_tasks::BackgroundTasksManager::new();
     let (shared_state, schema_state) = configure_app_from_config(
         router_config,
@@ -439,7 +453,10 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 );
                 cb_server_builder = cb_server_builder.workers(workers.get());
             }
+            let cb_cfg = SharedCfg::new("HIVE_ROUTER_CALLBACK")
+                .add(HttpServiceConfig::new().set_keepalive(keep_alive));
             let cb_server = cb_server_builder
+                .config(cb_cfg)
                 .bind(&cb_addr)
                 .map_err(|err| RouterInitError::HttpCallbackServerBindError(cb_addr, err))?
                 .run();
@@ -495,6 +512,8 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
         server = server.workers(workers.get());
     }
 
+    info!(target: targets::CORE, keep_alive = ?keep_alive, "configuring HTTP server keep-alive");
+
     let ntex_timeout = u16::try_from(
         shared_state_clone
             .router_config
@@ -513,6 +532,7 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
         .to_bytes() as usize;
 
     let http_cfg = HttpServiceConfig::new()
+        .set_keepalive(keep_alive)
         // ntex HTTP timeout is set as a safe-guard on top of Hive Router's timeout
         .set_client_timeout(Seconds(ntex_timeout))
         // ntex's parse buffer must fit the whole request head, otherwise limits
@@ -785,4 +805,49 @@ macro_rules! configure_global_allocator {
         #[global_allocator]
         static GLOBAL: RouterGlobalAllocator = RouterGlobalAllocator;
     };
+}
+
+#[cfg(test)]
+mod to_ntex_keep_alive_tests {
+    use std::time::Duration;
+
+    use ntex::{http::KeepAlive, time::Seconds};
+
+    use super::to_ntex_keep_alive;
+
+    #[test]
+    fn keeps_whole_seconds() {
+        assert_eq!(
+            to_ntex_keep_alive(Duration::from_secs(80)),
+            KeepAlive::Timeout(Seconds(80))
+        );
+    }
+
+    #[test]
+    fn rounds_partial_seconds_up() {
+        assert_eq!(
+            to_ntex_keep_alive(Duration::from_millis(1)),
+            KeepAlive::Timeout(Seconds(1))
+        );
+        assert_eq!(
+            to_ntex_keep_alive(Duration::from_millis(1500)),
+            KeepAlive::Timeout(Seconds(2))
+        );
+    }
+
+    #[test]
+    fn disables_keep_alive_for_zero() {
+        assert_eq!(
+            to_ntex_keep_alive(Duration::from_secs(0)),
+            KeepAlive::Disabled
+        );
+    }
+
+    #[test]
+    fn clamps_oversized_durations() {
+        assert_eq!(
+            to_ntex_keep_alive(Duration::from_secs(u64::from(u16::MAX) + 1)),
+            KeepAlive::Timeout(Seconds(u16::MAX))
+        );
+    }
 }

--- a/e2e/src/circuit_breaker.rs
+++ b/e2e/src/circuit_breaker.rs
@@ -1154,6 +1154,9 @@ mod circuit_breaker_e2e_tests {
                               interval: 30ms
                               max_export_timeout: 50ms
                 traffic_shaping:
+                    router:
+                        keep_alive: 60s
+                        request_timeout: 60s
                     all:
                         # Plenty of headroom so the router never times the
                         # subgraph out within the test window; only the

--- a/e2e/src/keep_alive.rs
+++ b/e2e/src/keep_alive.rs
@@ -43,8 +43,9 @@ mod keep_alive_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
-                http:
-                    keep_alive: 1s
+                traffic_shaping:
+                    router:
+                        keep_alive: 1s
                 "#,
             )
             .build()
@@ -89,8 +90,9 @@ mod keep_alive_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
-                http:
-                    keep_alive: 2s
+                traffic_shaping:
+                    router:
+                        keep_alive: 2s
                 "#,
             )
             .build()
@@ -123,8 +125,9 @@ mod keep_alive_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
-                http:
-                    keep_alive: 0s
+                traffic_shaping:
+                    router:
+                        keep_alive: 0s
                 "#,
             )
             .build()
@@ -165,8 +168,9 @@ mod keep_alive_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
-                http:
-                    keep_alive: 2s
+                traffic_shaping:
+                    router:
+                        keep_alive: 2s
                 "#,
             )
             .build()

--- a/e2e/src/keep_alive.rs
+++ b/e2e/src/keep_alive.rs
@@ -2,13 +2,14 @@
 mod keep_alive_tests {
     use std::time::Duration;
 
+    use sonic_rs::JsonValueTrait;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpStream,
         time::timeout,
     };
 
-    use crate::testkit::{TestRouter, TestSubgraphs};
+    use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
 
     const KEEP_ALIVE_REQUEST: &[u8] =
         b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n";
@@ -71,6 +72,135 @@ mod keep_alive_tests {
             "expected the router to close the idle connection per the configured 1s \
              http.keep_alive, but it was still alive after 3s idle and answered: {:?}",
             second.map(|b| String::from_utf8_lossy(&b).to_string())
+        );
+    }
+
+    #[ntex::test]
+    async fn should_not_interrupt_a_slow_in_flight_request_with_a_short_keep_alive() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_secs(4))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                http:
+                    keep_alive: 2s
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ topProducts { name price } }", None, None)
+            .await;
+
+        assert!(
+            res.status().is_success(),
+            "expected the 4s in-flight request to complete despite a 2s http.keep_alive, got status {}",
+            res.status()
+        );
+        let json_body = res.json_body().await;
+        assert!(
+            json_body["data"]["topProducts"].is_array(),
+            "expected a full GraphQL response, got: {json_body:?}"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_disable_keep_alive_when_configured_to_zero() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                http:
+                    keep_alive: 0s
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let mut stream = TcpStream::connect(router.serv().addr())
+            .await
+            .expect("failed to open a raw TCP connection to the router");
+
+        let first = try_request(&mut stream)
+            .await
+            .expect("expected a response to the first request on a fresh connection");
+        assert!(
+            first.starts_with(b"HTTP/1.1 200"),
+            "expected 200 OK on the first request, got: {}",
+            String::from_utf8_lossy(&first)
+        );
+
+        // No idle wait: with keep-alive disabled, the connection should already be closing.
+        let second = try_request(&mut stream).await;
+        assert!(
+            second.is_none(),
+            "expected the connection to be closed immediately after the first response with \
+             keep_alive: 0s, but it was still alive and answered: {:?}",
+            second.map(|b| String::from_utf8_lossy(&b).to_string())
+        );
+    }
+
+    /// The keep-alive timer must re-arm on every reuse, not just the first one: several
+    /// successful reuse cycles under the configured timeout must not leave the connection
+    /// either permanently alive or prematurely dead on a later cycle.
+    #[ntex::test]
+    async fn should_rearm_keep_alive_timer_across_multiple_reuse_cycles() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                http:
+                    keep_alive: 2s
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let mut stream = TcpStream::connect(router.serv().addr())
+            .await
+            .expect("failed to open a raw TCP connection to the router");
+
+        for cycle in 0..3 {
+            let response = try_request(&mut stream).await.unwrap_or_else(|| {
+                panic!("expected a response on reuse cycle {cycle}, but the connection was closed")
+            });
+            assert!(
+                response.starts_with(b"HTTP/1.1 200"),
+                "expected 200 OK on reuse cycle {cycle}, got: {}",
+                String::from_utf8_lossy(&response)
+            );
+
+            // Idle well under the 2s keep_alive before reusing the connection again.
+            tokio::time::sleep(Duration::from_millis(1200)).await;
+        }
+
+        // Idle past the 2s keep_alive: the connection must now actually be closed, proving the
+        // timer still enforces the timeout after being re-armed multiple times.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let after_timeout = try_request(&mut stream).await;
+        assert!(
+            after_timeout.is_none(),
+            "expected the connection to finally be closed after an idle period exceeding the \
+             2s keep_alive, but it was still alive and answered: {:?}",
+            after_timeout.map(|b| String::from_utf8_lossy(&b).to_string())
         );
     }
 }

--- a/e2e/src/keep_alive.rs
+++ b/e2e/src/keep_alive.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+mod keep_alive_tests {
+    use std::time::Duration;
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpStream,
+        time::timeout,
+    };
+
+    use crate::testkit::{TestRouter, TestSubgraphs};
+
+    const KEEP_ALIVE_REQUEST: &[u8] =
+        b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n";
+
+    /// Sends a request on `stream` and returns the response bytes, or `None` if the
+    /// write failed or the connection was already closed by the server (EOF).
+    async fn try_request(stream: &mut TcpStream) -> Option<Vec<u8>> {
+        if stream.write_all(KEEP_ALIVE_REQUEST).await.is_err() {
+            return None;
+        }
+
+        let mut buf = vec![0u8; 4096];
+        match timeout(Duration::from_secs(3), stream.read(&mut buf)).await {
+            Ok(Ok(0)) | Ok(Err(_)) | Err(_) => None,
+            Ok(Ok(n)) => Some(buf[..n].to_vec()),
+        }
+    }
+
+    /// Regression test for `http.keep_alive`
+    ///
+    /// Configures a short 1s keep-alive and expects
+    /// the router to close an idle connection shortly after that, well before
+    /// `traffic_shaping.router.request_timeout` (60s by default) would kick in.
+    #[ntex::test]
+    async fn should_close_idle_connection_after_the_configured_keep_alive_timeout() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                http:
+                    keep_alive: 1s
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let mut stream = TcpStream::connect(router.serv().addr())
+            .await
+            .expect("failed to open a raw TCP connection to the router");
+
+        let first = try_request(&mut stream)
+            .await
+            .expect("expected a response to the first request on a fresh connection");
+        assert!(
+            first.starts_with(b"HTTP/1.1 200"),
+            "expected 200 OK on the first request, got: {}",
+            String::from_utf8_lossy(&first)
+        );
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let second = try_request(&mut stream).await;
+        assert!(
+            second.is_none(),
+            "expected the router to close the idle connection per the configured 1s \
+             http.keep_alive, but it was still alive after 3s idle and answered: {:?}",
+            second.map(|b| String::from_utf8_lossy(&b).to_string())
+        );
+    }
+}

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -53,6 +53,8 @@ mod issues;
 #[cfg(test)]
 mod jwt;
 #[cfg(test)]
+mod keep_alive;
+#[cfg(test)]
 mod laboratory;
 #[cfg(test)]
 mod max_aliases;

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -13,9 +13,9 @@ use mockito::Mock;
 use ntex::{
     client::ClientResponse,
     io::Sealed,
-    time::Seconds,
-    web::{self, test},
+    web::{self, test, WebAppConfig},
     ws::WsConnection,
+    SharedCfg,
 };
 use rcgen::generate_simple_self_signed;
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
@@ -862,6 +862,8 @@ impl TestRouter<Built> {
                 let cb_subs = schema_state.callback_subscriptions.clone();
                 let cb_telemetry_context = shared_state.telemetry_context.clone();
 
+                let cb_cfg = SharedCfg::new("HIVE_ROUTER_TEST_CALLBACK")
+                    .add(hive_router::build_http_service_config(config));
                 let server = web::HttpServer::new(async move || {
                     let cb_subs = cb_subs.clone();
                     let cb_path = cb_path.clone();
@@ -871,6 +873,7 @@ impl TestRouter<Built> {
                         .state(telemetry_context)
                         .configure(move |m| add_callback_handler(m, &cb_path))
                 })
+                .config(cb_cfg)
                 .bind(&cb_addr)
                 .expect("failed to bind callback server")
                 .run();
@@ -898,24 +901,32 @@ impl TestRouter<Built> {
             std::net::TcpListener::bind(format!("127.0.0.1:{}", self.port))
                 .expect("failed to bind tcp listener for test server"),
         );
-        let serv_port = serv_listener
+        let serv_local_addr = serv_listener
             .local_addr()
-            .expect("failed to get local address of test server")
-            .port();
+            .expect("failed to get local address of test server");
+        let serv_port = serv_local_addr.port();
         let serv_paths = paths.clone();
         let serv_prometheus = prometheus.clone();
         let long_lived_limit = LongLivedClientLimitService::new(shared_state.router_config);
-        let mut serv_config = test::config()
-            .client_timeout(Seconds(
-                shared_state
-                    .router_config
-                    .traffic_shaping
-                    .router
-                    .request_timeout
-                    .as_secs() as u16
-                    + 1,
+
+        let secure = serv_shared_state
+            .router_config
+            .traffic_shaping
+            .router
+            .tls
+            .is_some();
+        let system_name = ntex::rt::System::current().name().to_string();
+        let srv_cfg = SharedCfg::new("HIVE_ROUTER_TEST")
+            .add(hive_router::build_http_service_config(config))
+            .add(WebAppConfig::with(
+                &system_name,
+                secure,
+                serv_local_addr,
+                format!("{serv_local_addr}"),
             ))
-            .listener(serv_listener);
+            .build();
+
+        let mut serv_config = test::config().server_cfg(srv_cfg).listener(serv_listener);
         if let Some(tls_config) = serv_shared_state
             .router_config
             .traffic_shaping

--- a/e2e/src/traffic_shaping.rs
+++ b/e2e/src/traffic_shaping.rs
@@ -83,10 +83,9 @@ mod traffic_shaping_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
-                http:
-                    keep_alive: 11s # kept above request_timeout, per the recommended relationship
                 traffic_shaping:
                     router:
+                        keep_alive: 11s # kept above request_timeout, per the recommended relationship
                         request_timeout: 10s
                 "#,
             )

--- a/e2e/src/traffic_shaping.rs
+++ b/e2e/src/traffic_shaping.rs
@@ -68,8 +68,11 @@ mod traffic_shaping_e2e_tests {
     }
 
     /// Reproduces a user report: a keep-alive connection that idles longer than ntex's default 5s
-    /// keep-alive gets closed by ntex itself, even though the router is configured with a higher
-    /// `request_timeout`.
+    /// keep-alive gets closed by ntex itself. Fixed by explicitly configuring `http.keep_alive`
+    /// above ntex's 5s default (see #1434). `request_timeout` is a separate, per-request
+    /// safeguard that does not govern idle keep-alive connections, but `keep_alive` is kept above
+    /// it here anyway — the recommended relationship, so a legitimately slow in-flight request
+    /// is never at risk of its connection being reclaimed as "idle" before its own timeout fires.
     ///
     // https://github.com/graphql-hive/router/issues/1144
     #[ntex::test]
@@ -80,9 +83,11 @@ mod traffic_shaping_e2e_tests {
                 supergraph:
                     source: file
                     path: supergraph.graphql
+                http:
+                    keep_alive: 11s # kept above request_timeout, per the recommended relationship
                 traffic_shaping:
                     router:
-                        request_timeout: 10s # ntex keep-alive defaults to 5s; a higher router timeout proves the router governs, not ntex
+                        request_timeout: 10s
                 "#,
             )
             .build()
@@ -121,20 +126,21 @@ mod traffic_shaping_e2e_tests {
         let first = String::from_utf8_lossy(&buf[..n]);
         assert!(first.contains("200"), "t=0 expected 200 OK, got: {first:?}");
 
-        // Idle past ntex's 5s keep-alive default, but well within the router's 10s timeout.
+        // Idle past ntex's 5s keep-alive default, but well within the configured 11s keep_alive.
         ntex::time::sleep(Duration::from_secs(6)).await;
 
-        // t=6: the connection must still be usable. If ntex closed it at 5s, the write/read here
-        // observes a closed socket (read returns 0 bytes or errors) — that is the bug we guard against.
+        // t=6: the connection must still be usable. If ntex closed it at its 5s default, the
+        // write/read here observes a closed socket (read returns 0 bytes or errors) — that is
+        // the bug we guard against.
         let _ = stream.write_all(graphql_request.as_bytes()).await;
         let _ = stream.flush().await;
         let n = stream
             .read(&mut buf)
             .await
-            .expect("t=6 read failed: connection was closed by ntex before the router timeout");
+            .expect("t=6 read failed: connection was closed before the configured keep_alive");
         assert!(
             n > 0,
-            "t=6 connection was closed by the server (ntex keep-alive fired before the router's request_timeout)"
+            "t=6 connection was closed by the server (ntex's 5s default keep-alive fired instead of the configured 11s http.keep_alive)"
         );
         let second = String::from_utf8_lossy(&buf[..n]);
         assert!(

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -536,6 +536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1609,12 @@ checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "defmt"
@@ -2705,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2762,6 +2778,7 @@ dependencies = [
  "ntex-error",
  "ntex-h2",
  "ntex-http",
+ "ntex-httparse",
  "ntex-io",
  "ntex-macros",
  "ntex-net",
@@ -2856,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3677,9 +3694,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -4083,10 +4100,11 @@ dependencies = [
 
 [[package]]
 name = "ntex"
-version = "3.10.0"
+version = "3.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0baaa4f3df86d4f7e84b9cf7153743496360c79c689152ca9a2f1172ca5c2f"
+checksum = "0fc7d3125f1466c1c039760c0009c45d983e4a58589bbf52584ff7d421657782"
 dependencies = [
+ "atoi_simd",
  "base64",
  "bitflags 2.13.0",
  "derive_more",
@@ -4103,6 +4121,7 @@ dependencies = [
  "ntex-error",
  "ntex-h2",
  "ntex-http",
+ "ntex-httparse",
  "ntex-io",
  "ntex-macros",
  "ntex-net",
@@ -4119,7 +4138,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1 0.10.6",
  "thiserror 2.0.18",
  "uuid",
  "variadics_please",
@@ -4128,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-bytes"
-version = "1.7.6"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79595696d276a1be070159fb057e44c7b8b7c921f6690ddd3323cda71c70e92"
+checksum = "a926235646aee003de6b410c56efbfe3f8f5f6bbf8a69f1837b64f667dc03df9"
 dependencies = [
  "bytes",
  "serde",
@@ -4162,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-error"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d47e8dee801da88cca194481cb2f04a5de7cb949e3e9785086fb1b6a010884d"
+checksum = "229806c94be0c192bde46633bd044d11e3d7f3e5c5ee32aa3f430c918e99f746"
 dependencies = [
  "backtrace",
  "foldhash 0.2.0",
@@ -4174,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-h2"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462aedfed773643f8dce7b6173edcfeedc24f9dbf55a8f2c2fce3906163924f0"
+checksum = "b9169669ce11efc5ff8f14e419a982e53529c9d40e4f44be61766731ebf6590b"
 dependencies = [
  "bitflags 2.13.0",
  "foldhash 0.2.0",
@@ -4213,6 +4231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntex-httparse"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd04f3587bb190f11af135f652edff77f368d0940db134fa5a48c1f12c60b07"
+dependencies = [
+ "simdutf8",
+]
+
+[[package]]
 name = "ntex-io"
 version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,20 +4271,20 @@ dependencies = [
 
 [[package]]
 name = "ntex-macros"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3d0edf86b3b7168391cae05c637be4923b23968f7f65ead861d38cdfa3db1e"
+checksum = "94b2cc43bf60ff32e9d28f9b3d9bae28faa5ea5e0953a9113a8158f1e6f8dfcc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "ntex-net"
-version = "3.13.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312bd7f8090f1dee5b3f0d9eaa3a29e1642341943ee63bef3299051b27dd1e55"
+checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4277,6 +4304,7 @@ dependencies = [
  "socket2",
  "thiserror 2.0.18",
  "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4308,9 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.15.4"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e619aa588c9ef95940a7fb99e45077ed261646dfc5a1754ca1712126175c9"
+checksum = "877696a0cec7fccd0813d1c075e5dbc12e3a3199e492c9bfa3dd2da63d609f35"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4323,6 +4351,7 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
+ "nix 0.31.3",
  "ntex-error",
  "ntex-service",
  "oneshot",
@@ -4335,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.10.4"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
+checksum = "3eecf7ebae34a050ab29978eb1fa7bf99590e46e3ab29b5526aff7790d4c9464"
 dependencies = [
  "async-channel",
  "atomic-waker",
@@ -4368,9 +4397,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-tls"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa8909d6cef273298d192c51345e1124200f6a655336848659464e7950de4cf"
+checksum = "ba8873e946975d18c561f700a410f4ac6739871a085341ff77f7f6469b8f0dc0"
 dependencies = [
  "log",
  "ntex-bytes",
@@ -7165,6 +7194,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/plugin_examples/Cargo.toml
+++ b/plugin_examples/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 [workspace.dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
-http = "1.3.1"
+http = "1.5.0"
 reqwest = { version = "0.12.23", default-features = false, features = ["http2", "rustls-tls"] }
 tokio = { version = "1.47.1", features = ["full"] }
 futures = "0.3.31"


### PR DESCRIPTION
In addition, replaces https://github.com/graphql-hive/router/pull/1408

## Problem

The router never calls ntex's `set_keepalive`, so inbound HTTP/1 keep-alive is ntex's hardcoded 5 second default. There is no Hive Router setting to change it.

Behind a reverse proxy whose idle timeout is longer than 5 seconds, the router closes the socket first. The proxy then reuses a connection the server has already dropped, which fails the next request on that socket. This is independent of `traffic_shaping.all.pool_idle_timeout`, which only covers outbound subgraph connections.

Related: https://github.com/graphql-hive/router/pull/1433 (graceful shutdown timeout). Same class of gap: an ntex HTTP-server default that Hive did not expose.

## Change

Adds `traffic_shaping.router.keep_alive`, a human-readable duration passed to ntex `HttpServiceConfig::set_keepalive` (not `set_keepalive_timeout`, which is a second setter on the same field):

```yaml
traffic_shaping:
  router:
    keep_alive: 80s
```

- Defaults to 5 seconds, so behaviour is unchanged for configurations that omit it.
- Applied to both the main server and a separately bound callback server.
- Overridable via `ROUTER_HTTP_KEEP_ALIVE`.
- Uses the repository's `humantime_serde` plus `schemars(with = "String")` convention.
- `0s` disables keep-alive (`KeepAlive::Disabled`).

When the router sits behind a reverse proxy, set this above that proxy's idle timeout so the proxy closes first.

ntex takes whole seconds, so partial seconds round up and oversized values clamp rather than wrap.

## Tests

Unit tests cover the 5 second default, parsing `80s`, the serialised duration-string shape, both environment override paths including precedence over a config file value, and the `Duration` to ntex `KeepAlive` conversion boundaries.

```
cargo test -p hive-router --lib -- keep_alive to_ntex_keep_alive config::
```
