### PR TITLE
feat(config): support list/array in `from_env` using `,` delimiter

### DIFF
--- a/.changeset/from-env-list-delimiter.md
+++ b/.changeset/from-env-list-delimiter.md
@@ -1,0 +1,19 @@
+---
+hive-router: patch
+---
+
+`from_env` now supports list/array fields using `,` as the delimiter
+
+A `from_env` placeholder whose `default` is a list is now resolved by splitting the environment
+variable's value on `,` into one item per entry, instead of being kept as a single literal string
+that would then fail to deserialize (or silently become a one-item list).
+
+```yaml
+cors:
+  policies:
+    - origins:
+        from_env: CORS_ALLOWED_ORIGINS
+        default:
+          - http://localhost:3000
+          - http://localhost:4000
+```

--- a/bin/router/src/config/from_env.rs
+++ b/bin/router/src/config/from_env.rs
@@ -2,14 +2,16 @@ use config_rs::{Map, Value, ValueKind};
 
 const FROM_ENV_KEY: &str = "from_env";
 const DEFAULT_KEY: &str = "default";
+const LIST_DELIMITER: char = ',';
 
 /// Recursively resolves `{ from_env: "VAR" }` (optionally with `default: <value>`) placeholders
 /// anywhere in a parsed config value tree, in place, before it gets deserialized into typed
 /// config structs.
 ///
 /// A placeholder is replaced by the referenced environment variable's value (as a string,
-/// letting the normal field deserialization coerce it into the target type). If the variable is
-/// not set:
+/// letting the normal field deserialization coerce it into the target type) - unless `default`
+/// is itself a list, in which case the value is split on `,` into one string per list item. If
+/// the variable is not set:
 /// - with a `default` given, the placeholder is replaced by that value instead;
 /// - otherwise, the placeholder is dropped entirely, so the field is treated as if it was never
 ///   present in the config file: `#[serde(default = ...)]` kicks in, or deserialization fails
@@ -45,7 +47,7 @@ fn resolve_and_keep(value: &mut Value, label: &str, warnings: &mut Vec<String>) 
     };
 
     if let Ok(resolved) = std::env::var(&marker.var_name) {
-        value.kind = ValueKind::String(resolved);
+        value.kind = resolved_value_kind(resolved, marker.default.as_ref());
         return true;
     }
 
@@ -66,6 +68,21 @@ fn resolve_and_keep(value: &mut Value, label: &str, warnings: &mut Vec<String>) 
             false
         }
     }
+}
+
+fn resolved_value_kind(resolved: String, default: Option<&Value>) -> ValueKind {
+    if !matches!(default.map(|d| &d.kind), Some(ValueKind::Array(_))) {
+        return ValueKind::String(resolved);
+    }
+
+    ValueKind::Array(
+        resolved
+            .split(LIST_DELIMITER)
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .map(|item| Value::new(None, item.to_string()))
+            .collect(),
+    )
 }
 
 struct FromEnvMarker {
@@ -225,6 +242,31 @@ mod tests {
         .unwrap();
         assert_eq!(sample.greeting, "hello there");
         unsafe { std::env::remove_var("FROM_ENV_TEST_PRESENT_WITH_DEFAULT") };
+    }
+
+    #[test]
+    fn resolves_env_var_as_a_comma_delimited_list_when_default_is_a_list() {
+        unsafe { std::env::set_var("FROM_ENV_TEST_LIST", "c, d ,e") };
+        let sample = build(
+            "required: r\nnested:\n  values:\n    from_env: FROM_ENV_TEST_LIST\n    default:\n      - a\n      - b\n",
+        )
+        .unwrap();
+        assert_eq!(
+            sample.nested.values,
+            vec!["c".to_string(), "d".to_string(), "e".to_string()],
+            "expected the env var to be split on `,` (and trimmed) instead of kept as one literal string"
+        );
+        unsafe { std::env::remove_var("FROM_ENV_TEST_LIST") };
+    }
+
+    #[test]
+    fn missing_env_var_uses_the_list_default_verbatim() {
+        unsafe { std::env::remove_var("FROM_ENV_TEST_MISSING_LIST") };
+        let sample = build(
+            "required: r\nnested:\n  values:\n    from_env: FROM_ENV_TEST_MISSING_LIST\n    default:\n      - a\n      - b\n",
+        )
+        .unwrap();
+        assert_eq!(sample.nested.values, vec!["a".to_string(), "b".to_string()]);
     }
 
     #[test]

--- a/bin/router/src/config/schema_from_env.rs
+++ b/bin/router/src/config/schema_from_env.rs
@@ -136,13 +136,22 @@ fn summarize_types(original_type: Option<&Value>) -> Option<Value> {
 }
 
 /// A schema is ineligible for a `from_env` alternative if it can only ever be satisfied by a
-/// bare object or array - there's no plain string an env var could resolve to that would match.
+/// bare object, or by an array of those - there's no plain string an env var could resolve to
+/// that would match. An array of *primitives* is the exception: [`resolve_from_env_placeholders`]
+/// splits the env var's value on `,` into one item per array entry, so it's eligible too.
 fn is_object_or_array_only(map: &Map<String, Value>) -> bool {
     if map.contains_key("properties") || map.contains_key("additionalProperties") {
         return true;
     }
-    if map.contains_key("items") || map.contains_key("prefixItems") {
+    // Tuple-shaped arrays have no single delimiter scheme that could fill every slot.
+    if map.contains_key("prefixItems") {
         return true;
+    }
+    if let Some(items) = map.get("items") {
+        return match items {
+            Value::Object(items_map) => is_object_or_array_only(items_map),
+            _ => true,
+        };
     }
 
     match map.get("type") {
@@ -337,7 +346,46 @@ mod tests {
             "items": { "type": "string" }
         }));
 
+        assert!(result["oneOf"][0]["items"]["oneOf"].is_array());
+    }
+
+    #[test]
+    fn adds_a_from_env_alternative_to_an_array_of_primitives() {
+        let result = augmented(json!({
+            "type": "array",
+            "items": { "type": "string" }
+        }));
+
+        let variants = result["oneOf"]
+            .as_array()
+            .expect("an array of primitives should be eligible for a from_env alternative");
+        assert_eq!(variants.len(), 2);
+        assert_eq!(variants[1]["required"], json!(["from_env"]));
+        // `default` must still be an array of the same item type as the field itself.
+        assert_eq!(
+            variants[1]["properties"]["default"]["items"]["type"],
+            json!(["string", "object"]),
+            "the default's items go through the same per-item from_env wrapping"
+        );
+    }
+
+    #[test]
+    fn does_not_add_a_from_env_alternative_to_an_array_of_objects() {
+        let result = augmented(json!({
+            "type": "array",
+            "items": { "type": "object", "properties": { "name": { "type": "string" } } }
+        }));
+
         assert!(result.get("oneOf").is_none());
-        assert!(result["items"]["oneOf"].is_array());
+    }
+
+    #[test]
+    fn does_not_add_a_from_env_alternative_to_a_nested_array() {
+        let result = augmented(json!({
+            "type": "array",
+            "items": { "type": "array", "items": { "type": "string" } }
+        }));
+
+        assert!(result.get("oneOf").is_none());
     }
 }

--- a/e2e/configs/cors_origins_from_env.router.yaml
+++ b/e2e/configs/cors_origins_from_env.router.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../supergraph.graphql
+cors:
+  enabled: true
+  policies:
+    - origins:
+        from_env: CORS_ALLOWED_ORIGINS
+        default:
+          - "http://localhost:3000"
+          - "http://localhost:4000"

--- a/e2e/src/env_vars.rs
+++ b/e2e/src/env_vars.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod env_vars_e2e_tests {
-    use crate::testkit::{ClientResponseExt, EnvVarsGuard, TestRouter, TestSubgraphs};
+    use crate::testkit::{
+        some_header_map, ClientResponseExt, EnvVarsGuard, TestRouter, TestSubgraphs,
+    };
 
     #[ntex::test]
     /// Test that a dynamic URL override for a subgraph based on an env var is respected.
@@ -143,6 +145,97 @@ mod env_vars_e2e_tests {
                     .get("x-router-env")
                     .map(|v| v.to_str().unwrap()),
                 Some("e2e")
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn should_resolve_list_default_from_env_as_a_delimited_list() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        // Without the env var set, the list `default` (`localhost:3000`/`4000`) is used as-is.
+        {
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .file_config("configs/cors_origins_from_env.router.yaml")
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request(
+                    "{ __typename }",
+                    None,
+                    some_header_map! {
+                        http::header::ORIGIN => "http://localhost:4000"
+                    },
+                )
+                .await;
+
+            assert_eq!(
+                res.headers()
+                    .get("access-control-allow-origin")
+                    .map(|v| v.to_str().unwrap()),
+                Some("http://localhost:4000"),
+                "expected the default origin list entry to be reflected"
+            );
+
+            drop(router); // Ensure router is dropped before subgraphs
+        }
+
+        // With the env var set to a comma-delimited list, each entry should be treated as its
+        // own allowed origin, not as one long literal string.
+        {
+            let _env_guard = EnvVarsGuard::new()
+                .set(
+                    "CORS_ALLOWED_ORIGINS",
+                    "http://foo.example.com,http://bar.example.com",
+                )
+                .apply()
+                .await;
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .file_config("configs/cors_origins_from_env.router.yaml")
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request(
+                    "{ __typename }",
+                    None,
+                    some_header_map! {
+                        http::header::ORIGIN => "http://bar.example.com"
+                    },
+                )
+                .await;
+
+            assert_eq!(
+                res.headers()
+                    .get("access-control-allow-origin")
+                    .map(|v| v.to_str().unwrap()),
+                Some("http://bar.example.com"),
+                "expected the second entry of the env var's delimited list to be reflected"
+            );
+
+            // An origin that isn't one of the two entries must still be rejected.
+            let res = router
+                .send_graphql_request(
+                    "{ __typename }",
+                    None,
+                    some_header_map! {
+                        http::header::ORIGIN => "http://localhost:3000"
+                    },
+                )
+                .await;
+
+            assert_eq!(
+                res.headers()
+                    .get("access-control-allow-origin")
+                    .map(|v| v.to_str().unwrap()),
+                Some("null"),
+                "expected an origin outside the env var's list to be rejected"
             );
         }
     }


### PR DESCRIPTION
Closes https://github.com/graphql-hive/router/issues/1438 

`from_env` now supports list/array fields using `,` as the delimiter

A `from_env` placeholder whose `default` is a list is now resolved by splitting the environment
variable's value on `,` into one item per entry, instead of being kept as a single literal string
that would then fail to deserialize (or silently become a one-item list).

Example:

```yaml
cors:
  policies:
    - origins:
        from_env: CORS_ALLOWED_ORIGINS
        default:
          - http://localhost:3000
          - http://localhost:4000
```

* Also, the JSON schema for the config now supports that and validates it correctly. 