### PR TITLE
fix(router): replace async-dropper-simple with a simple, safe `Drop` for usage reporting

### DIFF
--- a/.changeset/fix-usage-agent-drop-abort.md
+++ b/.changeset/fix-usage-agent-drop-abort.md
@@ -1,0 +1,16 @@
+---
+hive-router: patch
+hive-console-sdk: patch
+hive-apollo-router-plugin: patch
+---
+
+Fix the router process aborting on supergraph hot-reload when `telemetry.hive.usage_reporting` is enabled.
+
+Retiring a supergraph drops the previous generation's Hive usage-reporting agent.
+
+That agent used to flush on drop via a blocking bridge (`block_in_place`) that is only valid on a multi-threaded `tokio` runtime.
+The router runs on ntex's current-thread runtime, so this always panicked, and since the panic happened inside a `Drop` impl, it escalated to a full process abort (`panic in a destructor during cleanup`) instead of just failing the reload.
+
+The agent now uses a non-blocking flush, best-effort operation instead.
+
+Fixes https://github.com/graphql-hive/router/issues/1439

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,19 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dropper-simple"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c4748dfe8cd3d625ec68fc424fa80c134319881185866f9e173af9e5d8add8"
-dependencies = [
- "async-scoped",
- "async-trait",
- "futures",
- "rustc_version",
- "tokio",
-]
-
-[[package]]
 name = "async-graphql"
 version = "8.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,17 +422,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-scoped"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
-dependencies = [
- "futures",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -2593,7 +2569,6 @@ version = "0.3.20"
 dependencies = [
  "ahash",
  "anyhow",
- "async-dropper-simple",
  "async-trait",
  "bytes",
  "futures-util",

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -260,11 +260,11 @@ mod tests {
     use super::*;
     use graphql_tools::parser::schema::parse_schema;
 
-    // Reproduces https://github.com/graphql-hive/router/issues/1439: the router itself runs on
-    // ntex's current-thread runtime, where dropping the last `UsageAgent` reference aborts the
-    // process
+    // Regression test for https://github.com/graphql-hive/router/issues/1439: the router runs on
+    // ntex's current-thread runtime, so dropping the last `UsageAgent` reference must not abort
+    // the process.
     #[ntex::test]
-    async fn dropping_usage_agent_panics_on_ntex_current_thread_runtime() {
+    async fn dropping_usage_agent_does_not_panic_on_ntex_current_thread_runtime() {
         let agent = UsageAgent::builder()
             .token("token".into())
             .endpoint("http://localhost/usage".into())
@@ -274,7 +274,6 @@ mod tests {
         drop(agent);
     }
 
-    // usage agent async drop uses block_in_place, which requires tokio's multi-threaded runtime
     #[tokio::test(flavor = "multi_thread")]
     async fn lifetime_cancellation_flushes_before_the_worker_stops() {
         crate::init_rustls_crypto_provider();

--- a/bin/router/src/pipeline/usage_reporting.rs
+++ b/bin/router/src/pipeline/usage_reporting.rs
@@ -260,6 +260,20 @@ mod tests {
     use super::*;
     use graphql_tools::parser::schema::parse_schema;
 
+    // Reproduces https://github.com/graphql-hive/router/issues/1439: the router itself runs on
+    // ntex's current-thread runtime, where dropping the last `UsageAgent` reference aborts the
+    // process
+    #[ntex::test]
+    async fn dropping_usage_agent_panics_on_ntex_current_thread_runtime() {
+        let agent = UsageAgent::builder()
+            .token("token".into())
+            .endpoint("http://localhost/usage".into())
+            .build()
+            .unwrap();
+
+        drop(agent);
+    }
+
     // usage agent async drop uses block_in_place, which requires tokio's multi-threaded runtime
     #[tokio::test(flavor = "multi_thread")]
     async fn lifetime_cancellation_flushes_before_the_worker_stops() {

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -1092,6 +1092,42 @@ mod plugin_runtime_cache_tests {
         }
     }
 
+    /// Same as [`test_schema_state`], but with Hive usage reporting enabled so
+    /// `RouterSupergraphRuntime` actually builds a live `hive_usage_agent`.
+    ///
+    /// Related: https://github.com/graphql-hive/router/issues/1439
+    fn test_schema_state_with_hive_usage_reporting() -> SchemaState {
+        let mut state = test_schema_state();
+        state.runtime_context = Arc::new(RouterSupergraphRuntimeContext {
+            telemetry: state.runtime_context.telemetry.clone(),
+            callback_subscriptions: state.runtime_context.callback_subscriptions.clone(),
+            callback: state.runtime_context.callback.clone(),
+            persisted_documents_background_tasks: state
+                .runtime_context
+                .persisted_documents_background_tasks
+                .clone(),
+            hive_usage_reporting_background_tasks: state
+                .runtime_context
+                .hive_usage_reporting_background_tasks
+                .clone(),
+            hive: Some(HiveTelemetryConfig {
+                token: Some(
+                    crate::config::primitives::value_or_expression::ValueOrExpression::Value(
+                        "token".to_string(),
+                    ),
+                ),
+                usage_reporting: crate::config::usage_reporting::UsageReportingConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            storage_manager: state.runtime_context.storage_manager.clone(),
+            graphql_endpoint: state.runtime_context.graphql_endpoint.clone(),
+        });
+        state
+    }
+
     fn test_owner() -> Arc<Supergraph> {
         crate::init_rustls_crypto_provider();
         Arc::new(
@@ -1159,6 +1195,22 @@ mod plugin_runtime_cache_tests {
         tokio::time::timeout(Duration::from_secs(1), lifetime.cancelled())
             .await
             .expect("final runtime drop should cancel its background workers promptly");
+    }
+
+    // Regression test for https://github.com/graphql-hive/router/issues/1439: retiring a
+    // supergraph generation with Hive usage reporting enabled dropped the runtime's
+    // `hive_usage_agent`, which used to abort the process on ntex's current-thread runtime.
+    #[ntex::test]
+    async fn dropping_a_runtime_with_hive_usage_reporting_does_not_panic() {
+        let state = test_schema_state_with_hive_usage_reporting();
+        let owner = test_owner();
+        let runtime = RouterSupergraphRuntime::build(&owner.snapshot(), &state.runtime_context)
+            .await
+            .unwrap();
+
+        assert!(runtime.hive_usage_agent.is_some());
+
+        drop(runtime);
     }
 
     #[ntex::test]

--- a/lib/hive-console-sdk/Cargo.toml
+++ b/lib/hive-console-sdk/Cargo.toml
@@ -34,7 +34,6 @@ futures-util = { workspace = true }
 typify = "0.7.0"
 regress = "0.11.0"
 lazy_static = { workspace = true }
-async-dropper-simple = { version = "0.2.6", features = ["tokio", "no-default-bound"] }
 vrl = { workspace = true }
 http = { workspace = true }
 bytes ={ workspace = true }

--- a/lib/hive-console-sdk/src/agent/builder.rs
+++ b/lib/hive-console-sdk/src/agent/builder.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, time::Duration};
 
-use async_dropper_simple::AsyncDropper;
 use recloser::AsyncRecloser;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest_middleware::ClientBuilder;
@@ -10,7 +9,7 @@ use std::sync::LazyLock;
 use crate::agent::buffer::Buffer;
 use crate::agent::usage_agent::{
     non_empty_string, AgentError, AtLeastOnceSampling, Exclude, SamplingKey, UsageAgent,
-    UsageAgentInner,
+    UsageAgentHandle, UsageAgentInner,
 };
 use crate::agent::utils::OperationProcessor;
 use crate::circuit_breaker;
@@ -268,7 +267,7 @@ impl UsageAgentBuilder {
     }
     pub fn build(self) -> Result<UsageAgent, AgentError> {
         let agent = self.build_agent()?;
-        Ok(Arc::new(AsyncDropper::new(agent)))
+        Ok(Arc::new(UsageAgentHandle::new(agent)))
     }
 }
 

--- a/lib/hive-console-sdk/src/agent/usage_agent.rs
+++ b/lib/hive-console-sdk/src/agent/usage_agent.rs
@@ -1,4 +1,3 @@
-use async_dropper_simple::{AsyncDrop, AsyncDropper};
 use graphql_tools::parser::schema::Document;
 use rand::prelude::*;
 use recloser::AsyncRecloser;
@@ -125,7 +124,31 @@ pub enum AgentError {
     ExcludeExpressionResultConversionError(#[from] BooleanConversionError),
 }
 
-pub type UsageAgent = Arc<AsyncDropper<UsageAgentInner>>;
+pub struct UsageAgentHandle(Option<UsageAgentInner>);
+
+impl UsageAgentHandle {
+    pub(crate) fn new(inner: UsageAgentInner) -> Self {
+        Self(Some(inner))
+    }
+
+    fn inner(&self) -> &UsageAgentInner {
+        self.0.as_ref().expect("UsageAgentHandle used after drop")
+    }
+}
+
+impl Drop for UsageAgentHandle {
+    fn drop(&mut self) {
+        if let Some(inner) = self.0.take() {
+            tokio::spawn(async move {
+                if let Err(e) = inner.flush().await {
+                    tracing::error!(target: USAGE_REPORTING_TARGET, error = ?e, "Failed to flush usage reports during drop");
+                }
+            });
+        }
+    }
+}
+
+pub type UsageAgent = Arc<UsageAgentHandle>;
 
 #[async_trait::async_trait]
 pub trait UsageAgentExt {
@@ -546,15 +569,6 @@ pub fn get_vrl_value_from_execution_report_and_request(
     VrlValue::Object(map)
 }
 
-#[async_trait::async_trait]
-impl AsyncDrop for UsageAgentInner {
-    async fn async_drop(&mut self) {
-        if let Err(e) = self.flush().await {
-            tracing::error!(target: USAGE_REPORTING_TARGET, error = ?e, "Failed to flush usage reports during drop");
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, time::Duration};
@@ -571,6 +585,16 @@ mod tests {
         get_vrl_value_from_execution_report_and_request, ExecutionReport, OperationType, Report,
         UsageAgent, UsageAgentExt,
     };
+
+    async fn wait_for_mock(mock: &mockito::Mock) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !mock.matched_async().await {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("mock should be matched after usage agent drop flush");
+    }
 
     /// Helper to extract a nested VRL value from an Object using string keys.
     fn vrl_get<'a>(value: &'a VrlValue, keys: &[&str]) -> &'a VrlValue {
@@ -782,6 +806,7 @@ mod tests {
                 .await?;
         }
 
+        wait_for_mock(&mock).await;
         mock.assert_async().await;
 
         Ok(())
@@ -1054,6 +1079,7 @@ mod tests {
                 .await?;
         }
 
+        wait_for_mock(&mock).await;
         mock.assert_async().await;
         Ok(())
     }
@@ -1220,6 +1246,7 @@ mod tests {
                 .await?;
         }
 
+        wait_for_mock(&mock).await;
         mock.assert_async().await;
         Ok(())
     }
@@ -1287,6 +1314,7 @@ mod tests {
                 .await?;
         }
 
+        wait_for_mock(&mock).await;
         mock.assert_async().await;
         Ok(())
     }

--- a/lib/hive-console-sdk/src/lib.rs
+++ b/lib/hive-console-sdk/src/lib.rs
@@ -2,7 +2,6 @@ pub mod agent;
 pub mod circuit_breaker;
 pub mod persisted_documents;
 pub mod supergraph_fetcher;
-pub use async_dropper_simple::AsyncDropper;
 pub use graphql_tools;
 pub mod expressions;
 mod helpers;


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1439

Fix the router process aborting on supergraph hot-reload when `telemetry.hive.usage_reporting` is enabled.

Retiring a supergraph drops the previous generation's Hive usage-reporting agent.

That agent used to flush on drop via a blocking bridge (`block_in_place`) that is only valid on a multi-threaded `tokio` runtime.

The router runs on ntex's current-thread runtime, so this always panicked. 

The agent now uses a non-blocking flush, best-effort operation instead.

