### PR TITLE
fix(http): restore graceful SIGTERM drain after `ntex-server` 3.11

### DIFF
--- a/.changeset/restore-graceful-sigterm-drain.md
+++ b/.changeset/restore-graceful-sigterm-drain.md
@@ -1,0 +1,12 @@
+---
+hive-router: patch
+---
+
+Restore graceful HTTP server shutdown after the ntex-server 3.11 upgrade.
+
+ntex-server 3.11 made graceful signal handling opt-in, while
+`ntex::web::HttpServer` does not expose the new setting. This caused
+`SIGTERM` to force-drop workers immediately and bypass the configured
+`http.shutdown_timeout`. Pin `ntex-server` to 3.10.4 so SIGTERM drains
+in-flight requests until ntex provides a supported opt-in on the public
+HTTP server API.

--- a/.changeset/restore-graceful-sigterm-drain.md
+++ b/.changeset/restore-graceful-sigterm-drain.md
@@ -4,9 +4,11 @@ hive-router: patch
 
 Restore graceful HTTP server shutdown after the ntex-server 3.11 upgrade.
 
-ntex-server 3.11 made graceful signal handling opt-in, while
-`ntex::web::HttpServer` does not expose the new setting. This caused
-`SIGTERM` to force-drop workers immediately and bypass the configured
-`http.shutdown_timeout`. Pin `ntex-server` to 3.10.4 so SIGTERM drains
-in-flight requests until ntex provides a supported opt-in on the public
-HTTP server API.
+ntex-server 3.11 made graceful signal handling opt-in and defaults it to false,
+while `ntex::web::HttpServer` exposes no way to opt in. This caused `SIGTERM` to
+force-drop workers immediately and bypass the configured `http.shutdown_timeout`.
+
+Hold `ntex-server` at 3.10.4, together with `ntex-net` 3.14.1 and `ntex-rt`
+3.16.1, so that `SIGTERM` drains in-flight requests again. All three move
+together because ntex-rt 3.17 changed the `Signal` enum in a way 3.10.4 cannot
+build against, and ntex-net 3.15 requires that newer ntex-rt.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4207,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.11.1"
+version = "3.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eecf7ebae34a050ab29978eb1fa7bf99590e46e3ab29b5526aff7790d4c9464"
+checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
 dependencies = [
  "async-channel",
  "atomic-waker",
@@ -6736,7 +6736,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7028,7 +7028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-net"
-version = "3.15.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
+checksum = "ace516cc45d412d33165041edcb19048119589498f56fba69baf71ceba920af1"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -4179,9 +4179,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.17.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877696a0cec7fccd0813d1c075e5dbc12e3a3199e492c9bfa3dd2da63d609f35"
+checksum = "3692fad48ebe4431289a51807dc08bd3205369ce9f1ab10d300fe12cccefd5c5"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4194,7 +4194,6 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
- "nix 0.31.3",
  "ntex-error",
  "ntex-service",
  "oneshot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,18 +53,28 @@ ntex = { version = "=3.12.3", features = ["tokio", "rustls"] }
 ntex-http = { version = "=1.2.0"}
 ntex-codec = { version = "=1.2.1"}
 ntex-io = { version = "=3.13.1"}
-ntex-net = { version = "=3.15.0"}
+# Held back with ntex-rt and ntex-server, see the note above `ntex-server`.
+ntex-net = { version = "=3.14.1"}
 ntex-router = { version = "=1.0.0"}
 ntex-bytes = { version = "=1.9.0"}
 ntex-dispatcher = { version = "=3.2.1"}
 ntex-error = { version = "=2.4.0" }
 ntex-h2 = { version = "=3.13.0" }
-ntex-rt = { version = "=3.17.1" }
+# Held back with ntex-net and ntex-server, see the note above `ntex-server`.
+ntex-rt = { version = "=3.16.1" }
 ntex-macros = { version = "=3.5.0" }
 ntex-httparse = { version = "=2.1.0" }
-# Stay on 3.10.x until ntex::web::HttpServer can opt into 3.11's
-# graceful_shutdown flag. 3.11 defaults it to false, so SIGTERM force-drops
-# in-flight requests and ignores http.shutdown_timeout.
+# ntex-server 3.11 made graceful signal handling opt-in and defaults it to
+# false, and `ntex::web::HttpServer` exposes no way to opt in, so SIGTERM
+# force-drops in-flight requests and ignores `http.shutdown_timeout`.
+#
+# 3.10.4 cannot be pinned on its own: ntex-rt 3.17 added a `Signal::Panic`
+# variant and made `Signal` non-Copy, which 3.10.4 does not compile against,
+# and ntex-net 3.15 requires ntex-rt >=3.17. So ntex-net and ntex-rt are held
+# at the last releases that pair with it. ntex 3.12.3 accepts all three.
+#
+# Drop all three pins once a 3.x ntex exposes `HttpServer::graceful_shutdown`,
+# which ntex added in 4.0.0-beta.0.
 ntex-server = { version = "=3.10.4" }
 ntex-service = { version = "=4.6.0" }
 ntex-tls = { version = "=3.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,10 @@ ntex-h2 = { version = "=3.13.0" }
 ntex-rt = { version = "=3.17.1" }
 ntex-macros = { version = "=3.5.0" }
 ntex-httparse = { version = "=2.1.0" }
-ntex-server = { version = "=3.11.1" }
+# Stay on 3.10.x until ntex::web::HttpServer can opt into 3.11's
+# graceful_shutdown flag. 3.11 defaults it to false, so SIGTERM force-drops
+# in-flight requests and ignores http.shutdown_timeout.
+ntex-server = { version = "=3.10.4" }
 ntex-service = { version = "=4.6.0" }
 ntex-tls = { version = "=3.8.0" }
 ntex-util = { version = "=3.6.1" }


### PR DESCRIPTION
## Problem

`SIGTERM` force-drops in-flight requests, and `http.shutdown_timeout` (#1433) has no effect.

`ntex-server` 3.11.0 ([ntex-rs/ntex#964](https://github.com/ntex-rs/ntex/pull/964), `0f0fb48`) made graceful signal handling opt-in:

- added `WorkerPool.graceful_shutdown`, defaulting to `false`
- changed `Signal::Term` from `state.stop(true, ...)` to `state.stop(cfg.graceful_shutdown, ...)`
- exposed `.graceful_shutdown()` on `ntex_server::ServerBuilder` only

`ntex::web::HttpServer` has no `graceful_shutdown()` passthrough, so the router cannot opt in. With the flag `false`, `stop()` takes the non-graceful branch and calls `worker.stop(Millis::ZERO)`, a forced shutdown that ignores `shutdown_timeout` entirely.

This regressed when #1434 upgraded `ntex` to pull in `ntex-server` 3.11.1. It also contradicts the documented contract. [ntex's server guide](https://ntex.rs/docs/server) still states "SIGTERM - Graceful shutdown workers", and `HttpServer::shutdown_timeout` is still documented as the graceful drain window.

Measured against a subgraph that answers at T+6s, with `SIGTERM` sent at T+2s:

| | in-flight request | process exit |
|---|---|---|
| `ntex-server` 3.10.4 | completes, `200` at T+6.05s | 4.4s after `SIGTERM` |
| `ntex-server` 3.11.1 | `curl (52) Empty reply from server` at T+2.39s | 0.56s after `SIGTERM` |

## Change

Hold `ntex-server` at `=3.10.4`, and `ntex-net` at `=3.14.1` and `ntex-rt` at `=3.16.1` alongside it.

All three have to move together. `ntex-server` 3.10.4 does not build against `ntex-rt` 3.17, which added a `Signal::Panic(PanicSource)` variant and dropped `Copy` from `Signal`; 3.10.4's signal match then fails with `E0004` (non-exhaustive patterns) and `E0507` (cannot move out of `*sig`). `ntex-net` 3.15.0 in turn requires `ntex-rt >=3.17.0`, so it comes back to 3.14.1, the last release that pairs with `ntex-rt` 3.16.1.

`ntex` itself stays on 3.12.3, which accepts `ntex-net ^3.14.0`, `ntex-rt ^3.16.1` and `ntex-server ^3.10.4`, so there is no wider `ntex` downgrade.

The cost is `ntex`'s new worker panic supervision (`ntex-rt` 3.17's panic handling and `Arbiter::on_close`, `ntex-net` 3.15's "do not unwind reactor panics"). The router does not opt into any of it today, so nothing in-tree regresses, but it is a real capability held back and I'd rather not sit on it long.

## Preferred fix

This is a workaround, not where I think this should land. `web::HttpServer::graceful_shutdown()` already exists upstream — it was added in `ntex` [4.0.0-beta.0](https://docs.rs/ntex/4.0.0-beta.0/ntex/web/struct.HttpServer.html). If that passthrough were backported to a 3.x release, all three pins here collapse back to a plain version bump and the panic supervision comes with it.

Two options from my side, happy either way:

- I raise the backport on `ntex` and we hold this PR until a 3.x release carries it.
- We take these pins now to stop the regression bleeding, and revert them when the backport lands.

Alternatively the router could stop using `web::HttpServer` and drive `ntex::server::build().graceful_shutdown()` directly, replicating what `HttpServer::bind`/`listen` do. That keeps every version current but is a much larger change to the startup path, and it seemed wrong to reach for it while a five-line upstream passthrough exists.

## Tests

End-to-end behaviour was verified with the same harness as the table above: `SIGTERM` at T+2s during a 6s request returns `200` with the complete body, and the process exits about 4.4s after the signal.

I did not add an e2e test for this. As noted in #1433 I wasn't sure the existing testkit can deterministically sequence a stop with a request in flight, but happy to add one if you can point me at the right approach.
