### PR TITLE
feat(router): `include_claims` to filter what jwt claims are forwarded to subgraphs

### DIFF
--- a/.changeset/jwt-forward-include-claims.md
+++ b/.changeset/jwt-forward-include-claims.md
@@ -1,0 +1,21 @@
+---
+hive-router: minor
+---
+
+Add `jwt.forward_claims_to_upstream_extensions.include_claims` to forward only specific JWT claims to subgraphs
+
+Previously, enabling `forward_claims_to_upstream_extensions` always forwarded the entire JWT payload under `extensions.<field_name>`. You can now restrict this to a list of root-level claim keys:
+
+```yaml
+jwt:
+  forward_claims_to_upstream_extensions:
+    enabled: true
+    field_name: jwt
+    include_claims:
+      - sub
+      - org_id
+```
+
+If `include_claims` is not set, all claims are forwarded as before.
+
+Closes https://github.com/graphql-hive/router/issues/642

--- a/bin/router/src/config/jwt_auth.rs
+++ b/bin/router/src/config/jwt_auth.rs
@@ -91,12 +91,17 @@ impl Default for JwtAuthConfig {
 pub struct JwtClaimsForwardingConfig {
     pub enabled: bool,
     pub field_name: String,
+    /// Only forward these root-level claim keys, instead of the entire JWT payload.
+    /// If not specified, all claims are forwarded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_claims: Option<Vec<String>>,
 }
 
 fn default_forward_claims_to_upstream_extensions() -> JwtClaimsForwardingConfig {
     JwtClaimsForwardingConfig {
         enabled: false,
         field_name: "jwt".to_string(),
+        include_claims: None,
     }
 }
 

--- a/bin/router/src/executor/execution/jwt_forward.rs
+++ b/bin/router/src/executor/execution/jwt_forward.rs
@@ -1,4 +1,4 @@
-use sonic_rs::Value;
+use sonic_rs::{JsonValueTrait, Object, Value};
 
 use crate::executor::execution::client_request_details::JwtRequestDetails;
 
@@ -12,14 +12,26 @@ impl JwtRequestDetails {
     pub fn build_forwarding_plan(
         &self,
         extension_field_name: &str,
+        include_claims: Option<&[String]>,
     ) -> Result<Option<JwtAuthForwardingPlan>, JwtForwardingError> {
         Ok(match self {
             JwtRequestDetails::Authenticated { claims, .. } => Some(JwtAuthForwardingPlan {
                 extension_field_name: extension_field_name.to_string(),
-                extension_field_value: sonic_rs::to_value(&claims)?,
+                extension_field_value: filter_claims(claims, include_claims),
             }),
             _ => None,
         })
+    }
+}
+
+fn filter_claims(claims: &Value, include_claims: Option<&[String]>) -> Value {
+    match include_claims {
+        Some(keys) => keys
+            .iter()
+            .filter_map(|key| claims.get(key.as_str()).map(|value| (key.clone(), value)))
+            .collect::<Object>()
+            .into(),
+        None => claims.clone(),
     }
 }
 

--- a/bin/router/src/pipeline/execution.rs
+++ b/bin/router/src/pipeline/execution.rs
@@ -114,6 +114,12 @@ pub async fn execute_plan<'exec>(
                         .jwt
                         .forward_claims_to_upstream_extensions
                         .field_name,
+                    app_state
+                        .router_config
+                        .jwt
+                        .forward_claims_to_upstream_extensions
+                        .include_claims
+                        .as_deref(),
                 )?
         } else {
             None

--- a/e2e/configs/jwt_auth_forward_include_claims.router.yaml
+++ b/e2e/configs/jwt_auth_forward_include_claims.router.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../supergraph.graphql
+jwt:
+  enabled: true
+  require_authentication: true
+  forward_claims_to_upstream_extensions:
+    enabled: true
+    field_name: jwt
+    include_claims:
+      - sub
+      - role
+  jwks_providers:
+    - source: file
+      path: ../jwks.rsa512.json

--- a/e2e/src/jwt.rs
+++ b/e2e/src/jwt.rs
@@ -81,6 +81,66 @@ mod jwt_e2e_tests {
     }
 
     #[ntex::test]
+    async fn should_forward_only_included_claims_to_subgraph_via_extensions() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("configs/jwt_auth_forward_include_claims.router.yaml")
+            .build()
+            .start()
+            .await;
+
+        let exp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        let claims = json!({
+            "sub": "user1",
+            "role": "admin",
+            "name": "Dotan",
+            "iat": 1516239022,
+            "exp": exp,
+        });
+        let token = generate_jwt(&claims);
+
+        let res = router
+            .send_graphql_request(
+                "{ users { id } }",
+                None,
+                some_header_map! {
+                    http::header::AUTHORIZATION => format!("Bearer {}", token)
+                },
+            )
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+
+        let subgraph_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests sent to accounts subgraph");
+        assert_eq!(
+            subgraph_requests.len(),
+            1,
+            "expected 1 request to accounts subgraph"
+        );
+
+        let body: Value = sonic_rs::from_slice(
+            subgraph_requests[0]
+                .body
+                .as_ref()
+                .expect("expected request body"),
+        )
+        .expect("expected valid JSON body");
+        let extensions = body.get("extensions").unwrap();
+
+        assert_eq!(
+            extensions.get("jwt").unwrap(),
+            &json!({ "sub": "user1", "role": "admin" })
+        );
+    }
+
+    #[ntex::test]
     async fn should_allow_expressions_to_access_jwt_details() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()


### PR DESCRIPTION
Add `jwt.forward_claims_to_upstream_extensions.include_claims` to forward only specific JWT claims to subgraphs

Previously, enabling `forward_claims_to_upstream_extensions` always forwarded the entire JWT payload under `extensions.<field_name>`. You can now restrict this to a list of root-level claim keys:

```yaml
jwt:
  forward_claims_to_upstream_extensions:
    enabled: true
    field_name: jwt
    include_claims:
      - sub
      - org_id
```

If `include_claims` is not set, all claims are forwarded as before.

Closes https://github.com/graphql-hive/router/issues/642
Related https://github.com/graphql-hive/router/issues/1447