### PR TITLE
feat(plugin-system): custom inbound-dedupe partition

### DIFF
--- a/.changeset/dedupe-partition-hook.md
+++ b/.changeset/dedupe-partition-hook.md
@@ -1,0 +1,30 @@
+---
+hive-router: minor
+---
+
+Allow plugins to contribute a partition to the inbound (router-level) request dedupe key
+
+Plugins can now call `add_inbound_dedupe_partition(u64)` to add custom partition to the router's inbound
+query/subscription dedupe fingerprint. Requests with different partitions are never deduped
+into the same in-flight response.
+
+The method is only exposed on the `on_http_request` and `on_graphql_params` hook payloads, since
+those are the only hooks that run before the router computes the fingerprint — calling it from a
+later hook would silently have no effect, so it isn't offered there.
+
+```rust
+async fn on_graphql_params<'exec>(
+    &'exec self,
+    payload: OnGraphQLParamsStartHookPayload<'exec>,
+) -> OnGraphQLParamsStartHookResult<'exec> {
+    let partition = compute_partition_from_identity(&payload);
+    payload.add_inbound_dedupe_partition(partition);
+    payload.proceed()
+}
+```
+
+This is useful when the built-in `traffic_shaping.router.dedupe.headers` allowlist is not enough
+— for example, partitioning by an authenticated user extracted from a `Cookie` header without
+hashing the full cookie data.
+
+Closes https://github.com/graphql-hive/router/issues/1443

--- a/bin/router/src/executor/plugins/hooks/on_graphql_params.rs
+++ b/bin/router/src/executor/plugins/hooks/on_graphql_params.rs
@@ -143,6 +143,12 @@ impl<'exec> OnGraphQLParamsStartHookPayload<'exec> {
         self.graphql_params = Some(graphql_params);
         self
     }
+
+    /// Adds an extra partition component to the router's inbound (query/subscription) dedupe
+    /// fingerprint: requests with different partitions never share an in-flight response.
+    pub fn add_inbound_dedupe_partition(&self, partition: u64) {
+        self.context.add_inbound_dedupe_partition(partition);
+    }
 }
 
 impl<'exec> StartHookPayload<OnGraphQLParamsEndHookPayload<'exec>, Response>

--- a/bin/router/src/executor/plugins/hooks/on_http_request.rs
+++ b/bin/router/src/executor/plugins/hooks/on_http_request.rs
@@ -102,6 +102,12 @@ impl<'req> OnHttpRequestHookPayload<'req> {
             .extensions_mut()
             .insert(supergraph.snapshot());
     }
+
+    /// Adds an extra partition component to the router's inbound (query/subscription) dedupe
+    /// fingerprint: requests with different partitions never share an in-flight response.
+    pub fn add_inbound_dedupe_partition(&self, partition: u64) {
+        self.context.add_inbound_dedupe_partition(partition);
+    }
 }
 
 impl<'req> StartHookPayload<OnHttpResponseHookPayload<'req>, Response>

--- a/bin/router/src/executor/plugins/plugin_context.rs
+++ b/bin/router/src/executor/plugins/plugin_context.rs
@@ -44,6 +44,10 @@ pub struct PluginContext {
     inner: DashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 
+/// Extra partition component contributed by a plugin, mixed into the router's inbound
+/// (query/subscription) dedupe fingerprint. See [`PluginContext::add_inbound_dedupe_partition`].
+struct DedupePartition(u64);
+
 pub struct PluginContextRefEntry<'a, T> {
     pub entry: Ref<'a, TypeId, Box<dyn Any + Send + Sync>>,
     phantom: std::marker::PhantomData<T>,
@@ -196,6 +200,16 @@ impl PluginContext {
                 entry,
                 phantom: std::marker::PhantomData,
             })
+    }
+
+    /// Adds an extra partition component to the router's inbound (query/subscription) dedupe
+    /// fingerprint: requests with different partitions never share an in-flight response.
+    pub(crate) fn add_inbound_dedupe_partition(&self, partition: u64) {
+        self.insert(DedupePartition(partition));
+    }
+
+    pub(crate) fn inbound_dedupe_partition(&self) -> Option<u64> {
+        self.get_ref::<DedupePartition>().map(|p| p.0)
     }
 }
 

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -455,6 +455,9 @@ pub async fn graphql_request_handler(
                 .extensions
                 .as_ref()
                 .map_or(0, hash_graphql_extensions);
+            let partition = plugin_req_state
+                .as_ref()
+                .and_then(|state| state.context.inbound_dedupe_partition());
 
             Some(inbound_request_fingerprint(
                 // let chains are only allowed in Rust 2024 or later... so we assert
@@ -463,6 +466,7 @@ pub async fn graphql_request_handler(
                 normalize_payload.normalized_operation_hash,
                 variables_hash,
                 extensions_hash,
+                partition,
             ))
         } else {
             None
@@ -947,12 +951,14 @@ pub fn inbound_request_fingerprint(
     normalized_operation_hash: u64,
     variables_hash: u64,
     extensions_hash: u64,
+    partition: Option<u64>,
 ) -> InboundRequestFingerprint {
     let mut hasher = Xxh3::new();
     connection.hash(&mut hasher);
     normalized_operation_hash.hash(&mut hasher);
     variables_hash.hash(&mut hasher);
     extensions_hash.hash(&mut hasher);
+    partition.hash(&mut hasher);
     InboundRequestFingerprint::from_hash(hasher.finish())
 }
 
@@ -1051,12 +1057,36 @@ mod fingerprint_tests {
             connection_fingerprint(&Method::POST, "/graphql", &second, &policy, 7)
         );
         assert_ne!(
-            inbound_request_fingerprint(connection, 1, 2, 3),
-            inbound_request_fingerprint(connection, 2, 2, 3)
+            inbound_request_fingerprint(connection, 1, 2, 3, None),
+            inbound_request_fingerprint(connection, 2, 2, 3, None)
         );
         assert_eq!(
             connection,
             connection_fingerprint(&Method::POST, "/graphql", &first, &policy, 7)
+        );
+    }
+
+    #[test]
+    fn partition_changes_the_fingerprint() {
+        let policy = RouterRequestDedupeHeaderPolicy::None;
+        let connection =
+            connection_fingerprint(&Method::POST, "/graphql", &HeaderMap::new(), &policy, 7);
+
+        assert_eq!(
+            inbound_request_fingerprint(connection, 1, 2, 3, None),
+            inbound_request_fingerprint(connection, 1, 2, 3, None)
+        );
+        assert_ne!(
+            inbound_request_fingerprint(connection, 1, 2, 3, None),
+            inbound_request_fingerprint(connection, 1, 2, 3, Some(42))
+        );
+        assert_ne!(
+            inbound_request_fingerprint(connection, 1, 2, 3, Some(42)),
+            inbound_request_fingerprint(connection, 1, 2, 3, Some(43))
+        );
+        assert_eq!(
+            inbound_request_fingerprint(connection, 1, 2, 3, Some(42)),
+            inbound_request_fingerprint(connection, 1, 2, 3, Some(42))
         );
     }
 }

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -565,6 +565,9 @@ async fn handle_text_frame(
                           .extensions
                           .as_ref()
                           .map_or(0, hash_graphql_extensions);
+                      let partition = plugin_req_state
+                          .as_ref()
+                          .and_then(|state| state.context.inbound_dedupe_partition());
                       Some(inbound_request_fingerprint(
                           // let chains are only allowed in Rust 2024 or later... so we assert
                           // connection_fingerprint because it will be present when request_dedupe_enabled
@@ -572,6 +575,7 @@ async fn handle_text_frame(
                           normalize_payload.normalized_operation_hash,
                           variables_hash,
                           extensions_hash,
+                          partition,
                       ))
                   } else {
                       None

--- a/e2e/src/http.rs
+++ b/e2e/src/http.rs
@@ -10,6 +10,53 @@ mod http_tests {
     use crate::testkit::{
         some_header_map, wait_until_mock_matched, ClientResponseExt, TestRouter, TestSubgraphs,
     };
+    use hive_router::{
+        async_trait,
+        plugins::{
+            hooks::{
+                on_graphql_params::{
+                    OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult,
+                },
+                on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+            },
+            plugin_trait::{RouterPlugin, StartHookPayload},
+        },
+    };
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    #[derive(Default)]
+    struct DedupePartitionTestPlugin;
+
+    #[async_trait]
+    impl RouterPlugin for DedupePartitionTestPlugin {
+        type Config = ();
+
+        fn plugin_name() -> &'static str {
+            "test_dedupe_partition"
+        }
+
+        fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+            payload.initialize_plugin_with_defaults()
+        }
+
+        async fn on_graphql_params<'exec>(
+            &'exec self,
+            payload: OnGraphQLParamsStartHookPayload<'exec>,
+        ) -> OnGraphQLParamsStartHookResult<'exec> {
+            if let Some(value) = payload
+                .router_http_request
+                .headers
+                .get("x-partition")
+                .and_then(|v| v.to_str().ok())
+            {
+                let mut hasher = DefaultHasher::new();
+                value.hash(&mut hasher);
+                payload.add_inbound_dedupe_partition(hasher.finish());
+            }
+            payload.proceed()
+        }
+    }
 
     #[ntex::test]
     async fn should_allow_to_customize_graphql_endpoint() {
@@ -724,6 +771,129 @@ mod http_tests {
         assert_eq!(
             products_requests, 1,
             "expected exactly one products subgraph request when allowlisted header matches case-insensitively"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_partition_router_dedupe_via_plugin_context() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    all:
+                        dedupe_enabled: false
+                    router:
+                        dedupe:
+                            enabled: true
+                            headers: none
+                plugins:
+                    test_dedupe_partition:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<DedupePartitionTestPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let query = r#"
+            {
+                topProducts {
+                    name
+                    price
+                }
+            }
+        "#;
+
+        let (response_a, response_b) = futures::join!(
+            router
+                .send_graphql_request(query, None, some_header_map! { "x-partition" => "alice" },),
+            router.send_graphql_request(query, None, some_header_map! { "x-partition" => "bob" },)
+        );
+
+        assert!(response_a.status().is_success());
+        assert!(response_b.status().is_success());
+
+        let products_requests = subgraphs
+            .get_requests_log("products")
+            .unwrap_or_default()
+            .len();
+
+        assert_eq!(
+            products_requests, 2,
+            "expected requests with different plugin-contributed partitions to never share a dedupe entry"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_share_router_dedupe_partition_via_plugin_context() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    all:
+                        dedupe_enabled: false
+                    router:
+                        dedupe:
+                            enabled: true
+                            headers: none
+                plugins:
+                    test_dedupe_partition:
+                        enabled: true
+                "#,
+            )
+            .register_plugin::<DedupePartitionTestPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let query = r#"
+            {
+                topProducts {
+                    name
+                    price
+                }
+            }
+        "#;
+
+        let (response_a, response_b) = futures::join!(
+            router
+                .send_graphql_request(query, None, some_header_map! { "x-partition" => "alice" },),
+            router
+                .send_graphql_request(query, None, some_header_map! { "x-partition" => "alice" },)
+        );
+
+        assert!(response_a.status().is_success());
+        assert!(response_b.status().is_success());
+
+        let products_requests = subgraphs
+            .get_requests_log("products")
+            .unwrap_or_default()
+            .len();
+
+        assert_eq!(
+            products_requests, 1,
+            "expected requests with the same plugin-contributed partition to share a dedupe entry"
         );
     }
 }

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -342,19 +342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dropper-simple"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c4748dfe8cd3d625ec68fc424fa80c134319881185866f9e173af9e5d8add8"
-dependencies = [
- "async-scoped",
- "async-trait",
- "futures",
- "rustc_version",
- "tokio",
-]
-
-[[package]]
 name = "async-graphql"
 version = "8.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,17 +451,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-scoped"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
-dependencies = [
- "futures",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -1617,6 +1593,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
+name = "dedupe-partition-plugin-example"
+version = "0.0.1"
+dependencies = [
+ "e2e",
+ "futures",
+ "hive-router",
+ "http",
+ "jsonwebtoken",
+ "serde",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,11 +2672,10 @@ dependencies = [
 
 [[package]]
 name = "hive-console-sdk"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "ahash",
  "anyhow",
- "async-dropper-simple",
  "async-trait",
  "bytes",
  "futures-util",
@@ -2721,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4282,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-net"
-version = "3.15.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
+checksum = "ace516cc45d412d33165041edcb19048119589498f56fba69baf71ceba920af1"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4336,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.17.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877696a0cec7fccd0813d1c075e5dbc12e3a3199e492c9bfa3dd2da63d609f35"
+checksum = "3692fad48ebe4431289a51807dc08bd3205369ce9f1ab10d300fe12cccefd5c5"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4351,7 +4339,6 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
- "nix 0.31.3",
  "ntex-error",
  "ntex-service",
  "oneshot",
@@ -4364,9 +4351,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.11.1"
+version = "3.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eecf7ebae34a050ab29978eb1fa7bf99590e46e3ab29b5526aff7790d4c9464"
+checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
 dependencies = [
  "async-channel",
  "atomic-waker",

--- a/plugin_examples/Cargo.toml
+++ b/plugin_examples/Cargo.toml
@@ -22,7 +22,8 @@ members = [
   "error_mapping",
   "replace_schema",
   "field_nulling",
-  "custom_logger_correlation"
+  "custom_logger_correlation",
+  "dedupe_partition"
 ]
 
 [workspace.dependencies]

--- a/plugin_examples/dedupe_partition/Cargo.toml
+++ b/plugin_examples/dedupe_partition/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "dedupe-partition-plugin-example"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+authors = ["The Guild"]
+repository = "https://github.com/graphql-hive/router"
+homepage = "https://github.com/graphql-hive/router"
+publish = false
+
+[lib]
+
+[[bin]]
+name = "hive_router_with_dedupe_partition"
+path = "src/main.rs"
+
+[dependencies]
+hive-router = { version = "*", path = "../../bin/router" }
+serde = { workspace = true }
+jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
+xxhash-rust = { workspace = true }
+
+[dev-dependencies]
+e2e = { version = "*", path = "../../e2e" }
+futures = { workspace = true }
+http = { workspace = true }

--- a/plugin_examples/dedupe_partition/README.md
+++ b/plugin_examples/dedupe_partition/README.md
@@ -1,0 +1,37 @@
+# Dedupe Partition Example
+
+This example demonstrates `add_inbound_dedupe_partition`, which plugins can use to contribute an
+extra component to the router's inbound (query/subscription) dedupe fingerprint, without having
+to reimplement fingerprinting themselves.
+
+The underlying partition data lives in the request context, but the setter is only exposed on the
+hook payloads that run early enough to affect the fingerprint — `OnHttpRequestHookPayload` and
+`OnGraphQLParamsStartHookPayload` — instead of on the generic context. Calling it from a later
+hook (e.g. `on_execute`) is a compile error rather than a silent no-op, since by then the dedupe
+claim has already happened.
+
+The problem it solves: the built-in `traffic_shaping.router.dedupe.headers` allowlist can only
+include or exclude whole headers. A `Cookie` header usually carries more than identity (CSRF
+tokens, analytics IDs, ...), so including it in the dedupe key defeats deduplication for
+practically every request, while excluding it collapses requests from different users into one
+shared response.
+
+This plugin extracts a JWT from a configured cookie in `on_graphql_params` (before the router
+computes the dedupe fingerprint), validates it, and calls
+`payload.add_inbound_dedupe_partition(hash_of_sub)`:
+
+- Two requests with the same validated `sub` claim share a dedupe partition — same behavior as
+  today's dedupe, just scoped to that user.
+- Two requests with different `sub` claims never share a partition, and so never share a
+  response.
+- A missing or invalid token leaves the context untouched, so the request falls into the default,
+  shared "anonymous" partition. This assumes invalid tokens are otherwise treated as anonymous by
+  the rest of the stack — if your deployment instead rejects invalid tokens while allowing
+  anonymous access, a rejected request could join an anonymous leader's response, and you'd want
+  to partition invalid tokens by a random value instead of leaving the context untouched.
+
+Since identity now comes from this plugin, the config below sets `headers: none` on the built-in
+policy — otherwise the router would still hash the raw `Cookie` header on top of the plugin's
+partition, defeating the point.
+
+See `src/plugin.rs` for the implementation and `src/test.rs` for the dedupe assertions.

--- a/plugin_examples/dedupe_partition/router.config.yaml
+++ b/plugin_examples/dedupe_partition/router.config.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: ../../e2e/supergraph.graphql
+traffic_shaping:
+  all:
+    # kept separate from router-level dedupe below so the example isolates the
+    # partition behavior; a real deployment would likely leave this enabled.
+    dedupe_enabled: false
+  router:
+    dedupe:
+      enabled: true
+      # identity comes from the plugin's partition, not raw headers
+      headers: none
+plugins:
+  dedupe_partition:
+    enabled: true
+    config:
+      cookie_name: session
+      secret: ${JWT_SECRET}

--- a/plugin_examples/dedupe_partition/src/lib.rs
+++ b/plugin_examples/dedupe_partition/src/lib.rs
@@ -1,0 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
+pub mod plugin;
+#[cfg(test)]
+pub mod test;

--- a/plugin_examples/dedupe_partition/src/main.rs
+++ b/plugin_examples/dedupe_partition/src/main.rs
@@ -1,0 +1,17 @@
+use hive_router::{
+    configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
+    router_entrypoint, PluginRegistry, RouterGlobalAllocator,
+};
+
+configure_global_allocator!();
+
+#[hive_router::main]
+async fn main() -> Result<(), RouterInitError> {
+    init_rustls_crypto_provider();
+
+    router_entrypoint(
+        PluginRegistry::new()
+            .register::<dedupe_partition_plugin_example::plugin::DedupePartitionPlugin>(),
+    )
+    .await
+}

--- a/plugin_examples/dedupe_partition/src/plugin.rs
+++ b/plugin_examples/dedupe_partition/src/plugin.rs
@@ -1,0 +1,86 @@
+use std::hash::{Hash, Hasher};
+
+use hive_router::{
+    async_trait,
+    ntex::http::HeaderMap,
+    plugins::{
+        hooks::{
+            on_graphql_params::{OnGraphQLParamsStartHookPayload, OnGraphQLParamsStartHookResult},
+            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        },
+        plugin_trait::{RouterPlugin, StartHookPayload},
+    },
+};
+use jsonwebtoken::{decode, DecodingKey, Validation};
+use serde::Deserialize;
+use xxhash_rust::xxh3::Xxh3;
+
+#[derive(Deserialize)]
+pub struct DedupePartitionPluginConfig {
+    /// Name of the cookie carrying the JWT, e.g. "session"
+    pub cookie_name: String,
+    /// HMAC secret used to validate the JWT. A real deployment would likely use JWKS instead.
+    pub secret: String,
+}
+
+#[derive(Deserialize)]
+struct Claims {
+    sub: String,
+    #[allow(dead_code)]
+    exp: usize,
+}
+
+pub struct DedupePartitionPlugin {
+    cookie_name: String,
+    decoding_key: DecodingKey,
+    validation: Validation,
+}
+
+fn extract_cookie<'a>(headers: &'a HeaderMap, cookie_name: &str) -> Option<&'a str> {
+    let cookie_header = headers.get("cookie")?.to_str().ok()?;
+    cookie_header.split(';').find_map(|pair| {
+        let (name, value) = pair.trim().split_once('=')?;
+        (name == cookie_name).then_some(value)
+    })
+}
+
+#[async_trait]
+impl RouterPlugin for DedupePartitionPlugin {
+    type Config = DedupePartitionPluginConfig;
+
+    fn plugin_name() -> &'static str {
+        "dedupe_partition"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        let config = payload.config()?;
+        payload.initialize_plugin(Self {
+            cookie_name: config.cookie_name,
+            decoding_key: DecodingKey::from_secret(config.secret.as_bytes()),
+            validation: Validation::default(),
+        })
+    }
+
+    // Runs before the router computes the inbound dedupe fingerprint, so a partition
+    // set here is picked up by the claim that follows.
+    async fn on_graphql_params<'exec>(
+        &'exec self,
+        payload: OnGraphQLParamsStartHookPayload<'exec>,
+    ) -> OnGraphQLParamsStartHookResult<'exec> {
+        let token = extract_cookie(payload.router_http_request.headers, &self.cookie_name);
+
+        // A missing cookie and an invalid/expired token are treated identically: leave the
+        // context untouched, so the request stays in the shared "unauthenticated" partition.
+        if let Some(token) = token {
+            if let Ok(token_data) = decode::<Claims>(token, &self.decoding_key, &self.validation) {
+                // Partition by stable user identity: requests for the same `sub` coalesce,
+                // requests for different users never do.
+                let mut hasher = Xxh3::new();
+                token_data.claims.sub.hash(&mut hasher);
+                payload.add_inbound_dedupe_partition(hasher.finish());
+            }
+        }
+
+        payload.proceed()
+    }
+}

--- a/plugin_examples/dedupe_partition/src/test.rs
+++ b/plugin_examples/dedupe_partition/src/test.rs
@@ -1,0 +1,152 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use e2e::testkit::{some_header_map, Started, TestRouter, TestSubgraphs};
+    use hive_router::ntex;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde::Serialize;
+
+    const SECRET: &str = "test-secret";
+
+    #[derive(Serialize)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    fn jwt_cookie_for(sub: &str) -> String {
+        let claims = Claims {
+            sub: sub.to_string(),
+            exp: unix_now_plus_hour(),
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(SECRET.as_bytes()),
+        )
+        .unwrap();
+        format!("session={token}")
+    }
+
+    fn unix_now_plus_hour() -> usize {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        (now + 3600) as usize
+    }
+
+    async fn start_router(subgraphs: &TestSubgraphs<Started>) -> TestRouter<Started> {
+        TestRouter::builder()
+            .with_subgraphs(subgraphs)
+            .inline_config(include_str!("../router.config.yaml").replace("${JWT_SECRET}", SECRET))
+            .register_plugin::<crate::plugin::DedupePartitionPlugin>()
+            .build()
+            .start()
+            .await
+    }
+
+    const QUERY: &str = r#"
+        {
+            topProducts {
+                name
+                price
+            }
+        }
+    "#;
+
+    #[ntex::test]
+    async fn should_share_partition_for_the_same_jwt_subject() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = start_router(&subgraphs).await;
+
+        let cookie = jwt_cookie_for("alice");
+
+        let (response_a, response_b) = futures::join!(
+            router.send_graphql_request(QUERY, None, some_header_map! { "cookie" => &cookie },),
+            router.send_graphql_request(QUERY, None, some_header_map! { "cookie" => &cookie },)
+        );
+
+        assert!(response_a.status().is_success());
+        assert!(response_b.status().is_success());
+
+        let products_requests = subgraphs
+            .get_requests_log("products")
+            .unwrap_or_default()
+            .len();
+
+        assert_eq!(
+            products_requests, 1,
+            "expected requests with the same JWT subject to share a single dedupe partition"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_not_share_partition_for_different_jwt_subjects() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = start_router(&subgraphs).await;
+
+        let (response_a, response_b) = futures::join!(
+            router.send_graphql_request(
+                QUERY,
+                None,
+                some_header_map! { "cookie" => &jwt_cookie_for("alice") },
+            ),
+            router.send_graphql_request(
+                QUERY,
+                None,
+                some_header_map! { "cookie" => &jwt_cookie_for("bob") },
+            )
+        );
+
+        assert!(response_a.status().is_success());
+        assert!(response_b.status().is_success());
+
+        let products_requests = subgraphs
+            .get_requests_log("products")
+            .unwrap_or_default()
+            .len();
+
+        assert_eq!(
+            products_requests, 2,
+            "expected requests with different JWT subjects to fall into different dedupe partitions"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_share_anonymous_partition_when_cookie_is_missing() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_millis(100))
+            .build()
+            .start()
+            .await;
+        let router = start_router(&subgraphs).await;
+
+        let (response_a, response_b) = futures::join!(
+            router.send_graphql_request(QUERY, None, None),
+            router.send_graphql_request(QUERY, None, None)
+        );
+
+        assert!(response_a.status().is_success());
+        assert!(response_b.status().is_success());
+
+        let products_requests = subgraphs
+            .get_requests_log("products")
+            .unwrap_or_default()
+            .len();
+
+        assert_eq!(
+            products_requests, 1,
+            "expected requests without a JWT cookie to share the default anonymous partition"
+        );
+    }
+}


### PR DESCRIPTION
Closes https://github.com/graphql-hive/router/issues/1443


Allow plugins to contribute a partition to the inbound (router-level) request dedupe key

Plugins can now call `add_inbound_dedupe_partition(u64)` to add custom partition to the router's inbound
query/subscription dedupe fingerprint. Requests with different partitions are never deduped
into the same in-flight response.

The method is only exposed on the `on_http_request` and `on_graphql_params` hook payloads, since
those are the only hooks that run before the router computes the fingerprint — calling it from a
later hook would silently have no effect, so it isn't offered there.

```rust
async fn on_graphql_params<'exec>(
    &'exec self,
    payload: OnGraphQLParamsStartHookPayload<'exec>,
) -> OnGraphQLParamsStartHookResult<'exec> {
    let partition = compute_partition_from_identity(&payload);
    payload.add_inbound_dedupe_partition(partition);
    payload.proceed()
}
```

This is useful when the built-in `traffic_shaping.router.dedupe.headers` allowlist is not enough
— for example, partitioning by an authenticated user extracted from a `Cookie` header without
hashing the full cookie data.

