### PR TITLE
fix(logging): capture and print summary also for early rejections

### DIFF
--- a/.changeset/emit-summary-for-early-rejected-requests.md
+++ b/.changeset/emit-summary-for-early-rejected-requests.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+Emit a request summary log line for requests rejected early by a plugin's `on_http_request` hook (e.g. a malformed project key or missing authorization), not just requests that reach the GraphQL handler.
+
+Previously, a plugin ending the request from `on_http_request` skipped the handler entirely, and the handler was the only place that emitted the summary log line - so no `router::request` line was ever printed for these requests, making them invisible to access logs.
+
+Fixes https://github.com/graphql-hive/router/issues/1448

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -198,63 +198,47 @@ async fn graphql_endpoint_handler(
         .http_server
         .capture_request(&request);
 
-    let started_at = std::time::Instant::now();
-    let (response_mode, mut response, summary_guard) = async {
-        let summary_guard = summary::SummaryOnDrop::new(started_at);
-        debug!(
-            target: targets::HTTP_SERVER,
-            method = request.method().as_str(),
-            path = request.path(),
-            query_string = request.query_string(),
-            content_type = obtain_header_value(request.headers(), &CONTENT_TYPE),
-            accept = obtain_header_value(request.headers(), &ACCEPT),
-            user_agent = obtain_header_value(request.headers(), &USER_AGENT),
-            "http request started",
-        );
+    // logged here rather than in `RequestSummaryMiddleware` because we want custom coorelations to be included as well
+    debug!(
+        target: targets::HTTP_SERVER,
+        method = request.method().as_str(),
+        path = request.path(),
+        query_string = request.query_string(),
+        content_type = obtain_header_value(request.headers(), &CONTENT_TYPE),
+        accept = obtain_header_value(request.headers(), &ACCEPT),
+        user_agent = obtain_header_value(request.headers(), &USER_AGENT),
+        "http request started",
+    );
 
-        let (response_mode, inner_res) = graphql_endpoint_dispatch(
-            &mut request,
-            body_stream,
-            schema_state,
-            app_state.clone(),
-            parent_ctx,
-        )
-        .await;
-
-        let status_code = inner_res.status().as_u16();
-        let payload_bytes = match inner_res.body().size() {
-            BodySize::Empty | BodySize::None => 0,
-            BodySize::Sized(size) => i64::try_from(size).unwrap_or(i64::MAX),
-            BodySize::Stream => -1,
-        };
-
-        debug!(
-            target: targets::HTTP_SERVER,
-            status_code,
-            payload_bytes,
-            "http request completed",
-        );
-
-        summary::record(|s| {
-            s.status_code
-                .store(status_code, std::sync::atomic::Ordering::Relaxed);
-            s.payload_bytes
-                .store(payload_bytes, std::sync::atomic::Ordering::Relaxed);
-        });
-
-        (response_mode, inner_res, summary_guard)
-    }
+    let response = graphql_endpoint_dispatch(
+        &mut request,
+        body_stream,
+        schema_state,
+        app_state.clone(),
+        parent_ctx,
+    )
     .await;
 
-    if response_mode.can_stream() {
-        // Streamed responses must defer printing until the stream ends (or disconnects), not
-        // now - attaching the guard to the response body achieves that.
-        response = summary_guard.attach_to_response(response);
-    } else {
-        // Store the guard in the response's own extensions instead of allowing it to drop now.
-        // This allows us to emit the summary log line only after the response really completes sending
-        response.extensions_mut().insert(summary_guard);
-    }
+    let status_code = response.status().as_u16();
+    let payload_bytes = match response.body().size() {
+        BodySize::Empty | BodySize::None => 0,
+        BodySize::Sized(size) => i64::try_from(size).unwrap_or(i64::MAX),
+        BodySize::Stream => -1,
+    };
+
+    debug!(
+        target: targets::HTTP_SERVER,
+        status_code,
+        payload_bytes,
+        "http request completed",
+    );
+
+    summary::record(|s| {
+        s.status_code
+            .store(status_code, std::sync::atomic::Ordering::Relaxed);
+        s.payload_bytes
+            .store(payload_bytes, std::sync::atomic::Ordering::Relaxed);
+    });
 
     let graphql_operation = read_graphql_operation_metric_identity(&request);
     let graphql_operation_name = graphql_operation
@@ -283,7 +267,7 @@ async fn graphql_endpoint_dispatch(
     schema_state: web::types::State<Arc<SchemaState>>,
     app_state: web::types::State<Arc<RouterSharedState>>,
     parent_ctx: opentelemetry::Context,
-) -> (ResponseMode, web::HttpResponse) {
+) -> web::HttpResponse {
     let root_http_request_span = HttpServerRequestSpan::from_request(
         request,
         &app_state
@@ -367,7 +351,7 @@ async fn graphql_endpoint_dispatch(
 
         root_http_request_span.record_response(&response);
 
-        (response_mode, response)
+        response
     }
     .instrument(root_http_request_span.clone())
     .await
@@ -513,8 +497,8 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
                 paths_for_plugin,
                 prometheus.as_ref().map(|p| p.endpoint.clone()),
             ))
+            .middleware(RequestSummaryService::new(&graphql_path))
             .middleware(RequestIdentifiersService)
-            .middleware(RequestSummaryService)
             .state(shared_state.clone())
             .state(schema_state.clone())
             .state(shared_state.telemetry_context.clone())

--- a/bin/router/src/pipeline/request_summary.rs
+++ b/bin/router/src/pipeline/request_summary.rs
@@ -1,26 +1,54 @@
-use crate::telemetry::logging::summary::WithRequestSummary;
+use std::sync::atomic::Ordering::Relaxed;
+use std::time::Instant;
+
+use crate::telemetry::logging::summary::{self, SummaryOnDrop, WithRequestSummary};
 use ntex::{
+    http::body::{BodySize, MessageBody},
+    router::{Path, Router},
     service::{Service, ServiceCtx},
     web::{self, DefaultError},
     Middleware, SharedCfg,
 };
 
+/// Matches whatever `graphql_endpoint_handler` serves
+fn build_graphql_matcher(graphql_path: &str) -> Router<()> {
+    let mut builder = Router::build();
+    builder.path(graphql_path, ());
+    if graphql_path != "/" {
+        builder.prefix(graphql_path, ());
+    }
+    builder.finish()
+}
+
 /// Scopes the request summary as a task-local for the rest of the request, so every
-/// downstream middleware (`PluginService`, the coprocessor, etc.) can enrich it - not
-/// just the handler itself, which is where this used to happen.
-#[derive(Clone, Default)]
-pub struct RequestSummaryService;
+/// downstream middleware (`PluginService`, the coprocessor, etc.) can enrich it
+#[derive(Clone)]
+pub struct RequestSummaryService {
+    graphql_matcher: Router<()>,
+}
+
+impl RequestSummaryService {
+    pub fn new(graphql_path: &str) -> Self {
+        Self {
+            graphql_matcher: build_graphql_matcher(graphql_path),
+        }
+    }
+}
 
 impl<S> Middleware<S, SharedCfg> for RequestSummaryService {
     type Service = RequestSummaryMiddleware<S>;
 
     fn create(&self, service: S, _cfg: SharedCfg) -> Self::Service {
-        RequestSummaryMiddleware { service }
+        RequestSummaryMiddleware {
+            service,
+            graphql_matcher: self.graphql_matcher.clone(),
+        }
     }
 }
 
 pub struct RequestSummaryMiddleware<S> {
     service: S,
+    graphql_matcher: Router<()>,
 }
 
 impl<S> Service<web::WebRequest<DefaultError>> for RequestSummaryMiddleware<S>
@@ -37,6 +65,39 @@ where
         req: web::WebRequest<DefaultError>,
         ctx: ServiceCtx<'_, Self>,
     ) -> Result<Self::Response, Self::Error> {
-        ctx.call(&self.service, req).with_request_summary().await
+        // Only requests headed for the GraphQL endpoint get HTTP request/summary logging
+        if self
+            .graphql_matcher
+            .recognize(&mut Path::new(req.path()))
+            .is_none()
+        {
+            return ctx.call(&self.service, req).await;
+        }
+
+        let started_at = Instant::now();
+
+        // The guard is created while the task-local summary scope below is still active
+        let (response, guard) = async {
+            let response = ctx.call(&self.service, req).await?;
+
+            // Re-records over whatever the handler already set (e.g. before a plugin's `on_end`
+            // callback ran and read it) with the truly final response
+            let status_code = response.status().as_u16();
+            let payload_bytes = match response.response().body().size() {
+                BodySize::Empty | BodySize::None => 0,
+                BodySize::Sized(size) => i64::try_from(size).unwrap_or(i64::MAX),
+                BodySize::Stream => -1,
+            };
+            summary::record(|s| {
+                s.status_code.store(status_code, Relaxed);
+                s.payload_bytes.store(payload_bytes, Relaxed);
+            });
+
+            Ok::<_, S::Error>((response, SummaryOnDrop::new(started_at)))
+        }
+        .with_request_summary()
+        .await?;
+
+        Ok(guard.attach_to_response(response))
     }
 }

--- a/bin/router/src/telemetry/logging/summary.rs
+++ b/bin/router/src/telemetry/logging/summary.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use ntex::http::body::{Body, BodySize, MessageBody, ResponseBody};
 use ntex::util::Bytes;
-use ntex::web::HttpResponse;
+use ntex::web::WebResponse;
 use tokio::task::futures::TaskLocalFuture;
 use tracing::{info, Level};
 
@@ -238,9 +238,10 @@ impl SummaryOnDrop {
         }
     }
 
-    /// Moves the guard into a streamed response body, so the summary is emitted when the stream
-    /// terminates (or the client disconnects) instead of when the response was built.
-    pub fn attach_to_response(self, response: HttpResponse) -> HttpResponse {
+    /// Moves the guard into the response body, so the summary is emitted once the response is
+    /// actually done sending - immediately for a sized body, or on stream end/disconnect for one
+    /// that streams (subscriptions), rather than as soon as this call returns.
+    pub fn attach_to_response(self, response: WebResponse) -> WebResponse {
         response.map_body(|_, body| {
             ResponseBody::Body(Body::from_message(SummaryTrackedBody {
                 body,

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -15,9 +15,9 @@ use hive_router::{
     plugins::hooks::on_http_request::{OnHttpRequestHookFuture, OnHttpRequestHookPayload},
     plugins::hooks::on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
     plugins::plugin_trait::{EndHookPayload, RouterPlugin, StartHookPayload},
-    set_summary_attribute, set_summary_message,
+    set_summary_attribute, set_summary_message, GraphQLError,
 };
-use http::{HeaderMap, HeaderName, HeaderValue};
+use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use insta::assert_json_snapshot;
 use serde_json::{Map, Value};
 use sonic_rs::{json, JsonContainerTrait, JsonValueTrait};
@@ -923,5 +923,120 @@ plugins:
     assert!(
         subgraph_calls["products"].is_u64(),
         "expected a recorded duration for products, got: {subgraph_calls:?}"
+    );
+}
+
+#[derive(Default)]
+struct RejectMissingAuthPlugin;
+
+#[async_trait]
+impl RouterPlugin for RejectMissingAuthPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "test_reject_missing_auth"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin_with_defaults()
+    }
+
+    // Mirrors the auth-check shape from the async_auth plugin example, but rejecting from
+    // `on_http_request` itself, before the handler that creates `SummaryOnDrop` ever runs.
+    fn on_http_request<'req>(
+        &self,
+        payload: OnHttpRequestHookPayload<'req>,
+    ) -> OnHttpRequestHookFuture<'req> {
+        Box::pin(async move {
+            let is_graphql_request = payload.router_http_request.path() == "/graphql";
+            if is_graphql_request
+                && payload
+                    .router_http_request
+                    .headers()
+                    .get("authorization")
+                    .is_none()
+            {
+                return payload.end_with_graphql_error(
+                    GraphQLError::from_message_and_code("Unauthorized", "UNAUTHORIZED"),
+                    StatusCode::UNAUTHORIZED,
+                );
+            }
+
+            payload.proceed()
+        })
+    }
+}
+
+// https://github.com/graphql-hive/router/issues/1448
+#[ntex::test]
+async fn summary_is_emitted_for_requests_rejected_by_on_http_request() {
+    let (_subgraphs, router) = setup_router(
+        router_with_telemetry(
+            "\
+log:
+  level: info
+  format: json
+plugins:
+  test_reject_missing_auth:
+    enabled: true
+",
+        )
+        .register_plugin::<RejectMissingAuthPlugin>(),
+    )
+    .await;
+
+    let (stdout_log, status) = async { router.send_graphql_request(TEST_QUERY, None, None).await }
+        .capture_stdout_json_and_result()
+        .await;
+
+    assert_eq!(status.status(), StatusCode::UNAUTHORIZED);
+
+    let req_summary = stdout_log
+        .lines_json
+        .iter()
+        .find(|v| v.get("target").is_some_and(|v| v == targets::SUMMARY));
+
+    assert!(
+        req_summary.is_some(),
+        "expected a summary log line even for a request rejected by on_http_request, got lines: {:#?}",
+        stdout_log.lines_json
+    );
+}
+
+// Regression test for a templated `graphql_endpoint` (e.g. `/{tenant}/graphql`): a naive
+// `req.path() == graphql_path` string comparison never matches a literal request path against
+// a pattern, so the summary/HTTP_SERVER logging would silently never fire.
+#[ntex::test]
+async fn summary_is_emitted_for_templated_graphql_path() {
+    let (_subgraphs, router) = setup_router(router_with_telemetry(
+        "\
+http:
+  graphql_endpoint: /{tenant}/graphql
+log:
+  level: info
+  format: json
+",
+    ))
+    .await;
+
+    let (stdout_log, res) = async {
+        router
+            .send_post_request("/acme/graphql", json!({ "query": TEST_QUERY }), None)
+            .await
+    }
+    .capture_stdout_json_and_result()
+    .await;
+
+    assert!(res.status().is_success(), "Expected 200 OK");
+
+    let req_summary = stdout_log
+        .lines_json
+        .iter()
+        .find(|v| v.get("target").is_some_and(|v| v == targets::SUMMARY));
+
+    assert!(
+        req_summary.is_some(),
+        "expected a summary log line for a templated graphql_endpoint, got lines: {:#?}",
+        stdout_log.lines_json
     );
 }

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -966,8 +966,8 @@ impl TestRouter<Built> {
                         paths.clone(),
                         prometheus.as_ref().map(|p| p.endpoint.clone()),
                     ))
+                    .middleware(RequestSummaryService::new(&paths.graphql))
                     .middleware(RequestIdentifiersService)
-                    .middleware(RequestSummaryService)
                     .state(shared_state.clone())
                     .state(schema_state)
                     .state(callback_subs)

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -342,19 +342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dropper-simple"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c4748dfe8cd3d625ec68fc424fa80c134319881185866f9e173af9e5d8add8"
-dependencies = [
- "async-scoped",
- "async-trait",
- "futures",
- "rustc_version",
- "tokio",
-]
-
-[[package]]
 name = "async-graphql"
 version = "8.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,17 +451,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-scoped"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
-dependencies = [
- "futures",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -2683,11 +2659,10 @@ dependencies = [
 
 [[package]]
 name = "hive-console-sdk"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "ahash",
  "anyhow",
- "async-dropper-simple",
  "async-trait",
  "bytes",
  "futures-util",
@@ -2721,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4282,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-net"
-version = "3.15.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
+checksum = "ace516cc45d412d33165041edcb19048119589498f56fba69baf71ceba920af1"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4336,9 +4311,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.17.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877696a0cec7fccd0813d1c075e5dbc12e3a3199e492c9bfa3dd2da63d609f35"
+checksum = "3692fad48ebe4431289a51807dc08bd3205369ce9f1ab10d300fe12cccefd5c5"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4351,7 +4326,6 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
- "nix 0.31.3",
  "ntex-error",
  "ntex-service",
  "oneshot",
@@ -4364,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.11.1"
+version = "3.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eecf7ebae34a050ab29978eb1fa7bf99590e46e3ab29b5526aff7790d4c9464"
+checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
 dependencies = [
  "async-channel",
  "atomic-waker",


### PR DESCRIPTION
Emit a request summary log line for requests rejected early by a plugin's `on_http_request` hook (e.g. a malformed project key or missing authorization), not just requests that reach the GraphQL handler.

Previously, a plugin ending the request from `on_http_request` skipped the handler entirely, and the handler was the only place that emitted the summary log line - so no `router::request` line was ever printed for these requests, making them invisible to access logs.

I've moved the guard to be in the middleware itself (and it required me to do some route filtering, to make sure we don't print log lines for every unrelated request like health checks or metrics scraping).  

Fixes https://github.com/graphql-hive/router/issues/1448
