### PR TITLE
fix(query-planner): process `__typename` in `@provides` fieldset

### DIFF
--- a/.changeset/provides-typename-fieldset.md
+++ b/.changeset/provides-typename-fieldset.md
@@ -1,0 +1,7 @@
+---
+hive-router: patch
+---
+
+Fix graph construction failing for any supergraph where a `@provides` fieldset contains `__typename` (e.g. `@provides(fields: "item { __typename label }")`).
+
+Fixes https://github.com/graphql-hive/router/issues/1455

--- a/bin/router/fixture/tests/provides-requires-typename.supergraph.graphql
+++ b/bin/router/fixture/tests/provides-requires-typename.supergraph.graphql
@@ -1,0 +1,95 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ME @join__graph(name: "me", url: "")
+  REVIEWS @join__graph(name: "reviews", url: "")
+  SECRETS @join__graph(name: "secrets", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: ME)
+  @join__type(graph: REVIEWS)
+  @join__type(graph: SECRETS) {
+  review: Review @join__field(graph: REVIEWS)
+}
+
+type Review
+  @join__type(graph: REVIEWS, key: "id")
+  @join__type(graph: SECRETS, key: "id") {
+  id: ID!
+  body: String @join__field(graph: REVIEWS)
+  secret: String
+    @join__field(graph: REVIEWS, external: true)
+    @join__field(graph: SECRETS)
+  author: User
+    @join__field(graph: REVIEWS, requires: "secret", provides: "username __typename")
+}
+
+type User
+  @join__type(graph: ME, key: "id")
+  @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  name: String @join__field(graph: ME)
+  username: String
+    @join__field(graph: ME)
+    @join__field(graph: REVIEWS, external: true)
+}

--- a/bin/router/fixture/tests/provides-typename-interface.supergraph.graphql
+++ b/bin/router/fixture/tests/provides-typename-interface.supergraph.graphql
@@ -1,0 +1,152 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+interface Animal
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C) {
+  id: ID!
+  name: String @join__field(graph: B) @join__field(graph: C)
+}
+
+type Book implements Media
+  @join__implements(graph: A, interface: "Media")
+  @join__implements(graph: B, interface: "Media")
+  @join__implements(graph: C, interface: "Media")
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B)
+  @join__type(graph: C, key: "id") {
+  id: ID!
+  animals: [Animal]
+    @join__field(graph: A)
+    @join__field(graph: B, external: true)
+    @join__field(graph: C)
+}
+
+type Cat implements Animal
+  @join__implements(graph: A, interface: "Animal")
+  @join__implements(graph: B, interface: "Animal")
+  @join__implements(graph: C, interface: "Animal")
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B)
+  @join__type(graph: C, key: "id") {
+  id: ID!
+    @join__field(graph: A, external: true)
+    @join__field(graph: B, external: true)
+    @join__field(graph: C)
+  name: String @join__field(graph: B, external: true) @join__field(graph: C)
+  age: Int @join__field(graph: C)
+}
+
+type Dog implements Animal
+  @join__implements(graph: A, interface: "Animal")
+  @join__implements(graph: B, interface: "Animal")
+  @join__implements(graph: C, interface: "Animal")
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B)
+  @join__type(graph: C, key: "id") {
+  id: ID!
+    @join__field(graph: A, external: true)
+    @join__field(graph: B, external: true)
+    @join__field(graph: C)
+  name: String
+    @join__field(graph: A, external: true)
+    @join__field(graph: B, external: true)
+    @join__field(graph: C)
+  age: Int @join__field(graph: C)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A
+    @join__graph(
+      name: "a"
+      url: "http://localhost:4200/provides-typename-interface/a"
+    )
+  B
+    @join__graph(
+      name: "b"
+      url: "http://localhost:4200/provides-typename-interface/b"
+    )
+  C
+    @join__graph(
+      name: "c"
+      url: "http://localhost:4200/provides-typename-interface/c"
+    )
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+interface Media
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C) {
+  id: ID!
+  animals: [Animal] @join__field(graph: B) @join__field(graph: C)
+}
+
+type Query @join__type(graph: A) @join__type(graph: B) @join__type(graph: C) {
+  media: Media
+    @join__field(graph: A)
+    @join__field(graph: B, provides: "animals { id name }")
+  book: Book
+    @join__field(
+      graph: A
+      provides: "animals { __typename ... on Dog { __typename name } }"
+    )
+}

--- a/bin/router/fixture/tests/provides-typename-list.supergraph.graphql
+++ b/bin/router/fixture/tests/provides-typename-list.supergraph.graphql
@@ -1,0 +1,85 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  OWNER @join__graph(name: "owner", url: "")
+  PROVIDER @join__graph(name: "provider", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Holder
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  items: [Item] @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Item
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  label: String @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Query
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  status: String @join__field(graph: OWNER)
+  holder: Holder
+    @join__field(graph: PROVIDER, provides: "items { __typename label }")
+}

--- a/bin/router/fixture/tests/provides-typename-nested.supergraph.graphql
+++ b/bin/router/fixture/tests/provides-typename-nested.supergraph.graphql
@@ -1,0 +1,94 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  OWNER @join__graph(name: "owner", url: "")
+  PROVIDER @join__graph(name: "provider", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Holder
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  item: Item @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Item
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  nested: Nested @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Nested
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  label: String @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Query
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  status: String @join__field(graph: OWNER)
+  holder: Holder
+    @join__field(
+      graph: PROVIDER
+      provides: "item { __typename nested { __typename label } }"
+    )
+}

--- a/bin/router/fixture/tests/provides-typename.supergraph.graphql
+++ b/bin/router/fixture/tests/provides-typename.supergraph.graphql
@@ -1,0 +1,85 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  OWNER @join__graph(name: "owner", url: "")
+  PROVIDER @join__graph(name: "provider", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Holder
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  item: Item @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Item
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  label: String @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Query
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  status: String @join__field(graph: OWNER)
+  holder: Holder
+    @join__field(graph: PROVIDER, provides: "item { __typename label }")
+}

--- a/bin/router/src/query_planner/graph/mod.rs
+++ b/bin/router/src/query_planner/graph/mod.rs
@@ -252,6 +252,24 @@ impl Graph {
         }
     }
 
+    // __typename is a meta-field: it carries no declared field definition, so unlike
+    // other fields it always resolves to a plain "String" move, regardless of parent type.
+    fn upsert_typename_edge(&mut self, head: NodeIndex, tail: NodeIndex, parent_type_name: &str) {
+        self.upsert_edge(
+            head,
+            tail,
+            Edge::create_field_move(
+                "__typename".to_string(),
+                parent_type_name.to_string(),
+                true,
+                false,
+                None,
+                None,
+                None,
+            ),
+        );
+    }
+
     #[instrument(level = "trace", skip(self, state))]
     fn build_entity_reference_edges(&mut self, state: &SupergraphState) -> Result<(), GraphError> {
         for (def_name, definition) in state.definitions.iter() {
@@ -585,7 +603,6 @@ impl Graph {
                 ) && !is_interface_object;
 
                 if has_resolvable_typename {
-                    let field_name = "__typename".to_string();
                     trace!(
                         "[x] Creating owned field move edge '{}.__typename/{}' (type: String)",
                         def_name,
@@ -604,19 +621,7 @@ impl Graph {
                         false,
                     ));
 
-                    self.upsert_edge(
-                        head,
-                        tail,
-                        Edge::create_field_move(
-                            field_name,
-                            def_name.clone(),
-                            true,
-                            false,
-                            None,
-                            None,
-                            None,
-                        ),
-                    );
+                    self.upsert_typename_edge(head, tail, def_name);
                 }
 
                 trace!(
@@ -995,20 +1000,7 @@ impl Graph {
                         ));
 
                         self.upsert_edge(tail, tail, Edge::Selfie("String".to_string()));
-
-                        self.upsert_edge(
-                            head,
-                            tail,
-                            Edge::create_field_move(
-                                field.name.to_string(),
-                                parent_type_def.name().to_string(),
-                                true,
-                                false,
-                                None,
-                                None,
-                                None,
-                            ),
-                        );
+                        self.upsert_typename_edge(head, tail, parent_type_def.name());
 
                         continue;
                     }

--- a/bin/router/src/query_planner/graph/mod.rs
+++ b/bin/router/src/query_planner/graph/mod.rs
@@ -986,22 +986,35 @@ impl Graph {
             );
         }
 
+        let is_interface_object = parent_type_def
+            .extract_join_types_for(graph_id)
+            .iter()
+            .any(|j| j.is_interface_object);
+        let has_resolvable_typename = matches!(
+            parent_type_def,
+            SupergraphDefinition::Object(_)
+                | SupergraphDefinition::Union(_)
+                | SupergraphDefinition::Interface(_)
+        ) && !is_interface_object;
+
+        // __typename is a meta-field, resolvable from any subgraph that
+        // resolves the parent
+        if has_resolvable_typename {
+            let tail = self.upsert_node(Node::new_specialized_node(
+                "String",
+                state.resolve_graph_id(graph_id)?,
+                false,
+                SubgraphTypeSpecialization::Provides(view_id),
+            ));
+
+            self.upsert_edge(tail, tail, Edge::Selfie("String".to_string()));
+            self.upsert_typename_edge(head, tail, parent_type_def.name());
+        }
+
         for selection in selection_set.items.iter() {
             match selection {
                 Selection::Field(field) => {
-                    // __typename is a meta-field, resolvable from any subgraph that
-                    // resolves the parent, so it carries no declared field definition.
                     if field.name == "__typename" {
-                        let tail = self.upsert_node(Node::new_specialized_node(
-                            "String",
-                            state.resolve_graph_id(graph_id)?,
-                            false,
-                            SubgraphTypeSpecialization::Provides(view_id),
-                        ));
-
-                        self.upsert_edge(tail, tail, Edge::Selfie("String".to_string()));
-                        self.upsert_typename_edge(head, tail, parent_type_def.name());
-
                         continue;
                     }
 

--- a/bin/router/src/query_planner/graph/mod.rs
+++ b/bin/router/src/query_planner/graph/mod.rs
@@ -984,6 +984,35 @@ impl Graph {
         for selection in selection_set.items.iter() {
             match selection {
                 Selection::Field(field) => {
+                    // __typename is a meta-field, resolvable from any subgraph that
+                    // resolves the parent, so it carries no declared field definition.
+                    if field.name == "__typename" {
+                        let tail = self.upsert_node(Node::new_specialized_node(
+                            "String",
+                            state.resolve_graph_id(graph_id)?,
+                            false,
+                            SubgraphTypeSpecialization::Provides(view_id),
+                        ));
+
+                        self.upsert_edge(tail, tail, Edge::Selfie("String".to_string()));
+
+                        self.upsert_edge(
+                            head,
+                            tail,
+                            Edge::create_field_move(
+                                field.name.to_string(),
+                                parent_type_def.name().to_string(),
+                                true,
+                                false,
+                                None,
+                                None,
+                                None,
+                            ),
+                        );
+
+                        continue;
+                    }
+
                     let is_leaf = field.selection_set.items.is_empty();
                     let field_in_parent =
                         parent_type_def.fields().get(&field.name).ok_or_else(|| {

--- a/bin/router/src/query_planner/graph/tests.rs
+++ b/bin/router/src/query_planner/graph/tests.rs
@@ -370,7 +370,7 @@ mod graph_tests {
         let (viewed_incoming, viewed_outgoing) = find_node(&graph, &node1.display_name());
         viewed_outgoing.assert_field_edge("id", "String/foo");
         assert_eq!(viewed_incoming.edges.len(), 2); // +1 for Selfie
-        assert_eq!(viewed_outgoing.edges.len(), 3); // +1 for Selfie
+        assert_eq!(viewed_outgoing.edges.len(), 4); // +1 for Selfie, +1 for __typename
 
         let (_, to) = outgoing
             .edges_field("user")

--- a/bin/router/src/query_planner/graph/tests.rs
+++ b/bin/router/src/query_planner/graph/tests.rs
@@ -384,7 +384,7 @@ mod graph_tests {
         let (viewed_incoming, viewed_outgoing) = find_node(&graph, &node2.display_name());
         viewed_outgoing.assert_field_edge("name", "String/foo");
         assert_eq!(viewed_incoming.edges.len(), 2); // +1 for Selfie
-        assert_eq!(viewed_outgoing.edges.len(), 4); // +1 for Selfie
+        assert_eq!(viewed_outgoing.edges.len(), 5); // +1 for Selfie, +1 for __typename
 
         let (nested_provides_id, nested_provides_node) = viewed_outgoing
             .edge_field("profile")
@@ -397,7 +397,7 @@ mod graph_tests {
             .starts_with("Profile/foo/"));
 
         let mut nested_edges = graph.edges_from(nested_provides_id);
-        assert_eq!(nested_edges.clone().count(), 2); // +1 for Selfie
+        assert_eq!(nested_edges.clone().count(), 3); // +1 for Selfie, +1 for __typename
         assert_eq!(
             nested_edges.next().unwrap().weight().display_name(),
             String::from("age")

--- a/bin/router/src/query_planner/graph/tests.rs
+++ b/bin/router/src/query_planner/graph/tests.rs
@@ -408,4 +408,24 @@ mod graph_tests {
 
         Ok(())
     }
+
+    // https://github.com/graphql-hive/router/issues/1455
+    // `__typename` is a meta-field, not part of the fields set in the schema, so a `@provides`
+    // fieldset containing it must not fail when constructing the graph.
+    #[test]
+    fn provides_fieldset_with_typename() {
+        let supergraph_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture/tests/provides-typename.supergraph.graphql");
+        let schema = parse_schema(
+            &std::fs::read_to_string(supergraph_path).expect("Unable to read input file"),
+        );
+        let metadata = SupergraphState::new(&schema);
+        let graph = Graph::graph_from_supergraph_state(&metadata);
+
+        assert!(
+            graph.is_ok(),
+            "expected __typename inside a @provides fieldset to plan successfully, got: {:?}",
+            graph.err()
+        );
+    }
 }

--- a/bin/router/src/query_planner/graph/tests.rs
+++ b/bin/router/src/query_planner/graph/tests.rs
@@ -428,4 +428,106 @@ mod graph_tests {
             graph.err()
         );
     }
+
+    // __typename at two nested levels of the same @provides fieldset.
+    #[test]
+    fn provides_fieldset_with_nested_typename() -> Result<(), Box<dyn std::error::Error>> {
+        let supergraph_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture/tests/provides-typename-nested.supergraph.graphql");
+        let graph = init_test(
+            &std::fs::read_to_string(supergraph_path).expect("Unable to read input file"),
+        );
+
+        find_node(&graph, "Item/provider/1")
+            .1
+            .assert_field_edge("__typename", "String/provider")
+            .assert_field_edge("nested", "Nested/provider");
+
+        find_node(&graph, "Nested/provider/1")
+            .1
+            .assert_field_edge("__typename", "String/provider")
+            .assert_field_edge("label", "String/provider");
+
+        Ok(())
+    }
+
+    // __typename inside a @provides fieldset nested under a list-returning field.
+    #[test]
+    fn provides_fieldset_with_typename_on_list() -> Result<(), Box<dyn std::error::Error>> {
+        let supergraph_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture/tests/provides-typename-list.supergraph.graphql");
+        let graph = init_test(
+            &std::fs::read_to_string(supergraph_path).expect("Unable to read input file"),
+        );
+
+        let (_, outgoing) = find_node(&graph, "Holder/provider/1");
+        let (items_edge, to) = outgoing
+            .edge_field("items")
+            .expect("failed to find edge for field items");
+        match items_edge.weight() {
+            Edge::FieldMove(fm) => assert!(fm.is_list, "expected 'items' field move to be a list"),
+            other => panic!("expected a field move edge, got {:?}", other),
+        }
+
+        let node = graph.node(*to)?;
+        assert!(node.is_using_provides());
+
+        find_node(&graph, &node.display_name())
+            .1
+            .assert_field_edge("__typename", "String/provider")
+            .assert_field_edge("label", "String/provider");
+
+        Ok(())
+    }
+
+    // __typename both at the interface level and inside an inline fragment
+    // branch of the same @provides fieldset.
+    #[test]
+    fn provides_fieldset_with_typename_on_interface() -> Result<(), Box<dyn std::error::Error>> {
+        let supergraph_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture/tests/provides-typename-interface.supergraph.graphql");
+        let graph = init_test(
+            &std::fs::read_to_string(supergraph_path).expect("Unable to read input file"),
+        );
+
+        find_node(&graph, "Animal/a/1")
+            .1
+            .assert_field_edge("__typename", "String/a")
+            .assert_interface_edge("Dog", "Dog/a");
+
+        find_node(&graph, "Dog/a/1")
+            .1
+            .assert_field_edge("__typename", "String/a")
+            .assert_field_edge("name", "String/a");
+
+        Ok(())
+    }
+
+    // __typename inside a @provides fieldset for a field that also carries @requires.
+    #[test]
+    fn provides_fieldset_with_typename_and_requires() -> Result<(), Box<dyn std::error::Error>> {
+        let supergraph_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture/tests/provides-requires-typename.supergraph.graphql");
+        let graph = init_test(
+            &std::fs::read_to_string(supergraph_path).expect("Unable to read input file"),
+        );
+
+        let (_, outgoing) = find_node(&graph, "Review/reviews");
+        let (_, to) = outgoing
+            .edges_field("author")
+            .into_iter()
+            .find(|(edge_ref, _to)| {
+                format!("{:?}", edge_ref.weight()) == "author @requires(secret) @provides"
+            })
+            .expect("failed to find provides edge for field author");
+        let node = graph.node(*to)?;
+        assert!(node.is_using_provides());
+
+        find_node(&graph, &node.display_name())
+            .1
+            .assert_field_edge("username", "String/reviews")
+            .assert_field_edge("__typename", "String/reviews");
+
+        Ok(())
+    }
 }

--- a/bin/router/src/query_planner/tests/provides.rs
+++ b/bin/router/src/query_planner/tests/provides.rs
@@ -367,6 +367,163 @@ fn provides_on_interface_1_test() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// https://github.com/graphql-hive/router/issues/1455
+#[test]
+fn provides_fieldset_with_typename() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          holder {
+            item {
+              __typename
+              label
+            }
+          }
+        }"#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/provides-typename.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "provider") {
+        {
+          holder {
+            item {
+              __typename
+              label
+            }
+          }
+        }
+      },
+    },
+    "#);
+    Ok(())
+}
+
+#[test]
+fn provides_fieldset_with_nested_typename() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          holder {
+            item {
+              __typename
+              nested {
+                __typename
+                label
+              }
+            }
+          }
+        }"#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/provides-typename-nested.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "provider") {
+        {
+          holder {
+            item {
+              __typename
+              nested {
+                __typename
+                label
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+    Ok(())
+}
+
+#[test]
+fn provides_fieldset_with_typename_on_list() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          holder {
+            items {
+              __typename
+              label
+            }
+          }
+        }"#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/provides-typename-list.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "provider") {
+        {
+          holder {
+            items {
+              __typename
+              label
+            }
+          }
+        }
+      },
+    },
+    "#);
+    Ok(())
+}
+
+#[test]
+fn provides_fieldset_with_typename_on_interface() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          book {
+            animals {
+              __typename
+              ... on Dog {
+                __typename
+                name
+              }
+            }
+          }
+        }"#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/provides-typename-interface.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Fetch(service: "a") {
+        {
+          book {
+            animals {
+              __typename
+              ... on Dog {
+                name
+                __typename
+              }
+            }
+          }
+        }
+      },
+    },
+    "#);
+    Ok(())
+}
+
 #[test]
 fn provides_on_interface_2_test() -> Result<(), Box<dyn Error>> {
     init_logger();

--- a/bin/router/src/query_planner/tests/requires_provides.rs
+++ b/bin/router/src/query_planner/tests/requires_provides.rs
@@ -168,3 +168,74 @@ fn simple_requires_provides() -> Result<(), Box<dyn Error>> {
     "#);
     Ok(())
 }
+
+// https://github.com/graphql-hive/router/issues/1455
+#[test]
+fn provides_fieldset_with_typename_and_requires() -> Result<(), Box<dyn Error>> {
+    init_logger();
+    let document = parse_operation(
+        r#"
+        query {
+          review {
+            author {
+              username
+              __typename
+            }
+          }
+        }"#,
+    );
+    let query_plan = build_query_plan_with_defaults(
+        "fixture/tests/provides-requires-typename.supergraph.graphql",
+        document,
+    )?;
+
+    insta::assert_snapshot!(format!("{}", query_plan), @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "reviews") {
+          {
+            review {
+              __typename
+              id
+            }
+          }
+        },
+        Flatten(path: "review") {
+          Fetch(service: "secrets") {
+            {
+              ... on Review {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Review {
+                secret
+              }
+            }
+          },
+        },
+        Flatten(path: "review") {
+          Fetch(service: "reviews") {
+            {
+              ... on Review {
+                __typename
+                secret
+                id
+              }
+            } =>
+            {
+              ... on Review {
+                author {
+                  username
+                  __typename
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+    "#);
+    Ok(())
+}

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3423,9 +3423,7 @@ mod issues_e2e_tests {
             .expect(1)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                r#"{"data":{"holder":{"item":{"__typename":"Item","label":"hello"}}}}"#,
-            )
+            .with_body(r#"{"data":{"holder":{"item":{"__typename":"Item","label":"hello"}}}}"#)
             .create();
         // The whole operation is answerable from the @provides view alone,
         // so "owner" must never be called.

--- a/e2e/src/issues/mod.rs
+++ b/e2e/src/issues/mod.rs
@@ -3391,4 +3391,68 @@ mod issues_e2e_tests {
         }
         "#);
     }
+
+    #[ntex::test]
+    /// https://github.com/graphql-hive/router/issues/1455
+    /// __typename inside a @provides fieldset must not fail graph construction,
+    /// and the router must serve the operation from a single subgraph fetch.
+    async fn issue_1455_typename_in_provides_fieldset() {
+        let mut server = mockito::Server::new_async().await;
+        let host = server.host_with_port();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                  supergraph:
+                    source: file
+                    path: src/issues/supergraph.1455.graphql
+                  override_subgraph_urls:
+                    subgraphs:
+                      owner:
+                        url: "http://{host}/owner"
+                      provider:
+                        url: "http://{host}/provider"
+                  "#
+            ))
+            .build()
+            .start()
+            .await;
+
+        let provider_mock = server
+            .mock("POST", "/provider")
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"holder":{"item":{"__typename":"Item","label":"hello"}}}}"#,
+            )
+            .create();
+        // The whole operation is answerable from the @provides view alone,
+        // so "owner" must never be called.
+        let owner_mock = server.mock("POST", "/owner").expect(0).create();
+
+        let res = router
+            .send_graphql_request(
+                r#"query { holder { item { __typename label } } }"#,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+        provider_mock.assert();
+        owner_mock.assert();
+        insta::assert_snapshot!(res.json_body_string_pretty().await, @r#"
+        {
+          "data": {
+            "holder": {
+              "item": {
+                "__typename": "Item",
+                "label": "hello"
+              }
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/e2e/src/issues/supergraph.1455.graphql
+++ b/e2e/src/issues/supergraph.1455.graphql
@@ -64,22 +64,19 @@ enum link__Purpose {
   EXECUTION
 }
 
-type Holder
-  @join__type(graph: OWNER)
-  @join__type(graph: PROVIDER) {
-  item: Item @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+type Holder @join__type(graph: OWNER) @join__type(graph: PROVIDER) {
+  item: Item
+    @join__field(graph: OWNER)
+    @join__field(graph: PROVIDER, external: true)
 }
 
-type Item
-  @join__type(graph: OWNER)
-  @join__type(graph: PROVIDER) {
-  label: String @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+type Item @join__type(graph: OWNER) @join__type(graph: PROVIDER) {
+  label: String
+    @join__field(graph: OWNER)
+    @join__field(graph: PROVIDER, external: true)
 }
 
-type Query
-  @join__type(graph: OWNER)
-  @join__type(graph: PROVIDER) {
+type Query @join__type(graph: OWNER) @join__type(graph: PROVIDER) {
   status: String @join__field(graph: OWNER)
-  holder: Holder
-    @join__field(graph: PROVIDER, provides: "item { __typename label }")
+  holder: Holder @join__field(graph: PROVIDER, provides: "item { label }")
 }

--- a/e2e/src/issues/supergraph.1455.graphql
+++ b/e2e/src/issues/supergraph.1455.graphql
@@ -1,0 +1,85 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  OWNER @join__graph(name: "owner", url: "http://0.0.0.0:4200/owner")
+  PROVIDER @join__graph(name: "provider", url: "http://0.0.0.0:4200/provider")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Holder
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  item: Item @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Item
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  label: String @join__field(graph: OWNER) @join__field(graph: PROVIDER, external: true)
+}
+
+type Query
+  @join__type(graph: OWNER)
+  @join__type(graph: PROVIDER) {
+  status: String @join__field(graph: OWNER)
+  holder: Holder
+    @join__field(graph: PROVIDER, provides: "item { __typename label }")
+}


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/router/issues/1455 

Fix graph construction failing for any supergraph where a `@provides` fieldset contains `__typename` (e.g. `@provides(fields: "item { __typename label }")`).

To fix that, we check if the parent type in each selection set can resolve some concrete `__typename` (= is object, not an interface), and if so, we add `__typename` as a field that can be resolved in the `@provides` branch. This assumes that the providing subgraph can always also provide `__typename`, if requested. 

Also, added a few more test cases to ensure it's actually working. 

