### PR TITLE
chore(router): added tests for graceful shutdown, upgrade ntex to latest

### DIFF
--- a/.changeset/upgrade-ntex-graceful-shutdown-fix.md
+++ b/.changeset/upgrade-ntex-graceful-shutdown-fix.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+Upgrade `ntex` internal crates to latest
+
+Bumps `ntex-server` to `3.11.2` (and its `ntex-net`/`ntex-rt`/`ntex-error` siblings to matching latest versions), dropping the pins introduced in #1445.
+
+`ntex-server` `3.11.0`/`3.11.1` made graceful signal handling opt-in and defaulted it off, with no way for `ntex::web::HttpServer` to opt back in — a real `SIGTERM` force-dropped in-flight requests and ignored `http.shutdown_timeout` entirely. `3.11.2` restores the previous behavior, so the router no longer needs to hold these crates back at `3.10.4`/`3.14.1`/`3.16.1`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,14 @@ jobs:
       - name: setup rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
       - uses: ./.github/actions/install-tools
+      - name: build hive_router binary
+        # Needed for the e2e tests that spawn the real compiled binary as a subprocess
+        # (e.g. to send it a real SIGTERM) instead of running it in-process.
+        run: cargo build -p hive-router --bin hive_router --features testing
       - name: test e2e
-        run: cargo test_e2e
+        # --run-ignored all also runs #[ignore]'d tests, e.g. ones that spawn the real
+        # hive_router binary and require it pre-built (skipped by default locally).
+        run: cargo test_e2e --run-ignored all
         timeout-minutes: 10
         env:
           RUST_BACKTRACE: full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-error"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229806c94be0c192bde46633bd044d11e3d7f3e5c5ee32aa3f430c918e99f746"
+checksum = "37be4fd659180da86ea43a9c167a1e726ee43db154a346eefddea89261b4d4a5"
 dependencies = [
  "backtrace",
  "foldhash 0.2.0",
@@ -4125,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-net"
-version = "3.14.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace516cc45d412d33165041edcb19048119589498f56fba69baf71ceba920af1"
+checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -4179,9 +4179,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.16.1"
+version = "3.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3692fad48ebe4431289a51807dc08bd3205369ce9f1ab10d300fe12cccefd5c5"
+checksum = "aff50c4365282675402f680bc01d9d3b2f190cc7687947d251a8c31b80d6d11d"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4194,8 +4194,8 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
+ "nix 0.31.3",
  "ntex-error",
- "ntex-service",
  "oneshot",
  "parking_lot",
  "scoped-tls",
@@ -4206,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.10.4"
+version = "3.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
+checksum = "a0f3a1c0e5cd9c04d158bc954b3ed43ba3a2e1b19174112876e2af7f47851171"
 dependencies = [
  "async-channel",
  "atomic-waker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,29 +53,16 @@ ntex = { version = "=3.12.3", features = ["tokio", "rustls"] }
 ntex-http = { version = "=1.2.0"}
 ntex-codec = { version = "=1.2.1"}
 ntex-io = { version = "=3.13.1"}
-# Held back with ntex-rt and ntex-server, see the note above `ntex-server`.
-ntex-net = { version = "=3.14.1"}
+ntex-net = { version = "=3.15.0"}
 ntex-router = { version = "=1.0.0"}
 ntex-bytes = { version = "=1.9.0"}
 ntex-dispatcher = { version = "=3.2.1"}
-ntex-error = { version = "=2.4.0" }
+ntex-error = { version = "=2.5.0" }
 ntex-h2 = { version = "=3.13.0" }
-# Held back with ntex-net and ntex-server, see the note above `ntex-server`.
-ntex-rt = { version = "=3.16.1" }
+ntex-rt = { version = "=3.17.2" }
 ntex-macros = { version = "=3.5.0" }
 ntex-httparse = { version = "=2.1.0" }
-# ntex-server 3.11 made graceful signal handling opt-in and defaults it to
-# false, and `ntex::web::HttpServer` exposes no way to opt in, so SIGTERM
-# force-drops in-flight requests and ignores `http.shutdown_timeout`.
-#
-# 3.10.4 cannot be pinned on its own: ntex-rt 3.17 added a `Signal::Panic`
-# variant and made `Signal` non-Copy, which 3.10.4 does not compile against,
-# and ntex-net 3.15 requires ntex-rt >=3.17. So ntex-net and ntex-rt are held
-# at the last releases that pair with it. ntex 3.12.3 accepts all three.
-#
-# Drop all three pins once a 3.x ntex exposes `HttpServer::graceful_shutdown`,
-# which ntex added in 4.0.0-beta.0.
-ntex-server = { version = "=3.10.4" }
+ntex-server = { version = "=3.11.2" }
 ntex-service = { version = "=4.6.0" }
 ntex-tls = { version = "=3.8.0" }
 ntex-util = { version = "=3.6.1" }

--- a/e2e/src/demand_control/estimator.rs
+++ b/e2e/src/demand_control/estimator.rs
@@ -1087,16 +1087,7 @@ mod estimator_tests {
         )
         .await;
     }
-    // @defer fragments must contribute to the total estimated cost. The estimator walks both
-    // the primary node and all deferred fragment nodes (PlanNode::Defer handling).
-    #[ntex::test]
-    #[ignore = "@defer fragment cost accumulation requires @defer multipart protocol support in TestRouter"]
-    async fn deferred_fragment_cost_accumulation() {
-        // The cost estimator already handles PlanNode::Defer by summing primary + all deferred
-        // fragment costs. This E2E test is deferred until the test router can issue @defer
-        // requests and collect the full multipart response stream.
-        todo!()
-    }
+
     // @cost on INPUT_FIELD_DEFINITION adds cost when that input field is provided (non-null)
     // in a query argument, as specified by the IBM GraphQL Cost Directive specification.
     #[ntex::test]

--- a/e2e/src/graceful_shutdown.rs
+++ b/e2e/src/graceful_shutdown.rs
@@ -1,0 +1,153 @@
+#[cfg(test)]
+mod graceful_shutdown_tests {
+    use std::time::{Duration, Instant};
+
+    use sonic_rs::{json, JsonValueTrait};
+    use tokio::net::TcpStream;
+
+    use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
+
+    /// Graceful shutdown (`ntex`'s `Server::stop(true)`, triggered on `SIGTERM` in
+    /// production) must let in-flight requests finish rather than dropping them.
+    #[ntex::test]
+    async fn should_complete_an_in_flight_request_during_graceful_shutdown() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_secs(2))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let request = router.send_graphql_request("{ topProducts { name price } }", None, None);
+        let shutdown = router.serv().stop();
+
+        // Kick off the slow request first so shutdown starts while it is in flight.
+        let (res, ()) = tokio::join!(request, async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            shutdown.await;
+        });
+
+        assert!(
+            res.status().is_success(),
+            "expected the in-flight request to complete despite a graceful shutdown \
+             starting mid-flight, got status {}",
+            res.status()
+        );
+        let json_body = res.json_body().await;
+        assert!(
+            json_body["data"]["topProducts"].is_array(),
+            "expected a full GraphQL response, got: {json_body:?}"
+        );
+    }
+
+    /// Once graceful shutdown has completed, the listener must be gone: new connection
+    /// attempts should fail rather than hang or be silently accepted.
+    #[ntex::test]
+    async fn should_stop_accepting_new_connections_after_graceful_shutdown_completes() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let addr = router.serv().addr();
+        router.serv().stop().await;
+
+        let connect_result =
+            tokio::time::timeout(Duration::from_secs(3), TcpStream::connect(addr)).await;
+        assert!(
+            matches!(connect_result, Ok(Err(_))) || connect_result.is_err(),
+            "expected the router to refuse new connections after graceful shutdown completed, \
+             got: {connect_result:?}"
+        );
+    }
+
+    /// The `test::TestServer` used by the tests above always drains with ntex's internal
+    /// default timeout and ignores `http.shutdown_timeout` entirely, so it can't prove the
+    /// configured value is what actually governs the drain. This test binds the router with
+    /// the real `web::HttpServer` (via `with_real_http_server`) and configures a
+    /// `shutdown_timeout` far shorter than the in-flight request: if the configured value is
+    /// honored, the request must be force-dropped around that short timeout rather than
+    /// after the request's own 3s delay, and shutdown itself must complete around that same
+    /// short timeout instead of ntex's 30s default.
+    #[ntex::test]
+    async fn should_honor_the_configured_shutdown_timeout() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_secs(3))
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .with_real_http_server()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                http:
+                    shutdown_timeout: 500ms
+                "#,
+            )
+            .build()
+            .start_without_healthcheck()
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = router.real_serv().url("/graphql");
+        // Spawned so it actually starts executing concurrently: an un-awaited reqwest
+        // future does nothing on its own.
+        let request_handle = tokio::spawn(async move {
+            client
+                .post(url)
+                .header("content-type", "application/json")
+                .header("accept", "application/graphql-response+json")
+                .json(&json!({ "query": "{ topProducts { name price } }" }))
+                .send()
+                .await
+        });
+
+        // Give the request a moment to actually reach the slow subgraph call before
+        // shutdown starts draining.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let shutdown_started = Instant::now();
+        router.real_serv().stop().await;
+        let shutdown_elapsed = shutdown_started.elapsed();
+
+        assert!(
+            shutdown_elapsed < Duration::from_secs(2),
+            "expected graceful shutdown to force-drop the connection around the configured \
+             500ms http.shutdown_timeout, not wait out the request's 3s subgraph delay or \
+             ntex's 30s default, but shutdown took {shutdown_elapsed:?}"
+        );
+
+        // Bounded independently of `stop()`: if the connection was left dangling instead of
+        // force-dropped, this fails the test instead of hanging it.
+        if let Ok(Ok(Ok(res))) = tokio::time::timeout(Duration::from_secs(2), request_handle).await
+        {
+            assert!(
+                !res.status().is_success(),
+                "expected the in-flight request to be force-dropped once the configured \
+                 500ms shutdown_timeout elapsed, well before the subgraph's 3s delayed \
+                 response, but it completed successfully"
+            );
+        }
+    }
+}

--- a/e2e/src/graceful_shutdown.rs
+++ b/e2e/src/graceful_shutdown.rs
@@ -1,11 +1,17 @@
 #[cfg(test)]
 mod graceful_shutdown_tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        path::Path,
+        time::{Duration, Instant},
+    };
 
     use sonic_rs::{json, JsonValueTrait};
     use tokio::net::TcpStream;
 
-    use crate::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
+    use crate::testkit::{
+        get_available_port, supergraph_temp_file_with_subgraphs, ClientResponseExt, TestRouter,
+        TestSubgraphs,
+    };
 
     /// Graceful shutdown (`ntex`'s `Server::stop(true)`, triggered on `SIGTERM` in
     /// production) must let in-flight requests finish rather than dropping them.
@@ -149,5 +155,139 @@ mod graceful_shutdown_tests {
                  response, but it completed successfully"
             );
         }
+    }
+
+    /// Regression test for the class of bug fixed in #1445: `ntex-server` made graceful
+    /// signal handling opt-in (default off), but `ntex::web::HttpServer` has no way to opt
+    /// in, so a real `SIGTERM` silently force-drops in-flight requests and ignores
+    /// `http.shutdown_timeout`. The tests above all call `Server::stop(true)` directly,
+    /// which always requests a graceful stop regardless of that flag and so cannot catch
+    /// this — they exercise the drain mechanism, not the SIGTERM-to-graceful-flag wiring
+    /// that actually broke. This test spawns the real compiled router binary and sends it
+    /// an actual `SIGTERM`, exercising the same signal-handling path production relies on.
+    ///
+    /// Ignored by default: it requires the `hive_router` binary to be pre-built (see the
+    /// panic message below), which local `cargo test_e2e` runs don't do. CI's `e2e` job
+    /// builds it and runs with `--include-ignored` so this still runs there.
+    #[ntex::test]
+    #[ignore = "painful to run locally, but that's the only real way to test a real shutdown through SIGTERM"]
+    async fn should_gracefully_drain_in_flight_requests_on_real_sigterm() {
+        // This deliberately does NOT build the binary itself: invoking `cargo build` from
+        // inside a test spawned by `cargo nextest run` fights nextest's own build/process
+        // management (nested cargo invocations, and nextest's default 30s slow-test kill
+        // routinely fires before a cold build finishes). CI builds this binary as a
+        // separate step (see `.github/workflows/ci.yaml`); locally, build it once with:
+        //   cargo build -p hive-router --bin hive_router --features testing
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("e2e crate must be a workspace member");
+        let binary_path = workspace_root.join("target/debug/hive_router");
+        assert!(
+            binary_path.exists(),
+            "hive_router binary not found at {binary_path:?} — build it first with: \
+             cargo build -p hive-router --bin hive_router --features testing"
+        );
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_delay(Duration::from_secs(2))
+            .build()
+            .start()
+            .await;
+
+        let supergraph_path = concat!(env!("CARGO_MANIFEST_DIR"), "/supergraph.graphql");
+        let supergraph_temp_path =
+            supergraph_temp_file_with_subgraphs(supergraph_path, &subgraphs.url());
+
+        let port = get_available_port();
+
+        let mut child = tokio::process::Command::new(&binary_path)
+            .env("SUPERGRAPH_FILE_PATH", &supergraph_temp_path)
+            .env("PORT", port.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn hive_router subprocess");
+        let pid = child.id().expect("spawned child must have a pid");
+
+        let client = reqwest::Client::new();
+        let health_url = format!("http://127.0.0.1:{port}/health");
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                if let Ok(res) = client.get(&health_url).send().await {
+                    if res.status().is_success() {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        })
+        .await
+        .expect("hive_router subprocess did not become healthy in time");
+
+        let graphql_url = format!("http://127.0.0.1:{port}/graphql");
+        // Spawned so it actually starts executing concurrently: an un-awaited reqwest
+        // future does nothing on its own.
+        let request_handle = tokio::spawn(async move {
+            reqwest::Client::new()
+                .post(graphql_url)
+                .header("content-type", "application/json")
+                .header("accept", "application/graphql-response+json")
+                .json(&json!({ "query": "{ topProducts { name price } }" }))
+                .send()
+                .await
+        });
+
+        // Give the request a moment to actually reach the slow subgraph call before SIGTERM.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let sigterm_sent = Instant::now();
+        let kill_status = std::process::Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status()
+            .expect("failed to send SIGTERM to the hive_router subprocess");
+        assert!(kill_status.success(), "kill -TERM failed");
+
+        let exit_status = tokio::time::timeout(Duration::from_secs(15), child.wait())
+            .await
+            .expect("hive_router subprocess did not exit after SIGTERM")
+            .expect("failed to wait on hive_router subprocess");
+        let exit_elapsed = sigterm_sent.elapsed();
+
+        // The clearest signal of the regression from #1445's own measurements: on the
+        // broken ntex-server, the process exits well under a second after SIGTERM
+        // (a forced, non-graceful stop). A graceful stop stays alive until the 2s
+        // in-flight request finishes draining.
+        assert!(
+            exit_elapsed >= Duration::from_millis(1500),
+            "expected the process to stay alive until the 2s in-flight request finished \
+             draining, but it exited only {exit_elapsed:?} after SIGTERM \
+             (a near-instant exit means SIGTERM force-dropped the connection instead of \
+             gracefully draining it)"
+        );
+        assert!(
+            exit_status.success(),
+            "expected hive_router to exit cleanly after a graceful SIGTERM shutdown, got {exit_status:?}"
+        );
+
+        let res = tokio::time::timeout(Duration::from_secs(5), request_handle)
+            .await
+            .expect("timed out waiting for the in-flight request")
+            .expect("request task panicked")
+            .expect("request errored instead of completing");
+
+        assert!(
+            res.status().is_success(),
+            "expected the in-flight request to complete successfully despite SIGTERM \
+             arriving mid-flight, got status {}",
+            res.status()
+        );
+        let body: sonic_rs::Value =
+            sonic_rs::from_str(&res.text().await.expect("failed to read response body"))
+                .expect("failed to parse response body as JSON");
+        assert!(
+            body["data"]["topProducts"].is_array(),
+            "expected a full GraphQL response, got: {body:?}"
+        );
     }
 }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -35,6 +35,8 @@ mod extensions_propagation;
 #[cfg(test)]
 mod file_supergraph;
 #[cfg(test)]
+mod graceful_shutdown;
+#[cfg(test)]
 mod header_limit;
 #[cfg(test)]
 mod header_propagation;

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -591,6 +591,7 @@ pub struct TestRouterBuilder {
     subgraphs_url: Option<String>,
     port: u16,
     listener: Option<std::net::TcpListener>,
+    real_http_server: bool,
 }
 
 impl TestRouterBuilder {
@@ -603,6 +604,7 @@ impl TestRouterBuilder {
             subgraphs_url: None,
             port: 0,
             listener: None,
+            real_http_server: false,
         }
     }
 
@@ -653,6 +655,18 @@ impl TestRouterBuilder {
 
     pub fn skip_wait_for_ready_on_start(mut self) -> Self {
         self.wait_for_ready_on_start = false;
+        self
+    }
+
+    /// Binds the router with the real `ntex::web::HttpServer` (the same server type
+    /// production uses) instead of the lightweight `ntex::web::test` server used by default.
+    ///
+    /// The `test` server always uses ntex's internal default graceful-shutdown timeout and
+    /// has no way to override it, so it can't be used to verify that the router's configured
+    /// `http.shutdown_timeout` is actually honored. Use [`TestRouter::real_serv`] to interact
+    /// with the router started this way.
+    pub fn with_real_http_server(mut self) -> Self {
+        self.real_http_server = true;
         self
     }
 
@@ -707,6 +721,7 @@ impl TestRouterBuilder {
             listener: self.listener,
             config: Some(config.into_static()),
             plugins: self.plugins,
+            real_http_server: self.real_http_server,
             handle: None,
             _hold_until_drop,
             _state: PhantomData,
@@ -720,10 +735,34 @@ impl Default for TestRouterBuilder {
     }
 }
 
+/// A router bound with the real `ntex::web::HttpServer`, produced by
+/// [`TestRouterBuilder::with_real_http_server`]. Unlike [`test::TestServer`], this actually
+/// honors the router's configured `http.shutdown_timeout` on [`RealHttpServer::stop`].
+pub struct RealHttpServer {
+    addr: SocketAddr,
+    server: ntex::server::Server,
+}
+
+impl RealHttpServer {
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("http://{}{path}", self.addr)
+    }
+
+    /// Gracefully stops the server: in-flight requests are given up to the configured
+    /// `http.shutdown_timeout` to finish before being force-dropped.
+    pub async fn stop(&self) {
+        self.server.stop(true).await;
+    }
+}
+
 struct TestRouterHandle {
     schema_state: Arc<SchemaState>,
     shared_state: Arc<RouterSharedState>,
-    serv: test::TestServer,
+    serv: ntex::util::Either<test::TestServer, RealHttpServer>,
     bg_tasks_manager: BackgroundTasksManager,
     telemetry: Telemetry,
 }
@@ -801,6 +840,7 @@ pub struct TestRouter<State> {
     listener: Option<std::net::TcpListener>,
     config: Option<&'static HiveRouterConfig>,
     plugins: Vec<Box<dyn Fn(PluginRegistry) -> PluginRegistry>>,
+    real_http_server: bool,
     handle: Option<TestRouterHandle>,
     _hold_until_drop: Vec<Box<dyn Any>>,
     _state: PhantomData<State>,
@@ -927,20 +967,7 @@ impl TestRouter<Built> {
             ))
             .build();
 
-        let mut serv_config = test::config().server_cfg(srv_cfg).listener(serv_listener);
-        if let Some(tls_config) = serv_shared_state
-            .router_config
-            .traffic_shaping
-            .router
-            .tls
-            .as_ref()
-        {
-            let rustls_config = hive_router::tls::build_rustls_config(tls_config)
-                .expect("failed to build rustls config for test router");
-            serv_config = serv_config.rustls(rustls_config);
-        }
-
-        let serv = test::server_with(serv_config, move || {
+        let app_factory = move || {
             let shared_state = serv_shared_state.clone();
             let schema_state = serv_schema_state.clone();
             let paths = serv_paths.clone();
@@ -979,8 +1006,44 @@ impl TestRouter<Built> {
                         }
                     })
             }
-        })
-        .await;
+        };
+
+        // the `real_http_server` path binds the same production `web::HttpServer` used by
+        // `bin/router`, so it actually applies `config.shutdown_timeout()`; the `test` server
+        // below always uses ntex's internal default and ignores that config value.
+        let serv = if self.real_http_server {
+            // `.workers(1)` matches the `test` server's default: with the platform's full
+            // worker count, ntex's per-worker connection accounting loses track of the one
+            // in-flight connection during a graceful stop, so the client hangs forever
+            // instead of seeing the connection force-dropped at the shutdown timeout.
+            let server = web::HttpServer::new(app_factory)
+                .config(srv_cfg)
+                .shutdown_timeout(config.shutdown_timeout())
+                .workers(1)
+                .listen(serv_listener)
+                .expect("failed to bind real http server for test router")
+                .run();
+
+            ntex::util::Either::Right(RealHttpServer {
+                addr: serv_local_addr,
+                server,
+            })
+        } else {
+            let mut serv_config = test::config().server_cfg(srv_cfg).listener(serv_listener);
+            if let Some(tls_config) = shared_state
+                .router_config
+                .traffic_shaping
+                .router
+                .tls
+                .as_ref()
+            {
+                let rustls_config = hive_router::tls::build_rustls_config(tls_config)
+                    .expect("failed to build rustls config for test router");
+                serv_config = serv_config.rustls(rustls_config);
+            }
+
+            ntex::util::Either::Left(test::server_with(serv_config, app_factory).await)
+        };
 
         let mut hold_until_drop = self._hold_until_drop;
         hold_until_drop.push(Box::new(subscription_guard));
@@ -1001,6 +1064,7 @@ impl TestRouter<Built> {
             }),
             config: self.config,
             plugins: self.plugins,
+            real_http_server: self.real_http_server,
             _hold_until_drop: hold_until_drop,
             _state: PhantomData,
         }
@@ -1033,7 +1097,24 @@ impl TestRouter<Started> {
     }
 
     pub fn serv(&self) -> &test::TestServer {
-        &self.handle.as_ref().unwrap().serv
+        self.handle
+            .as_ref()
+            .unwrap()
+            .serv
+            .as_ref()
+            .left()
+            .expect("serv() is unavailable when built with TestRouterBuilder::with_real_http_server(); use real_serv() instead")
+    }
+
+    /// Only available when built with [`TestRouterBuilder::with_real_http_server`].
+    pub fn real_serv(&self) -> &RealHttpServer {
+        self.handle
+            .as_ref()
+            .unwrap()
+            .serv
+            .as_ref()
+            .right()
+            .expect("real_serv() requires TestRouterBuilder::with_real_http_server()")
     }
 
     /// Waits for the /health endpoint to return 200 OK, with an optional timeout (defaults to 5 seconds).
@@ -1124,7 +1205,7 @@ impl TestRouter<Started> {
     }
 
     pub async fn ws(&self) -> WsConnection<Sealed> {
-        let url = self.handle.as_ref().unwrap().serv.url(
+        let url = self.serv().url(
             self.websocket_path
                 .as_deref()
                 .expect("Websocket path not set"),


### PR DESCRIPTION
Tested the following:

- Used `ntex` test setup to test that in-flight requests are cancelled after the correct timing 
- Used a real, running HTTP server, in order to test that in-flight requests are really cancelled 
- Used a real `SIGTERM` to the process in order to confirm that `ntex` regression is fixed
- Upgraded `ntex` to latest to get the upstream fix 

Related https://github.com/graphql-hive/router/pull/1445  