### PR TITLE
feat(router): added `hive.router.request_dedupe.joined_total` metric counter

### DIFF
--- a/.changeset/request_dedupe_joined_metric.md
+++ b/.changeset/request_dedupe_joined_metric.md
@@ -1,0 +1,15 @@
+---
+hive-router: minor
+---
+
+# Add `hive.router.request_dedupe.joined_total` counter metric
+
+Adds observability for the router's inbound request deduplication (`traffic_shaping.router.dedupe`).
+
+| Metric                                      | Labels | Unit        | Description                                                                                     |
+| -------------------------------------------- | ------ | ----------- | ------------------------------------------------------------------------------------------------- |
+| `hive.router.request_dedupe.joined_total`   | none   | `{request}` | Number of inbound requests that joined an already in-flight deduplicated request instead of executing their own |
+
+The counter increments once per client request (HTTP or WebSocket) that was coalesced into an in-flight leader request. It stays at zero when router-level dedupe is disabled, or when every request executes independently.
+
+Closes https://github.com/graphql-hive/router/issues/1469

--- a/.changeset/request_dedupe_joined_metric.md
+++ b/.changeset/request_dedupe_joined_metric.md
@@ -6,10 +6,10 @@ hive-router: minor
 
 Adds observability for the router's inbound request deduplication (`traffic_shaping.router.dedupe`).
 
-| Metric                                      | Labels | Unit        | Description                                                                                     |
-| -------------------------------------------- | ------ | ----------- | ------------------------------------------------------------------------------------------------- |
-| `hive.router.request_dedupe.joined_total`   | none   | `{request}` | Number of inbound requests that joined an already in-flight deduplicated request instead of executing their own |
+| Metric                                      | Labels                   | Unit        | Description                                                                                     |
+| -------------------------------------------- | ------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `hive.router.request_dedupe.joined_total`   | `graphql.operation.type` | `{request}` | Number of inbound requests that joined an already in-flight deduplicated request instead of executing their own |
 
-The counter increments once per client request (HTTP or WebSocket) that was coalesced into an in-flight leader request. It stays at zero when router-level dedupe is disabled, or when every request executes independently.
+The counter increments once per client request (HTTP or WebSocket) that was coalesced into an in-flight leader request, labeled by `graphql.operation.type` (`query` or `subscription`, the only operation kinds eligible for inbound dedupe). It stays at zero when router-level dedupe is disabled, or when every request executes independently.
 
 Closes https://github.com/graphql-hive/router/issues/1469

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -512,7 +512,11 @@ pub async fn graphql_request_handler(
                     .await?
             };
             if role == InFlightRole::Joiner {
-                shared_state.telemetry_context.metrics.request_dedupe.record_joined();
+                shared_state
+                    .telemetry_context
+                    .metrics
+                    .request_dedupe
+                    .record_joined(normalize_payload.operation_kind.as_str());
             }
             Arc::unwrap_or_clone(shared_response)
         } else {

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -16,6 +16,7 @@ use crate::{
             plan::{CoerceVariablesPayload, PlanExecutionOutput, QueryPlanExecutionResult},
         },
         executors::common::{ConnectionFingerprint, InboundRequestFingerprint},
+        executors::inflight::InFlightRole,
         headers::response::{ResponseHeaderAggregator, ResponseHeaderSink},
         hooks::{
             on_graphql_analysis::{OnGraphqlAnalysisHookPayload, OnGraphqlAnalysisHookResult},
@@ -497,7 +498,7 @@ pub async fn graphql_request_handler(
         };
 
         let shared_response = if let Some(fp) = fingerprint {
-            let (shared_response, _role) = if is_subscription {
+            let (shared_response, role) = if is_subscription {
                 shared_state
                     .in_flight_requests
                     .claim(fp)
@@ -510,6 +511,9 @@ pub async fn graphql_request_handler(
                     .get_or_try_init(|| exec(None))
                     .await?
             };
+            if role == InFlightRole::Joiner {
+                shared_state.telemetry_context.metrics.request_dedupe.record_joined();
+            }
             Arc::unwrap_or_clone(shared_response)
         } else {
             exec(None).await?

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -21,6 +21,7 @@ use tracing::{debug, error, trace, warn, Instrument};
 use crate::executor::executors::graphql_transport_ws::{
     ClientMessage, CloseCode, ConnectionInitPayload, ServerMessage, WS_SUBPROTOCOL,
 };
+use crate::executor::executors::inflight::InFlightRole;
 use crate::executor::executors::websocket_common::{
     handshake_timeout, heartbeat, parse_frame_to_text, FrameNotParsedToText, WsState,
 };
@@ -639,7 +640,7 @@ async fn handle_text_frame(
                               .get_or_try_init(|| exec(None))
                               .await
                       };
-                      let (shared_response, _role) = match result {
+                      let (shared_response, role) = match result {
                           Ok(result) => result,
                           Err(PipelineError::Client(ClientPipelineError::JwtError(err))) => {
                               let _ = sink.send(err.clone().into_server_message(&id, shared_state)).await;
@@ -649,6 +650,9 @@ async fn handle_text_frame(
                           },
                           Err(err) => return Some(err.into_server_message(&id, shared_state)),
                       };
+                      if role == InFlightRole::Joiner {
+                          shared_state.telemetry_context.metrics.request_dedupe.record_joined();
+                      }
                       Arc::unwrap_or_clone(shared_response)
                   } else {
                       match exec(None).await {

--- a/bin/router/src/pipeline/websocket_server.rs
+++ b/bin/router/src/pipeline/websocket_server.rs
@@ -651,7 +651,11 @@ async fn handle_text_frame(
                           Err(err) => return Some(err.into_server_message(&id, shared_state)),
                       };
                       if role == InFlightRole::Joiner {
-                          shared_state.telemetry_context.metrics.request_dedupe.record_joined();
+                          shared_state
+                              .telemetry_context
+                              .metrics
+                              .request_dedupe
+                              .record_joined(normalize_payload.operation_kind.as_str());
                       }
                       Arc::unwrap_or_clone(shared_response)
                   } else {

--- a/bin/router/src/telemetry/metrics/catalog.rs
+++ b/bin/router/src/telemetry/metrics/catalog.rs
@@ -467,7 +467,10 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     ),
     (names::PERSISTED_DOCUMENTS_STORAGE_FAILURES_TOTAL, &[]),
     (names::PERSISTED_DOCUMENTS_EXTRACT_MISSING_ID_TOTAL, &[]),
-    (names::REQUEST_DEDUPE_JOINED_TOTAL, &[]),
+    (
+        names::REQUEST_DEDUPE_JOINED_TOTAL,
+        &[labels::GRAPHQL_OPERATION_TYPE],
+    ),
     (
         names::COPROCESSOR_REQUESTS_TOTAL,
         &[labels::COPROCESSOR_STAGE],

--- a/bin/router/src/telemetry/metrics/catalog.rs
+++ b/bin/router/src/telemetry/metrics/catalog.rs
@@ -193,6 +193,7 @@ pub mod names {
         "hive.router.persisted_documents.storage.failures_total";
     pub const PERSISTED_DOCUMENTS_EXTRACT_MISSING_ID_TOTAL: &str =
         "hive.router.persisted_documents.extract.missing_id_total";
+    pub const REQUEST_DEDUPE_JOINED_TOTAL: &str = "hive.router.request_dedupe.joined_total";
     pub const COPROCESSOR_REQUESTS_TOTAL: &str = "hive.router.coprocessor.requests_total";
     pub const COPROCESSOR_DURATION: &str = "hive.router.coprocessor.duration";
     pub const COPROCESSOR_ERRORS_TOTAL: &str = "hive.router.coprocessor.errors_total";
@@ -466,6 +467,7 @@ pub(crate) const METRIC_SPECS: &[(&str, &[&str])] = &[
     ),
     (names::PERSISTED_DOCUMENTS_STORAGE_FAILURES_TOTAL, &[]),
     (names::PERSISTED_DOCUMENTS_EXTRACT_MISSING_ID_TOTAL, &[]),
+    (names::REQUEST_DEDUPE_JOINED_TOTAL, &[]),
     (
         names::COPROCESSOR_REQUESTS_TOTAL,
         &[labels::COPROCESSOR_STAGE],

--- a/bin/router/src/telemetry/metrics/mod.rs
+++ b/bin/router/src/telemetry/metrics/mod.rs
@@ -8,6 +8,7 @@ pub mod graphql_metrics;
 pub mod http_client_metrics;
 pub mod http_server_metrics;
 pub mod persisted_documents_metrics;
+pub mod request_dedupe_metrics;
 pub mod setup;
 pub mod subscription_metrics;
 pub mod supergraph_metrics;
@@ -24,6 +25,7 @@ use crate::telemetry::metrics::graphql_metrics::GraphQLMetrics;
 use crate::telemetry::metrics::http_client_metrics::HttpClientMetrics;
 use crate::telemetry::metrics::http_server_metrics::HttpServerMetrics;
 use crate::telemetry::metrics::persisted_documents_metrics::PersistedDocumentsMetrics;
+use crate::telemetry::metrics::request_dedupe_metrics::RequestDedupeMetrics;
 use crate::telemetry::metrics::subscription_metrics::SubscriptionMetrics;
 use crate::telemetry::metrics::supergraph_metrics::SupergraphMetrics;
 use crate::telemetry::metrics::websocket_pool_metrics::WebSocketPoolMetrics;
@@ -40,6 +42,7 @@ pub struct Metrics {
     pub coprocessor: CoprocessorMetrics,
     pub subscriptions: SubscriptionMetrics,
     pub websocket_pool: WebSocketPoolMetrics,
+    pub request_dedupe: RequestDedupeMetrics,
 }
 
 impl Metrics {
@@ -56,6 +59,7 @@ impl Metrics {
             coprocessor: CoprocessorMetrics::new(meter),
             subscriptions: SubscriptionMetrics::new(meter),
             websocket_pool: WebSocketPoolMetrics::new(meter),
+            request_dedupe: RequestDedupeMetrics::new(meter),
         }
     }
 }

--- a/bin/router/src/telemetry/metrics/request_dedupe_metrics.rs
+++ b/bin/router/src/telemetry/metrics/request_dedupe_metrics.rs
@@ -1,8 +1,11 @@
-use opentelemetry::metrics::{Counter, Meter};
+use opentelemetry::{
+    metrics::{Counter, Meter},
+    KeyValue,
+};
 
 #[cfg(debug_assertions)]
 use crate::telemetry::metrics::catalog::debug_assert_attrs;
-use crate::telemetry::metrics::catalog::names;
+use crate::telemetry::metrics::catalog::{labels, names};
 
 #[derive(Clone)]
 pub struct RequestDedupeMetrics {
@@ -26,13 +29,18 @@ impl RequestDedupeMetrics {
     }
 
     /// Records that an inbound request joined an already in-flight deduplicated request.
-    pub fn record_joined(&self) {
+    pub fn record_joined(&self, operation_type: &str) {
         let Some(counter) = &self.joined_total else {
             return;
         };
 
+        let attributes = [KeyValue::new(
+            labels::GRAPHQL_OPERATION_TYPE,
+            operation_type.to_string(),
+        )];
+
         #[cfg(debug_assertions)]
-        debug_assert_attrs(names::REQUEST_DEDUPE_JOINED_TOTAL, &[]);
-        counter.add(1, &[]);
+        debug_assert_attrs(names::REQUEST_DEDUPE_JOINED_TOTAL, &attributes);
+        counter.add(1, &attributes);
     }
 }

--- a/bin/router/src/telemetry/metrics/request_dedupe_metrics.rs
+++ b/bin/router/src/telemetry/metrics/request_dedupe_metrics.rs
@@ -1,0 +1,38 @@
+use opentelemetry::metrics::{Counter, Meter};
+
+#[cfg(debug_assertions)]
+use crate::telemetry::metrics::catalog::debug_assert_attrs;
+use crate::telemetry::metrics::catalog::names;
+
+#[derive(Clone)]
+pub struct RequestDedupeMetrics {
+    joined_total: Option<Counter<u64>>,
+}
+
+impl RequestDedupeMetrics {
+    pub fn new(meter: Option<&Meter>) -> Self {
+        let joined_total = meter.map(|meter| {
+            meter
+                .u64_counter(names::REQUEST_DEDUPE_JOINED_TOTAL)
+                .with_unit("{request}")
+                .with_description(
+                    "Number of inbound requests that were deduplicated by joining an \
+                     already in-flight request instead of executing their own.",
+                )
+                .build()
+        });
+
+        Self { joined_total }
+    }
+
+    /// Records that an inbound request joined an already in-flight deduplicated request.
+    pub fn record_joined(&self) {
+        let Some(counter) = &self.joined_total else {
+            return;
+        };
+
+        #[cfg(debug_assertions)]
+        debug_assert_attrs(names::REQUEST_DEDUPE_JOINED_TOTAL, &[]);
+        counter.add(1, &[]);
+    }
+}

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 use std::time::Duration;
 
+use futures::{stream::FuturesUnordered, StreamExt};
+
 use crate::testkit::{
     otel::{CollectedMetrics, OtlpCollector},
     ClientResponseExt, TestRouter, TestSubgraphs,
@@ -1429,5 +1431,175 @@ async fn issue_1389_test_otlp_counter_names_have_single_total_suffix() {
     assert!(
         !metrics.has_counter(&doubled_name, &attrs),
         "OTLP counter names must not double the `_total` suffix, but found {doubled_name}"
+    );
+}
+
+/// Ensures `request_dedupe.joined_total` increments once per inbound request that joined
+/// an already in-flight deduplicated request, instead of executing its own.
+#[ntex::test]
+async fn test_otlp_request_dedupe_joined_total_counter_increments_when_requests_join_inflight() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+    let subgraphs = TestSubgraphs::builder()
+        .with_delay(Duration::from_millis(100))
+        .build()
+        .start()
+        .await;
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {}
+
+          traffic_shaping:
+            all:
+              dedupe_enabled: false
+            router:
+              dedupe:
+                enabled: true
+
+          telemetry:
+            metrics:
+              exporters:
+                - kind: otlp
+                  endpoint: {}
+                  protocol: http
+                  interval: 30ms
+                  max_export_timeout: 2s
+      "#,
+            supergraph_path.to_str().unwrap(),
+            otlp_endpoint
+        ))
+        .build()
+        .start()
+        .await;
+
+    let request_count = 12;
+    let mut requests = FuturesUnordered::new();
+
+    for _ in 0..request_count {
+        requests.push(router.send_graphql_request(
+            r#"
+            {
+                topProducts {
+                    name
+                    price
+                }
+            }
+            "#,
+            None,
+            None,
+        ));
+    }
+
+    while let Some(response) = requests.next().await {
+        assert!(response.status().is_success(), "Expected 200 OK");
+    }
+
+    wait_for_metrics_export().await;
+
+    let metrics = otlp_collector.metrics_view().await;
+    let no_attrs: [(&str, &str); 0] = [];
+
+    assert!(
+        metrics.has_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &no_attrs),
+        "Expected {} to be recorded when requests join an in-flight request",
+        names::REQUEST_DEDUPE_JOINED_TOTAL
+    );
+
+    let joined_total = metrics.latest_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &no_attrs);
+    assert!(
+        joined_total > 0.0 && joined_total < request_count as f64,
+        "expected between 1 and {} joined requests, got {joined_total}",
+        request_count - 1
+    );
+}
+
+/// Ensures `request_dedupe.joined_total` is never recorded when inbound dedupe is disabled,
+/// even when identical requests are sent concurrently.
+#[ntex::test]
+async fn test_otlp_request_dedupe_joined_total_absent_when_dedupe_disabled() {
+    let supergraph_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("supergraph.graphql");
+
+    let otlp_collector = OtlpCollector::start()
+        .await
+        .expect("Failed to start OTLP collector");
+    let otlp_endpoint = otlp_collector.http_metrics_endpoint();
+
+    let subgraphs = TestSubgraphs::builder()
+        .with_delay(Duration::from_millis(100))
+        .build()
+        .start()
+        .await;
+
+    let router = TestRouter::builder()
+        .with_subgraphs(&subgraphs)
+        .inline_config(format!(
+            r#"
+          supergraph:
+            source: file
+            path: {}
+
+          traffic_shaping:
+            all:
+              dedupe_enabled: false
+
+          telemetry:
+            metrics:
+              exporters:
+                - kind: otlp
+                  endpoint: {}
+                  protocol: http
+                  interval: 30ms
+                  max_export_timeout: 2s
+      "#,
+            supergraph_path.to_str().unwrap(),
+            otlp_endpoint
+        ))
+        .build()
+        .start()
+        .await;
+
+    let request_count = 12;
+    let mut requests = FuturesUnordered::new();
+
+    for _ in 0..request_count {
+        requests.push(router.send_graphql_request(
+            r#"
+            {
+                topProducts {
+                    name
+                    price
+                }
+            }
+            "#,
+            None,
+            None,
+        ));
+    }
+
+    while let Some(response) = requests.next().await {
+        assert!(response.status().is_success(), "Expected 200 OK");
+    }
+
+    wait_for_metrics_export().await;
+
+    let metrics = otlp_collector.metrics_view().await;
+    let no_attrs: [(&str, &str); 0] = [];
+
+    assert!(
+        !metrics.has_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &no_attrs),
+        "Expected {} to be absent when router-level dedupe is disabled",
+        names::REQUEST_DEDUPE_JOINED_TOTAL
     );
 }

--- a/e2e/src/telemetry/metrics.rs
+++ b/e2e/src/telemetry/metrics.rs
@@ -1508,15 +1508,15 @@ async fn test_otlp_request_dedupe_joined_total_counter_increments_when_requests_
     wait_for_metrics_export().await;
 
     let metrics = otlp_collector.metrics_view().await;
-    let no_attrs: [(&str, &str); 0] = [];
+    let query_attrs = [(labels::GRAPHQL_OPERATION_TYPE, "query")];
 
     assert!(
-        metrics.has_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &no_attrs),
-        "Expected {} to be recorded when requests join an in-flight request",
+        metrics.has_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &query_attrs),
+        "Expected {} with graphql.operation.type=query to be recorded when requests join an in-flight request",
         names::REQUEST_DEDUPE_JOINED_TOTAL
     );
 
-    let joined_total = metrics.latest_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &no_attrs);
+    let joined_total = metrics.latest_counter(names::REQUEST_DEDUPE_JOINED_TOTAL, &query_attrs);
     assert!(
         joined_total > 0.0 && joined_total < request_count as f64,
         "expected between 1 and {} joined requests, got {joined_total}",


### PR DESCRIPTION
Related: https://github.com/graphql-hive/router/issues/1469 

Adds observability for the router's inbound request deduplication (`traffic_shaping.router.dedupe`).

| Metric                                      | Labels                   | Unit        | Description                                                                                     |
| -------------------------------------------- | ------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
| `hive.router.request_dedupe.joined_total`   | `graphql.operation.type` | `{request}` | Number of inbound requests that joined an already in-flight deduplicated request instead of executing their own |

The counter increments once per client request (HTTP or WebSocket) that was coalesced into an in-flight leader request, labeled by `graphql.operation.type` (`query` or `subscription`, the only operation kinds eligible for inbound dedupe). It stays at zero when router-level dedupe is disabled, or when every request executes independently.

