### PR TITLE
fix(router): `@policy` decisions through plugin-system

### DIFF
--- a/.changeset/plugin_policy_decisions_before_enforcement.md
+++ b/.changeset/plugin_policy_decisions_before_enforcement.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+Fix: custom-plugin support for `@policy` decisions
+
+Added support for making `@policy` decisions in custom-plugin `on_graphql_analysis` hooks. 
+
+Plugin `on_graphql_analysis` hooks now run before authorization enforcement, the same way a coprocessor already did, so a plugin can decide `@policy` grants just like a coprocessor can.

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -846,31 +846,9 @@ pub async fn execute_pipeline<'exec>(
         }
     }
 
-    // Enforcement runs after the analysis stage so that `@policy` decisions taken by a
-    // coprocessor are already available in the request context.
-    let granted_policies = request_context
-        .read_lock()?
-        .authorization
-        .required_policies
-        .clone()
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|(policy, granted)| granted.unwrap_or(false).then_some(policy))
-        .collect();
-
-    let (mut normalize_payload, authorization_errors) = enforce_operation_authorization(
-        shared_state.router_config,
-        &normalize_payload,
-        &supergraph.runtime.authorization,
-        &supergraph.snapshot.metadata,
-        &variable_payload,
-        &client_request_details.jwt,
-        &granted_policies,
-    )?;
-
     let client_request_details = Arc::new(client_request_details.freeze());
 
-    let mut plugin_graphql_errors = Vec::new();
+    let mut plugin_filter_output = None;
     if let Some(plugin_req_state) = &plugin_req_state {
         let mut analysis_payload = OnGraphqlAnalysisHookPayload::new(
             &plugin_req_state.router_http_request,
@@ -894,7 +872,33 @@ pub async fn execute_pipeline<'exec>(
             }
         }
 
-        let filter_output = analysis_payload.run_operation_filters()?;
+        plugin_filter_output = Some(analysis_payload.run_operation_filters()?);
+    }
+
+    // Authorization enforcement runs after the analysis stage so that `@policy` decisions taken by a
+    // coprocessor _or_ a plugin are already available in the request context
+    let granted_policies = request_context
+        .read_lock()?
+        .authorization
+        .required_policies
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(policy, granted)| granted.unwrap_or(false).then_some(policy))
+        .collect();
+
+    let (mut normalize_payload, authorization_errors) = enforce_operation_authorization(
+        shared_state.router_config,
+        &normalize_payload,
+        &supergraph.runtime.authorization,
+        &supergraph.snapshot.metadata,
+        &variable_payload,
+        &client_request_details.jwt,
+        &granted_policies,
+    )?;
+
+    let mut plugin_graphql_errors = Vec::new();
+    if let Some(filter_output) = plugin_filter_output {
         if filter_output.has_changes() {
             (normalize_payload, plugin_graphql_errors) = filter_output.apply_to(&normalize_payload);
         }

--- a/plugin_examples/Cargo.lock
+++ b/plugin_examples/Cargo.lock
@@ -1524,6 +1524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom-policy-plugin-example"
+version = "0.0.1"
+dependencies = [
+ "e2e",
+ "hive-router",
+ "http",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,7 +2698,7 @@ dependencies = [
  "rand 0.10.2",
  "recloser",
  "regex-automata",
- "regress",
+ "regress 0.12.0",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "reqwest-retry",
@@ -2709,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "hive-router"
-version = "0.2.2"
+version = "0.2.5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4168,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-error"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229806c94be0c192bde46633bd044d11e3d7f3e5c5ee32aa3f430c918e99f746"
+checksum = "37be4fd659180da86ea43a9c167a1e726ee43db154a346eefddea89261b4d4a5"
 dependencies = [
  "backtrace",
  "foldhash 0.2.0",
@@ -4270,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-net"
-version = "3.14.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace516cc45d412d33165041edcb19048119589498f56fba69baf71ceba920af1"
+checksum = "6a7f6c9b66b79ea7b81d95bed1de8299343a7d7217ceb2a1488e260b728ba76d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4324,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "3.16.1"
+version = "3.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3692fad48ebe4431289a51807dc08bd3205369ce9f1ab10d300fe12cccefd5c5"
+checksum = "aff50c4365282675402f680bc01d9d3b2f190cc7687947d251a8c31b80d6d11d"
 dependencies = [
  "async-channel",
  "async-task",
@@ -4339,8 +4348,8 @@ dependencies = [
  "futures-timer",
  "libc",
  "log",
+ "nix 0.31.3",
  "ntex-error",
- "ntex-service",
  "oneshot",
  "parking_lot",
  "scoped-tls",
@@ -4351,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-server"
-version = "3.10.4"
+version = "3.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70eb9db7d9495585b82d8b734037eeeaee2778ab83c6a8ed8118df97b046837"
+checksum = "a0f3a1c0e5cd9c04d158bc954b3ed43ba3a2e1b19174112876e2af7f47851171"
 dependencies = [
  "async-channel",
  "atomic-waker",
@@ -5826,6 +5835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
 dependencies = [
  "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "regress"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32eef8b209c3c1c15dbad02c1f30f9539f00dc7253e0cbcdaae442a50a09d7c1"
+dependencies = [
  "memchr",
 ]
 
@@ -7837,7 +7855,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "regress",
+ "regress 0.11.1",
  "schemars 0.8.22",
  "semver",
  "serde",

--- a/plugin_examples/Cargo.toml
+++ b/plugin_examples/Cargo.toml
@@ -23,7 +23,8 @@ members = [
   "replace_schema",
   "field_nulling",
   "custom_logger_correlation",
-  "dedupe_partition"
+  "dedupe_partition",
+  "custom_policy"
 ]
 
 [workspace.dependencies]

--- a/plugin_examples/custom_policy/Cargo.toml
+++ b/plugin_examples/custom_policy/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "custom-policy-plugin-example"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+authors = ["The Guild"]
+repository = "https://github.com/graphql-hive/router"
+homepage = "https://github.com/graphql-hive/router"
+publish = false
+
+[lib]
+
+[[bin]]
+name = "hive_router_with_custom_policy"
+path = "src/main.rs"
+
+[dependencies]
+hive-router = { version = "*", path = "../../bin/router" }
+
+[dev-dependencies]
+e2e = { version = "*", path = "../../e2e" }
+http = { workspace = true }

--- a/plugin_examples/custom_policy/README.md
+++ b/plugin_examples/custom_policy/README.md
@@ -1,0 +1,105 @@
+# Custom `@policy` authorization
+
+Demonstrates deciding [`@policy`](https://the-guild.dev/graphql/hive/docs/router/security/policy)
+policies from a plugin instead of a coprocessor. Both go through the exact same mechanism: before
+the `graphql.analysis` stage runs, the router walks the operation and publishes every policy it
+depends on to the request context, as `hive::authorization::required_policies` - a map of
+`policy -> null`. Whoever answers the `graphql.analysis` stage - a
+[coprocessor](https://the-guild.dev/graphql/hive/docs/router/customizations/coprocessors/stages-and-protocol)
+over HTTP, or an in-process [plugin](https://the-guild.dev/graphql/hive/docs/router/customizations/plugin-system)
+like this one - decides which of them are granted by overwriting entries with `true`/`false`.
+Anything left `null`, or missing from the answer entirely, is denied and the field it protects is
+filtered out (or the whole operation rejected, depending on `authorization.directives.unauthorized.mode`).
+
+The example schema gates `Product.inStock` behind a `read_inventory` policy:
+
+```graphql
+inStock: Boolean @policy(policies: [["read_inventory"]])
+```
+
+The plugin grants every policy an operation depends on when the request carries an
+`x-user-role: admin` header, and denies all of them otherwise - see
+[`src/plugin.rs`](./src/plugin.rs).
+
+## How to run?
+
+```bash
+cargo run --package custom-policy-plugin-example
+```
+
+Then, without the header, `inStock` comes back `null` with an `UNAUTHORIZED_FIELD_OR_TYPE` error:
+
+```bash
+curl http://localhost:4000/graphql \
+  -H 'content-type: application/json' \
+  -d '{"query": "{ topProducts(first: 1) { upc inStock } }"}'
+```
+
+With the header, it resolves normally:
+
+```bash
+curl http://localhost:4000/graphql \
+  -H 'content-type: application/json' \
+  -H 'x-user-role: admin' \
+  -d '{"query": "{ topProducts(first: 1) { upc inStock } }"}'
+```
+
+## The plugin
+
+See the [`on_graphql_analysis` hook reference](https://the-guild.dev/graphql/hive/docs/router/customizations/plugin-system/hooks#on_graphql_analysis)
+for the full payload API.
+
+```rust
+async fn on_graphql_analysis<'exec>(
+    &'exec self,
+    payload: &mut OnGraphqlAnalysisHookPayload<'exec>,
+) -> OnGraphqlAnalysisHookResult {
+    let required_policies: Vec<String> = match payload.request_context.read() {
+        Ok(read) => read
+            .authorization()
+            .required_policies()
+            .map(|policies| policies.keys().cloned().collect())
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    };
+
+    if required_policies.is_empty() {
+        return OnGraphqlAnalysisHookResult::Proceed;
+    }
+
+    let is_admin = payload
+        .router_http_request
+        .headers
+        .get(ROLE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        == Some(ADMIN_ROLE);
+
+    if let Ok(mut write) = payload.request_context.write() {
+        let mut authorization = write.authorization();
+        for policy in required_policies {
+            authorization.set_policy_decision(policy, is_admin);
+        }
+    }
+
+    OnGraphqlAnalysisHookResult::Proceed
+}
+```
+
+A real plugin would decide each policy on its own merits (a permissions service, a database lookup,
+claims already present on the request context from an earlier hook) instead of granting every
+required policy to any admin - the router doesn't care how the decision is made, only that
+`set_policy_decision` gets called for the policies you want to grant before this hook returns.
+
+## Why a plugin instead of a coprocessor?
+
+Both are valid. A [coprocessor](https://the-guild.dev/graphql/hive/docs/router/customizations/coprocessors/stages-and-protocol)
+is a separate service, reachable over HTTP, useful when the authorization logic is shared across
+services or owned by a different team. A [plugin](https://the-guild.dev/graphql/hive/docs/router/customizations/plugin-system)
+runs in-process, with no network hop, and is a better fit when the router binary itself is already
+the right place to own the decision.
+
+## Further reading
+
+- [`@policy` directive](https://the-guild.dev/graphql/hive/docs/router/security/policy)
+- [Plugin system](https://the-guild.dev/graphql/hive/docs/router/customizations/plugin-system)
+- [`on_graphql_analysis` hook reference](https://the-guild.dev/graphql/hive/docs/router/customizations/plugin-system/hooks#on_graphql_analysis)

--- a/plugin_examples/custom_policy/router.config.yaml
+++ b/plugin_examples/custom_policy/router.config.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../router-config.schema.json
+supergraph:
+  source: file
+  path: supergraph.graphql
+plugins:
+  custom_policy:
+    enabled: true

--- a/plugin_examples/custom_policy/src/lib.rs
+++ b/plugin_examples/custom_policy/src/lib.rs
@@ -1,0 +1,6 @@
+// Needed because of ntex's way of defining middlewares
+#![recursion_limit = "256"]
+
+pub mod plugin;
+#[cfg(test)]
+pub mod test;

--- a/plugin_examples/custom_policy/src/main.rs
+++ b/plugin_examples/custom_policy/src/main.rs
@@ -1,0 +1,17 @@
+use hive_router::{
+    configure_global_allocator, error::RouterInitError, init_rustls_crypto_provider, ntex,
+    router_entrypoint, PluginRegistry, RouterGlobalAllocator,
+};
+
+configure_global_allocator!();
+
+#[hive_router::main]
+async fn main() -> Result<(), RouterInitError> {
+    init_rustls_crypto_provider();
+
+    router_entrypoint(
+        PluginRegistry::new()
+            .register::<custom_policy_plugin_example::plugin::CustomPolicyPlugin>(),
+    )
+    .await
+}

--- a/plugin_examples/custom_policy/src/plugin.rs
+++ b/plugin_examples/custom_policy/src/plugin.rs
@@ -1,0 +1,85 @@
+use hive_router::{
+    async_trait,
+    plugins::{
+        hooks::{
+            on_graphql_analysis::{OnGraphqlAnalysisHookPayload, OnGraphqlAnalysisHookResult},
+            on_plugin_init::{OnPluginInitPayload, OnPluginInitResult},
+        },
+        plugin_trait::RouterPlugin,
+    },
+    tracing,
+};
+
+/// The header this example reads its authorization decision from. A real
+/// plugin would look this up in a database, a permissions service, or decode
+/// it from a JWT claim instead of trusting a raw header.
+const ROLE_HEADER: &str = "x-user-role";
+const ADMIN_ROLE: &str = "admin";
+
+/// Demonstrates deciding `@policy` policies from a plugin instead of a
+/// coprocessor. Both share the exact same mechanism: the router publishes
+/// every policy the operation depends on to the `graphql.analysis` stage's
+/// request context, and whoever answers it - a coprocessor over HTTP, or a
+/// plugin like this one, in-process - decides which of them are granted.
+/// Anything left undecided is denied.
+pub struct CustomPolicyPlugin;
+
+#[async_trait]
+impl RouterPlugin for CustomPolicyPlugin {
+    type Config = ();
+
+    fn plugin_name() -> &'static str {
+        "custom_policy"
+    }
+
+    fn on_plugin_init(payload: OnPluginInitPayload<Self>) -> OnPluginInitResult<Self> {
+        payload.initialize_plugin(Self)
+    }
+
+    async fn on_graphql_analysis<'exec>(
+        &'exec self,
+        payload: &mut OnGraphqlAnalysisHookPayload<'exec>,
+    ) -> OnGraphqlAnalysisHookResult {
+        let required_policies: Vec<String> = match payload.request_context.read() {
+            Ok(read) => read
+                .authorization()
+                .required_policies()
+                .map(|policies| policies.keys().cloned().collect())
+                .unwrap_or_default(),
+            Err(err) => {
+                tracing::error!("custom_policy: failed to read request context: {err}");
+                Vec::new()
+            }
+        };
+
+        // Nothing in this operation is policy-gated - skip touching the
+        // context at all.
+        if required_policies.is_empty() {
+            return OnGraphqlAnalysisHookResult::Proceed;
+        }
+
+        let is_admin = payload
+            .router_http_request
+            .headers
+            .get(ROLE_HEADER)
+            .and_then(|value| value.to_str().ok())
+            == Some(ADMIN_ROLE);
+
+        match payload.request_context.write() {
+            Ok(mut write) => {
+                let mut authorization = write.authorization();
+                for policy in required_policies {
+                    // A real implementation would decide each policy on its
+                    // own merits (e.g. does this user's role grant *this*
+                    // specific policy). This example keeps it simple: the
+                    // `admin` role grants every policy the operation
+                    // requires, everyone else gets none of them.
+                    authorization.set_policy_decision(policy, is_admin);
+                }
+            }
+            Err(err) => tracing::error!("custom_policy: failed to write request context: {err}"),
+        }
+
+        OnGraphqlAnalysisHookResult::Proceed
+    }
+}

--- a/plugin_examples/custom_policy/src/test.rs
+++ b/plugin_examples/custom_policy/src/test.rs
@@ -1,0 +1,87 @@
+#[cfg(test)]
+mod tests {
+    use e2e::testkit::{ClientResponseExt, TestRouter, TestSubgraphs};
+    use hive_router::ntex;
+
+    /// No `x-user-role` header at all - `inStock` is denied and nulled, but
+    /// `upc`/`name` (not policy-gated) still come back, and the subgraph
+    /// still gets asked for whatever survived the filter.
+    #[ntex::test]
+    async fn denies_the_gated_field_without_the_admin_role() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("../plugin_examples/custom_policy/router.config.yaml")
+            .register_plugin::<crate::plugin::CustomPolicyPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let response = router
+            .send_graphql_request("{ topProducts(first: 1) { upc name inStock } }", None, None)
+            .await;
+
+        e2e::insta::assert_snapshot!(response.json_body_string_pretty_stable().await, @r#"
+        {
+          "data": {
+            "topProducts": [
+              {
+                "inStock": null,
+                "name": "Table",
+                "upc": "1"
+              }
+            ]
+          },
+          "errors": [
+            {
+              "extensions": {
+                "affectedPath": "topProducts.inStock",
+                "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+              },
+              "message": "Unauthorized field or type"
+            }
+          ]
+        }
+        "#);
+    }
+
+    /// `x-user-role: admin` grants every policy the operation depends on -
+    /// `inStock` comes back normally.
+    #[ntex::test]
+    async fn allows_the_gated_field_with_the_admin_role() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .file_config("../plugin_examples/custom_policy/router.config.yaml")
+            .register_plugin::<crate::plugin::CustomPolicyPlugin>()
+            .build()
+            .start()
+            .await;
+
+        let response = router
+            .send_graphql_request(
+                "{ topProducts(first: 1) { upc name inStock } }",
+                None,
+                e2e::some_header_map! {
+                    "x-user-role" => "admin"
+                },
+            )
+            .await;
+
+        e2e::insta::assert_snapshot!(response.json_body_string_pretty_stable().await, @r#"
+        {
+          "data": {
+            "topProducts": [
+              {
+                "inStock": true,
+                "name": "Table",
+                "upc": "1"
+              }
+            ]
+          }
+        }
+        "#);
+    }
+}

--- a/plugin_examples/custom_policy/supergraph.graphql
+++ b/plugin_examples/custom_policy/supergraph.graphql
@@ -1,0 +1,85 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+directive @policy(
+  policies: [[policy__Policy!]!]!
+) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+scalar join__FieldSet
+scalar link__Import
+scalar policy__Policy
+
+enum join__Graph {
+  INVENTORY @join__graph(name: "inventory", url: "http://0.0.0.0:4200/inventory")
+  PRODUCTS @join__graph(name: "products", url: "http://0.0.0.0:4200/products")
+}
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc") {
+  upc: String!
+  name: String @join__field(graph: PRODUCTS)
+  # Only visible to requests the plugin decides to grant `read_inventory` to.
+  inStock: Boolean
+    @join__field(graph: INVENTORY)
+    @policy(policies: [["read_inventory"]])
+}
+
+type Query @join__type(graph: PRODUCTS) {
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}


### PR DESCRIPTION
Added support for making `@policy` decisions in custom-plugin `on_graphql_analysis` hooks. 

Plugin `on_graphql_analysis` hooks now run before authorization enforcement, the same way a coprocessor already did, so a plugin can decide `@policy` grants just like a coprocessor can.

To fix that, I had to swap the order of execution in the main pipeline. 

Before:
```
coprocessor on_graphql_analysis
policy enforcement 
plugin_system on_graphql_analysis
``` 

After:
```
coprocessor on_graphql_analysis
plugin_system on_graphql_analysis
policy enforcement 
``` 

Also, added a plugin example. 
