### PR TITLE
feat(jwt): add `headers` to remote JWKS providers

### DIFF
--- a/.changeset/jwks_remote_headers.md
+++ b/.changeset/jwks_remote_headers.md
@@ -1,0 +1,27 @@
+---
+hive-router: minor
+---
+
+# Add `headers` to remote JWKS providers
+
+`jwt.jwks_providers` with `source: remote` now accepts a `headers` map, applied to the JWKS fetch.
+
+```yaml
+jwt:
+  jwks_providers:
+    - source: remote
+      url: http://idp.identity.svc.cluster.local/oauth/v2/keys
+      headers:
+        Host: auth.example.com
+      polling_interval: "15m"
+```
+
+This makes two previously unreachable setups work.
+
+An identity provider that resolves its tenant or instance from the `Host` header cannot be addressed by an internal URL: the connection succeeds, but the provider sees the internal authority, finds no tenant registered for it, and the fetch fails. Zitadel is one such provider — it matches the request `Host` against its registered instance domains and otherwise answers `Instance not found`. Setting `Host` here lets the router reach the provider over a cluster-internal address while still identifying the tenant, instead of routing every key refresh out through a public load balancer and back.
+
+A JWKS endpoint behind a gateway that expects an API key or a custom auth header is now also reachable, without a proxy in front of the router.
+
+Headers are applied to the request only; they do not change where the request is sent. The field defaults to empty, so existing configurations are unaffected.
+
+Closes https://github.com/graphql-hive/router/issues/1475

--- a/.changeset/jwks_remote_headers.md
+++ b/.changeset/jwks_remote_headers.md
@@ -11,17 +11,11 @@ jwt:
   jwks_providers:
     - source: remote
       url: http://idp.identity.svc.cluster.local/oauth/v2/keys
-      headers:
+      headers: # new 
         Host: auth.example.com
       polling_interval: "15m"
 ```
 
-This makes two previously unreachable setups work.
-
-An identity provider that resolves its tenant or instance from the `Host` header cannot be addressed by an internal URL: the connection succeeds, but the provider sees the internal authority, finds no tenant registered for it, and the fetch fails. Zitadel is one such provider — it matches the request `Host` against its registered instance domains and otherwise answers `Instance not found`. Setting `Host` here lets the router reach the provider over a cluster-internal address while still identifying the tenant, instead of routing every key refresh out through a public load balancer and back.
-
 A JWKS endpoint behind a gateway that expects an API key or a custom auth header is now also reachable, without a proxy in front of the router.
-
-Headers are applied to the request only; they do not change where the request is sent. The field defaults to empty, so existing configurations are unaffected.
 
 Closes https://github.com/graphql-hive/router/issues/1475

--- a/bin/router/src/config/jwt_auth.rs
+++ b/bin/router/src/config/jwt_auth.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
+use http::HeaderMap;
 use jsonwebtoken::Algorithm;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -136,6 +138,32 @@ pub enum JwksProviderSourceConfig {
         /// If set to `true`, the JWKS will be fetched on startup and cached. In case of invalid JWKS, the error will be ignored and the plugin will try to fetch again when server receives the first request.
         /// If set to `false`, the JWKS will be fetched on-demand, when the first request comes in.
         prefetch: Option<bool>,
+        /// Additional HTTP headers to send with the JWKS request.
+        ///
+        /// Useful when the JWKS endpoint is not reachable as a plain public URL:
+        /// an identity provider that selects its tenant from the `Host` header
+        /// while being addressed internally, or a JWKS endpoint behind a gateway
+        /// that expects an API key.
+        ///
+        /// Keys must be valid HTTP header names (RFC 7230) and values must be
+        /// valid HTTP header values.
+        ///
+        /// `Host` is honored: it is applied to the request and overrides the
+        /// authority derived from `url`, without changing where the request is
+        /// sent.
+        ///
+        /// Example:
+        /// ```yaml
+        /// headers:
+        ///   Host: "auth.example.com"
+        /// ```
+        #[serde(
+            default,
+            with = "http_serde::header_map",
+            skip_serializing_if = "HeaderMap::is_empty"
+        )]
+        #[schemars(with = "HashMap<String, String>")]
+        headers: HeaderMap,
     },
 }
 
@@ -187,7 +215,7 @@ pub enum JwtAuthPluginLookupLocation {
 
 #[cfg(test)]
 mod tests {
-    use super::JwtAuthConfig;
+    use super::{JwksProviderSourceConfig, JwtAuthConfig};
 
     #[test]
     fn scopes_claim_defaults_to_none() {
@@ -209,5 +237,43 @@ mod tests {
         )
         .expect("config should parse");
         assert_eq!(config.scopes_claim, Some("roles".to_string()));
+    }
+
+    #[test]
+    fn remote_jwks_headers_default_to_empty() {
+        let config = serde_json::from_str::<JwtAuthConfig>(
+            r#"{"jwks_providers":[{"source":"remote","url":"https://example.com/jwks.json"}]}"#,
+        )
+        .expect("config should parse");
+
+        match &config.jwks_providers[0] {
+            JwksProviderSourceConfig::Remote { headers, .. } => assert!(headers.is_empty()),
+            other => panic!("expected a remote provider, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remote_jwks_headers_are_parsed() {
+        let config = serde_json::from_str::<JwtAuthConfig>(
+            r#"{"jwks_providers":[{"source":"remote","url":"http://idp.internal/jwks.json","headers":{"Host":"auth.example.com","X-Api-Key":"secret"}}]}"#,
+        )
+        .expect("config should parse");
+
+        match &config.jwks_providers[0] {
+            JwksProviderSourceConfig::Remote { headers, .. } => {
+                assert_eq!(headers.len(), 2);
+                assert_eq!(headers.get("host").unwrap(), "auth.example.com");
+                assert_eq!(headers.get("x-api-key").unwrap(), "secret");
+            }
+            other => panic!("expected a remote provider, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remote_jwks_rejects_invalid_header_name() {
+        let result = serde_json::from_str::<JwtAuthConfig>(
+            r#"{"jwks_providers":[{"source":"remote","url":"https://example.com/jwks.json","headers":{"Invalid Header":"value"}}]}"#,
+        );
+        assert!(result.is_err(), "a header name with a space must not parse");
     }
 }

--- a/bin/router/src/jwt/jwks_manager.rs
+++ b/bin/router/src/jwt/jwks_manager.rs
@@ -117,12 +117,18 @@ pub enum JwksSourceError {
 impl JwksSource {
     async fn load_and_store_jwks(&self) -> Result<&Self, JwksSourceError> {
         let jwks_str = match &self.config {
-            JwksProviderSourceConfig::Remote { url, .. } => {
+            JwksProviderSourceConfig::Remote { url, headers, .. } => {
                 let client = reqwest::Client::new();
                 debug!(target: targets::JWT, url = ?url, "loading jwks from a remote source");
 
+                // `headers()` carries `Host` through as an override of the
+                // authority derived from `url`, without changing which address
+                // the request is sent to. That is what makes an internal URL
+                // usable against a virtual-host-routed issuer. An empty map is
+                // a no-op, so this is unconditional.
                 let response_text = client
                     .get(url)
+                    .headers(headers.clone())
                     .send()
                     .await
                     .map_err(JwksSourceError::RemoteJwksNetworkError)?
@@ -186,5 +192,84 @@ impl JwksSource {
         }
 
         Err(JwksSourceError::FailedToAcquireJwk)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::{HeaderMap, HeaderName, HeaderValue};
+
+    const JWKS_BODY: &str = r#"{"keys":[]}"#;
+
+    fn remote_source(url: String, headers: HeaderMap) -> JwksSource {
+        JwksSource {
+            config: JwksProviderSourceConfig::Remote {
+                url,
+                polling_interval: None,
+                prefetch: Some(false),
+                headers,
+            },
+            jwk: RwLock::new(None),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_jwks_sends_configured_headers() {
+        crate::init_rustls_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+
+        // `Host` is the reason this feature exists: it must reach the server as
+        // an override of the authority derived from the URL, while the request
+        // still goes to the URL's address.
+        let mock = server
+            .mock("GET", "/jwks.json")
+            .match_header("host", "auth.example.com")
+            .match_header("x-api-key", "secret")
+            .expect(1)
+            .with_status(200)
+            .with_body(JWKS_BODY)
+            .create_async()
+            .await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("host"),
+            HeaderValue::from_static("auth.example.com"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-api-key"),
+            HeaderValue::from_static("secret"),
+        );
+
+        let source = remote_source(format!("{}/jwks.json", server.url()), headers);
+        source
+            .load_and_store_jwks()
+            .await
+            .expect("jwks should load");
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_jwks_without_headers_is_unchanged() {
+        crate::init_rustls_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/jwks.json")
+            .expect(1)
+            .with_status(200)
+            .with_body(JWKS_BODY)
+            .create_async()
+            .await;
+
+        let source = remote_source(format!("{}/jwks.json", server.url()), HeaderMap::new());
+        source
+            .load_and_store_jwks()
+            .await
+            .expect("jwks should load");
+
+        mock.assert_async().await;
     }
 }

--- a/bin/router/src/jwt/jwks_manager.rs
+++ b/bin/router/src/jwt/jwks_manager.rs
@@ -77,12 +77,13 @@ impl BackgroundTask for JwksSourceTask {
     async fn run(&self, token: CancellationToken) {
         if let JwksProviderSourceConfig::Remote {
             polling_interval: Some(interval),
+            url,
             ..
         } = &self.0.config
         {
             info!(
                 target: targets::JWT,
-                source = ?self.0.config,
+                url = ?url,
                 "starting remote jwks polling for source",
             );
             let mut tokio_interval = tokio::time::interval(*interval);
@@ -92,7 +93,7 @@ impl BackgroundTask for JwksSourceTask {
                     _ = tokio_interval.tick() => { match self.0.load_and_store_jwks().await {
                         Ok(_) => {}
                         Err(err) => {
-                            error!(target: targets::JWT, error = ?err, source = ?self.0.config, "failed to load remote jwks");
+                            error!(target: targets::JWT, error = ?err, url = ?url, "failed to load remote jwks");
                         }
                     } }
                     _ = token.cancelled() => { info!(target: targets::JWT, "jwks source shutting down."); return; }

--- a/bin/router/src/jwt/jwks_manager.rs
+++ b/bin/router/src/jwt/jwks_manager.rs
@@ -132,6 +132,8 @@ impl JwksSource {
                     .send()
                     .await
                     .map_err(JwksSourceError::RemoteJwksNetworkError)?
+                    .error_for_status()
+                    .map_err(JwksSourceError::RemoteJwksNetworkError)?
                     .text()
                     .await
                     .map_err(JwksSourceError::RemoteJwksNetworkError)?;
@@ -269,6 +271,30 @@ mod tests {
             .load_and_store_jwks()
             .await
             .expect("jwks should load");
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_jwks_error_status_is_reported_as_network_error() {
+        crate::init_rustls_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/jwks.json")
+            .expect(1)
+            .with_status(401)
+            .with_body("unauthorized")
+            .create_async()
+            .await;
+
+        let source = remote_source(format!("{}/jwks.json", server.url()), HeaderMap::new());
+        let err = source
+            .load_and_store_jwks()
+            .await
+            .expect_err("401 response should not be parsed as jwks");
+
+        assert!(matches!(err, JwksSourceError::RemoteJwksNetworkError(_)));
 
         mock.assert_async().await;
     }


### PR DESCRIPTION
Related #1475. Implements the shape agreed in [that thread](https://github.com/graphql-hive/router/issues/1475#issuecomment-5508595223).

```yaml
jwt:
  jwks_providers:
    - source: remote
      url: http://idp.identity.svc.cluster.local/oauth/v2/keys
      headers:
        Host: auth.example.com
      polling_interval: "15m"
```

## Why

Two setups that previously could not be expressed.

**An IdP that resolves its tenant from the `Host` header.** Addressing it by an internal URL fails: the connection succeeds, but the provider sees the internal authority, finds no tenant registered for it, and the fetch errors. Zitadel matches the request `Host` against its registered instance domains and otherwise answers `Instance not found`. Without this, the only option is fetching keys over the public URL — so in a Kubernetes deployment every refresh leaves the cluster, traverses the external load balancer, and comes back to a pod one ClusterIP hop away, putting public DNS, the LB, and a public certificate on the token-validation path.

**A JWKS endpoint behind a gateway** expecting an API key or custom auth header, now reachable without a proxy in front of the router.

## Implementation

Follows `preflight_response_headers` in `cors.rs`: `http_serde::header_map` for (de)serialization, `schemars(with = "HashMap<String, String>")` for the JSON schema. No new dependencies.

The field defaults to empty and `.headers()` with an empty map is a no-op, so existing configurations are byte-for-byte unaffected.

## On `Host` specifically

Worth calling out, since it is the motivating case and could plausibly not work: `reqwest` might have derived `Host` from the URL authority and ignored the override. **It does not.** Verified against a raw listener before writing the tests:

```
GET /jwks.json HTTP/1.1
host: auth.example.com      <- the override, not 127.0.0.1:<port>
x-api-key: secret
accept: */*
```

The override reaches the wire while the request still goes to the URL's address — exactly the behaviour this feature needs. That assertion is now a test rather than a note, so a future `reqwest` change that breaks it fails CI instead of silently disabling the feature.

## Tests

`cargo test -p hive-router --lib config::jwt_auth jwt::jwks_manager` — 8 pass.

- **config**: headers absent → empty; headers parsed and normalized; an invalid header name (`"Invalid Header"`) is rejected at parse time
- **fetch** (`mockito`, already a dev-dependency): configured headers reach the server, asserted with `.match_header("host", "auth.example.com")`; and the no-headers path is unchanged

`cargo fmt --check` clean. `cargo clippy` reports nothing on the two changed files — note it reports 38 pre-existing errors on unmodified `main` for me (`websocket_server.rs` and the benches), presumably a newer clippy than CI pins; I have left those alone as out of scope.

## Not included

The docs site lives in another repo, so the `jwks_providers` reference there will need the new field. Happy to open that PR too — point me at the right place.