### PR TITLE
feat(router): `traffic_shaping.router.compression` 

### DIFF
--- a/.changeset/http_compression.md
+++ b/.changeset/http_compression.md
@@ -1,0 +1,39 @@
+---
+hive-router: minor
+---
+
+# HTTP compression between the client and the router
+
+Adds `traffic_shaping.router.compression`, controlling response compression (router → client)
+and request decompression (client → router). 
+
+`gzip`, `deflate`, `br` (Brotli), and `zstd` are all supported in both directions.
+
+The following defaults are set: 
+
+```yaml
+traffic_shaping:
+  router:
+    compression:
+      response:
+        enabled: true
+        algorithms:
+          - kind: gzip
+          - kind: zstd
+            level: 3
+          - kind: br
+            quality: 5
+          - kind: deflate
+        min_size: 1KiB
+      request:
+        enabled: true
+        algorithms: [gzip, zstd, br, deflate]
+```
+
+Response compression is negotiated against the client's `Accept-Encoding`.
+
+Request decompression is applied based on the client's `Content-Encoding`.
+
+Both directions default to enabled, with `gzip`, `zstd`, `br`, and `deflate` all allowed.
+
+Closes https://github.com/graphql-hive/router/issues/315

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: ./.github/actions/install-tools
       - name: test all
         run: cargo test_all
-        timeout-minutes: 8
+        timeout-minutes: 15
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-link",
@@ -1325,6 +1325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,8 +1827,10 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
+ "brotli",
  "bytes",
  "dashmap",
+ "flate2",
  "futures",
  "futures-util",
  "gag",
@@ -1851,6 +1862,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -2124,6 +2136,8 @@ version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -2722,6 +2736,7 @@ dependencies = [
  "uuid",
  "vrl",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]
@@ -3676,6 +3691,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,6 +3982,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "env_logger",
+ "flate2",
  "httparse",
  "httpdate",
  "log",
@@ -6662,6 +6688,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio-util = { version = "0.7.16" }
 tokio-stream = { version = "0.1.17" }
 rand = "0.10.1"
 jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
-ntex = { version = "=3.12.3", features = ["tokio", "rustls"] }
+ntex = { version = "=3.12.3", features = ["tokio", "rustls", "compress"] }
 ntex-http = { version = "=1.2.0"}
 ntex-codec = { version = "=1.2.1"}
 ntex-io = { version = "=3.13.1"}

--- a/bin/router/Cargo.toml
+++ b/bin/router/Cargo.toml
@@ -145,6 +145,7 @@ rustc-hash = "2.1.1"
 hyperlocal = "0.9.1"
 brotli = "8.0.3"
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] } # Use zlib-rs for performance
+zstd = "0.13.3"
 hyper-util = { version = "0.1.16", features = [
   "client",
   "client-legacy",

--- a/bin/router/src/config/headers.rs
+++ b/bin/router/src/config/headers.rs
@@ -20,6 +20,11 @@ pub const HOP_BY_HOP_HEADERS: &[&str] = &[
     "proxy-connection",
     "host",
     "content-length",
+    // The router decompresses client request bodies before subgraph fetches (and, symmetrically,
+    // would decompress subgraph responses before returning them to the client). Forwarding the
+    // original `content-encoding` would describe a body that no longer matches it, causing the
+    // receiving side to fail decompressing already-plaintext bytes.
+    "content-encoding",
 ];
 
 /// Headers that must never be comma-joined. If multiple values exist, they

--- a/bin/router/src/config/traffic_shaping.rs
+++ b/bin/router/src/config/traffic_shaping.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::HashMap, fmt, time::Duration};
 
 use http::StatusCode;
+use human_size::Size;
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{de, Deserialize, Serialize};
 
@@ -492,6 +493,14 @@ pub struct TrafficShapingRouterConfig {
     )]
     #[schemars(with = "String")]
     pub keep_alive: Duration,
+
+    /// HTTP compression between the client and the router: compressing responses sent to the
+    /// client, and decompressing requests received from the client.
+    ///
+    /// This is unrelated to `traffic_shaping.all`/`traffic_shaping.subgraphs`, which control
+    /// compression between the router and subgraphs.
+    #[serde(default)]
+    pub compression: TrafficShapingRouterCompressionConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -596,8 +605,258 @@ impl Default for TrafficShapingRouterConfig {
             tls: None,
             max_long_lived_clients: default_max_long_lived_clients(),
             keep_alive: http_server_keep_alive_default(),
+            compression: Default::default(),
         }
     }
+}
+
+/// HTTP compression settings for traffic between the client and the router.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+#[derive(Default)]
+pub struct TrafficShapingRouterCompressionConfig {
+    /// Compression of responses sent from the router to the client, negotiated via the
+    /// client's `Accept-Encoding` header.
+    #[serde(default)]
+    pub response: TrafficShapingRouterResponseCompressionConfig,
+
+    /// Decompression of requests sent from the client to the router, based on the
+    /// client's `Content-Encoding` header.
+    #[serde(default)]
+    pub request: TrafficShapingRouterRequestCompressionConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TrafficShapingRouterResponseCompressionConfig {
+    /// Enables/disables compressing responses sent to the client.
+    #[serde(default = "default_compression_enabled")]
+    pub enabled: bool,
+
+    /// Algorithms the router is allowed to compress responses with, and their tuning.
+    ///
+    /// The router picks the entry from this list whose `kind` best matches the client's
+    /// `Accept-Encoding` preference; a client asking for an algorithm not listed here
+    /// gets an uncompressed response instead. The list's order only matters as a
+    /// tie-breaker when the client's preferences don't disambiguate.
+    #[serde(default = "default_response_compression_algorithms")]
+    pub algorithms: Vec<ResponseCompressionAlgorithmConfig>,
+
+    /// Responses smaller than this are sent uncompressed, since compressing small
+    /// payloads costs more CPU than it saves in bytes transferred.
+    #[serde(default = "default_compression_min_size")]
+    #[schemars(with = "String")]
+    pub min_size: Size,
+}
+
+impl Default for TrafficShapingRouterResponseCompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_compression_enabled(),
+            algorithms: default_response_compression_algorithms(),
+            min_size: default_compression_min_size(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TrafficShapingRouterRequestCompressionConfig {
+    /// Enables/disables decompressing requests received from the client.
+    ///
+    /// When disabled, a request carrying a `Content-Encoding` header is rejected with
+    /// `415 Unsupported Media Type` instead of being decompressed.
+    #[serde(default = "default_compression_enabled")]
+    pub enabled: bool,
+
+    /// Algorithms the router accepts in a client's `Content-Encoding` header.
+    ///
+    /// A request encoded with an algorithm not listed here is rejected with
+    /// `415 Unsupported Media Type`.
+    #[serde(default = "default_request_compression_algorithms")]
+    pub algorithms: Vec<CompressionAlgorithm>,
+}
+
+impl Default for TrafficShapingRouterRequestCompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_compression_enabled(),
+            algorithms: default_request_compression_algorithms(),
+        }
+    }
+}
+
+/// A content-coding algorithm identified by its `Accept-Encoding`/`Content-Encoding` token.
+///
+/// Used for `compression.request.algorithms`: decompression has no per-algorithm tuning,
+/// so a plain allow-list is all that's needed there. See [`ResponseCompressionAlgorithmConfig`]
+/// for the response side, where `br`/`zstd` carry inline tuning.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompressionAlgorithm {
+    Gzip,
+    Deflate,
+    Br,
+    Zstd,
+}
+
+impl CompressionAlgorithm {
+    /// The `Accept-Encoding`/`Content-Encoding` token this variant matches.
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::Gzip => "gzip",
+            Self::Deflate => "deflate",
+            Self::Br => "br",
+            Self::Zstd => "zstd",
+        }
+    }
+
+    /// Parses a single `Content-Encoding` token (case-insensitive). Returns `None` for
+    /// anything that isn't one of the four known tokens - callers decide what that means
+    /// (identity, unsupported, or a stacked/malformed value).
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            t if t.eq_ignore_ascii_case("gzip") => Some(Self::Gzip),
+            t if t.eq_ignore_ascii_case("deflate") => Some(Self::Deflate),
+            t if t.eq_ignore_ascii_case("br") => Some(Self::Br),
+            t if t.eq_ignore_ascii_case("zstd") => Some(Self::Zstd),
+            _ => None,
+        }
+    }
+}
+
+/// One entry of `compression.response.algorithms`: an allowed algorithm plus, for
+/// algorithms that have one, its tuning - co-located so enabling an algorithm and
+/// configuring it happen in the same place instead of a separate lookup table.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResponseCompressionAlgorithmConfig {
+    Gzip,
+    Deflate,
+    Br(BrotliCompressionConfig),
+    Zstd(ZstdCompressionConfig),
+}
+
+impl ResponseCompressionAlgorithmConfig {
+    /// The `Accept-Encoding`/`Content-Encoding` token this entry matches/produces.
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::Gzip => "gzip",
+            Self::Deflate => "deflate",
+            Self::Br(_) => "br",
+            Self::Zstd(_) => "zstd",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrotliCompressionConfig {
+    /// Brotli quality level, from `0` (fastest, worst ratio) to `11` (slowest, best ratio).
+    ///
+    /// Defaults well below the maximum: quality `11` is slow enough to become a bottleneck
+    /// for dynamically generated GraphQL responses, where CPU time usually matters more
+    /// than squeezing out the last few percent of size.
+    #[serde(
+        default = "default_brotli_quality",
+        deserialize_with = "deserialize_brotli_quality"
+    )]
+    #[schemars(range(min = 0, max = 11))]
+    pub quality: u8,
+}
+
+fn deserialize_brotli_quality<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u8::deserialize(deserializer)?;
+    if value > 11 {
+        return Err(de::Error::custom(format!(
+            "brotli quality must be between 0 and 11, got: {value}"
+        )));
+    }
+    Ok(value)
+}
+
+impl Default for BrotliCompressionConfig {
+    fn default() -> Self {
+        Self {
+            quality: default_brotli_quality(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ZstdCompressionConfig {
+    /// Zstandard compression level, from `1` (fastest, worst ratio) to `22` (slowest, best ratio).
+    ///
+    /// Defaults to zstd's own standard default, which already gives a good balance of
+    /// speed and ratio for dynamically generated GraphQL responses.
+    #[serde(
+        default = "default_zstd_level",
+        deserialize_with = "deserialize_zstd_level"
+    )]
+    #[schemars(range(min = 1, max = 22))]
+    pub level: i32,
+}
+
+fn deserialize_zstd_level<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = i32::deserialize(deserializer)?;
+    if !(1..=22).contains(&value) {
+        return Err(de::Error::custom(format!(
+            "zstd level must be between 1 and 22, got: {value}"
+        )));
+    }
+    Ok(value)
+}
+
+impl Default for ZstdCompressionConfig {
+    fn default() -> Self {
+        Self {
+            level: default_zstd_level(),
+        }
+    }
+}
+
+fn default_compression_enabled() -> bool {
+    true
+}
+
+fn default_response_compression_algorithms() -> Vec<ResponseCompressionAlgorithmConfig> {
+    vec![
+        ResponseCompressionAlgorithmConfig::Gzip,
+        ResponseCompressionAlgorithmConfig::Zstd(ZstdCompressionConfig::default()),
+        ResponseCompressionAlgorithmConfig::Br(BrotliCompressionConfig::default()),
+        ResponseCompressionAlgorithmConfig::Deflate,
+    ]
+}
+
+fn default_request_compression_algorithms() -> Vec<CompressionAlgorithm> {
+    vec![
+        CompressionAlgorithm::Gzip,
+        CompressionAlgorithm::Zstd,
+        CompressionAlgorithm::Br,
+        CompressionAlgorithm::Deflate,
+    ]
+}
+
+fn default_compression_min_size() -> Size {
+    "1KiB"
+        .parse()
+        .expect("Default value for 'traffic_shaping.router.compression.response.min_size' should be a valid human-readable size")
+}
+
+fn default_brotli_quality() -> u8 {
+    5
+}
+
+fn default_zstd_level() -> i32 {
+    // matches zstd's own `ZSTD_CLEVEL_DEFAULT`
+    3
 }
 
 /// Matches ntex's own default HTTP/1 keep-alive, so configurations that omit
@@ -905,5 +1164,187 @@ mod tests {
             .cloned();
 
         assert_eq!(serialized, Some(serde_json::json!("1m 20s")));
+    }
+
+    #[test]
+    fn compression_defaults_are_enabled_with_gzip_br_deflate() {
+        let config: TrafficShapingRouterConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+
+        assert!(config.compression.response.enabled);
+        assert_eq!(
+            config.compression.response.algorithms,
+            vec![
+                super::ResponseCompressionAlgorithmConfig::Gzip,
+                super::ResponseCompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig {
+                    level: 3
+                }),
+                super::ResponseCompressionAlgorithmConfig::Br(super::BrotliCompressionConfig {
+                    quality: 5
+                }),
+                super::ResponseCompressionAlgorithmConfig::Deflate,
+            ]
+        );
+
+        assert!(config.compression.request.enabled);
+        assert_eq!(
+            config.compression.request.algorithms,
+            vec![
+                super::CompressionAlgorithm::Gzip,
+                super::CompressionAlgorithm::Zstd,
+                super::CompressionAlgorithm::Br,
+                super::CompressionAlgorithm::Deflate,
+            ]
+        );
+    }
+
+    #[test]
+    fn compression_min_size_defaults_to_one_kibibyte() {
+        let config: TrafficShapingRouterConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+
+        assert_eq!(
+            config.compression.response.min_size.to_bytes(),
+            1024,
+            "default min_size should be 1KiB"
+        );
+    }
+
+    #[test]
+    fn compression_algorithm_tokens_match_http_header_casing() {
+        // `gzip`/`deflate`/`br` are parsed directly from `Accept-Encoding`/`Content-Encoding`
+        // values, so the config's on-the-wire spelling must match those tokens exactly.
+        let algorithms: Vec<super::CompressionAlgorithm> =
+            serde_json::from_str(r#"["gzip", "deflate", "br", "zstd"]"#)
+                .expect("lowercase algorithm tokens should deserialize");
+
+        assert_eq!(
+            algorithms,
+            vec![
+                super::CompressionAlgorithm::Gzip,
+                super::CompressionAlgorithm::Deflate,
+                super::CompressionAlgorithm::Br,
+                super::CompressionAlgorithm::Zstd,
+            ]
+        );
+    }
+
+    #[test]
+    fn compression_response_algorithms_co_locate_tuning_with_kind() {
+        let config: TrafficShapingRouterConfig = serde_json::from_str(
+            r#"{
+                "compression": {
+                    "response": {
+                        "algorithms": [
+                            { "kind": "gzip" },
+                            { "kind": "br", "quality": 9 },
+                            { "kind": "zstd", "level": 10 },
+                            { "kind": "deflate" }
+                        ]
+                    }
+                }
+            }"#,
+        )
+        .expect("kind-tagged algorithms list should deserialize");
+
+        assert_eq!(
+            config.compression.response.algorithms,
+            vec![
+                super::ResponseCompressionAlgorithmConfig::Gzip,
+                super::ResponseCompressionAlgorithmConfig::Br(super::BrotliCompressionConfig {
+                    quality: 9
+                }),
+                super::ResponseCompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig {
+                    level: 10
+                }),
+                super::ResponseCompressionAlgorithmConfig::Deflate,
+            ]
+        );
+    }
+
+    #[test]
+    fn compression_response_algorithm_tuning_defaults_when_omitted() {
+        let config: TrafficShapingRouterConfig = serde_json::from_str(
+            r#"{ "compression": { "response": { "algorithms": [{ "kind": "br" }] } } }"#,
+        )
+        .expect("kind without tuning fields should deserialize using defaults");
+
+        assert_eq!(
+            config.compression.response.algorithms,
+            vec![super::ResponseCompressionAlgorithmConfig::Br(
+                super::BrotliCompressionConfig { quality: 5 }
+            )]
+        );
+    }
+
+    #[test]
+    fn compression_rejects_brotli_quality_above_eleven() {
+        let result: Result<TrafficShapingRouterConfig, _> = serde_json::from_str(
+            r#"{ "compression": { "response": { "algorithms": [{ "kind": "br", "quality": 12 }] } } }"#,
+        );
+
+        assert!(
+            result.is_err(),
+            "brotli quality above 11 should be rejected at config load time"
+        );
+    }
+
+    #[test]
+    fn compression_accepts_brotli_quality_at_the_boundaries() {
+        for quality in [0, 11] {
+            let config: TrafficShapingRouterConfig = serde_json::from_str(&format!(
+                r#"{{ "compression": {{ "response": {{ "algorithms": [{{ "kind": "br", "quality": {quality} }}] }} }} }}"#
+            ))
+            .unwrap_or_else(|err| panic!("quality {quality} should be valid: {err}"));
+
+            assert_eq!(
+                config.compression.response.algorithms,
+                vec![super::ResponseCompressionAlgorithmConfig::Br(
+                    super::BrotliCompressionConfig { quality }
+                )]
+            );
+        }
+    }
+
+    #[test]
+    fn compression_rejects_zstd_level_outside_one_to_twenty_two() {
+        for level in [0, 23, -1] {
+            let result: Result<TrafficShapingRouterConfig, _> = serde_json::from_str(&format!(
+                r#"{{ "compression": {{ "response": {{ "algorithms": [{{ "kind": "zstd", "level": {level} }}] }} }} }}"#
+            ));
+
+            assert!(
+                result.is_err(),
+                "zstd level {level} is outside 1-22 and should be rejected at config load time"
+            );
+        }
+    }
+
+    #[test]
+    fn compression_accepts_zstd_level_at_the_boundaries() {
+        for level in [1, 22] {
+            let config: TrafficShapingRouterConfig = serde_json::from_str(&format!(
+                r#"{{ "compression": {{ "response": {{ "algorithms": [{{ "kind": "zstd", "level": {level} }}] }} }} }}"#
+            ))
+            .unwrap_or_else(|err| panic!("level {level} should be valid: {err}"));
+
+            assert_eq!(
+                config.compression.response.algorithms,
+                vec![super::ResponseCompressionAlgorithmConfig::Zstd(
+                    super::ZstdCompressionConfig { level }
+                )]
+            );
+        }
+    }
+
+    #[test]
+    fn compression_rejects_unknown_fields() {
+        let result: Result<TrafficShapingRouterConfig, _> =
+            serde_json::from_str(r#"{ "compression": { "response": { "unknown_field": true } } }"#);
+
+        assert!(
+            result.is_err(),
+            "unknown fields under compression.response should be rejected"
+        );
     }
 }

--- a/bin/router/src/executor/coprocessor/runtime.rs
+++ b/bin/router/src/executor/coprocessor/runtime.rs
@@ -266,7 +266,9 @@ impl CoprocessorRuntime {
         // We read the request body only when this stage needs to include body
         let request_body = if stage.stage.include_body() {
             let body_stream = web::types::Payload(req.take_payload());
-            let new_body = match read_body_stream(&req, body_stream, self.body_size_limit).await {
+            let new_body = match read_body_stream(&req, body_stream, self.body_size_limit, None)
+                .await
+            {
                 Ok(body) => body,
                 // We deliberately do not map to CoprocessorError here,
                 // to follow the same logic for status codes

--- a/bin/router/src/http_utils/body.rs
+++ b/bin/router/src/http_utils/body.rs
@@ -1,4 +1,4 @@
-use std::cell::RefMut;
+use std::{cell::RefMut, io::Write};
 
 use http::header::CONTENT_LENGTH;
 use ntex::{
@@ -10,6 +10,8 @@ use ntex_bytes::{Bytes, BytesMut};
 use ntex_http::HeaderMap;
 use strum::IntoStaticStr;
 use tokio_stream::StreamExt;
+
+use crate::config::traffic_shaping::CompressionAlgorithm;
 
 /// Stores the request body size in bytes.
 ///
@@ -44,6 +46,10 @@ pub enum ReadBodyStreamError {
     #[error("Request body exceeds the maximum allowed size while reading the stream")]
     #[strum(serialize = "PAYLOAD_TOO_LARGE_BODY_STREAM")]
     PayloadTooLargeBodyStream,
+
+    #[error("Failed to decompress request body: {0}")]
+    #[strum(serialize = "DECOMPRESSION_FAILED")]
+    DecompressionFailed(String),
 }
 
 impl ReadBodyStreamError {
@@ -54,6 +60,7 @@ impl ReadBodyStreamError {
             Self::PayloadTooLargeContentLength(_) | Self::PayloadTooLargeBodyStream => {
                 http::StatusCode::PAYLOAD_TOO_LARGE
             }
+            Self::DecompressionFailed(_) => http::StatusCode::BAD_REQUEST,
         }
     }
 
@@ -98,6 +105,7 @@ pub async fn read_body_stream<R: RequestLike>(
     req: &R,
     mut body_stream: web::types::Payload,
     max_size: usize,
+    content_encoding: Option<CompressionAlgorithm>,
 ) -> Result<Bytes, ReadBodyStreamError> {
     let content_length: Option<usize> = {
         let content_length_header = req.headers().get(CONTENT_LENGTH);
@@ -129,24 +137,184 @@ pub async fn read_body_stream<R: RequestLike>(
         }
     };
 
-    let mut body = if let Some(content_length) = content_length {
-        BytesMut::with_capacity(content_length)
-    } else {
-        BytesMut::new()
+    let Some(encoding) = content_encoding else {
+        let mut body = if let Some(content_length) = content_length {
+            BytesMut::with_capacity(content_length)
+        } else {
+            BytesMut::new()
+        };
+
+        while let Some(chunk) = body_stream.try_next().await? {
+            // limit max size of in-memory payload
+            if chunk.len() > max_size.saturating_sub(body.len()) {
+                write_request_body_size(req, (body.len() + chunk.len()) as u64);
+                return Err(ReadBodyStreamError::PayloadTooLargeBodyStream);
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        write_request_body_size(req, body.len() as u64);
+        return Ok(body.freeze());
     };
 
+    // Decompress incrementally as wire chunks arrive. `RequestBodyDecoder` writes into a
+    // `SizeLimitedSink` that rejects growth past `max_size` as it happens (inside the
+    // decoders' own internal write calls), rather than only checking the total after each
+    // whole wire chunk has already been fully inflated - see `SizeLimitedSink` below for why
+    // that distinction matters for a highly compressible payload.
+    let mut decoder = RequestBodyDecoder::new(encoding, max_size)
+        .map_err(|err| ReadBodyStreamError::DecompressionFailed(err.to_string()))?;
+
     while let Some(chunk) = body_stream.try_next().await? {
-        // limit max size of in-memory payload
-        if chunk.len() > max_size.saturating_sub(body.len()) {
-            write_request_body_size(req, (body.len() + chunk.len()) as u64);
-            return Err(ReadBodyStreamError::PayloadTooLargeBodyStream);
+        if let Err(err) = decoder.write_all(&chunk) {
+            if decoder.size_limit_exceeded() {
+                write_request_body_size(req, decoder.len() as u64);
+                drain_body_stream(&mut body_stream).await;
+                return Err(ReadBodyStreamError::PayloadTooLargeBodyStream);
+            }
+            return Err(ReadBodyStreamError::DecompressionFailed(err.to_string()));
         }
-        body.extend_from_slice(&chunk);
     }
+
+    let body = decoder.finish().map_err(|err| {
+        if err.get_ref().is_some_and(|e| e.is::<SizeLimitExceeded>()) {
+            ReadBodyStreamError::PayloadTooLargeBodyStream
+        } else {
+            ReadBodyStreamError::DecompressionFailed(err.to_string())
+        }
+    })?;
 
     write_request_body_size(req, body.len() as u64);
 
-    Ok(body.freeze())
+    Ok(body)
+}
+
+#[derive(Debug)]
+struct SizeLimitExceeded;
+
+impl std::fmt::Display for SizeLimitExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "decompressed output exceeds the configured maximum request body size"
+        )
+    }
+}
+
+impl std::error::Error for SizeLimitExceeded {}
+
+/// A `Write` sink that rejects growth past `max_size` as soon as it would happen, instead of
+/// only being checked after an entire wire chunk has already been fully inflated into memory
+struct SizeLimitedSink {
+    buf: Vec<u8>,
+    max_size: usize,
+    exceeded: bool,
+}
+
+impl SizeLimitedSink {
+    fn new(max_size: usize) -> Self {
+        Self {
+            buf: Vec::new(),
+            max_size,
+            exceeded: false,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    fn size_limit_exceeded(&self) -> bool {
+        self.exceeded
+    }
+}
+
+impl Write for SizeLimitedSink {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        if self.buf.len().saturating_add(data.len()) > self.max_size {
+            self.exceeded = true;
+            return Err(std::io::Error::other(SizeLimitExceeded));
+        }
+        self.buf.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+enum RequestBodyDecoder {
+    Gzip(flate2::write::GzDecoder<SizeLimitedSink>),
+    Deflate(flate2::write::ZlibDecoder<SizeLimitedSink>),
+    Br(Box<brotli::DecompressorWriter<SizeLimitedSink>>),
+    Zstd(Box<zstd::stream::write::Decoder<'static, SizeLimitedSink>>),
+}
+
+impl RequestBodyDecoder {
+    fn new(algorithm: CompressionAlgorithm, max_size: usize) -> std::io::Result<Self> {
+        Ok(match algorithm {
+            CompressionAlgorithm::Gzip => Self::Gzip(flate2::write::GzDecoder::new(
+                SizeLimitedSink::new(max_size),
+            )),
+            CompressionAlgorithm::Deflate => Self::Deflate(flate2::write::ZlibDecoder::new(
+                SizeLimitedSink::new(max_size),
+            )),
+            CompressionAlgorithm::Br => Self::Br(Box::new(brotli::DecompressorWriter::new(
+                SizeLimitedSink::new(max_size),
+                4096,
+            ))),
+            CompressionAlgorithm::Zstd => Self::Zstd(Box::new(zstd::stream::write::Decoder::new(
+                SizeLimitedSink::new(max_size),
+            )?)),
+        })
+    }
+
+    fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Gzip(d) => d.write_all(data),
+            Self::Deflate(d) => d.write_all(data),
+            Self::Br(d) => d.write_all(data),
+            Self::Zstd(d) => d.write_all(data),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Gzip(d) => d.get_ref().len(),
+            Self::Deflate(d) => d.get_ref().len(),
+            Self::Br(d) => d.get_ref().len(),
+            Self::Zstd(d) => d.get_ref().len(),
+        }
+    }
+
+    fn size_limit_exceeded(&self) -> bool {
+        match self {
+            Self::Gzip(d) => d.get_ref().size_limit_exceeded(),
+            Self::Deflate(d) => d.get_ref().size_limit_exceeded(),
+            Self::Br(d) => d.get_ref().size_limit_exceeded(),
+            Self::Zstd(d) => d.get_ref().size_limit_exceeded(),
+        }
+    }
+
+    fn finish(self) -> std::io::Result<Bytes> {
+        let bytes = match self {
+            Self::Gzip(d) => d.finish()?.buf,
+            Self::Deflate(d) => d.finish()?.buf,
+            Self::Br(mut d) => {
+                d.close()
+                    .map_err(|_| std::io::Error::other("brotli stream did not close cleanly"))?;
+                d.into_inner()
+                    .map_err(|_| std::io::Error::other("brotli stream did not finish cleanly"))?
+                    .buf
+            }
+            Self::Zstd(mut d) => {
+                d.flush()?;
+                d.into_inner().buf
+            }
+        };
+        Ok(Bytes::from(bytes))
+    }
 }
 
 pub trait RequestLike {
@@ -171,5 +339,108 @@ impl RequestLike for WebRequest<DefaultError> {
 
     fn extensions_mut(&self) -> RefMut<'_, Extensions> {
         self.extensions_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn deflate(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::ZlibEncoder, Compression};
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn brotli_compress(data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut writer = brotli::CompressorWriter::new(&mut out, 4096, 5, 22);
+        writer.write_all(data).unwrap();
+        drop(writer);
+        out
+    }
+
+    fn zstd_compress(data: &[u8]) -> Vec<u8> {
+        zstd::stream::encode_all(data, 3).unwrap()
+    }
+
+    // Directly proves the fix for a decompression bomb arriving as a single wire chunk: the
+    // sink must reject growth as it happens *during* the decoder's internal write calls, so
+    // the backing buffer never grows past `max_size` - not just that the caller eventually
+    // gets an error back (which alone wouldn't rule out having fully inflated the payload
+    // into memory first).
+    #[test]
+    fn size_limited_sink_bounds_backing_buffer_for_all_algorithms() {
+        let max_size = 1024; // 1KiB
+        let inflated = vec![b'a'; 5_000_000]; // 5MB, highly compressible
+
+        let cases: [(CompressionAlgorithm, Vec<u8>); 4] = [
+            (CompressionAlgorithm::Gzip, gzip(&inflated)),
+            (CompressionAlgorithm::Deflate, deflate(&inflated)),
+            (CompressionAlgorithm::Br, brotli_compress(&inflated)),
+            (CompressionAlgorithm::Zstd, zstd_compress(&inflated)),
+        ];
+
+        for (algorithm, compressed) in cases {
+            let mut decoder = RequestBodyDecoder::new(algorithm, max_size)
+                .unwrap_or_else(|e| panic!("[{algorithm:?}] failed to construct decoder: {e}"));
+
+            // the whole compressed payload arrives as a single `write_all` call, mirroring a
+            // single wire chunk delivering an extreme compression ratio in one shot.
+            let result = decoder.write_all(&compressed);
+
+            assert!(
+                result.is_err(),
+                "[{algorithm:?}] expected write_all to fail once decompressed output exceeds max_size"
+            );
+            assert!(
+                decoder.size_limit_exceeded(),
+                "[{algorithm:?}] expected the sink to flag the size limit as exceeded"
+            );
+            assert!(
+                decoder.len() <= max_size,
+                "[{algorithm:?}] backing buffer grew to {} bytes, past the {max_size}-byte limit",
+                decoder.len()
+            );
+        }
+    }
+
+    #[test]
+    fn size_limited_sink_allows_output_at_or_under_the_limit() {
+        let max_size = 1024;
+        // small enough that its decompressed output stays under max_size
+        let small = vec![b'a'; 100];
+
+        for (algorithm, compressed) in [
+            (CompressionAlgorithm::Gzip, gzip(&small)),
+            (CompressionAlgorithm::Deflate, deflate(&small)),
+            (CompressionAlgorithm::Br, brotli_compress(&small)),
+            (CompressionAlgorithm::Zstd, zstd_compress(&small)),
+        ] {
+            let mut decoder = RequestBodyDecoder::new(algorithm, max_size)
+                .unwrap_or_else(|e| panic!("[{algorithm:?}] failed to construct decoder: {e}"));
+
+            decoder
+                .write_all(&compressed)
+                .unwrap_or_else(|e| panic!("[{algorithm:?}] unexpected write_all failure: {e}"));
+
+            let body = decoder
+                .finish()
+                .unwrap_or_else(|e| panic!("[{algorithm:?}] unexpected finish failure: {e}"));
+
+            assert_eq!(
+                body.as_ref(),
+                small.as_slice(),
+                "[{algorithm:?}] roundtrip mismatch"
+            );
+        }
     }
 }

--- a/bin/router/src/http_utils/headers.rs
+++ b/bin/router/src/http_utils/headers.rs
@@ -1,0 +1,30 @@
+use ntex_http::{header, HeaderMap, HeaderValue};
+
+pub(crate) fn append_vary(headers: &mut HeaderMap, token: &str) {
+    if let Some(existing) = headers.get(header::VARY).and_then(|v| v.to_str().ok()) {
+        if existing
+            .split(',')
+            .map(|s| s.trim())
+            .any(|t| t.eq_ignore_ascii_case(token))
+        {
+            // already present
+            return;
+        }
+
+        let new_header_value = if existing.is_empty() {
+            HeaderValue::from_str(token)
+        } else {
+            HeaderValue::from_str(&format!("{}, {}", existing, token))
+        };
+
+        if let Ok(v) = new_header_value {
+            headers.insert(header::VARY, v);
+        }
+
+        return;
+    }
+
+    if let Ok(v) = HeaderValue::from_str(token) {
+        headers.insert(header::VARY, v);
+    }
+}

--- a/bin/router/src/http_utils/mod.rs
+++ b/bin/router/src/http_utils/mod.rs
@@ -1,5 +1,6 @@
 // The `graphiql` feature skips Laboratory asset generation, so there is no page to seed.
 pub mod body;
+pub(crate) mod headers;
 #[cfg(not(feature = "graphiql"))]
 pub mod laboratory;
 pub mod landing_page;

--- a/bin/router/src/lib.rs
+++ b/bin/router/src/lib.rs
@@ -51,6 +51,7 @@ use crate::{
         },
         request_identifiers::RequestIdentifiersService,
         request_summary::RequestSummaryService,
+        response_compression::ResponseCompressionService,
         timeout::handle_timeout,
         usage_reporting::HiveUsageReportingBackgroundTasks,
         validation::{
@@ -485,11 +486,13 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
     let graphql_path = graphql_path.to_string();
     let long_lived_client_limit_service =
         LongLivedClientLimitService::new(shared_state.router_config);
+    let response_compression_service = ResponseCompressionService::new(shared_state.router_config);
 
     let mut server = web::HttpServer::new(async move || {
         let landing_page_path = graphql_path.clone();
         let prometheus = prometheus.clone();
         let long_lived_client_limit_service = long_lived_client_limit_service.clone();
+        let response_compression_service = response_compression_service.clone();
         let paths_for_plugin = paths.clone();
         web::App::new()
             .middleware(long_lived_client_limit_service)
@@ -499,6 +502,10 @@ pub async fn router_entrypoint(plugin_registry: PluginRegistry) -> Result<(), Ro
             ))
             .middleware(RequestSummaryService::new(&graphql_path))
             .middleware(RequestIdentifiersService)
+            // last: the outermost layer, so it's the final thing touching the response body
+            // before it reaches the socket - everything above still sees the real,
+            // uncompressed size/content (RequestSummaryService's logged size included).
+            .middleware(response_compression_service)
             .state(shared_state.clone())
             .state(schema_state.clone())
             .state(shared_state.telemetry_context.clone())

--- a/bin/router/src/pipeline/cors.rs
+++ b/bin/router/src/pipeline/cors.rs
@@ -1,10 +1,12 @@
-use crate::config::cors::{CORSConfig, CORSPolicyConfig};
+use crate::{
+    config::cors::{CORSConfig, CORSPolicyConfig},
+    http_utils::headers::append_vary,
+};
 use http::{header, StatusCode};
 use ntex::{
     http::{header::HeaderValue, HeaderMap, Method},
     web::{self, HttpRequest},
 };
-// use regex::Regex;
 use regex_automata::{
     meta::{BuildError, Regex},
     util::syntax::Config as SyntaxConfig,
@@ -269,35 +271,6 @@ fn merge_preflight_headers(
     let mut out = global.clone();
     out.extend(overrides.iter().map(|(k, v)| (k.clone(), v.clone())));
     out
-}
-
-fn append_vary(headers: &mut HeaderMap, token: &str) {
-    if let Some(existing) = headers.get(header::VARY).and_then(|v| v.to_str().ok()) {
-        if existing
-            .split(',')
-            .map(|s| s.trim())
-            .any(|t| t.eq_ignore_ascii_case(token))
-        {
-            // already present
-            return;
-        }
-
-        let new_header_value = if existing.is_empty() {
-            HeaderValue::from_str(token)
-        } else {
-            HeaderValue::from_str(&format!("{}, {}", existing, token))
-        };
-
-        if let Ok(v) = new_header_value {
-            headers.insert(header::VARY, v);
-        }
-
-        return;
-    }
-
-    if let Ok(v) = HeaderValue::from_str(token) {
-        headers.insert(header::VARY, v);
-    }
 }
 
 #[cfg(test)]

--- a/bin/router/src/pipeline/error.rs
+++ b/bin/router/src/pipeline/error.rs
@@ -51,6 +51,7 @@ pub type PipelineErrorAdditionalHeaders = Vec<(HeaderName, HeaderValue)>;
 /// unsupported transport, etc).
 /// Their `Display` message is safe to return to the client as-is because it's derived only from client-controlled data.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
+#[non_exhaustive]
 pub enum ClientPipelineError {
     #[error("Unsupported HTTP method: {0}")]
     #[strum(serialize = "METHOD_NOT_ALLOWED")]
@@ -67,6 +68,10 @@ pub enum ClientPipelineError {
     #[error("Content-Type header is not supported")]
     #[strum(serialize = "UNSUPPORTED_CONTENT_TYPE")]
     UnsupportedContentType,
+
+    #[error("Content-Encoding '{0}' is not supported")]
+    #[strum(serialize = "UNSUPPORTED_CONTENT_ENCODING")]
+    UnsupportedContentEncoding(String),
 
     #[error("Request headers exceed the maximum allowed size")]
     #[strum(serialize = "REQUEST_HEADER_FIELDS_TOO_LARGE")]
@@ -174,6 +179,7 @@ pub enum ClientPipelineError {
 /// must never reach the client - only the generic message from `graphql_error_message()`
 /// does. The real message is still logged for debugging purposes.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
+#[non_exhaustive]
 pub enum InternalPipelineError {
     #[error("Failed to produce a plan: {0}")]
     #[strum(serialize = "QUERY_PLAN_BUILD_FAILED")]
@@ -233,6 +239,10 @@ pub enum InternalPipelineError {
     #[error("Supergraph runtime error")]
     #[strum(serialize = "SUPERGRAPH_RUNTIME_ERROR")]
     RouterSupergraphRuntimeError(RouterSupergraphRuntimeError),
+
+    #[error("Failed to read response body while compressing it: {0}")]
+    #[strum(serialize = "RESPONSE_COMPRESSION_FAILED")]
+    ResponseCompressionFailed(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -399,6 +409,7 @@ impl ClientPipelineError {
             (Self::AuthorizationFailed(_), _) => StatusCode::FORBIDDEN,
             (Self::MissingContentTypeHeader, _) => StatusCode::NOT_ACCEPTABLE,
             (Self::UnsupportedContentType, _) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            (Self::UnsupportedContentEncoding(_), _) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             (Self::RequestHeadersTooLarge, _) => StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             (Self::CsrfPreventionFailed, _) => StatusCode::FORBIDDEN,
             (Self::JwtError(err), _) => err.status_code(),

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -1,4 +1,5 @@
 use crate::http_utils::body::read_body_stream;
+use crate::pipeline::request_decompression::negotiate_request_encoding;
 use crate::query_planner::{
     state::supergraph_state::OperationKind, utils::cancellation::CancellationToken,
 };
@@ -105,9 +106,11 @@ pub mod parser;
 pub mod persisted_documents;
 pub mod progressive_override;
 pub mod query_plan;
+pub mod request_decompression;
 pub mod request_extensions;
 pub mod request_identifiers;
 pub mod request_summary;
+pub mod response_compression;
 pub mod sse;
 pub mod timeout;
 pub(crate) mod trie;
@@ -176,6 +179,19 @@ pub async fn graphql_request_handler(
 
         perform_csrf_prevention(req, &shared_state.router_config.csrf)?;
 
+        let content_encoding = match negotiate_request_encoding(
+            req.headers(),
+            &shared_state.router_config.traffic_shaping.router.compression.request,
+        ) {
+            Ok(content_encoding) => content_encoding,
+            Err(err) => {
+                // drain a small amount of the body so the connection can be closed
+                // cleanly instead of being reset (see `read_body_stream`)
+                drain_body_stream(&mut body_stream).await;
+                return Err(err.into());
+            }
+        };
+
         let body_bytes = read_body_stream(
             req,
             body_stream,
@@ -184,6 +200,7 @@ pub async fn graphql_request_handler(
                 .limits
                 .max_request_body_size
                 .to_bytes() as usize,
+            content_encoding,
         )
         .await?;
 

--- a/bin/router/src/pipeline/request_decompression.rs
+++ b/bin/router/src/pipeline/request_decompression.rs
@@ -1,0 +1,36 @@
+use http::header::CONTENT_ENCODING;
+use ntex::http::HeaderMap;
+
+use crate::{
+    config::traffic_shaping::{CompressionAlgorithm, TrafficShapingRouterRequestCompressionConfig},
+    pipeline::error::ClientPipelineError,
+};
+
+pub fn negotiate_request_encoding(
+    headers: &HeaderMap,
+    config: &TrafficShapingRouterRequestCompressionConfig,
+) -> Result<Option<CompressionAlgorithm>, ClientPipelineError> {
+    let Some(header) = headers.get(&CONTENT_ENCODING) else {
+        return Ok(None);
+    };
+
+    let raw = header
+        .to_str()
+        .map_err(|_| ClientPipelineError::InvalidHeaderValue(CONTENT_ENCODING))?
+        .trim();
+
+    if raw.eq_ignore_ascii_case("identity") {
+        return Ok(None);
+    }
+
+    if !config.enabled || raw.contains(',') {
+        return Err(ClientPipelineError::UnsupportedContentEncoding(
+            raw.to_string(),
+        ));
+    }
+
+    CompressionAlgorithm::from_token(raw)
+        .filter(|algorithm| config.algorithms.contains(algorithm))
+        .ok_or_else(|| ClientPipelineError::UnsupportedContentEncoding(raw.to_string()))
+        .map(Some)
+}

--- a/bin/router/src/pipeline/response_compression.rs
+++ b/bin/router/src/pipeline/response_compression.rs
@@ -1,0 +1,251 @@
+use std::{cmp::Ordering, io::Write, rc::Rc};
+
+use http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE};
+use ntex::{
+    http::{
+        body::{Body, BodySize, MessageBody, ResponseBody},
+        encoding::Encoder,
+        header::{ContentEncoding, HeaderValue},
+        StatusCode,
+    },
+    service::{Service, ServiceCtx},
+    util::{Bytes, BytesMut},
+    web::{self, DefaultError},
+    Middleware, SharedCfg,
+};
+use tokio_stream::StreamExt;
+use tracing::error;
+
+use crate::{
+    config::traffic_shaping::{
+        BrotliCompressionConfig, ResponseCompressionAlgorithmConfig,
+        TrafficShapingRouterCompressionConfig, ZstdCompressionConfig,
+    },
+    executor::{execution::plan::FailedExecutionResult, response::graphql_error::GraphQLError},
+    http_utils::headers::append_vary,
+    pipeline::error::{InternalPipelineError, PipelineError},
+    telemetry::logging::targets,
+};
+
+#[derive(Clone)]
+pub struct ResponseCompressionService {
+    response_compression_config: &'static TrafficShapingRouterCompressionConfig,
+}
+
+impl ResponseCompressionService {
+    pub fn new(router_config: &'static crate::config::HiveRouterConfig) -> Self {
+        Self {
+            response_compression_config: &router_config.traffic_shaping.router.compression,
+        }
+    }
+}
+
+impl<S> Middleware<S, SharedCfg> for ResponseCompressionService {
+    type Service = ResponseCompressionMiddleware<S>;
+
+    fn create(&self, service: S, _cfg: SharedCfg) -> Self::Service {
+        ResponseCompressionMiddleware {
+            service,
+            response_compression_config: self.response_compression_config,
+        }
+    }
+}
+
+pub struct ResponseCompressionMiddleware<S> {
+    service: S,
+    response_compression_config: &'static TrafficShapingRouterCompressionConfig,
+}
+
+impl<S> Service<web::WebRequest<DefaultError>> for ResponseCompressionMiddleware<S>
+where
+    S: Service<web::WebRequest<DefaultError>, Response = web::WebResponse, Error = web::Error>,
+{
+    type Response = web::WebResponse;
+    type Error = S::Error;
+
+    ntex::forward_ready!(service);
+
+    async fn call(
+        &self,
+        req: web::WebRequest<DefaultError>,
+        ctx: ServiceCtx<'_, Self>,
+    ) -> Result<Self::Response, Self::Error> {
+        let config = &self.response_compression_config.response;
+
+        if !config.enabled {
+            return ctx.call(&self.service, req).await;
+        }
+
+        let negotiated = negotiate(req.headers().get(&ACCEPT_ENCODING), &config.algorithms);
+        let mut response = ctx.call(&self.service, req).await?;
+
+        // An indicator for caching/proxy layers that the response depends on Accept-Encoding
+        // and that compression was applied to it.
+        append_vary(response.headers_mut(), ACCEPT_ENCODING.as_str());
+
+        let Some(algorithm) = negotiated else {
+            return Ok(response);
+        };
+
+        let min_size = config.min_size.to_bytes();
+        let should_compress = match response.response().body().size() {
+            BodySize::Sized(n) => n >= min_size,
+            // SSE or unknown stream size are not compressible
+            BodySize::Stream => false,
+            BodySize::Empty => false,
+            _ => false,
+        };
+
+        if !should_compress {
+            return Ok(response);
+        }
+
+        let response = match algorithm {
+            ResponseCompressionAlgorithmConfig::Gzip => {
+                response.map_body(|head, body| Encoder::response(ContentEncoding::Gzip, head, body))
+            }
+            ResponseCompressionAlgorithmConfig::Deflate => response
+                .map_body(|head, body| Encoder::response(ContentEncoding::Deflate, head, body)),
+            ResponseCompressionAlgorithmConfig::Br(brotli) => {
+                compress_full_body(response, "br", brotli_compressor(*brotli)).await
+            }
+            ResponseCompressionAlgorithmConfig::Zstd(zstd) => {
+                compress_full_body(response, "zstd", zstd_compressor(*zstd)).await
+            }
+        };
+
+        Ok(response)
+    }
+}
+
+/// Picks the algorithm from `algorithms` that best matches the client's `Accept-Encoding` preference
+fn negotiate<'cfg>(
+    accept_encoding: Option<&HeaderValue>,
+    algorithms: &'cfg [ResponseCompressionAlgorithmConfig],
+) -> Option<&'cfg ResponseCompressionAlgorithmConfig> {
+    let header = accept_encoding?.to_str().ok()?;
+
+    // Keep `q=0` entries in here (rather than dropping them) - per RFC 9110 §12.5.3, `*`
+    // only matches codings that aren't explicitly named elsewhere in the field, and an
+    // explicit `gzip;q=0` still counts as "named" even though it's not itself acceptable.
+    let mut candidates: Vec<(&str, f64)> = header
+        .split(',')
+        .filter_map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            let mut segments = part.split(';');
+            let token = segments.next()?.trim();
+            let quality = segments
+                .find_map(|seg| seg.trim().strip_prefix("q=")?.trim().parse::<f64>().ok())
+                .unwrap_or(1.0);
+            Some((token, quality))
+        })
+        .collect();
+
+    // stable sort by quality: ties keep the client's original listed order
+    candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+
+    let is_explicitly_named = |token: &str| {
+        candidates
+            .iter()
+            .any(|(t, _)| *t != "*" && t.eq_ignore_ascii_case(token))
+    };
+
+    for (token, quality) in &candidates {
+        if *quality <= 0.0 {
+            continue;
+        }
+        if *token == "*" {
+            if let Some(algorithm) = algorithms.iter().find(|a| !is_explicitly_named(a.token())) {
+                return Some(algorithm);
+            }
+            continue;
+        }
+        if let Some(algorithm) = algorithms
+            .iter()
+            .find(|a| a.token().eq_ignore_ascii_case(token))
+        {
+            return Some(algorithm);
+        }
+    }
+
+    None
+}
+
+fn brotli_compressor(config: BrotliCompressionConfig) -> impl FnOnce(&[u8]) -> Option<Vec<u8>> {
+    move |data| {
+        let mut out = Vec::new();
+        let mut writer = brotli::CompressorWriter::new(&mut out, 4096, config.quality as u32, 22);
+        writer.write_all(data).ok()?;
+        drop(writer);
+        Some(out)
+    }
+}
+
+fn zstd_compressor(config: ZstdCompressionConfig) -> impl FnOnce(&[u8]) -> Option<Vec<u8>> {
+    move |data| zstd::stream::encode_all(data, config.level).ok()
+}
+
+/// Drains the response body, runs `compress` on a blocking-pool thread, and rebuilds the
+/// response with the compressed bytes and a `Content-Encoding` header
+///
+/// Compression is best-effort: if it fails, we log the failure/error and return the original response
+async fn compress_full_body(
+    response: web::WebResponse,
+    token: &'static str,
+    compress: impl FnOnce(&[u8]) -> Option<Vec<u8>> + Send + 'static,
+) -> web::WebResponse {
+    let (http_response, request) = response.into_parts();
+    let (mut head, body) = http_response.into_parts();
+
+    let original = match drain_body(body).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            let pipeline_err: PipelineError =
+                InternalPipelineError::ResponseCompressionFailed(err.to_string()).into();
+
+            error!(
+                target: targets::HTTP_SERVER,
+                error = %pipeline_err,
+                "failed to read response body while compressing it; the body stream broke \
+                 mid-read and the original response can't be recovered"
+            );
+
+            let error_response = web::HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(CONTENT_TYPE, "application/json")
+                .body(
+                    FailedExecutionResult {
+                        errors: vec![GraphQLError::from_message_and_code(
+                            pipeline_err.graphql_error_message(),
+                            pipeline_err.graphql_error_code(),
+                        )],
+                    }
+                    .serialize(),
+                );
+
+            return web::WebResponse::new(error_response, request);
+        }
+    };
+
+    let fallback = original.clone();
+    let body = match ntex::rt::spawn_blocking(move || compress(&original)).await {
+        Ok(Some(compressed)) => {
+            head.headers_mut()
+                .insert(CONTENT_ENCODING, HeaderValue::from_static(token));
+            Body::Bytes(Bytes::from(compressed))
+        }
+        _ => Body::Bytes(fallback),
+    };
+
+    web::WebResponse::new(head.set_body(body), request)
+}
+
+async fn drain_body(mut body: ResponseBody<Body>) -> Result<Bytes, Rc<dyn std::error::Error>> {
+    let mut buf = BytesMut::new();
+    while let Some(chunk) = body.try_next().await? {
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.freeze())
+}

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -49,3 +49,8 @@ gag = "1.0.0"
 # Storage testing
 s3s = "0.13"
 s3s-fs = "0.13"
+
+# Compression test fixtures (gzip/deflate/brotli/zstd), versions match bin/router where applicable
+flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
+brotli = "8.0.3"
+zstd = "0.13.3"

--- a/e2e/src/compression.rs
+++ b/e2e/src/compression.rs
@@ -1,0 +1,1264 @@
+#[cfg(test)]
+mod compression_e2e_tests {
+    use std::io::Write;
+
+    use http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE, VARY};
+    use ntex::http::StatusCode;
+    use sonic_rs::JsonValueTrait;
+
+    use crate::testkit::{some_header_map, ClientResponseExt, Started, TestRouter, TestSubgraphs};
+
+    /// ntex's test HTTP client transparently decompresses `gzip`/`deflate` response bodies
+    /// (and strips nothing from the headers while doing it), which would hide exactly what
+    /// we're trying to assert on here. `.no_decompress()` gets us the real wire bytes and
+    /// headers, matching what an actual client would see before it decodes anything itself.
+    async fn send_graphql_request_raw(
+        router: &TestRouter<Started>,
+        query: &str,
+        headers: http::HeaderMap,
+    ) -> ntex::client::ClientResponse {
+        let mut req = router
+            .serv()
+            .post(router.graphql_path())
+            .no_decompress()
+            .header(CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "application/graphql-response+json");
+        for (key, value) in headers.iter() {
+            req = req.set_header(key, value);
+        }
+        req.send_json(&sonic_rs::json!({ "query": query, "variables": null }))
+            .await
+            .expect("failed to send graphql request")
+    }
+
+    fn gzip_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).expect("failed to gzip data");
+        encoder.finish().expect("failed to finish gzip stream")
+    }
+
+    fn gzip_decompress(data: &[u8]) -> Vec<u8> {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        let mut decoder = GzDecoder::new(data);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("failed to gunzip response body");
+        out
+    }
+
+    fn deflate_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::ZlibEncoder, Compression};
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).expect("failed to deflate data");
+        encoder.finish().expect("failed to finish deflate stream")
+    }
+
+    fn deflate_decompress(data: &[u8]) -> Vec<u8> {
+        use flate2::read::ZlibDecoder;
+        use std::io::Read;
+        let mut decoder = ZlibDecoder::new(data);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("failed to inflate response body");
+        out
+    }
+
+    fn brotli_compress(data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut writer = brotli::CompressorWriter::new(&mut out, 4096, 5, 22);
+            writer.write_all(data).expect("failed to brotli data");
+        }
+        out
+    }
+
+    fn brotli_decompress(data: &[u8]) -> Vec<u8> {
+        use std::io::Read;
+        let mut decoder = brotli::Decompressor::new(data, 4096);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("failed to un-brotli response body");
+        out
+    }
+
+    fn zstd_compress(data: &[u8]) -> Vec<u8> {
+        zstd::stream::encode_all(data, 3).expect("failed to zstd data")
+    }
+
+    fn zstd_decompress(data: &[u8]) -> Vec<u8> {
+        zstd::stream::decode_all(data).expect("failed to un-zstd response body")
+    }
+
+    fn typename_query_body() -> Vec<u8> {
+        sonic_rs::to_vec(&sonic_rs::json!({ "query": "{ __typename }" }))
+            .expect("failed to serialize graphql request body")
+    }
+
+    fn assert_typename_response(body: &[u8]) {
+        let value: sonic_rs::Value =
+            sonic_rs::from_slice(body).expect("response body should be valid JSON");
+        assert_eq!(
+            value["data"]["__typename"].as_str(),
+            Some("Query"),
+            "unexpected response body: {}",
+            String::from_utf8_lossy(body)
+        );
+    }
+
+    #[ntex::test]
+    async fn should_compress_response_with_gzip_when_client_accepts_it() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"gzip".as_slice()),
+            "expected a gzip-encoded response"
+        );
+
+        let raw_body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&gzip_decompress(&raw_body));
+    }
+
+    #[ntex::test]
+    async fn should_compress_response_with_deflate_when_client_accepts_it() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "deflate" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"deflate".as_slice()),
+            "expected a deflate-encoded response"
+        );
+
+        let raw_body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&deflate_decompress(&raw_body));
+    }
+
+    #[ntex::test]
+    async fn should_compress_response_with_brotli_when_client_accepts_it() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "br" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"br".as_slice()),
+            "expected a brotli-encoded response"
+        );
+
+        let raw_body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&brotli_decompress(&raw_body));
+    }
+
+    #[ntex::test]
+    async fn should_compress_response_with_zstd_when_client_accepts_it() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "zstd" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"zstd".as_slice()),
+            "expected a zstd-encoded response"
+        );
+
+        let raw_body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&zstd_decompress(&raw_body));
+    }
+
+    #[ntex::test]
+    async fn should_not_compress_response_when_client_does_not_accept_any_configured_algorithm() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // "compress" (old Unix LZW) is a registered content-coding token that's never actually
+        // implemented anywhere, so it's not in the default `algorithms` allow-list. The router
+        // must fall back to an uncompressed response instead of erroring.
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "compress" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()),
+            None,
+            "response must not be encoded when the client only accepts an unsupported algorithm"
+        );
+
+        let raw_body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&raw_body);
+    }
+
+    #[ntex::test]
+    async fn should_skip_compression_for_responses_smaller_than_min_size() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // default min_size is 1KiB; `{ __typename }` produces a response far smaller than that.
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()),
+            None,
+            "tiny responses should be left uncompressed under the default min_size"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_compress_responses_at_or_above_min_size() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"gzip".as_slice()),
+            "with min_size lowered to 1B, even a tiny response should be compressed"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_not_compress_response_when_response_compression_disabled() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                enabled: false
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()),
+            None,
+            "response compression must be entirely off when response.enabled is false"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_not_compress_streaming_subscription_response() {
+        let subgraphs = TestSubgraphs::builder()
+            .with_http_streaming_subscriptions_protocol(
+                subgraphs::HTTPStreamingSubscriptionProtocol::SseOnly,
+            )
+            .build()
+            .start()
+            .await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            r#"
+            subscription {
+                reviewAdded(intervalInMs: 0) {
+                    product {
+                        upc
+                    }
+                }
+            }
+            "#,
+            some_header_map! {
+                ACCEPT_ENCODING => "gzip",
+                http::header::ACCEPT => "text/event-stream"
+            }
+            .unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()),
+            None,
+            "streaming (SSE/multipart) responses must never be compressed, \
+             since compressors buffer output and would delay live event delivery"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_accept_gzip_compressed_request_body() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = gzip_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "gzip")
+            .send_body(compressed)
+            .await
+            .expect("failed to send gzip-compressed request");
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&body);
+    }
+
+    #[ntex::test]
+    async fn should_accept_deflate_compressed_request_body() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = deflate_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "deflate")
+            .send_body(compressed)
+            .await
+            .expect("failed to send deflate-compressed request");
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&body);
+    }
+
+    #[ntex::test]
+    async fn should_accept_brotli_compressed_request_body() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = brotli_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "br")
+            .send_body(compressed)
+            .await
+            .expect("failed to send brotli-compressed request");
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&body);
+    }
+
+    #[ntex::test]
+    async fn should_accept_zstd_compressed_request_body() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = zstd_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "zstd")
+            .send_body(compressed)
+            .await
+            .expect("failed to send zstd-compressed request");
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&body);
+    }
+
+    #[ntex::test]
+    async fn should_reject_unsupported_content_encoding_with_415() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // "compress" (old Unix LZW) is not in the default `algorithms` allow-list.
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "compress")
+            .send_body(typename_query_body())
+            .await
+            .expect("request should get an HTTP response, not a transport error");
+
+        assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[ntex::test]
+    async fn should_reject_multi_valued_content_encoding_with_415() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // stacked codings (e.g. "gzip, br") are explicitly out of scope; the router should
+        // reject cleanly rather than attempt a single-pass decode of double-encoded bytes.
+        let compressed = gzip_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "gzip, br")
+            .send_body(compressed)
+            .await
+            .expect("request should get an HTTP response, not a transport error");
+
+        assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[ntex::test]
+    async fn should_reject_compressed_request_when_decompression_disabled() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            request:
+                                enabled: false
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = gzip_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "gzip")
+            .send_body(compressed)
+            .await
+            .expect("request should get an HTTP response, not a transport error");
+
+        assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[ntex::test]
+    async fn should_reject_oversized_decompressed_body_with_413() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                limits:
+                    max_request_body_size: 100B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // Highly compressible payload: tiny on the wire, but decompresses past the
+        // configured 100B limit. The size guard must apply to the inflated bytes.
+        let inflated = vec![b'a'; 10_000];
+        let compressed = gzip_compress(&inflated);
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "gzip")
+            .send_body(compressed)
+            .await;
+
+        match res {
+            Ok(res) => assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE),
+            Err(e) => panic!("expected an HTTP 413 response, got a transport error: {e:?}"),
+        }
+    }
+
+    // Confirms something similar to Apollo Router's CVE-2024-28101: the request body size
+    // limit was only enforced *after* the compressed body had been fully decompressed into
+    // memory, so a small, highly compressible payload could exhaust memory before the check
+    // ever ran
+    #[ntex::test]
+    async fn should_reject_single_chunk_decompression_bomb_promptly() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                limits:
+                    max_request_body_size: 50KiB
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // ~25MB of a single repeated byte compresses to ~24KB with gzip - comfortably under
+        // the 50KiB limit on the wire, but the decompressed size (25MB) is nowhere close.
+        let inflated = vec![b'a'; 25_000_000];
+        let compressed = gzip_compress(&inflated);
+        assert!(
+            compressed.len() < 50 * 1024,
+            "test payload must compress to under the 50KiB limit for this test to be meaningful, got {} bytes",
+            compressed.len()
+        );
+
+        let send = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "gzip")
+            .send_body(compressed);
+
+        let res = tokio::time::timeout(std::time::Duration::from_secs(10), send)
+            .await
+            .expect("router did not respond within 10s - something is going wrong");
+
+        match res {
+            Ok(res) => {
+                assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+                let body: sonic_rs::Value = res.json_body().await;
+
+                // PAYLOAD_TOO_LARGE_BODY_STREAM is set when we really hit the limit while
+                // reading the body, and not based on content-length
+                assert_eq!(
+                    body["errors"][0]["extensions"]["code"].as_str(),
+                    Some("PAYLOAD_TOO_LARGE_BODY_STREAM"),
+                    "expected the decompressed-size guard to reject this, not the \
+                     Content-Length fast-path, got: {body:?}"
+                );
+            }
+            Err(e) => panic!("expected an HTTP 413 response, got a transport error: {e:?}"),
+        }
+    }
+
+    #[ntex::test]
+    async fn should_reject_malformed_body_for_each_algorithm_with_400() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let garbage = b"this is plain text, not compressed data of any kind: 1234567890".to_vec();
+
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let res = router
+                .serv()
+                .post(router.graphql_path())
+                .header(CONTENT_TYPE, "application/json")
+                .header(CONTENT_ENCODING, algorithm)
+                .send_body(garbage.clone())
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("[{algorithm}] expected an HTTP response, got a transport error: {e:?}")
+                });
+
+            assert_eq!(
+                res.status(),
+                StatusCode::BAD_REQUEST,
+                "[{algorithm}] expected 400 for a body that doesn't match the claimed encoding"
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn should_never_propagate_content_encoding_to_subgraphs() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                headers:
+                    all:
+                        request:
+                            - propagate:
+                                matching: ".*"
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = gzip_compress(
+            &sonic_rs::to_vec(&sonic_rs::json!({ "query": "{ users { id } }" })).unwrap(),
+        );
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "gzip")
+            .send_body(compressed)
+            .await
+            .expect("failed to send gzip-compressed request");
+
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let subgraph_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests sent to accounts subgraph");
+        assert_eq!(
+            subgraph_requests.len(),
+            1,
+            "expected 1 request to accounts subgraph"
+        );
+
+        let subgraph_request = &subgraph_requests[0];
+        assert!(
+            subgraph_request.headers.get("content-encoding").is_none(),
+            "content-encoding must never be forwarded to subgraphs, even under a \".*\" propagate rule"
+        );
+
+        // the subgraph must have received the already-decompressed, valid JSON body
+        let subgraph_body = subgraph_request
+            .body
+            .as_ref()
+            .expect("expected a body to have been sent to the subgraph");
+        sonic_rs::from_slice::<sonic_rs::Value>(subgraph_body)
+            .expect("subgraph should have received valid, decompressed JSON");
+    }
+
+    // test the `>=` semantics of `min_size`
+    #[ntex::test]
+    async fn should_treat_min_size_as_an_inclusive_lower_bound() {
+        let probe_router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+        let probe_res =
+            send_graphql_request_raw(&probe_router, "{ __typename }", http::HeaderMap::new()).await;
+        let body_len = probe_res
+            .body()
+            .await
+            .expect("failed to read probe response body")
+            .len();
+
+        for (min_size, should_compress) in [
+            (body_len + 1, false),
+            (body_len, true),
+            (body_len.saturating_sub(1).max(1), true),
+        ] {
+            let router = TestRouter::builder()
+                .inline_config(format!(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    traffic_shaping:
+                        router:
+                            compression:
+                                response:
+                                    min_size: {min_size}B
+                    "#
+                ))
+                .build()
+                .start()
+                .await;
+
+            let res = send_graphql_request_raw(
+                &router,
+                "{ __typename }",
+                some_header_map! { ACCEPT_ENCODING => "gzip" }.unwrap(),
+            )
+            .await;
+
+            let is_compressed = res.header(CONTENT_ENCODING.as_str()).is_some();
+            assert_eq!(
+                is_compressed, should_compress,
+                "min_size={min_size}, response body is {body_len} bytes uncompressed"
+            );
+        }
+    }
+
+    fn vary_contains(res: &ntex::client::ClientResponse, token: &str) -> bool {
+        res.header(VARY.as_str())
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.split(',').any(|t| t.trim().eq_ignore_ascii_case(token)))
+            .unwrap_or(false)
+    }
+
+    #[ntex::test]
+    async fn should_set_vary_accept_encoding_when_compression_is_negotiated() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip" }.unwrap(),
+        )
+        .await;
+
+        assert!(
+            res.header(CONTENT_ENCODING.as_str()).is_some(),
+            "sanity check: response should actually be compressed here"
+        );
+        assert!(
+            vary_contains(&res, "accept-encoding"),
+            "expected Vary to include accept-encoding, got: {:?}",
+            res.header(VARY.as_str())
+        );
+    }
+
+    #[ntex::test]
+    async fn should_set_vary_accept_encoding_even_when_response_is_not_compressed() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(&router, "{ __typename }", http::HeaderMap::new()).await;
+
+        assert!(res.header(CONTENT_ENCODING.as_str()).is_none());
+        assert!(
+            vary_contains(&res, "accept-encoding"),
+            "expected Vary to include accept-encoding even for an uncompressed response, got: {:?}",
+            res.header(VARY.as_str())
+        );
+    }
+
+    #[ntex::test]
+    async fn should_append_to_existing_vary_header_instead_of_overwriting() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                cors:
+                    enabled: true
+                    policies:
+                        - origins: ["https://example.com"]
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! {
+                ACCEPT_ENCODING => "gzip",
+                http::header::ORIGIN => "https://example.com"
+            }
+            .unwrap(),
+        )
+        .await;
+
+        assert!(
+            vary_contains(&res, "origin"),
+            "expected CORS's own Vary: Origin to survive, got: {:?}",
+            res.header(VARY.as_str())
+        );
+        assert!(
+            vary_contains(&res, "accept-encoding"),
+            "expected accept-encoding to be appended, not to replace CORS's Vary, got: {:?}",
+            res.header(VARY.as_str())
+        );
+    }
+
+    #[ntex::test]
+    async fn should_prefer_higher_quality_algorithm_via_accept_encoding_q_values() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        // gzip is listed first (and is earlier in the default `algorithms` preference order),
+        // but br has the higher q-value and must win.
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip;q=0.1, br;q=0.9" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"br".as_slice()),
+            "the higher q-value (br) should win over gzip, despite gzip being listed first"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_compress_with_wildcard_accept_encoding() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "*" }.unwrap(),
+        )
+        .await;
+
+        // default `algorithms` preference order is [gzip, zstd, br, deflate]
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"gzip".as_slice()),
+            "a bare wildcard should pick the router's own top preference"
+        );
+    }
+
+    // Regression test: per RFC 9110 §12.5.3, `*` only matches content-codings that aren't
+    // explicitly named elsewhere in the field. `gzip;q=0` explicitly marks gzip as
+    // unacceptable, and `*` must not override that even though gzip is the router's own top
+    // preference - it should fall through to the next preferred algorithm the client didn't
+    // explicitly exclude.
+    #[ntex::test]
+    async fn should_not_let_wildcard_override_an_explicit_q0_exclusion() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip;q=0, *" }.unwrap(),
+        )
+        .await;
+
+        // default `algorithms` preference order is [gzip, zstd, br, deflate] - gzip is
+        // explicitly excluded, so the wildcard must resolve to zstd (the next preference).
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"zstd".as_slice()),
+            "gzip;q=0 must stay unacceptable even though * is also present"
+        );
+    }
+
+    // Regression test: if every configured algorithm is explicitly excluded with q=0, the
+    // wildcard must not match any of them, and the response should be left uncompressed.
+    #[ntex::test]
+    async fn should_not_compress_when_wildcard_cannot_satisfy_any_explicitly_excluded_algorithm() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                                algorithms:
+                                    - kind: gzip
+                                    - kind: deflate
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "gzip;q=0, deflate;q=0, *" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()),
+            None,
+            "every configured algorithm was explicitly excluded, so * has nothing left to match"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_negotiate_response_encoding_case_insensitively() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "GZIP" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            res.header(CONTENT_ENCODING.as_str()).map(|v| v.as_bytes()),
+            Some(b"gzip".as_slice()),
+            "Accept-Encoding token matching must be case-insensitive"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_decompress_request_encoding_case_insensitively() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let compressed = gzip_compress(&typename_query_body());
+
+        let res = router
+            .serv()
+            .post(router.graphql_path())
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_ENCODING, "GZIP")
+            .send_body(compressed)
+            .await
+            .expect("failed to send gzip-compressed request");
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.body().await.expect("failed to read response body");
+        assert_typename_response(&body);
+    }
+
+    #[ntex::test]
+    async fn should_not_compress_when_accept_encoding_header_is_empty() {
+        let router = TestRouter::builder()
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    router:
+                        compression:
+                            response:
+                                min_size: 1B
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = send_graphql_request_raw(
+            &router,
+            "{ __typename }",
+            some_header_map! { ACCEPT_ENCODING => "" }.unwrap(),
+        )
+        .await;
+
+        assert_eq!(res.status(), 200);
+        assert!(res.header(CONTENT_ENCODING.as_str()).is_none());
+    }
+}

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -13,6 +13,8 @@ mod cache_control;
 #[cfg(test)]
 mod circuit_breaker;
 #[cfg(test)]
+mod compression;
+#[cfg(test)]
 mod conditional_directives;
 #[cfg(test)]
 mod coprocessor;

--- a/e2e/src/testkit/mod.rs
+++ b/e2e/src/testkit/mod.rs
@@ -46,8 +46,10 @@ use hive_router::{
     configure_ntex_app, init_rustls_crypto_provider, invoke_shutdown_hooks,
     pipeline::long_lived_client_limit::LongLivedClientLimitService,
     pipeline::request_identifiers::RequestIdentifiersService,
-    pipeline::request_summary::RequestSummaryService, plugins::plugins_service::PluginService,
-    telemetry::Telemetry, PluginRegistry, RouterPaths, RouterSharedState, SchemaState,
+    pipeline::request_summary::RequestSummaryService,
+    pipeline::response_compression::ResponseCompressionService,
+    plugins::plugins_service::PluginService, telemetry::Telemetry, PluginRegistry, RouterPaths,
+    RouterSharedState, SchemaState,
 };
 use subgraphs::{subgraphs_app, HTTPStreamingSubscriptionProtocol};
 
@@ -949,6 +951,7 @@ impl TestRouter<Built> {
         let serv_paths = paths.clone();
         let serv_prometheus = prometheus.clone();
         let long_lived_limit = LongLivedClientLimitService::new(shared_state.router_config);
+        let response_compression = ResponseCompressionService::new(shared_state.router_config);
 
         let secure = serv_shared_state
             .router_config
@@ -975,6 +978,7 @@ impl TestRouter<Built> {
             let serv_callback_path = serv_callback_path.clone();
             let callback_subs = serv_callback_subs.clone();
             let long_lived_limit = long_lived_limit.clone();
+            let response_compression = response_compression.clone();
 
             // set the tracing dispatch on the server thread. the guard is
             // intentionally leaked: dropping it would restore the no-op default
@@ -995,6 +999,7 @@ impl TestRouter<Built> {
                     ))
                     .middleware(RequestSummaryService::new(&paths.graphql))
                     .middleware(RequestIdentifiersService)
+                    .middleware(response_compression)
                     .state(shared_state.clone())
                     .state(schema_state)
                     .state(callback_subs)


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/315

HTTP compression between the client and the router. Supports gzip, deflate, br, and zstd in both directions.

Default config:

```yaml
traffic_shaping:
  router:
    compression:
      response:
        enabled: true
        algorithms:
          - kind: gzip
          - kind: zstd
            level: 3
          - kind: br
            quality: 5
          - kind: deflate
        min_size: 1KiB
      request:
        enabled: true
        algorithms: [gzip, zstd, br, deflate]
```


## Response Compression

- Negotiated against the client's `Accept-Encoding` (`q`-value aware, `*`-aware), restricted to a configurable algorithms allow-list — br/zstd carry their own inline tuning (quality/level) co-located with their entry in that list.
-  Responses below `min_size` (default 1KiB) are left uncompressed; Also streaming responses (SSE/multipart subscriptions) are never compressed.
- gzip/deflate reuse `ntex`'s built-in encoder; br/zstd (unsupported by `ntex`) compress on the blocking pool. 
- Best-effort: a compression failure falls back to the original uncompressed body rather than erroring.
- Sets `Vary: Accept-Encoding` on every response while compression is enabled, appending to any existing Vary (e.g. from CORS) rather than clobbering it — needed for downstream cache layer

## Request Decompression

- Applied based on the client's `Content-Encoding`, validated against `compression.request` (enabled + algorithm allow-list). Unsupported, disabled, or stacked/multi-valued (`gzip, br`) encodings are rejected with HTTP 415.
- Decompresses incrementally as chunks arrive, checking the decompressed size against `limits.max_request_body_size` after each chunk — this is what actually guards against decompression bombs.
- A body that doesn't actually match its claimed `Content-Encoding` fails closed with HTTP 400, for all four algorithms.

## Other stuff 
- Fixed a pre-existing bug: `content-encoding` was missing from the router's hop-by-hop header deny-list. Now it's more crucial so fixes. 