### PR TITLE
feat(router): compression between router and subgraphs

### DIFF
--- a/.changeset/subgraph_http_compression.md
+++ b/.changeset/subgraph_http_compression.md
@@ -1,0 +1,37 @@
+---
+hive-router: minor
+---
+
+# HTTP compression between the router and subgraphs
+
+Implements HTTP compression for router ↔ subgraph calls. `gzip`, `deflate`, `br` (Brotli), and `zstd` are supported.
+
+```yaml
+traffic_shaping:
+  all:
+    compression:
+      request:
+        enabled: false
+        algorithm:
+          kind: gzip
+  subgraphs:
+    accounts:
+      compression:
+        request:
+          enabled: true
+          algorithm:
+            kind: zstd
+            level: 5
+```
+
+Compressing outbound requests to a subgraph is opt-in and off by default, since compressing
+unconditionally could break a subgraph that doesn't decompress. 
+
+A per-subgraph override fully replaces the `all` default rather than merging field-by-field.
+
+Decompressing subgraph responses is always on and unconfigured, so the router transparently decompresses any subgraph response carrying a
+recognized `Content-Encoding` regardless of the outbound setting.
+
+The router now also always advertises `Accept-Encoding: gzip, deflate, br, zstd` to every subgraph, independent of whether outbound compression is enabled.
+
+Closes https://github.com/graphql-hive/router/issues/315

--- a/bin/router/src/config/traffic_shaping.rs
+++ b/bin/router/src/config/traffic_shaping.rs
@@ -84,6 +84,21 @@ impl SupergraphTrafficShapingConfig {
             .unwrap_or(self.all.pool_idle_timeout)
     }
 
+    /// Returns the resolved compression config for a subgraph.
+    ///
+    /// A per-subgraph `compression` block fully replaces `traffic_shaping.all.compression`
+    /// (unlike `websocket`, fields aren't merged - `request.enabled` and `request.algorithm`
+    /// always come from the same level).
+    pub fn subgraph_compression(
+        &self,
+        subgraph_name: &str,
+    ) -> TrafficShapingSubgraphCompressionConfig {
+        self.subgraphs
+            .get(subgraph_name)
+            .and_then(|config| config.compression)
+            .unwrap_or(self.all.compression)
+    }
+
     /// Returns whether any configured traffic-shaping rule can reuse WebSocket connections.
     ///
     /// This is used to avoid connection fingerprinting when pooling is disabled globally and for
@@ -215,6 +230,12 @@ pub struct TrafficShapingExecutorSubgraphConfig {
     /// Omitted fields inherit their values from `traffic_shaping.all.websocket`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub websocket: Option<TrafficShapingWebSocketConfig>,
+
+    /// Overrides compression of request bodies sent to this subgraph.
+    ///
+    /// When omitted, `traffic_shaping.all.compression` is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compression: Option<TrafficShapingSubgraphCompressionConfig>,
 }
 
 /// Controls which transport queries and mutations use for WebSocket-enabled subgraphs.
@@ -403,6 +424,17 @@ pub struct TrafficShapingExecutorGlobalConfig {
     /// Per-subgraph values under `traffic_shaping.subgraphs.<name>.websocket` take precedence.
     #[serde(default)]
     pub websocket: TrafficShapingWebSocketConfig,
+
+    /// Default compression of request bodies sent to subgraphs.
+    ///
+    /// Per-subgraph values under `traffic_shaping.subgraphs.<name>.compression` take precedence.
+    ///
+    /// This only controls the router -> subgraph direction. Subgraph responses are always
+    /// transparently decompressed when they carry a recognized `Content-Encoding` (`gzip`,
+    /// `deflate`, `br`, `zstd`) - there's no configuration for that direction, matching Apollo
+    /// Router, Cosmo, and Hive Gateway's behavior here.
+    #[serde(default)]
+    pub compression: TrafficShapingSubgraphCompressionConfig,
 }
 
 fn default_request_timeout() -> DurationOrExpression {
@@ -435,8 +467,54 @@ impl Default for TrafficShapingExecutorGlobalConfig {
             allow_only_http2: false,
             forward_operation_name: false,
             websocket: Default::default(),
+            compression: Default::default(),
         }
     }
+}
+
+/// Compression of traffic between the router and a subgraph.
+///
+/// Subgraph responses are always transparently decompressed when they carry a recognized
+/// `Content-Encoding` - `request` is the only configurable direction for now (compressing
+/// outbound requests unconditionally could break a subgraph that doesn't decompress, so it's
+/// opt-in). Nested under its own key so a `response` section (e.g. tuning for the always-on
+/// decompression) can be added later without a breaking shape change.
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy)]
+#[serde(deny_unknown_fields)]
+pub struct TrafficShapingSubgraphCompressionConfig {
+    /// Compresses request bodies sent to the subgraph.
+    #[serde(default)]
+    pub request: TrafficShapingSubgraphRequestCompressionConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
+#[serde(deny_unknown_fields)]
+pub struct TrafficShapingSubgraphRequestCompressionConfig {
+    /// Enables/disables compressing request bodies sent to the subgraph.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// The algorithm to compress with, and its tuning for `br`/`zstd`. Only relevant when
+    /// `enabled` is `true`.
+    ///
+    /// Unlike the client-facing `traffic_shaping.router.compression.response.algorithms`,
+    /// this is a single choice, not an allow-list: the router doesn't negotiate with the
+    /// subgraph, it unilaterally picks one algorithm and sends it.
+    #[serde(default = "default_subgraph_compression_algorithm")]
+    pub algorithm: CompressionAlgorithmConfig,
+}
+
+impl Default for TrafficShapingSubgraphRequestCompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            algorithm: default_subgraph_compression_algorithm(),
+        }
+    }
+}
+
+fn default_subgraph_compression_algorithm() -> CompressionAlgorithmConfig {
+    CompressionAlgorithmConfig::Gzip
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -640,7 +718,7 @@ pub struct TrafficShapingRouterResponseCompressionConfig {
     /// gets an uncompressed response instead. The list's order only matters as a
     /// tie-breaker when the client's preferences don't disambiguate.
     #[serde(default = "default_response_compression_algorithms")]
-    pub algorithms: Vec<ResponseCompressionAlgorithmConfig>,
+    pub algorithms: Vec<CompressionAlgorithmConfig>,
 
     /// Responses smaller than this are sent uncompressed, since compressing small
     /// payloads costs more CPU than it saves in bytes transferred.
@@ -689,7 +767,7 @@ impl Default for TrafficShapingRouterRequestCompressionConfig {
 /// A content-coding algorithm identified by its `Accept-Encoding`/`Content-Encoding` token.
 ///
 /// Used for `compression.request.algorithms`: decompression has no per-algorithm tuning,
-/// so a plain allow-list is all that's needed there. See [`ResponseCompressionAlgorithmConfig`]
+/// so a plain allow-list is all that's needed there. See [`CompressionAlgorithmConfig`]
 /// for the response side, where `br`/`zstd` carry inline tuning.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -730,14 +808,14 @@ impl CompressionAlgorithm {
 /// configuring it happen in the same place instead of a separate lookup table.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-pub enum ResponseCompressionAlgorithmConfig {
+pub enum CompressionAlgorithmConfig {
     Gzip,
     Deflate,
     Br(BrotliCompressionConfig),
     Zstd(ZstdCompressionConfig),
 }
 
-impl ResponseCompressionAlgorithmConfig {
+impl CompressionAlgorithmConfig {
     /// The `Accept-Encoding`/`Content-Encoding` token this entry matches/produces.
     pub fn token(&self) -> &'static str {
         match self {
@@ -826,12 +904,12 @@ fn default_compression_enabled() -> bool {
     true
 }
 
-fn default_response_compression_algorithms() -> Vec<ResponseCompressionAlgorithmConfig> {
+fn default_response_compression_algorithms() -> Vec<CompressionAlgorithmConfig> {
     vec![
-        ResponseCompressionAlgorithmConfig::Gzip,
-        ResponseCompressionAlgorithmConfig::Zstd(ZstdCompressionConfig::default()),
-        ResponseCompressionAlgorithmConfig::Br(BrotliCompressionConfig::default()),
-        ResponseCompressionAlgorithmConfig::Deflate,
+        CompressionAlgorithmConfig::Gzip,
+        CompressionAlgorithmConfig::Zstd(ZstdCompressionConfig::default()),
+        CompressionAlgorithmConfig::Br(BrotliCompressionConfig::default()),
+        CompressionAlgorithmConfig::Deflate,
     ]
 }
 
@@ -1133,7 +1211,7 @@ pub struct ClientAuthConfig {
 mod tests {
     use std::time::Duration;
 
-    use super::TrafficShapingRouterConfig;
+    use super::{SupergraphTrafficShapingConfig, TrafficShapingConfig, TrafficShapingRouterConfig};
 
     #[test]
     fn keep_alive_defaults_to_five_seconds() {
@@ -1175,14 +1253,12 @@ mod tests {
         assert_eq!(
             config.compression.response.algorithms,
             vec![
-                super::ResponseCompressionAlgorithmConfig::Gzip,
-                super::ResponseCompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig {
-                    level: 3
-                }),
-                super::ResponseCompressionAlgorithmConfig::Br(super::BrotliCompressionConfig {
+                super::CompressionAlgorithmConfig::Gzip,
+                super::CompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig { level: 3 }),
+                super::CompressionAlgorithmConfig::Br(super::BrotliCompressionConfig {
                     quality: 5
                 }),
-                super::ResponseCompressionAlgorithmConfig::Deflate,
+                super::CompressionAlgorithmConfig::Deflate,
             ]
         );
 
@@ -1250,14 +1326,12 @@ mod tests {
         assert_eq!(
             config.compression.response.algorithms,
             vec![
-                super::ResponseCompressionAlgorithmConfig::Gzip,
-                super::ResponseCompressionAlgorithmConfig::Br(super::BrotliCompressionConfig {
+                super::CompressionAlgorithmConfig::Gzip,
+                super::CompressionAlgorithmConfig::Br(super::BrotliCompressionConfig {
                     quality: 9
                 }),
-                super::ResponseCompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig {
-                    level: 10
-                }),
-                super::ResponseCompressionAlgorithmConfig::Deflate,
+                super::CompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig { level: 10 }),
+                super::CompressionAlgorithmConfig::Deflate,
             ]
         );
     }
@@ -1271,7 +1345,7 @@ mod tests {
 
         assert_eq!(
             config.compression.response.algorithms,
-            vec![super::ResponseCompressionAlgorithmConfig::Br(
+            vec![super::CompressionAlgorithmConfig::Br(
                 super::BrotliCompressionConfig { quality: 5 }
             )]
         );
@@ -1299,7 +1373,7 @@ mod tests {
 
             assert_eq!(
                 config.compression.response.algorithms,
-                vec![super::ResponseCompressionAlgorithmConfig::Br(
+                vec![super::CompressionAlgorithmConfig::Br(
                     super::BrotliCompressionConfig { quality }
                 )]
             );
@@ -1330,7 +1404,7 @@ mod tests {
 
             assert_eq!(
                 config.compression.response.algorithms,
-                vec![super::ResponseCompressionAlgorithmConfig::Zstd(
+                vec![super::CompressionAlgorithmConfig::Zstd(
                     super::ZstdCompressionConfig { level }
                 )]
             );
@@ -1346,5 +1420,57 @@ mod tests {
             result.is_err(),
             "unknown fields under compression.response should be rejected"
         );
+    }
+
+    #[test]
+    fn subgraph_compression_defaults_to_disabled_gzip() {
+        let config: TrafficShapingConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let compression = resolved.subgraph_compression("accounts");
+        assert!(!compression.request.enabled);
+        assert_eq!(
+            compression.request.algorithm,
+            super::CompressionAlgorithmConfig::Gzip
+        );
+    }
+
+    #[test]
+    fn subgraph_compression_inherits_from_all_when_not_overridden() {
+        let config: TrafficShapingConfig = serde_json::from_str(
+            r#"{ "all": { "compression": { "request": { "enabled": true, "algorithm": { "kind": "zstd", "level": 5 } } } } }"#,
+        )
+        .expect("config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let compression = resolved.subgraph_compression("accounts");
+        assert!(compression.request.enabled);
+        assert_eq!(
+            compression.request.algorithm,
+            super::CompressionAlgorithmConfig::Zstd(super::ZstdCompressionConfig { level: 5 })
+        );
+    }
+
+    #[test]
+    fn subgraph_compression_override_replaces_all_entirely_rather_than_merging() {
+        let config: TrafficShapingConfig = serde_json::from_str(
+            r#"{
+                "all": { "compression": { "request": { "enabled": true, "algorithm": { "kind": "gzip" } } } },
+                "subgraphs": { "accounts": { "compression": { "request": { "enabled": false } } } }
+            }"#,
+        )
+        .expect("config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let accounts = resolved.subgraph_compression("accounts");
+        assert!(
+            !accounts.request.enabled,
+            "subgraph override should replace, not merge with, `all`"
+        );
+
+        // an unrelated subgraph without its own override still inherits from `all`
+        let products = resolved.subgraph_compression("products");
+        assert!(products.request.enabled);
     }
 }

--- a/bin/router/src/executor/executors/error.rs
+++ b/bin/router/src/executor/executors/error.rs
@@ -67,6 +67,9 @@ pub enum SubgraphExecutorError {
     #[error("Invalid content type returned from subgraph '{0}': '{1}'")]
     #[strum(serialize = "SUBREQUEST_MALFORMED_RESPONSE")]
     InvalidContentType(String, String, Arc<HeaderMap>),
+    #[error("Failed to decompress response from subgraph \"{0}\" (Content-Encoding: {1})")]
+    #[strum(serialize = "SUBGRAPH_RESPONSE_DECOMPRESSION_FAILURE")]
+    ResponseDecompressionFailure(String, String, Arc<HeaderMap>),
     #[error(transparent)]
     #[strum(serialize = "SUBGRAPH_HTTPS_CERTS_FAILURE")]
     TlsCertificatesError(#[from] TlsCertificatesError),
@@ -138,6 +141,7 @@ impl SubgraphExecutorError {
             Self::ResponseDeserializationFailure(_, headers) => headers.as_deref(),
             Self::MalformedResponse(headers) => headers.as_deref(),
             Self::InvalidContentType(_, _, headers) => Some(headers.as_ref()),
+            Self::ResponseDecompressionFailure(_, _, headers) => Some(headers.as_ref()),
             _ => None,
         }
     }

--- a/bin/router/src/executor/executors/http.rs
+++ b/bin/router/src/executor/executors/http.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::config::traffic_shaping::{
+    CompressionAlgorithm, TrafficShapingSubgraphRequestCompressionConfig,
+};
 use crate::executor::executors::dedupe::unique_leader_fingerprint;
 use crate::executor::executors::inflight::InFlightRole;
 use crate::executor::executors::map::InflightRequestsMap;
@@ -15,6 +18,7 @@ use crate::executor::plugin_context::PluginRequestState;
 use crate::executor::plugin_trait::{EndControlFlow, StartControlFlow};
 use crate::executor::plugins::hooks;
 use crate::executor::response::subgraph_response::SubgraphResponse;
+use crate::http_utils::compression;
 use crate::query_planner::planner::plan_nodes::CustomScalarPaths;
 use crate::telemetry::logging::targets;
 use crate::telemetry::metrics::catalog::values::GraphQLResponseStatus;
@@ -58,6 +62,7 @@ pub struct HTTPSubgraphExecutor {
     pub in_flight_requests: InflightRequestsMap,
     pub telemetry_context: Arc<TelemetryContext>,
     pub subgraph_buffer_capacity: usize,
+    pub compression: TrafficShapingSubgraphRequestCompressionConfig,
 }
 
 const FIRST_VARIABLE_STR: &[u8] = b",\"variables\":{";
@@ -167,6 +172,7 @@ impl HTTPSubgraphExecutor {
         in_flight_requests: InflightRequestsMap,
         telemetry_context: Arc<TelemetryContext>,
         subgraph_buffer_capacity: usize,
+        compression: TrafficShapingSubgraphRequestCompressionConfig,
     ) -> Self {
         let mut header_map = HeaderMap::new();
         header_map.insert(
@@ -176,6 +182,13 @@ impl HTTPSubgraphExecutor {
         header_map.insert(
             http::header::CONNECTION,
             HeaderValue::from_static("keep-alive"),
+        );
+
+        // Always send the algorithms we can decompress, regardless of whether outbound
+        // request compression is enabled
+        header_map.insert(
+            http::header::ACCEPT_ENCODING,
+            HeaderValue::from_static("gzip, deflate, br, zstd"),
         );
 
         Self {
@@ -188,6 +201,7 @@ impl HTTPSubgraphExecutor {
             in_flight_requests,
             telemetry_context,
             subgraph_buffer_capacity,
+            compression,
         }
     }
 }
@@ -201,6 +215,7 @@ pub struct SendRequestOpts<'a> {
     pub headers: HeaderMap,
     pub timeout: Option<Duration>,
     pub telemetry_context: &'a Arc<TelemetryContext>,
+    pub compression: TrafficShapingSubgraphRequestCompressionConfig,
 }
 
 async fn send_request<'a>(
@@ -212,10 +227,29 @@ async fn send_request<'a>(
         subgraph_name,
         method,
         body,
-        headers,
+        mut headers,
         timeout,
         telemetry_context,
+        compression,
     } = opts;
+
+    let body = if compression.enabled {
+        match compression::compress(&body, compression.algorithm) {
+            Some(compressed) => {
+                headers.insert(
+                    http::header::CONTENT_ENCODING,
+                    HeaderValue::from_static(compression.algorithm.token()),
+                );
+                compressed
+            }
+            // compression is best-effort: if it fails, send the original body uncompressed
+            // rather than failing the whole subgraph request over it.
+            None => body,
+        }
+    } else {
+        body
+    };
+
     let request_body_size = body.len() as u64;
 
     let mut req = hyper::Request::builder()
@@ -271,6 +305,28 @@ async fn send_request<'a>(
                     parts.headers.into(),
                 ));
             }
+        };
+
+        let body = match parts.headers.get(http::header::CONTENT_ENCODING) {
+            Some(content_encoding) => {
+                let algorithm = content_encoding
+                    .to_str()
+                    .ok()
+                    .and_then(CompressionAlgorithm::from_token);
+                let decompressed =
+                    algorithm.and_then(|algorithm| compression::decompress(&body, algorithm));
+                match decompressed {
+                    Some(decompressed) => Bytes::from(decompressed),
+                    None => {
+                        return Err(SubgraphExecutorError::ResponseDecompressionFailure(
+                            subgraph_name.to_string(),
+                            content_encoding.to_str().unwrap_or("<invalid>").to_string(),
+                            parts.headers.into(),
+                        ));
+                    }
+                }
+            }
+            None => body,
         };
 
         if body.is_empty() {
@@ -392,6 +448,7 @@ impl SubgraphExecutor for HTTPSubgraphExecutor {
                     headers: execution_request.headers,
                     timeout,
                     telemetry_context: &self.telemetry_context,
+                    compression: self.compression,
                 };
 
                 if deduplicate_request {

--- a/bin/router/src/executor/executors/map.rs
+++ b/bin/router/src/executor/executors/map.rs
@@ -10,7 +10,7 @@ use crate::config::{
     subscriptions::{SubscriptionProtocol, SupergraphSubscriptionsConfig},
     traffic_shaping::{
         DurationOrExpression, StatusCodeMatcher, SupergraphTrafficShapingConfig,
-        WebSocketExecuteMode,
+        TrafficShapingSubgraphRequestCompressionConfig, WebSocketExecuteMode,
     },
 };
 use crate::executor::executors::inflight::InFlightMap;
@@ -134,6 +134,7 @@ struct ResolvedSubgraphConfig<'a> {
     client: Arc<HttpClient>,
     timeout_config: &'a DurationOrExpression,
     dedupe_enabled: bool,
+    compression: TrafficShapingSubgraphRequestCompressionConfig,
 }
 
 pub type InflightRequestsMap = InFlightMap<u64, (SubgraphHttpResponse, u64)>;
@@ -865,6 +866,7 @@ impl SubgraphExecutorMap {
                     self.in_flight_requests.clone(),
                     self.telemetry_context.clone(),
                     self.config.subscriptions.subgraph_buffer_capacity,
+                    subgraph_config.compression,
                 )
                 .to_boxed_arc();
 
@@ -961,6 +963,11 @@ impl SubgraphExecutorMap {
             client: self.client.clone(),
             timeout_config: &self.config.traffic_shaping.all.request_timeout,
             dedupe_enabled: self.config.traffic_shaping.all.dedupe_enabled,
+            compression: self
+                .config
+                .traffic_shaping
+                .subgraph_compression(subgraph_name)
+                .request,
         };
 
         let Some(subgraph_config) = self.config.traffic_shaping.subgraphs.get(subgraph_name) else {

--- a/bin/router/src/http_utils/compression.rs
+++ b/bin/router/src/http_utils/compression.rs
@@ -1,0 +1,72 @@
+use std::io::{Read, Write};
+
+use crate::config::traffic_shaping::{
+    BrotliCompressionConfig, CompressionAlgorithm, CompressionAlgorithmConfig,
+    ZstdCompressionConfig,
+};
+
+pub fn compress(data: &[u8], algorithm: CompressionAlgorithmConfig) -> Option<Vec<u8>> {
+    match algorithm {
+        CompressionAlgorithmConfig::Gzip => gzip_compress(data),
+        CompressionAlgorithmConfig::Deflate => deflate_compress(data),
+        CompressionAlgorithmConfig::Br(config) => brotli_compress(data, config),
+        CompressionAlgorithmConfig::Zstd(config) => zstd_compress(data, config),
+    }
+}
+
+pub fn decompress(data: &[u8], algorithm: CompressionAlgorithm) -> Option<Vec<u8>> {
+    match algorithm {
+        CompressionAlgorithm::Gzip => gzip_decompress(data),
+        CompressionAlgorithm::Deflate => deflate_decompress(data),
+        CompressionAlgorithm::Br => brotli_decompress(data),
+        CompressionAlgorithm::Zstd => zstd::stream::decode_all(data).ok(),
+    }
+}
+
+fn gzip_compress(data: &[u8]) -> Option<Vec<u8>> {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(data).ok()?;
+    encoder.finish().ok()
+}
+
+fn gzip_decompress(data: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    flate2::read::GzDecoder::new(data)
+        .read_to_end(&mut out)
+        .ok()?;
+    Some(out)
+}
+
+fn deflate_compress(data: &[u8]) -> Option<Vec<u8>> {
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(data).ok()?;
+    encoder.finish().ok()
+}
+
+fn deflate_decompress(data: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    flate2::read::ZlibDecoder::new(data)
+        .read_to_end(&mut out)
+        .ok()?;
+    Some(out)
+}
+
+fn brotli_compress(data: &[u8], config: BrotliCompressionConfig) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut writer = brotli::CompressorWriter::new(&mut out, 4096, config.quality as u32, 22);
+    writer.write_all(data).ok()?;
+    drop(writer);
+    Some(out)
+}
+
+fn brotli_decompress(data: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    brotli::Decompressor::new(data, 4096)
+        .read_to_end(&mut out)
+        .ok()?;
+    Some(out)
+}
+
+fn zstd_compress(data: &[u8], config: ZstdCompressionConfig) -> Option<Vec<u8>> {
+    zstd::stream::encode_all(data, config.level).ok()
+}

--- a/bin/router/src/http_utils/mod.rs
+++ b/bin/router/src/http_utils/mod.rs
@@ -1,5 +1,6 @@
 // The `graphiql` feature skips Laboratory asset generation, so there is no page to seed.
 pub mod body;
+pub mod compression;
 pub(crate) mod headers;
 #[cfg(not(feature = "graphiql"))]
 pub mod laboratory;

--- a/bin/router/src/pipeline/response_compression.rs
+++ b/bin/router/src/pipeline/response_compression.rs
@@ -18,8 +18,8 @@ use tracing::error;
 
 use crate::{
     config::traffic_shaping::{
-        BrotliCompressionConfig, ResponseCompressionAlgorithmConfig,
-        TrafficShapingRouterCompressionConfig, ZstdCompressionConfig,
+        BrotliCompressionConfig, CompressionAlgorithmConfig, TrafficShapingRouterCompressionConfig,
+        ZstdCompressionConfig,
     },
     executor::{execution::plan::FailedExecutionResult, response::graphql_error::GraphQLError},
     http_utils::headers::append_vary,
@@ -101,15 +101,15 @@ where
         }
 
         let response = match algorithm {
-            ResponseCompressionAlgorithmConfig::Gzip => {
+            CompressionAlgorithmConfig::Gzip => {
                 response.map_body(|head, body| Encoder::response(ContentEncoding::Gzip, head, body))
             }
-            ResponseCompressionAlgorithmConfig::Deflate => response
+            CompressionAlgorithmConfig::Deflate => response
                 .map_body(|head, body| Encoder::response(ContentEncoding::Deflate, head, body)),
-            ResponseCompressionAlgorithmConfig::Br(brotli) => {
+            CompressionAlgorithmConfig::Br(brotli) => {
                 compress_full_body(response, "br", brotli_compressor(*brotli)).await
             }
-            ResponseCompressionAlgorithmConfig::Zstd(zstd) => {
+            CompressionAlgorithmConfig::Zstd(zstd) => {
                 compress_full_body(response, "zstd", zstd_compressor(*zstd)).await
             }
         };
@@ -121,8 +121,8 @@ where
 /// Picks the algorithm from `algorithms` that best matches the client's `Accept-Encoding` preference
 fn negotiate<'cfg>(
     accept_encoding: Option<&HeaderValue>,
-    algorithms: &'cfg [ResponseCompressionAlgorithmConfig],
-) -> Option<&'cfg ResponseCompressionAlgorithmConfig> {
+    algorithms: &'cfg [CompressionAlgorithmConfig],
+) -> Option<&'cfg CompressionAlgorithmConfig> {
     let header = accept_encoding?.to_str().ok()?;
 
     // Keep `q=0` entries in here (rather than dropping them) - per RFC 9110 §12.5.3, `*`

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -81,6 +81,8 @@ mod router_timeout;
 #[cfg(test)]
 mod storage;
 #[cfg(test)]
+mod subgraph_compression;
+#[cfg(test)]
 mod subscriptions;
 #[cfg(test)]
 mod supergraph;

--- a/e2e/src/subgraph_compression.rs
+++ b/e2e/src/subgraph_compression.rs
@@ -1,0 +1,661 @@
+#[cfg(test)]
+mod subgraph_compression_e2e_tests {
+    use std::io::Write;
+
+    use bytes::Bytes;
+    use http::{header::CONTENT_ENCODING, StatusCode};
+    use sonic_rs::{JsonContainerTrait, JsonValueTrait};
+
+    use crate::testkit::{ClientResponseExt, ResponseLike, TestRouter, TestSubgraphs};
+
+    fn gzip_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).expect("failed to gzip data");
+        encoder.finish().expect("failed to finish gzip stream")
+    }
+
+    fn gzip_decompress(data: &[u8]) -> Vec<u8> {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        let mut decoder = GzDecoder::new(data);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("failed to gunzip request body");
+        out
+    }
+
+    fn deflate_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::ZlibEncoder, Compression};
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).expect("failed to deflate data");
+        encoder.finish().expect("failed to finish deflate stream")
+    }
+
+    fn deflate_decompress(data: &[u8]) -> Vec<u8> {
+        use flate2::read::ZlibDecoder;
+        use std::io::Read;
+        let mut decoder = ZlibDecoder::new(data);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("failed to inflate request body");
+        out
+    }
+
+    fn brotli_compress(data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut writer = brotli::CompressorWriter::new(&mut out, 4096, 5, 22);
+            writer.write_all(data).expect("failed to brotli data");
+        }
+        out
+    }
+
+    fn brotli_decompress(data: &[u8]) -> Vec<u8> {
+        use std::io::Read;
+        let mut decoder = brotli::Decompressor::new(data, 4096);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("failed to un-brotli request body");
+        out
+    }
+
+    fn zstd_compress(data: &[u8]) -> Vec<u8> {
+        zstd::stream::encode_all(data, 3).expect("failed to zstd data")
+    }
+
+    fn decompress(algorithm: &str, data: &[u8]) -> Vec<u8> {
+        match algorithm {
+            "gzip" => gzip_decompress(data),
+            "deflate" => deflate_decompress(data),
+            "br" => brotli_decompress(data),
+            "zstd" => zstd::stream::decode_all(data).expect("failed to un-zstd request body"),
+            other => panic!("unsupported algorithm in test: {other}"),
+        }
+    }
+
+    fn compress(algorithm: &str, data: &[u8]) -> Vec<u8> {
+        match algorithm {
+            "gzip" => gzip_compress(data),
+            "deflate" => deflate_compress(data),
+            "br" => brotli_compress(data),
+            "zstd" => zstd_compress(data),
+            other => panic!("unsupported algorithm in test: {other}"),
+        }
+    }
+
+    #[ntex::test]
+    async fn should_compress_request_body_for_each_algorithm_when_enabled() {
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let subgraphs = TestSubgraphs::builder().build().start().await;
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(format!(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    traffic_shaping:
+                        all:
+                            compression:
+                                request:
+                                    enabled: true
+                                    algorithm:
+                                        kind: {algorithm}
+                    "#
+                ))
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+
+            assert_eq!(
+                res.status(),
+                200,
+                "[{algorithm}] expected a successful response"
+            );
+
+            let subgraph_requests = subgraphs
+                .get_requests_log("accounts")
+                .expect("expected requests sent to accounts subgraph");
+            assert_eq!(
+                subgraph_requests.len(),
+                1,
+                "[{algorithm}] expected 1 request to accounts subgraph"
+            );
+
+            let subgraph_request = &subgraph_requests[0];
+            assert_eq!(
+                subgraph_request
+                    .headers
+                    .get(CONTENT_ENCODING.as_str())
+                    .map(|v| v.as_bytes()),
+                Some(algorithm.as_bytes()),
+                "[{algorithm}] expected the subgraph request to carry Content-Encoding"
+            );
+
+            let raw_body = subgraph_request
+                .body
+                .as_ref()
+                .expect("expected a body to have been sent to the subgraph");
+            let decompressed = decompress(algorithm, raw_body);
+            let body: sonic_rs::Value = sonic_rs::from_slice(&decompressed).unwrap_or_else(|e| {
+                panic!("[{algorithm}] subgraph should receive valid, decompressed JSON: {e}")
+            });
+            assert!(
+                body["query"].as_str().is_some_and(|q| q.contains("users")),
+                "[{algorithm}] decompressed subgraph request body should contain the forwarded query, got: {decompressed:?}"
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn should_not_compress_request_body_by_default() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+        assert_eq!(res.status(), 200);
+
+        let subgraph_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests sent to accounts subgraph");
+        let subgraph_request = &subgraph_requests[0];
+
+        assert!(
+            subgraph_request
+                .headers
+                .get(CONTENT_ENCODING.as_str())
+                .is_none(),
+            "request compression must be off by default"
+        );
+    }
+
+    // regardless of whether request compression is enabled, the router should always tell
+    // subgraphs which encodings it can decompress in their responses.
+    #[ntex::test]
+    async fn should_always_advertise_accept_encoding_to_subgraphs() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+        assert_eq!(res.status(), 200);
+
+        let subgraph_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests sent to accounts subgraph");
+        let subgraph_request = &subgraph_requests[0];
+
+        assert!(
+            subgraph_request
+                .headers
+                .get(http::header::ACCEPT_ENCODING.as_str())
+                .is_some(),
+            "the router should always advertise Accept-Encoding to subgraphs"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_apply_per_subgraph_compression_override() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    subgraphs:
+                        accounts:
+                            compression:
+                                request:
+                                    enabled: true
+                                    algorithm:
+                                        kind: gzip
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } topProducts { upc } }", None, None)
+            .await;
+        assert_eq!(res.status(), 200);
+
+        let accounts_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests to accounts");
+        assert!(
+            accounts_requests[0]
+                .headers
+                .get(CONTENT_ENCODING.as_str())
+                .is_some(),
+            "accounts has its own compression override and should compress"
+        );
+
+        if let Some(products_requests) = subgraphs.get_requests_log("products") {
+            assert!(
+                products_requests[0]
+                    .headers
+                    .get(CONTENT_ENCODING.as_str())
+                    .is_none(),
+                "products has no override and no `all` default, so it should not compress"
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn should_decompress_subgraph_response_for_each_algorithm() {
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let body = sonic_rs::to_vec(&sonic_rs::json!({
+                "data": { "users": [{ "id": "compressed-user-1" }] }
+            }))
+            .unwrap();
+            let compressed = compress(algorithm, &body);
+
+            let subgraphs = TestSubgraphs::builder()
+                .with_on_request(move |req| {
+                    if req.path.contains("accounts") {
+                        Some(ResponseLike {
+                            status: StatusCode::OK,
+                            headers: {
+                                let mut h = http::HeaderMap::new();
+                                h.insert(
+                                    http::header::CONTENT_TYPE,
+                                    "application/json".parse().unwrap(),
+                                );
+                                h.insert(CONTENT_ENCODING, algorithm.parse().unwrap());
+                                h
+                            },
+                            body: Some(Bytes::from(compressed.clone())),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
+                .start()
+                .await;
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    "#,
+                )
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+
+            assert_eq!(
+                res.status(),
+                200,
+                "[{algorithm}] expected a successful response"
+            );
+            let response_body = res.json_body().await;
+            assert_eq!(
+                response_body["data"]["users"][0]["id"].as_str(),
+                Some("compressed-user-1"),
+                "[{algorithm}] expected the router to transparently decompress the subgraph response, got: {response_body:?}"
+            );
+        }
+    }
+
+    #[ntex::test]
+    async fn should_return_a_clean_error_for_malformed_compressed_subgraph_response() {
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let garbage = b"this is not compressed data of any kind: 1234567890".to_vec();
+
+            let subgraphs = TestSubgraphs::builder()
+                .with_on_request(move |req| {
+                    if req.path.contains("accounts") {
+                        Some(ResponseLike {
+                            status: StatusCode::OK,
+                            headers: {
+                                let mut h = http::HeaderMap::new();
+                                h.insert(
+                                    http::header::CONTENT_TYPE,
+                                    "application/json".parse().unwrap(),
+                                );
+                                h.insert(CONTENT_ENCODING, algorithm.parse().unwrap());
+                                h
+                            },
+                            body: Some(Bytes::from(garbage.clone())),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
+                .start()
+                .await;
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    "#,
+                )
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+
+            // the router should surface a normal GraphQL error (subgraph fetch failure), not
+            // hang, panic, or crash the worker.
+            let body = res.json_body().await;
+            assert!(
+                body["errors"].as_array().is_some_and(|e| !e.is_empty()),
+                "[{algorithm}] expected a GraphQL error for a malformed compressed subgraph response, got: {body:?}"
+            );
+        }
+    }
+
+    // Content-Length must describe the bytes actually sent (the compressed body), not the
+    // original JSON's length - a wrong length here would silently truncate or corrupt
+    // every compressed subgraph request
+    #[ntex::test]
+    async fn should_set_content_length_to_the_compressed_body_size() {
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let subgraphs = TestSubgraphs::builder().build().start().await;
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(format!(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    traffic_shaping:
+                        all:
+                            compression:
+                                request:
+                                    enabled: true
+                                    algorithm:
+                                        kind: {algorithm}
+                    "#
+                ))
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+            assert_eq!(
+                res.status(),
+                200,
+                "[{algorithm}] expected a successful response"
+            );
+
+            let subgraph_requests = subgraphs
+                .get_requests_log("accounts")
+                .expect("expected requests sent to accounts subgraph");
+            let subgraph_request = &subgraph_requests[0];
+
+            let raw_body = subgraph_request
+                .body
+                .as_ref()
+                .expect("expected a body to have been sent to the subgraph");
+            let content_length: usize = subgraph_request
+                .headers
+                .get(http::header::CONTENT_LENGTH.as_str())
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "[{algorithm}] expected a Content-Length header on the compressed request"
+                    )
+                });
+
+            assert_eq!(
+                content_length,
+                raw_body.len(),
+                "[{algorithm}] Content-Length must match the actual (compressed) body size, \
+                 not the original JSON size"
+            );
+        }
+    }
+
+    // A truncated compressed stream (valid header/magic bytes, cut off mid-stream)
+    #[ntex::test]
+    async fn should_return_a_clean_error_for_a_truncated_compressed_subgraph_response() {
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let body = sonic_rs::to_vec(&sonic_rs::json!({
+                "data": { "users": [{ "id": "1" }] }
+            }))
+            .unwrap();
+            let compressed = compress(algorithm, &body);
+            let truncated = compressed[..compressed.len() / 2].to_vec();
+
+            let subgraphs = TestSubgraphs::builder()
+                .with_on_request(move |req| {
+                    if req.path.contains("accounts") {
+                        Some(ResponseLike {
+                            status: StatusCode::OK,
+                            headers: {
+                                let mut h = http::HeaderMap::new();
+                                h.insert(
+                                    http::header::CONTENT_TYPE,
+                                    "application/json".parse().unwrap(),
+                                );
+                                h.insert(CONTENT_ENCODING, algorithm.parse().unwrap());
+                                h
+                            },
+                            body: Some(Bytes::from(truncated.clone())),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
+                .start()
+                .await;
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    "#,
+                )
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+
+            let body = res.json_body().await;
+            assert!(
+                body["errors"].as_array().is_some_and(|e| !e.is_empty()),
+                "[{algorithm}] expected a GraphQL error for a truncated compressed subgraph response, got: {body:?}"
+            );
+        }
+    }
+
+    // `Content-Encoding` names one algorithm, but the bytes are actually a different algorithm
+    #[ntex::test]
+    async fn should_return_a_clean_error_when_content_encoding_does_not_match_the_actual_bytes() {
+        let mismatched_pairs = [
+            ("zstd", "gzip"),
+            ("gzip", "deflate"),
+            ("deflate", "br"),
+            ("br", "zstd"),
+        ];
+
+        for (declared, actual) in mismatched_pairs {
+            let body = sonic_rs::to_vec(&sonic_rs::json!({
+                "data": { "users": [{ "id": "1" }] }
+            }))
+            .unwrap();
+            let compressed = compress(actual, &body);
+
+            let subgraphs = TestSubgraphs::builder()
+                .with_on_request(move |req| {
+                    if req.path.contains("accounts") {
+                        Some(ResponseLike {
+                            status: StatusCode::OK,
+                            headers: {
+                                let mut h = http::HeaderMap::new();
+                                h.insert(
+                                    http::header::CONTENT_TYPE,
+                                    "application/json".parse().unwrap(),
+                                );
+                                h.insert(CONTENT_ENCODING, declared.parse().unwrap());
+                                h
+                            },
+                            body: Some(Bytes::from(compressed.clone())),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
+                .start()
+                .await;
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    "#,
+                )
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+
+            let body = res.json_body().await;
+            assert!(
+                body["errors"].as_array().is_some_and(|e| !e.is_empty()),
+                "declared={declared} actual={actual}: expected a GraphQL error when \
+                 Content-Encoding doesn't match the actual bytes, got: {body:?}"
+            );
+        }
+    }
+
+    // Make sure subgraph responses with errors are also handled the same way.
+    #[ntex::test]
+    async fn should_decompress_a_subgraph_response_that_itself_contains_a_graphql_error() {
+        for algorithm in ["gzip", "deflate", "br", "zstd"] {
+            let body = sonic_rs::to_vec(&sonic_rs::json!({
+                "data": { "users": null },
+                "errors": [{ "message": "compressed-subgraph-error-marker" }]
+            }))
+            .unwrap();
+            let compressed = compress(algorithm, &body);
+
+            let subgraphs = TestSubgraphs::builder()
+                .with_on_request(move |req| {
+                    if req.path.contains("accounts") {
+                        Some(ResponseLike {
+                            status: StatusCode::OK,
+                            headers: {
+                                let mut h = http::HeaderMap::new();
+                                h.insert(
+                                    http::header::CONTENT_TYPE,
+                                    "application/json".parse().unwrap(),
+                                );
+                                h.insert(CONTENT_ENCODING, algorithm.parse().unwrap());
+                                h
+                            },
+                            body: Some(Bytes::from(compressed.clone())),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
+                .start()
+                .await;
+
+            let router = TestRouter::builder()
+                .with_subgraphs(&subgraphs)
+                .inline_config(
+                    r#"
+                    supergraph:
+                        source: file
+                        path: supergraph.graphql
+                    "#,
+                )
+                .build()
+                .start()
+                .await;
+
+            let res = router
+                .send_graphql_request("{ users { id } }", None, None)
+                .await;
+
+            let body = res.json_body().await;
+            let error_codes: Vec<&str> = body["errors"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e["extensions"]["code"].as_str())
+                .collect();
+
+            assert!(
+                error_codes.contains(&"DOWNSTREAM_SERVICE_ERROR"),
+                "[{algorithm}] expected the compressed subgraph error response to be decompressed \
+                 and routed as a normal subgraph-reported error (DOWNSTREAM_SERVICE_ERROR), not a \
+                 malformed-response failure, got: {body:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/315
Continues https://github.com/graphql-hive/router/pull/1477 

Implements HTTP compression for router ↔ subgraph calls. `gzip`, `deflate`, `br` (Brotli), and `zstd` are supported.

```yaml
traffic_shaping:
  all:
    compression:
      request:
        enabled: false
        algorithm:
          kind: gzip
  subgraphs:
    accounts:
      compression:
        request:
          enabled: true
          algorithm:
            kind: zstd
            level: 5
```

Compressing outbound requests to a subgraph is opt-in and off by default, since compressing
unconditionally could break a subgraph that doesn't decompress. 

A per-subgraph override fully replaces the `all` default rather than merging field-by-field.

Decompressing subgraph responses is always on and unconfigured, so the router transparently decompresses any subgraph response carrying a
recognized `Content-Encoding` regardless of the outbound setting.

The router now also always advertises `Accept-Encoding: gzip, deflate, br, zstd` to every subgraph, independent of whether outbound compression is enabled.
