### PR TITLE
chore(ci): mark all config structs as non_exhaustive

### DIFF
--- a/bin/router/src/config/authorization.rs
+++ b/bin/router/src/config/authorization.rs
@@ -3,12 +3,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct AuthorizationConfig {
     pub directives: AuthorizationDirectivesConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct AuthorizationDirectivesConfig {
     #[serde(default = "default_directives_enabled")]
     pub enabled: bool,
@@ -18,6 +20,7 @@ pub struct AuthorizationDirectivesConfig {
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct UnauthorizedConfig {
     #[serde(default)]
     pub mode: UnauthorizedMode,
@@ -25,6 +28,7 @@ pub struct UnauthorizedConfig {
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum UnauthorizedMode {
     #[default]
     Filter,

--- a/bin/router/src/config/coprocessor.rs
+++ b/bin/router/src/config/coprocessor.rs
@@ -10,6 +10,7 @@ use crate::config::primitives::value_or_expression::ValueOrExpression;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorConfig {
     /// Endpoint for the external coprocessor service.
     ///
@@ -44,6 +45,7 @@ fn default_coprocessor_timeout() -> Duration {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum CoprocessorProtocol {
     /// HTTP/1.1 over TCP.
     Http1,
@@ -55,6 +57,7 @@ pub enum CoprocessorProtocol {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorStagesConfig {
     #[serde(default)]
     /// Hooks around the router HTTP boundary
@@ -66,6 +69,7 @@ pub struct CoprocessorStagesConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorRouterStageConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Configuration for `router.request` hook.
@@ -77,6 +81,7 @@ pub struct CoprocessorRouterStageConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorGraphqlStageConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Configuration for `graphql.request` hook.
@@ -91,6 +96,7 @@ pub struct CoprocessorGraphqlStageConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorHookConfig<I: Default> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Optional condition expression.
@@ -104,6 +110,7 @@ pub struct CoprocessorHookConfig<I: Default> {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorRouterRequestIncludeConfig {
     #[serde(default)]
     /// Include the inbound HTTP request body.
@@ -129,6 +136,7 @@ pub struct CoprocessorRouterRequestIncludeConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorRouterResponseIncludeConfig {
     #[serde(default)]
     /// Include outbound HTTP response body.
@@ -151,6 +159,7 @@ pub struct CoprocessorRouterResponseIncludeConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorGraphqlRequestIncludeConfig {
     #[serde(default)]
     /// Include GraphQL request body fields.
@@ -181,6 +190,7 @@ pub struct CoprocessorGraphqlRequestIncludeConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorGraphqlResponseIncludeConfig {
     #[serde(default)]
     /// Include GraphQL response body.
@@ -206,6 +216,7 @@ pub struct CoprocessorGraphqlResponseIncludeConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CoprocessorGraphqlAnalysisIncludeConfig {
     #[serde(default)]
     /// Include GraphQL request body fields.
@@ -236,6 +247,7 @@ pub struct CoprocessorGraphqlAnalysisIncludeConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum GraphqlBodyField {
     /// Include the GraphQL query string.
     Query,
@@ -254,6 +266,7 @@ pub enum GraphqlBodyField {
 /// - `true` => all body fields
 /// - `false` => no body fields
 /// - list => selected body fields
+#[non_exhaustive]
 pub struct GraphqlBodySelection {
     /// Include `query`.
     pub query: bool,
@@ -378,6 +391,7 @@ impl JsonSchema for GraphqlBodySelection {
 /// - `true` => include full context
 /// - `false` => include no context
 /// - list => include only selected context keys
+#[non_exhaustive]
 pub struct ContextSelection {
     all: bool,
     keys: HashSet<String>,
@@ -477,6 +491,7 @@ impl JsonSchema for ContextSelection {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Target endpoint for coprocessor communication.
+#[non_exhaustive]
 pub enum CoprocessorEndpoint {
     Http {
         /// HTTP endpoint URL in `http://host[:port][/path]` form.

--- a/bin/router/src/config/cors.rs
+++ b/bin/router/src/config/cors.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[schemars(example = cors_example_1())]
 #[schemars(example = cors_example_2())]
+#[non_exhaustive]
 pub struct CORSConfig {
     #[serde(default = "default_cors_enabled")]
     pub enabled: bool,
@@ -117,6 +118,7 @@ pub struct CORSConfig {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct CORSPolicyConfig {
     /// List of allowed origins. If `allow_any_origin` is true, this field is ignored.
     /// If both `origins` and `match_origin` are set, the request origin must match one of the values in either list to be allowed.

--- a/bin/router/src/config/csrf.rs
+++ b/bin/router/src/config/csrf.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 /// Cross-site request forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they're currently authenticated.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[schemars(example = csrf_prevention_example_1())]
+#[non_exhaustive]
 pub struct CSRFPreventionConfig {
     /// Enables CSRF prevention.
     ///

--- a/bin/router/src/config/demand_control.rs
+++ b/bin/router/src/config/demand_control.rs
@@ -7,6 +7,7 @@ use crate::config::primitives::http_header::HttpHeaderName;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct DemandControlConfig {
     /// Enable demand control processing. Must be `true` for any cost estimation,
     /// enforcement or telemetry to take effect.
@@ -49,6 +50,7 @@ const DEFAULT_ESTIMATED_HEADER_NAME: &str = "X-Cost-Estimated";
 const DEFAULT_ACTUAL_HEADER_NAME: &str = "X-Cost-Actual";
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct OperationCostConfig {
     /// The maximum cost allowed for a single operation, based on the estimated value.
     ///
@@ -75,6 +77,7 @@ pub struct OperationCostConfig {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
+#[non_exhaustive]
 pub struct DemandControlExposeHeadersConfig {
     #[serde(default, deserialize_with = "deserialize_max_header")]
     pub max: Option<HttpHeaderName>,
@@ -139,6 +142,7 @@ where
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum DemandControlMode {
     Enforce,
     Measure,
@@ -146,6 +150,7 @@ pub enum DemandControlMode {
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DemandControlActualCostMode {
     /// Computes the cost of each subgraph response and sums them to get the
     /// total query cost. This is the default and preferred mode.
@@ -159,6 +164,7 @@ pub enum DemandControlActualCostMode {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct SubgraphsBudgetConfig {
     /// The mode to use for subgraph budget enforcement.
     ///
@@ -182,6 +188,7 @@ pub struct SubgraphsBudgetConfig {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
+#[non_exhaustive]
 pub struct DefaultListSizeConfig {
     /// Default list size for fields in the supergraph that have no `@listSize` directive.
     pub all: Option<usize>,

--- a/bin/router/src/config/env_overrides.rs
+++ b/bin/router/src/config/env_overrides.rs
@@ -5,6 +5,7 @@ use tracing::debug;
 use crate::config::log::{LogFormat, LogLevel};
 
 #[derive(Default, Envconfig)]
+#[non_exhaustive]
 pub struct EnvVarOverrides {
     // Logger overrides
     #[envconfig(from = "LOG_LEVEL")]
@@ -78,6 +79,7 @@ pub struct EnvVarOverrides {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EnvVarOverridesError {
     #[error("Failed to override configuration: {0}")]
     FailedToOverrideConfig(#[from] ConfigError),

--- a/bin/router/src/config/error_masking.rs
+++ b/bin/router/src/config/error_masking.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ErrorMaskingConfig {
     /// A switch for enabling or disabling error masking feature completely.
     ///
@@ -45,6 +46,7 @@ impl Default for ErrorMaskingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct AllErrorMaskingConfig {
     /// Whether to redact the error message in subgraph errors. The default is `true`.
     #[serde(default = "default_redact_error_message")]
@@ -72,6 +74,7 @@ impl Default for AllErrorMaskingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct SubgraphErrorMaskingConfig {
     /// Whether to redact the `error_message` in errors, for that specific subgraph.
     ///
@@ -89,6 +92,7 @@ pub struct SubgraphErrorMaskingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, tag = "mode")]
+#[non_exhaustive]
 pub enum ExtensionsMaskingConfig {
     /// Redact extensions based on the allowlist.
     #[serde(rename = "allow")]

--- a/bin/router/src/config/headers.rs
+++ b/bin/router/src/config/headers.rs
@@ -43,6 +43,7 @@ pub static NEVER_JOIN_HEADERS: &[&str] = &["set-cookie", "www-authenticate"];
 /// are never comma-joined. Multiple values are preserved as separate fields.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[schemars(example = headers_example_1())]
+#[non_exhaustive]
 pub struct HeadersConfig {
     /// Rules applied to all subgraphs (global defaults).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -105,6 +106,7 @@ fn headers_example_1() -> HeadersConfig {
 /// You can specify independent rule lists for **request** (to subgraphs)
 /// and **response** (to clients). Within each list, rules are applied in order.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
+#[non_exhaustive]
 pub struct HeaderRules {
     /// Rules that shape the **request** sent from the router to subgraphs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -118,6 +120,7 @@ pub struct HeaderRules {
 /// Request-header rules (applied before sending to a subgraph).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum RequestHeaderRule {
     /// Forward headers from the client request into the subgraph request.
     ///
@@ -145,6 +148,7 @@ pub enum RequestHeaderRule {
 /// Response-header rules (applied before sending back to the client).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ResponseHeaderRule {
     /// Forward headers from subgraph responses into the final client response.
     ///
@@ -168,6 +172,7 @@ pub enum ResponseHeaderRule {
 
 /// Remove headers matched by the specification.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct RemoveRule {
     #[serde(flatten)]
     pub spec: MatchSpec,
@@ -189,6 +194,7 @@ pub struct RemoveRule {
 /// # If another Set-Cookie exists, this creates another header line (never joined)
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct RequestInsertRule {
     /// Header name to insert or overwrite (case-insensitive).
     pub name: HeaderName,
@@ -213,6 +219,7 @@ pub struct RequestInsertRule {
 /// # If another Set-Cookie exists, this creates another header line (never joined)
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct ResponseInsertRule {
     /// Header name to insert or overwrite (case-insensitive).
     pub name: HeaderName,
@@ -228,6 +235,7 @@ pub struct ResponseInsertRule {
 /// Source for an inserted header value.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum InsertSource {
     /// Static value provided in the config.
     Value { value: String },
@@ -261,6 +269,7 @@ pub enum InsertSource {
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum OneOrMany<T> {
     One(T),
     Many(Vec<T>),
@@ -288,6 +297,7 @@ pub enum OneOrMany<T> {
 /// exclude: ["^x-legacy-.*"]
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
+#[non_exhaustive]
 pub struct MatchSpec {
     /// Match headers by exact name (OR).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -327,6 +337,7 @@ pub struct MatchSpec {
 ///   default: "Bearer test-token"
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
+#[non_exhaustive]
 pub struct RequestPropagateRule {
     #[serde(flatten)]
     pub spec: MatchSpec,
@@ -350,6 +361,7 @@ pub struct RequestPropagateRule {
 /// See [`AggregationAlgo::Append`] for the cache-control merge semantics.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum AggregationAlgo {
     /// Take the first value encountered and ignore later ones.
     First,
@@ -411,6 +423,7 @@ pub enum AggregationAlgo {
 ///   algorithm: append
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct ResponsePropagateRule {
     #[serde(flatten)]
     pub spec: MatchSpec,

--- a/bin/router/src/config/http_server.rs
+++ b/bin/router/src/config/http_server.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct HttpServerConfig {
     /// The endpoint to serve GraphQL requests. By default, `/graphql` is used.
     #[serde(default = "graphql_endpoint_default")]

--- a/bin/router/src/config/introspection_policy.rs
+++ b/bin/router/src/config/introspection_policy.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// or an object containing the expression that evaluates to a boolean.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum IntrospectionPermissionConfig {
     /// A static boolean value to enable or disable the introspection.
     Boolean(bool),

--- a/bin/router/src/config/jwt_auth.rs
+++ b/bin/router/src/config/jwt_auth.rs
@@ -8,6 +8,7 @@ use crate::config::primitives::{file_path::FilePath, http_header::HttpHeaderName
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct JwtAuthConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
@@ -88,6 +89,7 @@ impl Default for JwtAuthConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct JwtClaimsForwardingConfig {
     pub enabled: bool,
     pub field_name: String,
@@ -107,6 +109,7 @@ fn default_forward_claims_to_upstream_extensions() -> JwtClaimsForwardingConfig 
 
 #[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
 #[serde(tag = "source")]
+#[non_exhaustive]
 pub enum JwksProviderSourceConfig {
     /// A local file on the file-system. This file will be read once on startup and cached.
     #[serde(rename = "file")]
@@ -169,6 +172,7 @@ pub fn default_allowed_algorithms() -> Option<Vec<Algorithm>> {
 
 #[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
 #[serde(tag = "source")]
+#[non_exhaustive]
 pub enum JwtAuthPluginLookupLocation {
     #[serde(rename = "header")]
     #[schemars(title = "header")]

--- a/bin/router/src/config/laboratory.rs
+++ b/bin/router/src/config/laboratory.rs
@@ -7,6 +7,7 @@ use crate::config::primitives::http_header::HttpHeaderName;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct LaboratoryConfig {
     /// Enables/disables the Hive Laboratory interface. By default, the Hive Laboratory interface is enabled.
     ///
@@ -88,6 +89,7 @@ pub struct LaboratoryConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct LaboratoryOperationConfig {
     /// The name of the operation. Used as the tab title, and must be unique across all seeded
     /// operations.
@@ -117,6 +119,7 @@ pub struct LaboratoryOperationConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct LaboratoryCollectionConfig {
     /// The name of the collection. Used as the sidebar label, and must be unique across all seeded
     /// collections.

--- a/bin/router/src/config/limits.rs
+++ b/bin/router/src/config/limits.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct LimitsConfig {
     /// Configuration of limiting the depth of the incoming GraphQL operations.
     /// If not specified, depth limiting is disabled.
@@ -60,6 +61,7 @@ impl Default for LimitsConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct MaxDepthRuleConfig {
     /// Depth threshold
     pub n: usize,
@@ -82,18 +84,21 @@ fn default_flatten_fragments() -> bool {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct MaxDirectivesRuleConfig {
     /// Directives threshold
     pub n: usize,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct MaxTokensRuleConfig {
     /// Tokens threshold
     pub n: usize,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct MaxAliasesRuleConfig {
     /// Aliases threshold
     pub n: usize,

--- a/bin/router/src/config/log.rs
+++ b/bin/router/src/config/log.rs
@@ -9,6 +9,7 @@ use crate::config::primitives::http_header::HttpHeaderName;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct LoggingConfig {
     /// The level of logging to use.
     ///
@@ -53,6 +54,7 @@ impl LoggingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum LogLevel {
     #[cfg(debug_assertions)]
     Trace,
@@ -117,6 +119,7 @@ impl From<&LogLevel> for LevelFilter {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub enum LogFormat {
     #[serde(rename = "text")]
     Text,
@@ -159,6 +162,7 @@ impl Default for LogFormat {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CorrelationConfig {
     #[serde(default = "default_correlation_id_header")]
     pub id_header: HttpHeaderName,

--- a/bin/router/src/config/mod.rs
+++ b/bin/router/src/config/mod.rs
@@ -54,6 +54,7 @@ use crate::config::{
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct HiveRouterConfig {
     #[serde(skip)]
     root_directory: PathBuf,
@@ -183,6 +184,7 @@ pub struct HiveRouterConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct PluginConfig {
     #[serde(default = "default_plugin_enabled")]
     pub enabled: bool,
@@ -274,6 +276,7 @@ impl HiveRouterConfig {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RouterConfigError {
     #[error("Failed to load configuration: {0}")]
     ConfigLoadError(#[from] config_rs::ConfigError),

--- a/bin/router/src/config/override_labels.rs
+++ b/bin/router/src/config/override_labels.rs
@@ -11,6 +11,7 @@ pub type OverrideLabelsConfig = HashMap<String, LabelOverrideValue>;
 /// or an object containing the expression that evaluates to a boolean.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum LabelOverrideValue {
     /// A static boolean value to enable or disable the label.
     Boolean(bool),

--- a/bin/router/src/config/override_subgraph_urls.rs
+++ b/bin/router/src/config/override_subgraph_urls.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 #[schemars(example = override_subgraph_urls_example_1())]
+#[non_exhaustive]
 pub struct OverrideSubgraphUrlsConfig {
     /// URL overrides for specific subgraphs.
     ///
@@ -60,24 +61,28 @@ impl OverrideSubgraphUrlsConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OverrideUrlConfig {
     pub url: UrlOrExpression,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OverrideAllUrlConfig {
     pub url: OverrideExpressionConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OverrideExpressionConfig {
     pub expression: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum UrlOrExpression {
     /// A static URL string.
     Url(String),

--- a/bin/router/src/config/persisted_documents.rs
+++ b/bin/router/src/config/persisted_documents.rs
@@ -10,6 +10,7 @@ use crate::config::primitives::toggle::ToggleWith;
 use crate::config::primitives::value_or_expression::ValueOrExpression;
 
 #[derive(Debug, Serialize, JsonSchema, Clone, Default)]
+#[non_exhaustive]
 pub struct PersistedDocumentsConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -81,6 +82,7 @@ impl<'de> Deserialize<'de> for PersistedDocumentsConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PersistedDocumentsStorageConfig {
     File {
         #[serde(flatten)]
@@ -98,6 +100,7 @@ pub enum PersistedDocumentsStorageConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct PersistedDocumentsFileStorageConfig {
     pub path: FilePath,
     #[serde(default = "default_watch")]
@@ -106,6 +109,7 @@ pub struct PersistedDocumentsFileStorageConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct PersistedDocumentsStorageRefConfig {
     pub storage_id: String,
     pub location: String,
@@ -124,6 +128,7 @@ fn default_storage_poll_interval() -> Option<Duration> {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct PersistedDocumentsHiveStorageConfig {
     /// The CDN endpoint from Hive Console target.
     /// Can also be set using the `HIVE_CDN_ENDPOINT` environment variable.
@@ -159,6 +164,7 @@ pub struct PersistedDocumentsHiveStorageConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct PersistedDocumentsHiveNegativeCacheConfig {
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -178,6 +184,7 @@ impl Default for PersistedDocumentsHiveNegativeCacheConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct PersistedDocumentsHiveCircuitBreakerConfig {
     #[serde(default = "default_circuit_breaker_error_threshold")]
     pub error_threshold: f32,
@@ -244,6 +251,7 @@ const fn default_watch() -> bool {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PersistedDocumentExtractorConfig {
     JsonPath {
         path: PersistedDocumentJsonPath,

--- a/bin/router/src/config/primitives/file_path.rs
+++ b/bin/router/src/config/primitives/file_path.rs
@@ -11,6 +11,7 @@ use serde::{
 };
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct FilePath {
     #[serde(flatten)]
     pub relative: String,

--- a/bin/router/src/config/primitives/percentage.rs
+++ b/bin/router/src/config/primitives/percentage.rs
@@ -3,6 +3,7 @@ use std::{fmt::Display, str::FromStr};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct Percentage {
     value: f64,
 }

--- a/bin/router/src/config/primitives/retry_policy.rs
+++ b/bin/router/src/config/primitives/retry_policy.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
 pub struct RetryPolicyConfig {
     /// The maximum number of retries to attempt.
     ///

--- a/bin/router/src/config/primitives/single_or_multiple.rs
+++ b/bin/router/src/config/primitives/single_or_multiple.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum SingleOrMultiple<T> {
     Single(T),
     Multiple(Vec<T>),

--- a/bin/router/src/config/primitives/toggle.rs
+++ b/bin/router/src/config/primitives/toggle.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ToggleWith<T: Default> {
     Disabled,
     Enabled(T),

--- a/bin/router/src/config/primitives/value_or_expression.rs
+++ b/bin/router/src/config/primitives/value_or_expression.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ValueOrExpression<T: Default> {
     Value(T),
     Expression { expression: String },

--- a/bin/router/src/config/query_planner.rs
+++ b/bin/router/src/config/query_planner.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct QueryPlannerConfig {
     /// A flag to allow exposing the query plan in the response.
     /// When set to `true` and an incoming request has a `hive-expose-query-plan: true` header, the query plan will be exposed in the response, as part of `extensions`.

--- a/bin/router/src/config/response_extensions.rs
+++ b/bin/router/src/config/response_extensions.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for propagating `extensions` from subgraph responses to the
 /// client response.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct ResponseExtensionsConfig {
     /// Rules for propagating subgraph response `extensions` to the client.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -12,6 +13,7 @@ pub struct ResponseExtensionsConfig {
 
 /// Configuration for propagating subgraph extensions to the client response.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[non_exhaustive]
 pub struct ExtensionsPropagateConfig {
     /// How to merge an extension key seen across multiple subgraph responses.
     /// Default: `last`.
@@ -30,6 +32,7 @@ pub struct ExtensionsPropagateConfig {
 /// How to merge an extension key seen across multiple subgraph responses.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ExtensionsMergeAlgo {
     /// Keep the first value encountered for a key, ignore later ones.
     /// Note that the subgraph response order is not guaranteed, so this may be non-deterministic.

--- a/bin/router/src/config/storage/mod.rs
+++ b/bin/router/src/config/storage/mod.rs
@@ -9,6 +9,7 @@ pub mod s3;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, tag = "type")]
+#[non_exhaustive]
 pub enum StorageSourceConfig {
     /// Configuration for an Amazon S3 (or S3-compatible) object storage backend.
     ///

--- a/bin/router/src/config/storage/s3.rs
+++ b/bin/router/src/config/storage/s3.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::primitives::value_or_expression::ValueOrExpression;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct S3StorageConfig {
     /// Name of the S3 bucket to read from.
     pub bucket: ValueOrExpression<String>,
@@ -111,6 +112,7 @@ pub struct S3StorageConfig {
 ///    default when `credentials` is omitted entirely)
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum S3Credentials {
     /// Long-lived or temporary static credentials.
     ///

--- a/bin/router/src/config/subscriptions.rs
+++ b/bin/router/src/config/subscriptions.rs
@@ -9,6 +9,7 @@ use crate::config::primitives::value_or_expression::ValueOrExpression;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct SubscriptionsConfig {
     /// Enables/disables subscriptions. By default, the subscriptions are disabled.
     ///
@@ -61,6 +62,7 @@ pub struct SubscriptionsConfig {
 /// Configuration for the HTTP Callback subscription mode.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct CallbackConfig {
     /// The public URL that subgraphs will use to send callback messages to this router.
     ///
@@ -122,6 +124,7 @@ fn default_heartbeat_interval() -> Duration {
 /// Configuration for the WebSocket subscription mode.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct WebSocketConfig {
     /// The default configuration that will be applied to all subgraphs using
     /// WebSocket protocol, unless overridden by a specific subgraph configuration.
@@ -137,6 +140,7 @@ pub struct WebSocketConfig {
 /// WebSocket configuration for a specific subgraph or the default for all subgraphs.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct WebSocketSubgraphConfig {
     /// Determines the URL path to use for the subscription endpoint:
     ///
@@ -154,6 +158,7 @@ pub struct WebSocketSubgraphConfig {
 
 /// Subscription settings used by subgraph executors for one supergraph.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct SupergraphSubscriptionsConfig {
     pub callback_subgraphs: HashSet<String>,
     pub websocket: Option<WebSocketConfig>,
@@ -251,6 +256,7 @@ mod tests {
 
 /// The selected protocol for the subscriptions towards subgraphs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SubscriptionProtocol {
     /// Uses any HTTP streaming protocol that the subgraph accepts. Supported protocols are:
     /// - Server-Sent Events (SSE). Respecting only the "distinct connection mode" of the GraphQL over SSE specification. See: https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode.

--- a/bin/router/src/config/supergraph.rs
+++ b/bin/router/src/config/supergraph.rs
@@ -10,6 +10,7 @@ use crate::config::primitives::{
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, tag = "source")]
+#[non_exhaustive]
 pub enum SupergraphSource {
     /// Loads a supergraph from the filesystem.
     /// The path can be either absolute or relative to the router's working directory.

--- a/bin/router/src/config/telemetry.rs
+++ b/bin/router/src/config/telemetry.rs
@@ -17,6 +17,7 @@ pub mod tracing;
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
+#[non_exhaustive]
 pub struct TelemetryConfig {
     #[serde(default)]
     pub hive: Option<HiveTelemetryConfig>,
@@ -42,6 +43,7 @@ impl TelemetryConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ResourceConfig {
     #[serde(default)]
     pub attributes: HashMap<String, ValueOrExpression<String>>,
@@ -49,6 +51,7 @@ pub struct ResourceConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ClientIdentificationConfig {
     #[serde(default = "default_client_name_header")]
     pub name_header: HttpHeaderName,
@@ -92,6 +95,7 @@ impl Default for ClientIdentificationConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ClientIpHeaderConfig {
     HeaderName(HttpHeaderName),
     TrustedProxies(ClientIpHeaderTrustedProxiesConfig),
@@ -99,6 +103,7 @@ pub enum ClientIpHeaderConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ClientIpHeaderTrustedProxiesConfig {
     /// Header name containing client and proxy chain values.
     pub name: HttpHeaderName,

--- a/bin/router/src/config/telemetry/hive.rs
+++ b/bin/router/src/config/telemetry/hive.rs
@@ -11,6 +11,7 @@ use crate::config::{
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
+#[non_exhaustive]
 pub struct HiveTelemetryConfig {
     /// Your [Registry Access Token](https://the-guild.dev/graphql/hive/docs/management/targets#registry-access-tokens) with write permission.
     #[serde(default)]
@@ -61,6 +62,7 @@ impl Default for TracingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TracingConfig {
     #[serde(default = "default_tracing_enabled")]
     pub enabled: bool,
@@ -76,6 +78,7 @@ fn default_tracing_enabled() -> bool {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TraceBatchProcessorConfig {
     /// Maximum number of unique traces to keep in memory simultaneously.
     ///

--- a/bin/router/src/config/telemetry/metrics.rs
+++ b/bin/router/src/config/telemetry/metrics.rs
@@ -14,6 +14,7 @@ use crate::config::telemetry::{
 /// Configures metrics collection, processing, and export.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsConfig {
     /// List of metrics exporters.
     ///
@@ -42,6 +43,7 @@ fn default_metrics_max_export_timeout() -> Duration {
 /// Defines how metric values accumulate across collection cycles.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, Default)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum MetricsTemporality {
     /// A measurement interval that continues to expand forward in time from a
     /// starting point.
@@ -58,6 +60,7 @@ pub enum MetricsTemporality {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsInstrumentationConfig {
     #[serde(default)]
     pub common: MetricsCommonConfig,
@@ -67,6 +70,7 @@ pub struct MetricsInstrumentationConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsCommonConfig {
     #[serde(default)]
     pub histogram: MetricsHistogramConfig,
@@ -74,6 +78,7 @@ pub struct MetricsCommonConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, tag = "aggregation", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum MetricsHistogramConfig {
     Explicit {
         #[serde(default = "default_explicit_histogram_seconds")]
@@ -100,6 +105,7 @@ impl Default for MetricsHistogramConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsExplicitHistogramUnitConfig {
     pub buckets: MetricsHistogramBuckets,
     #[serde(default)]
@@ -108,6 +114,7 @@ pub struct MetricsExplicitHistogramUnitConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum MetricsHistogramBuckets {
     Numeric(Vec<f64>),
     HumanReadable(Vec<String>),
@@ -178,12 +185,14 @@ fn default_explicit_histogram_bytes() -> MetricsExplicitHistogramUnitConfig {
 pub type MetricsInstrumentsConfig = HashMap<String, ToggleWith<InstrumentConfig>>;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub struct InstrumentConfig {
     pub attributes: HashMap<String, bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, tag = "kind")]
+#[non_exhaustive]
 pub enum MetricsExporterConfig {
     #[serde(rename = "otlp")]
     Otlp(Box<MetricsOtlpConfig>),
@@ -202,6 +211,7 @@ impl MetricsExporterConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsOtlpConfig {
     /// Enables or disables this OTLP metrics exporter.
     ///
@@ -254,6 +264,7 @@ fn default_otlp_config_enabled() -> bool {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsPrometheusConfig {
     #[serde(default = "default_prometheus_enabled")]
     pub enabled: bool,

--- a/bin/router/src/config/telemetry/tracing.rs
+++ b/bin/router/src/config/telemetry/tracing.rs
@@ -10,6 +10,7 @@ use crate::config::primitives::value_or_expression::ValueOrExpression;
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
+#[non_exhaustive]
 pub struct TracingConfig {
     #[serde(default)]
     pub collect: TracingCollectConfig,
@@ -32,6 +33,7 @@ impl TracingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TracingInstrumentationConfig {
     #[serde(default)]
     pub spans: TracingSpansInstrumentationConfig,
@@ -39,6 +41,7 @@ pub struct TracingInstrumentationConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TracingSpansInstrumentationConfig {
     /// Controls which semantic conventions are emitted on spans.
     /// Default: SpecCompliant (only stable attributes).
@@ -60,6 +63,7 @@ fn default_spans_mode() -> SpansSemanticConventionsMode {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum SpansSemanticConventionsMode {
     /// Only spec-compliant attributes (http.request.*, http.response.*, url.*, etc).
     SpecCompliant,
@@ -71,6 +75,7 @@ pub enum SpansSemanticConventionsMode {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TracingCollectConfig {
     #[serde(default = "default_max_events_per_span")]
     pub max_events_per_span: u32,
@@ -121,6 +126,7 @@ impl Default for TracingCollectConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TracingOtlpConfig {
     #[serde(default = "default_otlp_config_enabled")]
     pub enabled: bool,
@@ -141,6 +147,7 @@ fn default_otlp_config_enabled() -> bool {
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OtlpHttpConfig {
     #[serde(default)]
     pub headers: std::collections::HashMap<String, ValueOrExpression<String>>,
@@ -148,6 +155,7 @@ pub struct OtlpHttpConfig {
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OtlpGrpcConfig {
     #[serde(default)]
     pub metadata: std::collections::HashMap<String, ValueOrExpression<String>>,
@@ -157,6 +165,7 @@ pub struct OtlpGrpcConfig {
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OtlpGrpcTlsConfig {
     /// The domain name used to verify the server's TLS certificate.
     pub domain_name: Option<String>,
@@ -203,6 +212,7 @@ impl TryFrom<&OtlpGrpcTlsConfig> for tonic::transport::ClientTlsConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, tag = "kind")]
+#[non_exhaustive]
 pub enum TracingExporterConfig {
     #[serde(rename = "otlp")]
     Otlp(Box<TracingOtlpConfig>),
@@ -212,6 +222,7 @@ pub enum TracingExporterConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct StdoutExporterConfig {
     #[serde(default = "default_stdout_config_enabled")]
     pub enabled: bool,
@@ -234,6 +245,7 @@ impl TracingExporterConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct BatchProcessorConfig {
     #[serde(default = "default_batch_max_concurrent_exports")]
     pub max_concurrent_exports: u32,
@@ -291,6 +303,7 @@ fn default_batch_scheduled_delay() -> Duration {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TracingPropagationConfig {
     #[serde(default = "default_propagation_trace_context")]
     pub trace_context: bool,
@@ -328,6 +341,7 @@ fn default_propagation_jaeger() -> bool {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub enum OtlpProtocol {
     #[serde(rename = "grpc")]
     Grpc,

--- a/bin/router/src/config/traffic_shaping.rs
+++ b/bin/router/src/config/traffic_shaping.rs
@@ -11,6 +11,7 @@ use crate::config::primitives::{
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingConfig {
     /// The default configuration that will be applied to all subgraphs, unless overridden by a specific subgraph configuration.
     #[serde(default)]
@@ -40,6 +41,7 @@ impl Default for TrafficShapingConfig {
 
 /// Traffic shaping that belongs to one supergraph's subgraph executors.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct SupergraphTrafficShapingConfig {
     pub all: TrafficShapingExecutorGlobalConfig,
     pub subgraphs: HashMap<String, TrafficShapingExecutorSubgraphConfig>,
@@ -139,6 +141,7 @@ fn default_router_dedupe_enabled() -> bool {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingExecutorSubgraphConfig {
     /// Overrides how long idle pooled connections for this subgraph remain available for reuse.
     ///
@@ -220,6 +223,7 @@ pub struct TrafficShapingExecutorSubgraphConfig {
 /// mutation fetches may use those declared WebSocket endpoints.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum WebSocketExecuteMode {
     /// Always executes queries and mutations over HTTP.
     ///
@@ -246,6 +250,7 @@ pub enum WebSocketExecuteMode {
 /// `traffic_shaping.all.websocket`. Fields omitted from `all` use their documented defaults.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingWebSocketConfig {
     /// Enables multiplexing operations over matching initialized WebSocket connections.
     ///
@@ -322,6 +327,7 @@ pub struct TrafficShapingWebSocketConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingExecutorGlobalConfig {
     /// Controls how long idle pooled connections remain available for reuse by default.
     ///
@@ -404,6 +410,7 @@ fn default_request_timeout() -> DurationOrExpression {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum DurationOrExpression {
     /// A fixed duration, e.g., "5s" or "100ms".
     #[serde(
@@ -433,6 +440,7 @@ impl Default for TrafficShapingExecutorGlobalConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingRouterConfig {
     #[serde(default)]
     pub dedupe: TrafficShapingRouterDedupeConfig,
@@ -488,6 +496,7 @@ pub struct TrafficShapingRouterConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingRouterDedupeConfig {
     /// Enables/disables in-flight request and active subscriptions deduplication at the router level.
     ///
@@ -541,6 +550,7 @@ pub struct TrafficShapingRouterDedupeConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum TrafficShapingRouterDedupeHeadersKeyword {
     #[default]
     All,
@@ -549,6 +559,7 @@ pub enum TrafficShapingRouterDedupeHeadersKeyword {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum TrafficShapingRouterDedupeHeadersConfig {
     Keyword(TrafficShapingRouterDedupeHeadersKeyword),
     Include { include: Vec<HttpHeaderName> },
@@ -601,6 +612,7 @@ fn default_circuit_breaker_config() -> Option<TrafficShapingSubgraphCircuitBreak
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ServerTLSConfig {
     pub cert_file: SingleOrMultiple<FilePath>,
     pub key_file: FilePath,
@@ -609,6 +621,7 @@ pub struct ServerTLSConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct TrafficShapingSubgraphCircuitBreakerConfig {
     /// Enable or disable the circuit breaker for the subgraph.
     /// Default: false (circuit breaker is disabled)
@@ -688,6 +701,7 @@ pub struct TrafficShapingSubgraphCircuitBreakerConfig {
 /// See [`TrafficShapingSubgraphCircuitBreakerConfig::error_status_codes`] for
 /// the accepted syntax.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum StatusCodeMatcher {
     /// A single exact HTTP status code, e.g. `503`.
     Exact(StatusCode),
@@ -831,6 +845,7 @@ impl JsonSchema for StatusCodeMatcher {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ServerClientAuthConfig {
     pub cert_file: SingleOrMultiple<FilePath>,
     #[serde(default)]
@@ -839,6 +854,7 @@ pub struct ServerClientAuthConfig {
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ClientTLSConfig {
     pub cert_file: Option<SingleOrMultiple<FilePath>>,
     pub client_auth: Option<ClientAuthConfig>,
@@ -848,6 +864,7 @@ pub struct ClientTLSConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ClientAuthConfig {
     pub cert_file: SingleOrMultiple<FilePath>,
     pub key_file: FilePath,

--- a/bin/router/src/config/usage_reporting.rs
+++ b/bin/router/src/config/usage_reporting.rs
@@ -8,6 +8,7 @@ use crate::config::primitives::percentage::Percentage;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum UsageReportingExclude {
     Expression { expression: String },
     OperationNames(Vec<String>),
@@ -15,6 +16,7 @@ pub enum UsageReportingExclude {
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum UsageReportingSamplingKeyKind {
     #[default]
     OperationName,
@@ -26,6 +28,7 @@ pub type UsageReportingSamplingKey = OneOrMany<UsageReportingSamplingKeyKind>;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct AtLeastOnceSamplingConfig {
     /// The key used for at-least-once sampling, to determine unique operations.
     ///
@@ -53,6 +56,7 @@ pub struct AtLeastOnceSamplingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct UsageReportingSamplingConfig {
     #[serde(default = "default_sample_rate")]
     #[schemars(with = "String")]
@@ -82,6 +86,7 @@ impl Default for UsageReportingSamplingConfig {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct UsageReportingConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,

--- a/bin/router/src/config/websocket.rs
+++ b/bin/router/src/config/websocket.rs
@@ -5,6 +5,7 @@ use crate::config::primitives::absolute_path::AbsolutePath;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct WebSocketConfig {
     /// Enables/disables WebSocket connections.
     ///
@@ -30,6 +31,7 @@ pub struct WebSocketConfig {
 
 #[derive(Default, Deserialize, Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum WebSocketHeadersSource {
     /// Do not accept headers from any source inside WebSocket connections.
     None,
@@ -81,6 +83,7 @@ pub enum WebSocketHeadersSource {
 
 #[derive(Default, Deserialize, Serialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct WebSocketHeadersConfig {
     /// The source(s) from which to accept headers for WebSocket connections.
     pub source: WebSocketHeadersSource,


### PR DESCRIPTION
This will prevent flagging additions to config structs as breaking changes in semver ci checks. 