### PR TITLE
Close quiet upstream subscriptions after client disconnects

### DIFF
--- a/.changeset/close_quiet_upstream_subs.md
+++ b/.changeset/close_quiet_upstream_subs.md
@@ -1,0 +1,10 @@
+---
+hive-router: patch
+node-addon: patch
+---
+
+# Close quiet upstream subscriptions after client disconnects
+
+The router now closes an upstream subscription as soon as its final downstream client disconnects, even when the upstream emits no further events.
+
+Closes https://github.com/graphql-hive/router/issues/1494

--- a/.changeset/close_quiet_upstream_subs.md
+++ b/.changeset/close_quiet_upstream_subs.md
@@ -1,6 +1,5 @@
 ---
 hive-router: patch
-node-addon: patch
 ---
 
 # Close quiet upstream subscriptions after client disconnects

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -695,7 +695,10 @@ pub async fn execute_planned_request<'exec>(
                                 None => break,
                             }
                         }
-                        _ = producer_handle.sender().closed() => break,
+                        _ = producer_handle.sender().closed() => {
+                            debug!(target: targets::SUBSCRIPTIONS, "all downstream clients disconnected, closing upstream subscription");
+                            break;
+                        }
                         _ = supergraph.snapshot.retired() => {
                             // the supergraph this subscription was selected from has been
                             // retired (configured reload, or the owning plugin dropped/replaced

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -695,6 +695,7 @@ pub async fn execute_planned_request<'exec>(
                                 None => break,
                             }
                         }
+                        _ = producer_handle.sender().closed() => break,
                         _ = supergraph.snapshot.retired() => {
                             // the supergraph this subscription was selected from has been
                             // retired (configured reload, or the owning plugin dropped/replaced

--- a/e2e/src/subscriptions.rs
+++ b/e2e/src/subscriptions.rs
@@ -1174,6 +1174,57 @@ mod subscriptions_e2e_tests {
     }
 
     #[ntex::test]
+    async fn quiet_subscription_closes_upstream_when_client_disconnects() {
+        use futures::StreamExt;
+
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                subscriptions:
+                    enabled: true
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let mut res = router
+            .send_graphql_request(
+                r#"
+                subscription {
+                    reviewAddedLooping(intervalInMs: 60000) {
+                        id
+                    }
+                }
+                "#,
+                None,
+                some_header_map! {
+                    http::header::ACCEPT => "text/event-stream"
+                },
+            )
+            .await;
+
+        assert!(res.status().is_success(), "Expected 200 OK");
+        let _ = res.next().await.expect("expected at least one chunk");
+        assert_eq!(subgraphs.active_subscriptions(), 1);
+
+        drop(res);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while subgraphs.active_subscriptions() != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("upstream subscription remained active after the client disconnected");
+    }
+
+    #[ntex::test]
     async fn subscription_stream_client_cancelled() {
         use futures::StreamExt;
 


### PR DESCRIPTION
Related #1494

The router now closes an upstream subscription as soon as its final downstream client disconnects, even when the upstream emits no further events.