### PR TITLE
feat(router): add controls around router->subgraph `Accept-Encoding` header 

### DIFF
--- a/.changeset/subgraph_accept_encoding_config.md
+++ b/.changeset/subgraph_accept_encoding_config.md
@@ -1,0 +1,40 @@
+---
+hive-router: minor
+---
+
+# Configurable `Accept-Encoding` header sent to subgraphs
+
+The router previously always advertised `Accept-Encoding: gzip, deflate, br, zstd` to every
+subgraph, with no way to disable it or change the advertised algorithms/order. This is now
+configurable under `traffic_shaping.*.compression.response.accept_encoding`:
+
+```yaml
+traffic_shaping:
+  all:
+    compression:
+      response:
+        accept_encoding:
+          publish: true # default true
+          algorithms: # order matters - some subgraphs pick the first one they support
+            - zstd
+            - gzip
+            - br
+            - deflate
+  subgraphs:
+    accounts:
+      compression:
+        response:
+          accept_encoding:
+            publish: false
+```
+
+`publish` controls whether the header is sent at all (default: `true`, matching prior behavior).
+
+`algorithms` controls which encodings are advertised and in what order (default: `gzip, deflate,
+br, zstd`, matching the router's previous hard-coded value). An empty `algorithms` list behaves
+like `publish: false`.
+
+This only affects what the router asks for - it always transparently decompresses any of `gzip`,
+`deflate`, `br`, or `zstd` it receives back from a subgraph, regardless of this setting.
+
+Closes https://github.com/graphql-hive/router/issues/1500

--- a/bin/router/src/config/traffic_shaping.rs
+++ b/bin/router/src/config/traffic_shaping.rs
@@ -95,8 +95,8 @@ impl SupergraphTrafficShapingConfig {
     ) -> TrafficShapingSubgraphCompressionConfig {
         self.subgraphs
             .get(subgraph_name)
-            .and_then(|config| config.compression)
-            .unwrap_or(self.all.compression)
+            .and_then(|config| config.compression.clone())
+            .unwrap_or_else(|| self.all.compression.clone())
     }
 
     /// Returns whether any configured traffic-shaping rule can reuse WebSocket connections.
@@ -475,16 +475,95 @@ impl Default for TrafficShapingExecutorGlobalConfig {
 /// Compression of traffic between the router and a subgraph.
 ///
 /// Subgraph responses are always transparently decompressed when they carry a recognized
-/// `Content-Encoding` - `request` is the only configurable direction for now (compressing
-/// outbound requests unconditionally could break a subgraph that doesn't decompress, so it's
-/// opt-in). Nested under its own key so a `response` section (e.g. tuning for the always-on
-/// decompression) can be added later without a breaking shape change.
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy)]
+/// `Content-Encoding` - `request` controls compressing outbound requests (opt-in, since
+/// compressing unconditionally could break a subgraph that doesn't decompress) and `response`
+/// controls the `Accept-Encoding` header the router advertises for that always-on response decompression.
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TrafficShapingSubgraphCompressionConfig {
     /// Compresses request bodies sent to the subgraph.
     #[serde(default)]
     pub request: TrafficShapingSubgraphRequestCompressionConfig,
+
+    /// Compression controls for the subgraph response.
+    #[serde(default)]
+    pub response: TrafficShapingSubgraphResponseCompressionConfig,
+}
+
+/// Response-direction compression settings for traffic between the router and a subgraph.
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TrafficShapingSubgraphResponseCompressionConfig {
+    /// Controls the `Accept-Encoding` header sent to the subgraph.
+    #[serde(default)]
+    pub accept_encoding: AcceptEncodingConfig,
+}
+
+/// Controls the `Accept-Encoding` header the router sends to a subgraph.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptEncodingConfig {
+    /// Enables/disables sending the `Accept-Encoding` header to the subgraph.
+    ///
+    /// When disabled, the router sends no `Accept-Encoding` header at all, leaving it up to the
+    /// subgraph whether to compress its response. This has no effect on decompression: the
+    /// router still transparently decompresses any recognized `Content-Encoding` it receives.
+    #[serde(default = "default_accept_encoding_publish")]
+    pub publish: bool,
+
+    /// Algorithms advertised in the `Accept-Encoding` header sent to the subgraph, in
+    /// preference order.
+    ///
+    /// The order matters: some subgraphs pick the first algorithm from this list that they
+    /// support, rather than their own preferred algorithm, so this is a preference list rather
+    /// than an unordered allow-list. It only controls what the router asks for - regardless of
+    /// this setting, the router always transparently decompresses any of `gzip`, `deflate`,
+    /// `br`, or `zstd` it receives back.
+    ///
+    /// An empty list is equivalent to `publish: false`: no `Accept-Encoding` header is sent.
+    #[serde(default = "default_accept_encoding_algorithms")]
+    pub algorithms: Vec<CompressionAlgorithm>,
+}
+
+impl Default for AcceptEncodingConfig {
+    fn default() -> Self {
+        Self {
+            publish: default_accept_encoding_publish(),
+            algorithms: default_accept_encoding_algorithms(),
+        }
+    }
+}
+
+impl AcceptEncodingConfig {
+    /// The `Accept-Encoding` header value to send to the subgraph, or `None` when publishing is
+    /// disabled or there are no algorithms to advertise.
+    pub fn header_value(&self) -> Option<String> {
+        if !self.publish || self.algorithms.is_empty() {
+            return None;
+        }
+
+        Some(
+            self.algorithms
+                .iter()
+                .map(|algorithm| algorithm.token())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}
+
+fn default_accept_encoding_publish() -> bool {
+    true
+}
+
+fn default_accept_encoding_algorithms() -> Vec<CompressionAlgorithm> {
+    // Matches the router's hard-coded `Accept-Encoding` value before this became configurable.
+    vec![
+        CompressionAlgorithm::Gzip,
+        CompressionAlgorithm::Deflate,
+        CompressionAlgorithm::Br,
+        CompressionAlgorithm::Zstd,
+    ]
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
@@ -1434,6 +1513,78 @@ mod tests {
             compression.request.algorithm,
             super::CompressionAlgorithmConfig::Gzip
         );
+    }
+
+    #[test]
+    fn accept_encoding_defaults_to_publishing_gzip_deflate_br_zstd_in_order() {
+        let config: TrafficShapingConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let compression = resolved.subgraph_compression("accounts");
+        assert!(compression.response.accept_encoding.publish);
+        assert_eq!(
+            compression.response.accept_encoding.algorithms,
+            vec![
+                super::CompressionAlgorithm::Gzip,
+                super::CompressionAlgorithm::Deflate,
+                super::CompressionAlgorithm::Br,
+                super::CompressionAlgorithm::Zstd,
+            ]
+        );
+        assert_eq!(
+            compression
+                .response
+                .accept_encoding
+                .header_value()
+                .as_deref(),
+            Some("gzip, deflate, br, zstd"),
+            "default Accept-Encoding value must match the router's pre-existing hard-coded value"
+        );
+    }
+
+    #[test]
+    fn accept_encoding_header_value_respects_configured_order() {
+        let config: TrafficShapingConfig = serde_json::from_str(
+            r#"{ "all": { "compression": { "response": { "accept_encoding": { "algorithms": ["zstd", "gzip"] } } } } }"#,
+        )
+        .expect("config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let compression = resolved.subgraph_compression("accounts");
+        assert_eq!(
+            compression
+                .response
+                .accept_encoding
+                .header_value()
+                .as_deref(),
+            Some("zstd, gzip"),
+            "Accept-Encoding value must preserve the configured algorithm order"
+        );
+    }
+
+    #[test]
+    fn accept_encoding_header_value_is_none_when_publish_is_disabled() {
+        let config: TrafficShapingConfig = serde_json::from_str(
+            r#"{ "all": { "compression": { "response": { "accept_encoding": { "publish": false } } } } }"#,
+        )
+        .expect("config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let compression = resolved.subgraph_compression("accounts");
+        assert_eq!(compression.response.accept_encoding.header_value(), None);
+    }
+
+    #[test]
+    fn accept_encoding_header_value_is_none_when_algorithms_list_is_empty() {
+        let config: TrafficShapingConfig = serde_json::from_str(
+            r#"{ "all": { "compression": { "response": { "accept_encoding": { "algorithms": [] } } } } }"#,
+        )
+        .expect("config should deserialize");
+        let resolved = SupergraphTrafficShapingConfig::from(&config);
+
+        let compression = resolved.subgraph_compression("accounts");
+        assert_eq!(compression.response.accept_encoding.header_value(), None);
     }
 
     #[test]

--- a/bin/router/src/executor/executors/http.rs
+++ b/bin/router/src/executor/executors/http.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::config::traffic_shaping::{
-    CompressionAlgorithm, TrafficShapingSubgraphRequestCompressionConfig,
+    AcceptEncodingConfig, CompressionAlgorithm, TrafficShapingSubgraphRequestCompressionConfig,
 };
 use crate::executor::executors::dedupe::unique_leader_fingerprint;
 use crate::executor::executors::inflight::InFlightRole;
@@ -173,6 +173,7 @@ impl HTTPSubgraphExecutor {
         telemetry_context: Arc<TelemetryContext>,
         subgraph_buffer_capacity: usize,
         compression: TrafficShapingSubgraphRequestCompressionConfig,
+        accept_encoding: AcceptEncodingConfig,
     ) -> Self {
         let mut header_map = HeaderMap::new();
         header_map.insert(
@@ -184,12 +185,13 @@ impl HTTPSubgraphExecutor {
             HeaderValue::from_static("keep-alive"),
         );
 
-        // Always send the algorithms we can decompress, regardless of whether outbound
-        // request compression is enabled
-        header_map.insert(
-            http::header::ACCEPT_ENCODING,
-            HeaderValue::from_static("gzip, deflate, br, zstd"),
-        );
+        // Advertise the algorithms we can decompress, regardless of whether outbound request
+        // compression is enabled - unless the user disabled or emptied out the list.
+        if let Some(value) = accept_encoding.header_value() {
+            if let Ok(value) = HeaderValue::from_str(&value) {
+                header_map.insert(http::header::ACCEPT_ENCODING, value);
+            }
+        }
 
         Self {
             subgraph_name,

--- a/bin/router/src/executor/executors/map.rs
+++ b/bin/router/src/executor/executors/map.rs
@@ -10,7 +10,7 @@ use crate::config::{
     subscriptions::{SubscriptionProtocol, SupergraphSubscriptionsConfig},
     traffic_shaping::{
         DurationOrExpression, StatusCodeMatcher, SupergraphTrafficShapingConfig,
-        TrafficShapingSubgraphRequestCompressionConfig, WebSocketExecuteMode,
+        TrafficShapingSubgraphCompressionConfig, WebSocketExecuteMode,
     },
 };
 use crate::executor::executors::inflight::InFlightMap;
@@ -134,7 +134,7 @@ struct ResolvedSubgraphConfig<'a> {
     client: Arc<HttpClient>,
     timeout_config: &'a DurationOrExpression,
     dedupe_enabled: bool,
-    compression: TrafficShapingSubgraphRequestCompressionConfig,
+    compression: TrafficShapingSubgraphCompressionConfig,
 }
 
 pub type InflightRequestsMap = InFlightMap<u64, (SubgraphHttpResponse, u64)>;
@@ -866,7 +866,8 @@ impl SubgraphExecutorMap {
                     self.in_flight_requests.clone(),
                     self.telemetry_context.clone(),
                     self.config.subscriptions.subgraph_buffer_capacity,
-                    subgraph_config.compression,
+                    subgraph_config.compression.request,
+                    subgraph_config.compression.response.accept_encoding,
                 )
                 .to_boxed_arc();
 
@@ -966,8 +967,7 @@ impl SubgraphExecutorMap {
             compression: self
                 .config
                 .traffic_shaping
-                .subgraph_compression(subgraph_name)
-                .request,
+                .subgraph_compression(subgraph_name),
         };
 
         let Some(subgraph_config) = self.config.traffic_shaping.subgraphs.get(subgraph_name) else {

--- a/e2e/src/subgraph_compression.rs
+++ b/e2e/src/subgraph_compression.rs
@@ -190,10 +190,11 @@ mod subgraph_compression_e2e_tests {
         );
     }
 
-    // regardless of whether request compression is enabled, the router should always tell
-    // subgraphs which encodings it can decompress in their responses.
+    // regardless of whether request compression is enabled, the router should by default tell
+    // subgraphs which encodings it can decompress in their responses, using the pre-existing
+    // hard-coded order (gzip, deflate, br, zstd) now that this is configurable.
     #[ntex::test]
-    async fn should_always_advertise_accept_encoding_to_subgraphs() {
+    async fn should_advertise_accept_encoding_to_subgraphs_by_default() {
         let subgraphs = TestSubgraphs::builder().build().start().await;
         let router = TestRouter::builder()
             .with_subgraphs(&subgraphs)
@@ -218,13 +219,148 @@ mod subgraph_compression_e2e_tests {
             .expect("expected requests sent to accounts subgraph");
         let subgraph_request = &subgraph_requests[0];
 
+        assert_eq!(
+            subgraph_request
+                .headers
+                .get(http::header::ACCEPT_ENCODING.as_str())
+                .map(|v| v.as_bytes()),
+            Some("gzip, deflate, br, zstd".as_bytes()),
+            "the router should advertise its default Accept-Encoding value to subgraphs"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_not_advertise_accept_encoding_when_publish_is_disabled() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    all:
+                        compression:
+                            response:
+                                accept_encoding:
+                                    publish: false
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+        assert_eq!(res.status(), 200);
+
+        let subgraph_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests sent to accounts subgraph");
+        let subgraph_request = &subgraph_requests[0];
+
         assert!(
             subgraph_request
                 .headers
                 .get(http::header::ACCEPT_ENCODING.as_str())
-                .is_some(),
-            "the router should always advertise Accept-Encoding to subgraphs"
+                .is_none(),
+            "Accept-Encoding must not be sent when publish is disabled"
         );
+    }
+
+    #[ntex::test]
+    async fn should_advertise_accept_encoding_in_the_configured_order() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    all:
+                        compression:
+                            response:
+                                accept_encoding:
+                                    algorithms: [zstd, gzip]
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+        assert_eq!(res.status(), 200);
+
+        let subgraph_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests sent to accounts subgraph");
+        let subgraph_request = &subgraph_requests[0];
+
+        assert_eq!(
+            subgraph_request
+                .headers
+                .get(http::header::ACCEPT_ENCODING.as_str())
+                .map(|v| v.as_bytes()),
+            Some("zstd, gzip".as_bytes()),
+            "Accept-Encoding must reflect the configured algorithm subset and order"
+        );
+    }
+
+    #[ntex::test]
+    async fn should_apply_per_subgraph_accept_encoding_override() {
+        let subgraphs = TestSubgraphs::builder().build().start().await;
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                traffic_shaping:
+                    subgraphs:
+                        accounts:
+                            compression:
+                                response:
+                                    accept_encoding:
+                                        publish: false
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } topProducts { upc } }", None, None)
+            .await;
+        assert_eq!(res.status(), 200);
+
+        let accounts_requests = subgraphs
+            .get_requests_log("accounts")
+            .expect("expected requests to accounts");
+        assert!(
+            accounts_requests[0]
+                .headers
+                .get(http::header::ACCEPT_ENCODING.as_str())
+                .is_none(),
+            "accounts has publish disabled and should not advertise Accept-Encoding"
+        );
+
+        if let Some(products_requests) = subgraphs.get_requests_log("products") {
+            assert_eq!(
+                products_requests[0]
+                    .headers
+                    .get(http::header::ACCEPT_ENCODING.as_str())
+                    .map(|v| v.as_bytes()),
+                Some("gzip, deflate, br, zstd".as_bytes()),
+                "products has no override and should keep the default Accept-Encoding"
+            );
+        }
     }
 
     #[ntex::test]


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/1500 

The router previously always advertised `Accept-Encoding: gzip, deflate, br, zstd` to every
subgraph, with no way to disable it or change the advertised algorithms/order. This is now
configurable under `traffic_shaping.*.compression.response.accept_encoding`:

```yaml
traffic_shaping:
  all:
    compression:
      response:
        accept_encoding:
          publish: true # default true
          algorithms: # order matters - some subgraphs pick the first one they support
            - zstd
            - gzip
            - br
            - deflate
  subgraphs:
    accounts:
      compression:
        response:
          accept_encoding:
            publish: false
```

`publish` controls whether the header is sent at all (default: `true`, matching prior behavior).

`algorithms` controls which encodings are advertised and in what order (default: `gzip, deflate,
br, zstd`, matching the router's previous hard-coded value). An empty `algorithms` list behaves
like `publish: false`.
