### PR TITLE
perf: reducing allocations and caching type name resolution in projection

### DIFF
--- a/.changeset/projection-performance-improvements.md
+++ b/.changeset/projection-performance-improvements.md
@@ -1,0 +1,13 @@
+---
+hive-router: patch
+---
+
+# Faster response and entity projection with fewer allocations
+
+Projecting subgraph responses into client responses, and projecting representations, is now faster and allocates less.
+
+- Type-name resolution during projection is lazy and shared across sibling fields and list items instead of being cloned per node
+- `__typename` lookups in `requires` projection and hashing happen at most once per object
+- Repeated field lookups across list items reuse saved positions through a small stack-backed cache (heap-backed only for selections wider than 16 fields)
+
+The `projection_lists`, `projection_nested_lists`, and `requires_loops` benchmarks show list projection running ~25-45% faster on typical selections, with no heap allocation for common short lists.

--- a/bin/router/benches/executor_benches.rs
+++ b/bin/router/benches/executor_benches.rs
@@ -7,6 +7,7 @@ use hive_router::executor::response::value::Value;
 use hive_router::query_planner::ast::normalization::normalize_operation;
 use hive_router::query_planner::utils::parsing::{parse_operation, parse_schema};
 use std::hint::black_box;
+mod projection;
 pub mod raw_result;
 
 fn project_data_by_operation_test(c: &mut Criterion) {
@@ -62,6 +63,7 @@ fn project_data_by_operation_test(c: &mut Criterion) {
 
 fn all_benchmarks(c: &mut Criterion) {
     project_data_by_operation_test(c);
+    projection::benchmarks(c);
 }
 
 criterion_group!(benches, all_benchmarks);

--- a/bin/router/benches/projection/mod.rs
+++ b/bin/router/benches/projection/mod.rs
@@ -1,0 +1,235 @@
+use criterion::{BenchmarkId, Criterion, Throughput};
+use hive_router::executor::{
+    introspection::schema::{FieldNullability, SchemaMetadata},
+    projection::{
+        plan::{FieldProjectionPlan, ProjectionValueSource},
+        request::project_requires,
+        response::project_by_operation,
+    },
+    response::value::Value,
+};
+use std::{hint::black_box, sync::Arc};
+
+fn field(name: &str, selections: Option<Vec<FieldProjectionPlan>>) -> FieldProjectionPlan {
+    FieldProjectionPlan {
+        field_name: name.into(),
+        response_key: name.into(),
+        is_typename: name == "__typename",
+        nullability: FieldNullability::Leaf { non_null: false },
+        parent_type_guard: None,
+        conditions: None,
+        value: ProjectionValueSource::ResponseData {
+            selections: selections.map(Arc::new),
+        },
+    }
+}
+
+pub fn benchmarks(c: &mut Criterion) {
+    requires_benchmarks(c);
+    // Build the Value and plan outside the timed loop, so this measures projection
+    // (including its output allocation), rather than parsing or planning.
+    let schema = SchemaMetadata::default();
+    let mut group = c.benchmark_group("projection_lists");
+    for field_count in [5, 15, 20, 50] {
+        let keys: Vec<_> = (0..field_count).map(|i| format!("field_{i:02}")).collect();
+        let selected_count = field_count.min(10);
+        let plans = vec![field(
+            "items",
+            Some(
+                // Reverse the selection order to ensure response order is preserved.
+                (0..selected_count)
+                    .rev()
+                    .map(|i| field(&keys[i * field_count / selected_count], None))
+                    .collect(),
+            ),
+        )];
+        for count in [1, 2, 4, 8, 10, 100, 1_000, 10_000] {
+            for mixed in [false, true] {
+                let objects = (0..count)
+                    .map(|row| {
+                        Value::Object(
+                            keys.iter()
+                                .enumerate()
+                                .filter(|(i, _)| !mixed || (row + i) % 7 != 0)
+                                .map(|(i, key)| (key.as_str(), Value::U64(i as u64)))
+                                .collect(),
+                        )
+                    })
+                    .collect();
+                let data = Value::Object(vec![("items", Value::Array(objects))]);
+                let shape = if mixed { "mixed" } else { "uniform" };
+                group.throughput(Throughput::Elements(count as u64));
+                group.bench_with_input(
+                    BenchmarkId::new(format!("{shape}_{field_count}_fields"), count),
+                    &data,
+                    |b, data| {
+                        b.iter(|| {
+                            black_box(
+                                project_by_operation(
+                                    black_box(data),
+                                    vec![],
+                                    &Default::default(),
+                                    "Query",
+                                    black_box(&plans),
+                                    &None,
+                                    count * selected_count * 16,
+                                    &schema,
+                                )
+                                .unwrap(),
+                            )
+                        });
+                    },
+                );
+            }
+        }
+    }
+    // Wide shape: 32 selected fields is more than the stack cache holds,
+    // so this exercises the heap path with few and many elements.
+    // Small matrix on purpose.
+    let wide_keys: Vec<_> = (0..32).map(|i| format!("wide_{i:02}")).collect();
+    let wide_plans = vec![field(
+        "items",
+        Some((0..32).rev().map(|i| field(&wide_keys[i], None)).collect()),
+    )];
+    for count in [2, 8, 100] {
+        for mixed in [false, true] {
+            let objects = (0..count)
+                .map(|row| {
+                    Value::Object(
+                        wide_keys
+                            .iter()
+                            .enumerate()
+                            .filter(|(i, _)| !mixed || (row + i) % 7 != 0)
+                            .map(|(i, key)| (key.as_str(), Value::U64(i as u64)))
+                            .collect(),
+                    )
+                })
+                .collect();
+            let data = Value::Object(vec![("items", Value::Array(objects))]);
+            let shape = if mixed { "mixed" } else { "uniform" };
+            group.throughput(Throughput::Elements(count as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{shape}_wide_32_fields"), count),
+                &data,
+                |b, data| {
+                    b.iter(|| {
+                        black_box(
+                            project_by_operation(
+                                black_box(data),
+                                vec![],
+                                &Default::default(),
+                                "Query",
+                                black_box(&wide_plans),
+                                &None,
+                                count * 32 * 16,
+                                &schema,
+                            )
+                            .unwrap(),
+                        )
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+
+    // Each level creates deferred type context. With typename unselected, the
+    // context stays unresolved; selecting it also exercises lazy resolution.
+    let mut group = c.benchmark_group("projection_nested_lists");
+    for with_typename in [false, true] {
+        let mut plans = vec![field("value", None)];
+        let mut data = Value::Object(vec![
+            ("__typename", Value::String("Node".into())),
+            ("value", Value::U64(42)),
+        ]);
+        for _ in 0..4 {
+            if with_typename {
+                plans.push(field("__typename", None));
+            }
+            plans = vec![field("children", Some(plans))];
+            data = Value::Object(vec![
+                ("__typename", Value::String("Node".into())),
+                ("children", Value::Array(vec![data; 8])),
+            ]);
+        }
+        group.bench_function(
+            if with_typename {
+                "resolved"
+            } else {
+                "deferred"
+            },
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        project_by_operation(
+                            black_box(&data),
+                            vec![],
+                            &Default::default(),
+                            "Query",
+                            black_box(&plans),
+                            &None,
+                            200_000,
+                            &schema,
+                        )
+                        .unwrap(),
+                    )
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn requires_benchmarks(c: &mut Criterion) {
+    use graphql_tools::parser::query::{Definition, OperationDefinition};
+    use hive_router::query_planner::{
+        ast::selection_set::SelectionSet, utils::parsing::parse_operation,
+    };
+
+    let keys: Vec<_> = (0..50).map(|i| format!("field_{i:02}")).collect();
+    let mut entries = vec![("__typename", Value::String("Item".into()))];
+    entries.extend(keys.iter().map(|key| (key.as_str(), Value::U64(42))));
+    let data = Value::Object(entries);
+    let types = Default::default();
+    let mut group = c.benchmark_group("requires_loops");
+    for fragments in [0, 1, 8] {
+        // Keep all eight fields selected; vary only how many are wrapped in fragments.
+        let fields = (0..8)
+            .map(|i| {
+                if i < fragments {
+                    format!("... on Item {{ field_{i:02} }}")
+                } else {
+                    format!("field_{i:02}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let document = parse_operation(&format!("{{ {fields} }}"));
+        let Definition::Operation(OperationDefinition::SelectionSet(selections)) =
+            document.definitions.into_iter().next().unwrap()
+        else {
+            unreachable!()
+        };
+        let selections: SelectionSet = selections.into();
+        let input = format!("{fragments}_fragments");
+        group.bench_function(BenchmarkId::new("hash_8_fields", &input), |b| {
+            b.iter(|| black_box(black_box(&data).to_hash(black_box(&selections.items), &types)));
+        });
+        group.bench_function(BenchmarkId::new("project_8_fields", &input), |b| {
+            let mut buffer = Vec::with_capacity(512);
+            b.iter(|| {
+                buffer.clear();
+                project_requires(
+                    &types,
+                    black_box(&selections.items),
+                    black_box(&data),
+                    &mut buffer,
+                    true,
+                    None,
+                );
+                black_box(&buffer);
+            });
+        });
+    }
+    group.finish();
+}

--- a/bin/router/src/executor/projection/request.rs
+++ b/bin/router/src/executor/projection/request.rs
@@ -225,14 +225,7 @@ fn project_requires_map_mut(
             SelectionItem::InlineFragment(requires_selection) => {
                 let type_condition = &requires_selection.type_condition;
 
-                let type_name = match entity_obj
-                    .iter()
-                    .find(|(key, _)| key == &TYPENAME_FIELD_NAME)
-                    .and_then(|(_, val)| val.as_str())
-                {
-                    Some(type_name) => type_name,
-                    _ => type_condition,
-                };
+                let type_name = type_name.unwrap_or(type_condition);
                 // For projection, both sides of the condition are valid
                 if possible_types.entity_satisfies_type_condition(type_name, type_condition)
                     || possible_types.entity_satisfies_type_condition(type_condition, type_name)

--- a/bin/router/src/executor/projection/response.rs
+++ b/bin/router/src/executor/projection/response.rs
@@ -10,7 +10,6 @@ use bytes::BufMut;
 use sonic_rs::JsonValueTrait;
 use std::cell::OnceCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use crate::executor::introspection::schema::{FieldNullability, SchemaMetadata};
 use crate::executor::json_writer::{write_and_escape_string, write_f64, write_i64, write_u64};
@@ -36,22 +35,21 @@ impl NullPropagationDecision {
 /// Represents a type's name that can be either already resolved or lazily computed.
 /// This avoids computing the type name when it's not needed, which is important for performance.
 ///
-/// The enum is recursive - a Deferred variant can contain another TypeName as its parent,
-/// creating a lazy chain that only resolves when actually needed.
-#[derive(Clone)]
-enum TypeName<'a> {
+/// Deferred contexts borrow their parent on the traversal stack, sharing its lazy
+/// resolution across sibling fields and list items without allocation or cloning.
+enum TypeName<'a, 'ctx> {
     Resolved(&'a str),
     Deferred {
         selection: &'a FieldProjectionPlan,
         data: Option<&'a Value<'a>>,
-        parent: Rc<TypeName<'a>>,
+        parent: &'ctx TypeName<'a, 'ctx>,
         schema: &'a SchemaMetadata,
         /// Cache for the resolved type name to avoid recomputation
         cached: OnceCell<Result<&'a str, ProjectionError>>,
     },
 }
 
-impl<'a> TypeName<'a> {
+impl<'a, 'ctx> TypeName<'a, 'ctx> {
     #[inline]
     fn resolved(type_name: &'a str) -> Self {
         TypeName::Resolved(type_name)
@@ -61,13 +59,13 @@ impl<'a> TypeName<'a> {
     fn deferred(
         selection: &'a FieldProjectionPlan,
         data: Option<&'a Value>,
-        parent: TypeName<'a>,
+        parent: &'ctx TypeName<'a, 'ctx>,
         schema: &'a SchemaMetadata,
     ) -> Self {
         TypeName::Deferred {
             selection,
             data,
-            parent: Rc::new(parent),
+            parent,
             schema,
             cached: OnceCell::new(),
         }
@@ -120,10 +118,11 @@ pub fn project_by_operation(
             &mut errors,
             selections,
             variable_values,
-            TypeName::resolved(operation_type_name),
+            &TypeName::resolved(operation_type_name),
             &mut buffer,
             &mut first,
             schema_metadata,
+            &mut [],
         )?;
 
         if null_propagation_decision.should_propagate() {
@@ -205,6 +204,9 @@ pub fn serialize_value_to_buffer(data: &Value, buffer: &mut Vec<u8>) {
     };
 }
 
+/// How many field positions fit in the per-list stack cache.
+const STACK_CACHE_SIZE: usize = 16;
+
 #[allow(clippy::too_many_arguments)]
 fn project_selection_set<'a>(
     data: &'a Value,
@@ -212,12 +214,43 @@ fn project_selection_set<'a>(
     selection: &'a FieldProjectionPlan,
     variable_values: &Option<HashMap<String, sonic_rs::Value>>,
     buffer: &mut Vec<u8>,
-    parent_type_name: TypeName<'a>,
+    parent_type_name: &TypeName<'a, '_>,
     schema_metadata: &'a SchemaMetadata,
     nullability: &'a FieldNullability,
+    indexes: &mut [usize],
 ) -> Result<NullPropagationDecision, ProjectionError> {
     match data {
         Value::Array(arr) => {
+            // Remember field positions so later objects in the same list can
+            // skip searching. Lists inside lists share the saved positions,
+            // fields inside objects start fresh. Small selections keep the
+            // positions on the stack, so common short lists (2-3 objects
+            // with a few fields) never touch the heap. Only unusually wide
+            // selections use the heap, which still pays off because one
+            // allocation replaces dozens of searches.
+            let cache_size = if indexes.is_empty() && arr.len() > 1 {
+                if let ProjectionValueSource::ResponseData {
+                    selections: Some(plans),
+                } = &selection.value
+                {
+                    Some(plans.len())
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            // `vec![..; 0]` never allocates.
+            let mut heap_cache = match cache_size {
+                Some(len) if len > STACK_CACHE_SIZE => vec![usize::MAX; len],
+                _ => Vec::new(),
+            };
+            let mut stack_cache = [usize::MAX; STACK_CACHE_SIZE];
+            let indexes = match cache_size {
+                Some(len) if len <= STACK_CACHE_SIZE => &mut stack_cache[..len],
+                Some(_) if !heap_cache.is_empty() => heap_cache.as_mut_slice(),
+                _ => indexes,
+            };
             let null_propagation_checkpoint = buffer.len();
             let list_item_nullability = nullability.list_item();
             let item_non_null = list_item_nullability.is_some_and(FieldNullability::is_non_null);
@@ -233,9 +266,10 @@ fn project_selection_set<'a>(
                     selection,
                     variable_values,
                     buffer,
-                    parent_type_name.clone(),
+                    parent_type_name,
                     schema_metadata,
                     list_item_nullability.unwrap_or(nullability),
+                    indexes,
                 )?;
 
                 // A `null` at a Non-Null element of this list propagates to the list itself.
@@ -269,10 +303,11 @@ fn project_selection_set<'a>(
                         errors,
                         selections,
                         variable_values,
-                        type_name,
+                        &type_name,
                         buffer,
                         &mut first,
                         schema_metadata,
+                        indexes,
                     )?;
 
                     if null_propagation_decision.should_propagate() {
@@ -320,12 +355,13 @@ fn project_selection_set_with_map<'a>(
     errors: &mut Vec<GraphQLError>,
     plans: &'a [FieldProjectionPlan],
     variable_values: &Option<HashMap<String, sonic_rs::Value>>,
-    parent_type_name: TypeName<'a>,
+    parent_type_name: &TypeName<'a, '_>,
     buffer: &mut Vec<u8>,
     first: &mut bool,
     schema_metadata: &'a SchemaMetadata,
+    indexes: &mut [usize],
 ) -> Result<NullPropagationDecision, ProjectionError> {
-    for plan in plans {
+    for (plan_index, plan) in plans.iter().enumerate() {
         if let Some(guard) = &plan.parent_type_guard {
             let name = parent_type_name.get()?;
             if !guard.matches(name) {
@@ -334,17 +370,14 @@ fn project_selection_set_with_map<'a>(
             }
         }
 
-        let field_val = obj
-            .binary_search_by_key(&plan.response_key.as_str(), |(k, _)| *k)
-            .ok()
-            .map(|idx| &obj[idx].1);
+        let field_val = find_field(obj, &plan.response_key, indexes.get_mut(plan_index));
 
         let res = if let Some(conditions) = &plan.conditions {
             let field_type_name_cell = OnceCell::new();
             let field_type_name_fn = || {
                 field_type_name_cell
                     .get_or_init(|| {
-                        resolve_type_name(plan, field_val, &parent_type_name, schema_metadata)
+                        resolve_type_name(plan, field_val, parent_type_name, schema_metadata)
                     })
                     .clone()
             };
@@ -393,9 +426,10 @@ fn project_selection_set_with_map<'a>(
                                 plan,
                                 variable_values,
                                 buffer,
-                                parent_type_name.clone(),
+                                parent_type_name,
                                 schema_metadata,
                                 &plan.nullability,
+                                &mut [],
                             )?
                         } else {
                             // If the field is not found in the object, set it to Null
@@ -461,6 +495,30 @@ fn project_selection_set_with_map<'a>(
     }
 
     Ok(NullPropagationDecision::KeepNullValue)
+}
+
+#[inline]
+fn find_field<'a>(
+    obj: &'a [(&str, Value)],
+    response_key: &str,
+    hint: Option<&mut usize>,
+) -> Option<&'a Value<'a>> {
+    // The saved position is only a hint: check that the key still matches.
+    if let Some((key, value)) = hint.as_ref().and_then(|hint| obj.get(**hint)) {
+        if *key == response_key {
+            return Some(value);
+        }
+    }
+
+    // A previous object may have left the field out or kept it in a different
+    // spot, so always search the current object and save what is found.
+    let found = obj
+        .binary_search_by_key(&response_key, |(key, _)| *key)
+        .ok();
+    if let Some(hint) = hint {
+        *hint = found.unwrap_or(usize::MAX);
+    }
+    found.map(|index| &obj[index].1)
 }
 
 #[inline]
@@ -569,7 +627,7 @@ where
 fn resolve_type_name<'a>(
     plan: &'a FieldProjectionPlan,
     field_val: Option<&'a Value>,
-    parent_type_name: &TypeName<'a>,
+    parent_type_name: &TypeName<'a, '_>,
     schema_metadata: &'a SchemaMetadata,
 ) -> Result<&'a str, ProjectionError> {
     if plan.is_typename {

--- a/bin/router/src/executor/response/value.rs
+++ b/bin/router/src/executor/response/value.rs
@@ -111,6 +111,10 @@ impl<'a> Value<'a> {
         selection_items: &[SelectionItem],
         possible_types: &PossibleTypes,
     ) {
+        // Read __typename at most once per object, and only when a fragment
+        // needs it. Also remember when it is missing: each fragment then
+        // falls back to its own type instead.
+        let mut type_name = None;
         for item in selection_items {
             match item {
                 SelectionItem::Field(field_selection) => {
@@ -127,10 +131,12 @@ impl<'a> Value<'a> {
                 }
                 SelectionItem::InlineFragment(inline_fragment) => {
                     let type_condition = &inline_fragment.type_condition;
-                    let type_name = obj
-                        .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
-                        .ok()
-                        .and_then(|idx| obj[idx].1.as_str())
+                    let type_name = type_name
+                        .get_or_insert_with(|| {
+                            obj.binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
+                                .ok()
+                                .and_then(|idx| obj[idx].1.as_str())
+                        })
                         .unwrap_or(type_condition);
 
                     if possible_types.entity_satisfies_type_condition(type_name, type_condition) {


### PR DESCRIPTION
Replaces `Rc<TypeName>` with borrowed references to avoid allocation. Caches typename lookup once per fragment instead of per field. Reuses index positions among objects with matching projection plans. Adds benchmarks for projection and requires.