### PR TITLE
fix(router): correctly handle `Content-Encoding: identity` from subgraphs

### DIFF
--- a/.changeset/identity_content_encoding_passthrough.md
+++ b/.changeset/identity_content_encoding_passthrough.md
@@ -1,0 +1,9 @@
+---
+hive-router: patch
+---
+
+# Treat `identity` subgraph `Content-Encoding` as uncompressed
+
+When a subgraph responds with `Content-Encoding: identity` (the RFC 9110 token for "no encoding") or an empty `Content-Encoding` value, the router now passes the body through unchanged instead of failing the fetch with a `SUBGRAPH_RESPONSE_DECOMPRESSION_FAILURE` error. This matches how a missing `Content-Encoding` header is handled. Unrecognized compression algorithms still surface a clean decompression error.
+
+Closes https://github.com/graphql-hive/router/issues/1511

--- a/bin/router/src/executor/executors/http.rs
+++ b/bin/router/src/executor/executors/http.rs
@@ -308,7 +308,8 @@ async fn send_request<'a>(
         };
 
         let body = match parts.headers.get(http::header::CONTENT_ENCODING) {
-            Some(content_encoding) => {
+            // `identity` (RFC 9110 §8.4.1) and an empty token both mean "no encoding"
+            Some(content_encoding) if !is_identity_or_empty_encoding(content_encoding) => {
                 let algorithm = content_encoding
                     .to_str()
                     .ok()
@@ -326,7 +327,7 @@ async fn send_request<'a>(
                     }
                 }
             }
-            None => body,
+            _ => body,
         };
 
         if body.is_empty() {
@@ -811,6 +812,20 @@ pub struct SubgraphHttpResponse {
 
 const VALID_GRAPHQL_CONTENT_TYPES: [&str; 2] =
     ["application/json", "application/graphql-response+json"];
+
+/// Whether a `Content-Encoding` value means "no encoding" - either the explicit `identity`
+/// token (RFC 9110 §8.4.1) or an empty value - so the body can be used as-is without
+/// decompression
+#[inline]
+fn is_identity_or_empty_encoding(value: &HeaderValue) -> bool {
+    match value.to_str() {
+        Ok(token) => {
+            let token = token.trim();
+            token.is_empty() || token.eq_ignore_ascii_case("identity")
+        }
+        Err(_) => false,
+    }
+}
 
 #[inline]
 fn is_valid_graphql_content_type(header_value: &str) -> bool {

--- a/e2e/src/subgraph_compression.rs
+++ b/e2e/src/subgraph_compression.rs
@@ -343,6 +343,74 @@ mod subgraph_compression_e2e_tests {
     }
 
     #[ntex::test]
+    async fn should_treat_identity_content_encoding_as_uncompressed() {
+        let body = sonic_rs::to_vec(&sonic_rs::json!({
+            "data": { "users": [{ "id": "identity-user-1" }] }
+        }))
+        .unwrap();
+
+        let subgraphs = TestSubgraphs::builder()
+            .with_on_request(move |req| {
+                if req.path.contains("accounts") {
+                    Some(ResponseLike {
+                        status: StatusCode::OK,
+                        headers: {
+                            let mut h = http::HeaderMap::new();
+                            h.insert(
+                                http::header::CONTENT_TYPE,
+                                "application/json".parse().unwrap(),
+                            );
+                            // the subgraph explicitly declares the "no encoding" token, and
+                            // sends the body uncompressed.
+                            h.insert(CONTENT_ENCODING, "identity".parse().unwrap());
+                            h
+                        },
+                        body: Some(Bytes::from(body.clone())),
+                    })
+                } else {
+                    None
+                }
+            })
+            .build()
+            .start()
+            .await;
+
+        let router = TestRouter::builder()
+            .with_subgraphs(&subgraphs)
+            .inline_config(
+                r#"
+                supergraph:
+                    source: file
+                    path: supergraph.graphql
+                "#,
+            )
+            .build()
+            .start()
+            .await;
+
+        let res = router
+            .send_graphql_request("{ users { id } }", None, None)
+            .await;
+
+        assert_eq!(
+            res.status(),
+            200,
+            "expected a successful response for an `identity`-encoded subgraph response"
+        );
+        let response_body = res.json_body().await;
+        assert!(
+            response_body["errors"].is_null(),
+            "`identity` Content-Encoding must not produce an error, got: {response_body:?}"
+        );
+        assert_eq!(
+            response_body["data"]["users"][0]["id"].as_str(),
+            Some("identity-user-1"),
+            "expected the router to pass through an `identity`-encoded subgraph response \
+             unchanged, got: {response_body:?}"
+        );
+    }
+
+    #[ntex::test]
     async fn should_return_a_clean_error_for_malformed_compressed_subgraph_response() {
         for algorithm in ["gzip", "deflate", "br", "zstd"] {
             let garbage = b"this is not compressed data of any kind: 1234567890".to_vec();


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/1511

When a subgraph responds with `Content-Encoding: identity` (the RFC 9110 token for "no encoding") or an empty `Content-Encoding` value, the router now passes the body through unchanged instead of failing the fetch with a `SUBGRAPH_RESPONSE_DECOMPRESSION_FAILURE` error. This matches how a missing `Content-Encoding` header is handled. Unrecognized compression algorithms still surface a clean decompression error.

