### PR TITLE
feat(router): advertise compression information in request summary

### DIFF
--- a/.changeset/response_compression_summary_log.md
+++ b/.changeset/response_compression_summary_log.md
@@ -2,23 +2,25 @@
 hive-router: minor
 ---
 
-# Log the response compression algorithm in the request summary
+# Log response compression details in the request summary
 
-The request summary log line (`router::request`) now includes a `response_compression`
-field recording which algorithm the router compressed the client-facing response with
-(`gzip`, `deflate`, `br`, or `zstd`):
+The request access log / summary log line (`router::request`) now reports how the client-facing response was compressed:
+
+- `response_compression` - the algorithm the response was compressed with (`gzip`, `deflate`, `br`, or `zstd`).
+- `response_bytes` - the compressed size, in bytes, actually sent over the wire. This sits next to the existing `payload_bytes`, which remains the uncompressed size, so the two make the achieved compression ratio visible.
 
 ```json
 {
   "target": "router::request",
   "operation_type": "query",
   "status_code": 200,
-  "payload_bytes": 1234,
-  "response_compression": "gzip"
+  "payload_bytes": 4096,
+  "response_compression": "gzip",
+  "response_bytes": 512
 }
 ```
 
-The field is omitted when the response is sent uncompressed (compression disabled, the
+Both fields are omitted when the response is sent uncompressed (compression disabled, the
 client didn't advertise a supported `Accept-Encoding`, or the payload was below
 `traffic_shaping.router.compression.response.min_size`).
 

--- a/.changeset/response_compression_summary_log.md
+++ b/.changeset/response_compression_summary_log.md
@@ -24,4 +24,4 @@ Both fields are omitted when the response is sent uncompressed (compression disa
 client didn't advertise a supported `Accept-Encoding`, or the payload was below
 `traffic_shaping.router.compression.response.min_size`).
 
-Related https://github.com/graphql-hive/router/issues/1513
+Closes https://github.com/graphql-hive/router/issues/1513

--- a/.changeset/response_compression_summary_log.md
+++ b/.changeset/response_compression_summary_log.md
@@ -1,0 +1,25 @@
+---
+hive-router: minor
+---
+
+# Log the response compression algorithm in the request summary
+
+The request summary log line (`router::request`) now includes a `response_compression`
+field recording which algorithm the router compressed the client-facing response with
+(`gzip`, `deflate`, `br`, or `zstd`):
+
+```json
+{
+  "target": "router::request",
+  "operation_type": "query",
+  "status_code": 200,
+  "payload_bytes": 1234,
+  "response_compression": "gzip"
+}
+```
+
+The field is omitted when the response is sent uncompressed (compression disabled, the
+client didn't advertise a supported `Accept-Encoding`, or the payload was below
+`traffic_shaping.router.compression.response.min_size`).
+
+Related https://github.com/graphql-hive/router/issues/1513

--- a/bin/router/src/pipeline/request_summary.rs
+++ b/bin/router/src/pipeline/request_summary.rs
@@ -80,11 +80,7 @@ where
         let (response, guard) = async {
             let response = ctx.call(&self.service, req).await?;
 
-            // Bridge the summary out to the response-compression middleware, which sits
-            // *outside* this task-local scope (it's the outermost layer) and so can't reach
-            // the summary via `summary::record`. Stashing the shared handle on the request's
-            // extensions - which travel with the response - lets it record the negotiated
-            // `Content-Encoding` back onto the very same summary before it's emitted.
+            // This ensures that response summary is available for middlewares that runs after this one (like compression)
             if summary::is_enabled() {
                 if let Some(summary) = summary::current_summary() {
                     response.request().extensions_mut().insert(summary);

--- a/bin/router/src/pipeline/request_summary.rs
+++ b/bin/router/src/pipeline/request_summary.rs
@@ -80,6 +80,17 @@ where
         let (response, guard) = async {
             let response = ctx.call(&self.service, req).await?;
 
+            // Bridge the summary out to the response-compression middleware, which sits
+            // *outside* this task-local scope (it's the outermost layer) and so can't reach
+            // the summary via `summary::record`. Stashing the shared handle on the request's
+            // extensions - which travel with the response - lets it record the negotiated
+            // `Content-Encoding` back onto the very same summary before it's emitted.
+            if summary::is_enabled() {
+                if let Some(summary) = summary::current_summary() {
+                    response.request().extensions_mut().insert(summary);
+                }
+            }
+
             // Re-records over whatever the handler already set (e.g. before a plugin's `on_end`
             // callback ran and read it) with the truly final response
             let status_code = response.status().as_u16();

--- a/bin/router/src/pipeline/response_compression.rs
+++ b/bin/router/src/pipeline/response_compression.rs
@@ -1,4 +1,11 @@
-use std::{cmp::Ordering, io::Write, rc::Rc, sync::Arc};
+use std::{
+    cmp::Ordering,
+    error::Error,
+    io::Write,
+    rc::Rc,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE};
 use ntex::{
@@ -100,26 +107,37 @@ where
             return Ok(response);
         }
 
-        // Record the negotiated encoding on the request summary *before* applying it: the
-        // `br`/`zstd` paths drain the body inside `compress_full_body`, and draining emits
-        // the summary, so recording afterwards would be too late. The summary handle is put
-        // on the request extensions by `RequestSummaryMiddleware` (which runs inside this
-        // outermost middleware), and rides along with the response.
-        if let Some(summary) = response.request().extensions().get::<Arc<RequestSummary>>() {
-            summary.set_response_compression(algorithm.token());
+        let summary = response
+            .request()
+            .extensions()
+            .get::<Arc<RequestSummary>>()
+            .cloned();
+        let token = algorithm.token();
+
+        if let Some(summary) = &summary {
+            summary.set_response_compression(token);
         }
 
         let response = match algorithm {
-            CompressionAlgorithmConfig::Gzip => {
-                response.map_body(|head, body| Encoder::response(ContentEncoding::Gzip, head, body))
-            }
-            CompressionAlgorithmConfig::Deflate => response
-                .map_body(|head, body| Encoder::response(ContentEncoding::Deflate, head, body)),
+            CompressionAlgorithmConfig::Gzip => response.map_body(move |head, body| {
+                track_response_bytes(
+                    Encoder::response(ContentEncoding::Gzip, head, body),
+                    summary,
+                )
+            }),
+            CompressionAlgorithmConfig::Deflate => response.map_body(move |head, body| {
+                track_response_bytes(
+                    Encoder::response(ContentEncoding::Deflate, head, body),
+                    summary,
+                )
+            }),
+            // br/zstd buffer the whole body; `compress_full_body` records the compressed size once
+            // compression succeeds.
             CompressionAlgorithmConfig::Br(brotli) => {
-                compress_full_body(response, "br", brotli_compressor(*brotli)).await
+                compress_full_body(response, token, brotli_compressor(*brotli)).await
             }
             CompressionAlgorithmConfig::Zstd(zstd) => {
-                compress_full_body(response, "zstd", zstd_compressor(*zstd)).await
+                compress_full_body(response, token, zstd_compressor(*zstd)).await
             }
         };
 
@@ -207,9 +225,9 @@ async fn compress_full_body(
     compress: impl FnOnce(&[u8]) -> Option<Vec<u8>> + Send + 'static,
 ) -> web::WebResponse {
     let (http_response, request) = response.into_parts();
-    let (mut head, body) = http_response.into_parts();
+    let (mut head, mut body) = http_response.into_parts();
 
-    let original = match drain_body(body).await {
+    let original = match drain_body(&mut body).await {
         Ok(bytes) => bytes,
         Err(err) => {
             let pipeline_err: PipelineError =
@@ -239,22 +257,70 @@ async fn compress_full_body(
     };
 
     let fallback = original.clone();
-    let body = match ntex::rt::spawn_blocking(move || compress(&original)).await {
+    let compressed_body = match ntex::rt::spawn_blocking(move || compress(&original)).await {
         Ok(Some(compressed)) => {
             head.headers_mut()
                 .insert(CONTENT_ENCODING, HeaderValue::from_static(token));
+
+            if let Some(summary) = request.extensions().get::<Arc<RequestSummary>>() {
+                summary.set_response_bytes(compressed.len() as i64);
+            }
+
             Body::Bytes(Bytes::from(compressed))
         }
         _ => Body::Bytes(fallback),
     };
 
-    web::WebResponse::new(head.set_body(body), request)
+    web::WebResponse::new(head.set_body(compressed_body), request)
 }
 
-async fn drain_body(mut body: ResponseBody<Body>) -> Result<Bytes, Rc<dyn std::error::Error>> {
+async fn drain_body(body: &mut ResponseBody<Body>) -> Result<Bytes, Rc<dyn std::error::Error>> {
     let mut buf = BytesMut::new();
     while let Some(chunk) = body.try_next().await? {
         buf.extend_from_slice(&chunk);
     }
     Ok(buf.freeze())
+}
+
+fn track_response_bytes(
+    body: ResponseBody<Body>,
+    summary: Option<Arc<RequestSummary>>,
+) -> ResponseBody<Body> {
+    match summary {
+        Some(summary) => ResponseBody::Body(Body::from_message(ResponseBytesTrackedBody {
+            body,
+            summary,
+            response_bytes: 0,
+        })),
+        None => body,
+    }
+}
+
+struct ResponseBytesTrackedBody {
+    body: ResponseBody<Body>,
+    summary: Arc<RequestSummary>,
+    response_bytes: i64,
+}
+
+impl MessageBody for ResponseBytesTrackedBody {
+    fn size(&self) -> BodySize {
+        self.body.size()
+    }
+
+    fn poll_next_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Rc<dyn Error>>>> {
+        let poll = self.body.poll_next_chunk(cx);
+        if let Poll::Ready(Some(Ok(chunk))) = &poll {
+            self.response_bytes = self.response_bytes.saturating_add(chunk.len() as i64);
+        }
+        poll
+    }
+}
+
+impl Drop for ResponseBytesTrackedBody {
+    fn drop(&mut self) {
+        self.summary.set_response_bytes(self.response_bytes);
+    }
 }

--- a/bin/router/src/pipeline/response_compression.rs
+++ b/bin/router/src/pipeline/response_compression.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, io::Write, rc::Rc};
+use std::{cmp::Ordering, io::Write, rc::Rc, sync::Arc};
 
 use http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE};
 use ntex::{
@@ -24,7 +24,7 @@ use crate::{
     executor::{execution::plan::FailedExecutionResult, response::graphql_error::GraphQLError},
     http_utils::headers::append_vary,
     pipeline::error::{InternalPipelineError, PipelineError},
-    telemetry::logging::targets,
+    telemetry::logging::{summary::RequestSummary, targets},
 };
 
 #[derive(Clone)]
@@ -98,6 +98,15 @@ where
 
         if !should_compress {
             return Ok(response);
+        }
+
+        // Record the negotiated encoding on the request summary *before* applying it: the
+        // `br`/`zstd` paths drain the body inside `compress_full_body`, and draining emits
+        // the summary, so recording afterwards would be too late. The summary handle is put
+        // on the request extensions by `RequestSummaryMiddleware` (which runs inside this
+        // outermost middleware), and rides along with the response.
+        if let Some(summary) = response.request().extensions().get::<Arc<RequestSummary>>() {
+            summary.set_response_compression(algorithm.token());
         }
 
         let response = match algorithm {

--- a/bin/router/src/telemetry/logging/summary.rs
+++ b/bin/router/src/telemetry/logging/summary.rs
@@ -20,6 +20,7 @@ use crate::telemetry::logging::request_id::{RequestIdentifiers, REQUEST_IDENTIFI
 use crate::telemetry::logging::targets;
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct RequestSummary {
     pub client_name: OnceLock<String>,
     pub client_version: OnceLock<String>,

--- a/bin/router/src/telemetry/logging/summary.rs
+++ b/bin/router/src/telemetry/logging/summary.rs
@@ -85,8 +85,6 @@ impl RequestSummary {
         let _ = self.response_mode.set(mode);
     }
 
-    /// Records the algorithm the client-facing response was compressed with. First call
-    /// wins; the response is only ever compressed with a single algorithm per request.
     pub fn set_response_compression(&self, algorithm: &'static str) {
         let _ = self.response_compression.set(algorithm);
     }

--- a/bin/router/src/telemetry/logging/summary.rs
+++ b/bin/router/src/telemetry/logging/summary.rs
@@ -39,6 +39,7 @@ pub struct RequestSummary {
     pub response_compression: OnceLock<&'static str>,
     pub status_code: AtomicU16,
     pub payload_bytes: AtomicI64,
+    pub response_bytes: AtomicI64,
     pub duration_ms: AtomicU64,
     pub supergraph_identifier: AtomicU64,
     pub custom: Mutex<BTreeMap<String, sonic_rs::Value>>,
@@ -88,6 +89,10 @@ impl RequestSummary {
     /// wins; the response is only ever compressed with a single algorithm per request.
     pub fn set_response_compression(&self, algorithm: &'static str) {
         let _ = self.response_compression.set(algorithm);
+    }
+
+    pub fn set_response_bytes(&self, bytes: i64) {
+        self.response_bytes.store(bytes, Relaxed);
     }
 
     pub fn set_duration(&self, duration: Duration) {
@@ -140,6 +145,9 @@ impl RequestSummary {
             })
             .unwrap_or_default();
 
+        let response_bytes = self.response_bytes.load(Relaxed);
+        let response_bytes = (response_bytes > 0).then_some(response_bytes);
+
         info!(
             target: targets::SUMMARY,
             message = self.message.get().map(Cow::as_ref),
@@ -158,6 +166,7 @@ impl RequestSummary {
             response_compression = self.response_compression.get().copied(),
             status_code = self.status_code.load(Relaxed),
             payload_bytes = self.payload_bytes.load(Relaxed),
+            response_bytes = response_bytes,
             supergraph_identifier = self.supergraph_identifier.load(Relaxed),
             duration_ms = self.duration_ms.load(Relaxed),
         );

--- a/bin/router/src/telemetry/logging/summary.rs
+++ b/bin/router/src/telemetry/logging/summary.rs
@@ -34,6 +34,9 @@ pub struct RequestSummary {
     pub partial_response: AtomicBool,
     pub response_code: OnceLock<&'static str>,
     pub response_mode: OnceLock<&'static str>,
+    /// The `Content-Encoding` the router compressed the client-facing response with
+    /// (e.g. `gzip`, `br`), or unset when the response was sent uncompressed.
+    pub response_compression: OnceLock<&'static str>,
     pub status_code: AtomicU16,
     pub payload_bytes: AtomicI64,
     pub duration_ms: AtomicU64,
@@ -79,6 +82,12 @@ impl RequestSummary {
 
     pub fn set_response_mode(&self, mode: &'static str) {
         let _ = self.response_mode.set(mode);
+    }
+
+    /// Records the algorithm the client-facing response was compressed with. First call
+    /// wins; the response is only ever compressed with a single algorithm per request.
+    pub fn set_response_compression(&self, algorithm: &'static str) {
+        let _ = self.response_compression.set(algorithm);
     }
 
     pub fn set_duration(&self, duration: Duration) {
@@ -146,6 +155,7 @@ impl RequestSummary {
             partial_response = self.partial_response.load(Relaxed),
             error_code = self.response_code.get().copied(),
             response_mode = self.response_mode.get().copied(),
+            response_compression = self.response_compression.get().copied(),
             status_code = self.status_code.load(Relaxed),
             payload_bytes = self.payload_bytes.load(Relaxed),
             supergraph_identifier = self.supergraph_identifier.load(Relaxed),

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -315,10 +315,11 @@ async fn json_log_req_summary() {
 }
 
 /// The request summary records which algorithm the client-facing response was compressed
-/// with. This exercises both response-compression code paths, which emit the summary at
-/// different times: `gzip` streams through an encoder (summary emitted on body drop), while
-/// `br` drains the whole body up front (summary emitted mid-drain), so both must record the
-/// encoding *before* the body is consumed.
+/// with, plus the compressed wire size (`response_bytes`) alongside the uncompressed size
+/// (`payload_bytes`). This exercises both response-compression code paths, which emit the
+/// summary at different times: `gzip` streams through an encoder (summary emitted on body
+/// drop), while `br` buffers the whole body up front (summary emitted after compression), so
+/// both must record the encoding and compressed size *before* the summary is emitted.
 #[ntex::test]
 async fn json_log_req_summary_records_response_compression() {
     // `min_size: 1B` so even the tiny test response gets compressed.
@@ -351,6 +352,23 @@ traffic_shaping:
             find_attr(req_summary, "response_compression").as_deref(),
             Some(algorithm),
             "summary should record the `{algorithm}` encoding the response was compressed with"
+        );
+
+        let response_bytes = req_summary
+            .get("response_bytes")
+            .and_then(Value::as_i64)
+            .unwrap_or_else(|| panic!("`{algorithm}` summary should record `response_bytes`"));
+        assert!(
+            response_bytes > 0,
+            "`{algorithm}` compressed size should be positive, got {response_bytes}"
+        );
+        // The uncompressed size is still reported, and separately from the compressed one.
+        assert!(
+            req_summary
+                .get("payload_bytes")
+                .and_then(Value::as_i64)
+                .is_some_and(|payload_bytes| payload_bytes > 0),
+            "`{algorithm}` summary should still report the uncompressed `payload_bytes`"
         );
     }
 }

--- a/e2e/src/telemetry/logging.rs
+++ b/e2e/src/telemetry/logging.rs
@@ -314,6 +314,47 @@ async fn json_log_req_summary() {
     "#);
 }
 
+/// The request summary records which algorithm the client-facing response was compressed
+/// with. This exercises both response-compression code paths, which emit the summary at
+/// different times: `gzip` streams through an encoder (summary emitted on body drop), while
+/// `br` drains the whole body up front (summary emitted mid-drain), so both must record the
+/// encoding *before* the body is consumed.
+#[ntex::test]
+async fn json_log_req_summary_records_response_compression() {
+    // `min_size: 1B` so even the tiny test response gets compressed.
+    let builder = router_with_telemetry(
+        "\
+log:
+  level: info
+  format: json
+traffic_shaping:
+  router:
+    compression:
+      response:
+        min_size: 1B
+",
+    );
+    let (_subgraphs, router) = setup_router(builder).await;
+
+    for algorithm in ["gzip", "br"] {
+        let stdout_log = router
+            .send_graphql_request(
+                TEST_QUERY,
+                None,
+                Some(single_header("accept-encoding", algorithm)),
+            )
+            .capture_stdout_json()
+            .await;
+
+        let req_summary = log_line_by_target(&stdout_log, targets::SUMMARY);
+        assert_eq!(
+            find_attr(req_summary, "response_compression").as_deref(),
+            Some(algorithm),
+            "summary should record the `{algorithm}` encoding the response was compressed with"
+        );
+    }
+}
+
 #[ntex::test]
 async fn test_logging_of_subscriptions() {
     let subgraphs = TestSubgraphs::builder()


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/1513

The request access log / summary log line (`router::request`) now reports how the client-facing response was compressed:

- `response_compression` - the algorithm the response was compressed with (`gzip`, `deflate`, `br`, or `zstd`).
- `response_bytes` - the compressed size, in bytes, actually sent over the wire. This sits next to the existing `payload_bytes`, which remains the uncompressed size, so the two make the achieved compression ratio visible.

```json
{
  "target": "router::request",
  "operation_type": "query",
  "status_code": 200,
  "payload_bytes": 4096,
  "response_compression": "gzip",
  "response_bytes": 512
}
```

Both fields are omitted when the response is sent uncompressed (compression disabled, the
client didn't advertise a supported `Accept-Encoding`, or the payload was below
`traffic_shaping.router.compression.response.min_size`).

