### PR TITLE
fix(router): reliably reload a supergraph file that uses symlinks

### DIFF
--- a/.changeset/configmap_symlink_reload.md
+++ b/.changeset/configmap_symlink_reload.md
@@ -1,0 +1,11 @@
+---
+hive-router: patch
+---
+
+# Reliably reload a supergraph file mounted from a Kubernetes `ConfigMap`
+
+Fixes intermittent `Failed to read supergraph file: No such file or directory` errors (and stale schemas) when the supergraph is loaded from a file mounted from a Kubernetes `ConfigMap` with polling enabled.
+
+The file supergraph poller additionally retries transient `NotFound`/`ESTALE` errors that can occur if a read races with the atomic swap, and detects content changes by any modification-time difference (not only newer timestamps), so a rolled-back revision is still picked up.
+
+Closes https://github.com/graphql-hive/router/issues/1516

--- a/bin/router/src/config/primitives/file_path.rs
+++ b/bin/router/src/config/primitives/file_path.rs
@@ -70,12 +70,12 @@ impl<'de> Visitor<'de> for FilePathVisitor {
     {
         let path = Path::new(v);
         if path.is_absolute() {
-            let canonical_path = fs::canonicalize(path)
-                .map_err(|err| E::custom(format!("Failed to canonicalize path: {}", err)))?;
+            let absolute_path = validate_existing_path(path.to_path_buf())
+                .map_err(|err| E::custom(format!("Failed to resolve path: {}", err)))?;
 
             return Ok(FilePath {
                 relative: v.to_string(),
-                absolute: canonical_path.to_string_lossy().to_string(),
+                absolute: absolute_path.to_string_lossy().to_string(),
             });
         }
 
@@ -83,7 +83,7 @@ impl<'de> Visitor<'de> for FilePathVisitor {
             if let Some(start_path) = ctx.borrow().as_ref() {
                 match FilePath::resolve_relative(start_path, v, true) {
                     Ok(file_path) => Ok(file_path),
-                    Err(err) => Err(E::custom(format!("Failed to canonicalize path: {}", err))),
+                    Err(err) => Err(E::custom(format!("Failed to resolve path: {}", err))),
                 }
             } else {
                 Err(E::custom(
@@ -111,18 +111,25 @@ impl FilePath {
     fn resolve_relative<RootPath: AsRef<Path>>(
         base_path: &RootPath,
         relative_path: &str,
-        canonicalize: bool,
+        validate_exists: bool,
     ) -> io::Result<FilePath> {
         let absolute_path = base_path.as_ref().join(relative_path);
-        let canonical_path = if canonicalize {
-            fs::canonicalize(absolute_path)?
+        let absolute_path = if validate_exists {
+            validate_existing_path(absolute_path)?
         } else {
             absolute_path
         };
 
         Ok(FilePath {
             relative: relative_path.to_string(),
-            absolute: canonical_path.to_string_lossy().to_string(),
+            absolute: absolute_path.to_string_lossy().to_string(),
         })
     }
+}
+
+/// Resolve a configured file path to an absolute path **without** following symlinks.
+fn validate_existing_path(path: PathBuf) -> io::Result<PathBuf> {
+    // Follows symlinks, confirming the file is currently readable through the stable path.
+    fs::metadata(&path)?;
+    Ok(path)
 }

--- a/bin/router/src/supergraph/file.rs
+++ b/bin/router/src/supergraph/file.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::time::Duration;
 
 use crate::config::primitives::file_path::FilePath;
@@ -7,6 +8,16 @@ use tokio::{fs, sync::RwLock};
 use tracing::{debug, trace};
 
 use crate::supergraph::base::{LoadSupergraphError, ReloadSupergraphResult, SupergraphLoader};
+
+/// Maximum number of retry attempts for a transient read failure.
+const MAX_TRANSIENT_RETRIES: usize = 3;
+
+/// A read of ConfigMap (K8s) that lands in that tiny window can fail with not found error
+/// or stale error on linux.
+fn is_transient_read_error(err: &std::io::Error) -> bool {
+    // ESTALE has no dedicated `ErrorKind` variant, so match its raw errno (116 on Linux).
+    matches!(err.kind(), ErrorKind::NotFound) || err.raw_os_error() == Some(116)
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum FileSupergraphError {
@@ -24,11 +35,38 @@ pub struct SupergraphFileLoader {
 
 impl SupergraphFileLoader {
     async fn load_with_polling(&self) -> Result<ReloadSupergraphResult, FileSupergraphError> {
+        // Retry transient failures caused by a ConfigMap atomic swap racing with our
+        // read (see `is_transient_read_error`). Retries settle well within one poll
+        // interval, so a genuine `NotFound` still surfaces as an error after a few tries.
+        let mut attempt: usize = 0;
+        loop {
+            match self.try_load_with_polling().await {
+                Err(FileSupergraphError::ReadFileError(err))
+                    if is_transient_read_error(&err) && attempt < MAX_TRANSIENT_RETRIES =>
+                {
+                    attempt += 1;
+
+                    debug!(
+                        target: targets::SUPERGRAPH,
+                        path = ?self.file_path.absolute,
+                        attempt,
+                        error = ?err,
+                        "transient read during supergraph reload, retrying",
+                    );
+
+                    tokio::time::sleep(Duration::from_millis(50 * attempt as u64)).await;
+                }
+                other => return other,
+            }
+        }
+    }
+
+    async fn try_load_with_polling(&self) -> Result<ReloadSupergraphResult, FileSupergraphError> {
         let file_metadata = fs::metadata(&self.file_path.absolute).await?;
         let current_time = file_metadata.modified()?;
         let mut modified_time = self.modified_time.write().await;
 
-        if modified_time.is_none() || current_time > modified_time.unwrap() {
+        if modified_time.is_none_or(|previous| current_time != previous) {
             let content = fs::read_to_string(&self.file_path.absolute).await?;
             *modified_time = Some(current_time);
 

--- a/e2e/src/file_supergraph.rs
+++ b/e2e/src/file_supergraph.rs
@@ -6,6 +6,103 @@ mod file_supergraph_e2e_tests {
 
     use crate::testkit::{ClientResponseExt, TestRouter};
 
+    /// The router is pointed at a symlink and must reload when the symlink is repointed to
+    /// a new file and the previous target is deleted. This is the essential mechanic behind
+    /// a Kubernetes `ConfigMap` update (kubelet swaps its internal `..data` symlink and
+    /// removes the old data): the reader must keep following the symlink rather than pinning
+    /// to (and then failing on) the resolved, now-deleted target.
+    #[cfg(unix)]
+    #[ntex::test]
+    async fn should_reload_supergraph_when_symlink_target_swaps() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let link_path = dir.path().join("supergraph.graphql");
+
+        // Atomically repoint `link_path` at a fresh file containing `content`, then remove
+        // the file it previously pointed at.
+        let swap = |version: u32, content: &str| {
+            let target = dir.path().join(format!("supergraph.v{version}.graphql"));
+            fs::write(&target, content).expect("failed to write target file");
+
+            let old_target = fs::read_link(&link_path).ok();
+            let tmp = dir.path().join(".supergraph.tmp");
+            let _ = fs::remove_file(&tmp);
+            std::os::unix::fs::symlink(&target, &tmp).expect("failed to create tmp symlink");
+            // rename(2) over the existing symlink swaps it atomically.
+            fs::rename(&tmp, &link_path).expect("failed to swap symlink");
+
+            if let Some(old) = old_target {
+                let _ = fs::remove_file(old);
+            }
+        };
+
+        swap(1, "type Query { f: String }");
+        let supergraph_file_path = link_path.to_str().expect("path is valid utf-8").to_string();
+
+        let router = TestRouter::builder()
+            .inline_config(format!(
+                r#"
+                supergraph:
+                    source: file
+                    path: {supergraph_file_path}
+                    poll_interval: 100ms
+                "#,
+            ))
+            .build()
+            .start()
+            .await;
+
+        // Initial schema: Query present, NewType absent.
+        let res = router
+            .send_graphql_request("{ __schema { types { name } } }", None, None)
+            .await;
+        assert!(res.status().is_success(), "Expected 200 OK");
+        let body = res.body().await.unwrap();
+        assert!(
+            !String::from_utf8_lossy(&body).contains("NewType"),
+            "Expected initial schema to not contain 'NewType'"
+        );
+
+        // Poll the router until the schema reloaded to contain `expected_type`.
+        let router_ref = &router;
+        let wait_for_type = move |expected_type: &'static str| async move {
+            for _ in 0..20 {
+                let res = router_ref
+                    .send_graphql_request("{ __schema { types { name } } }", None, None)
+                    .await;
+                if res.status().is_success() {
+                    let body = res.body().await.unwrap();
+                    if String::from_utf8_lossy(&body).contains(expected_type) {
+                        return true;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            false
+        };
+
+        // Swap the symlink target (and delete the old file). The router must pick up the
+        // new schema through the stable symlink path.
+        swap(
+            2,
+            "type Query { dummyNew: NewType } type NewType { id: ID! }",
+        );
+        assert!(
+            wait_for_type("NewType").await,
+            "Supergraph did not reload after the symlink target was swapped"
+        );
+
+        // A second swap must reload again, proving the reader keeps following the symlink
+        // rather than caching a resolved (now-deleted) path.
+        swap(
+            3,
+            "type Query { second: SecondType } type SecondType { id: ID! }",
+        );
+        assert!(
+            wait_for_type("SecondType").await,
+            "Supergraph did not reload after a second symlink target swap"
+        );
+    }
+
     #[ntex::test]
     async fn should_load_supergraph_from_file() {
         let file = NamedTempFile::new().expect("failed to create temp file");

--- a/e2e/src/tls.rs
+++ b/e2e/src/tls.rs
@@ -20,7 +20,7 @@ mod tls_tests {
 
     #[ntex::test]
     #[should_panic(
-        expected = "failed to parse inline YAML config: ConfigLoadError(Failed to canonicalize path: No such file or directory (os error 2) for key `traffic_shaping.router.tls.key_file`)"
+        expected = "failed to parse inline YAML config: ConfigLoadError(Failed to resolve path: No such file or directory (os error 2) for key `traffic_shaping.router.tls.key_file`)"
     )]
     async fn config_validation_fails_due_to_missing_key_file() {
         let generated_key_pair = generate_keypair().await;
@@ -45,7 +45,7 @@ mod tls_tests {
 
     #[ntex::test]
     #[should_panic(
-        expected = "failed to parse inline YAML config: ConfigLoadError(expected single value or array, but parsing both failed with error: Failed to canonicalize path: No such file or directory (os error 2) for key `traffic_shaping.router.tls.cert_file"
+        expected = "failed to parse inline YAML config: ConfigLoadError(expected single value or array, but parsing both failed with error: Failed to resolve path: No such file or directory (os error 2) for key `traffic_shaping.router.tls.cert_file"
     )]
     async fn config_validation_fails_due_to_missing_cert_file() {
         let generated_key_pair = generate_keypair().await;


### PR DESCRIPTION
Related https://github.com/graphql-hive/router/issues/1516

Fixes intermittent `Failed to read supergraph file: No such file or directory` errors (and stale schemas) when the supergraph is loaded from a file mounted from a Kubernetes `ConfigMap` with polling enabled, or when symlink is used to point to the supergraph. 

The file supergraph poller additionally retries transient `NotFound`/`ESTALE` errors that can occur if a read races with the atomic swap, and detects content changes by any modification-time difference (not only newer timestamps), so a rolled-back revision is still picked up.

