### PR TITLE
fix(router): keep demand control cost formula next to the query plan

### DIFF
--- a/.changeset/plan_cache_formula_identity.md
+++ b/.changeset/plan_cache_formula_identity.md
@@ -1,0 +1,19 @@
+---
+hive-router: patch
+---
+
+# Query costs could come from the wrong plan when progressive `@override` was used
+
+The demand control cost formula was cached under the operation hash alone. The query plan it
+describes is cached under more than that: the override context and any plugin operation filtering
+are part of the plan cache key too. Two requests that produced different plans could therefore share
+one cost formula, and the first one compiled won - including its split of the cost across subgraphs.
+
+The formula is now stored with the plan it was compiled from, in the same cache entry, so it can
+only ever be used with that plan. The separate formula cache is gone. Queries that differ only in
+introspection fields still share one formula, because they still share one plan.
+
+## Removed
+
+The `cost.formula_cache_hit` attribute is gone from operation spans. It was never recorded, and the
+cache it described no longer exists; the plan cache hit already on the span covers it.

--- a/.changeset/plan_cache_formula_identity.md
+++ b/.changeset/plan_cache_formula_identity.md
@@ -2,18 +2,15 @@
 hive-router: patch
 ---
 
-# Query costs could come from the wrong plan when progressive `@override` was used
+# Query costs could use the wrong plan with progressive `@override`
 
-The demand control cost formula was cached under the operation hash alone. The query plan it
-describes is cached under more than that: the override context and any plugin operation filtering
-are part of the plan cache key too. Two requests that produced different plans could therefore share
-one cost formula, and the first one compiled won - including its split of the cost across subgraphs.
+The demand control cost formula was cached using only the operation hash. The query plan uses a larger cache key. It also includes the override context and any operation changes made by plugins.
+Because of this, two requests could use different query plans but still share the same cost formula. Whichever formula was created first was reused, including how the cost was split between subgraphs.
 
-The formula is now stored with the plan it was compiled from, in the same cache entry, so it can
-only ever be used with that plan. The separate formula cache is gone. Queries that differ only in
-introspection fields still share one formula, because they still share one plan.
+The cost formula is now stored together with the query plan it was created from. This makes sure a formula is only used with the correct plan. The separate formula cache has been removed.
+
+Queries that differ only by introspection fields still share the same formula because they also share the same query plan.
 
 ## Removed
 
-The `cost.formula_cache_hit` attribute is gone from operation spans. It was never recorded, and the
-cache it described no longer exists; the plan cache hit already on the span covers it.
+The `cost.formula_cache_hit` attribute has been removed from operation spans. It was never recorded, and the separate formula cache no longer exists. The existing plan cache hit attribute already provides this information.

--- a/bin/router/src/pipeline/demand_control/runtime.rs
+++ b/bin/router/src/pipeline/demand_control/runtime.rs
@@ -22,7 +22,6 @@ use crate::telemetry::metrics::Metrics;
 use crate::telemetry::traces::spans::graphql::GraphQLSpanOperationIdentity;
 use ahash::{HashMap as AHashMap, HashMapExt};
 use http::{HeaderName, HeaderValue};
-use moka::future::Cache;
 use tracing::{debug, info, warn};
 
 use crate::pipeline::error::{ClientPipelineError, PipelineError};
@@ -36,7 +35,6 @@ pub struct DemandControlRuntime {
     config: DemandControlConfig,
     expose_headers_flags: Arc<DemandControlExposeHeadersConfig>,
     metrics: Arc<Metrics>,
-    formula_cache: Cache<u64, Arc<DemandControlFormulaPlan>>,
 }
 
 impl DemandControlRuntime {
@@ -84,44 +82,22 @@ impl DemandControlRuntime {
             expose_headers_flags: Arc::new(config.operation_cost.expose_headers.clone()),
             config: config.clone(),
             metrics,
-            formula_cache: Cache::new(1000),
         })
-    }
-
-    pub fn formula_cache(&self) -> &Cache<u64, Arc<DemandControlFormulaPlan>> {
-        &self.formula_cache
     }
 }
 
 impl DemandControlRuntime {
-    #[allow(clippy::too_many_arguments)]
-    pub async fn evaluate<'exec>(
+    pub fn evaluate<'exec>(
         &self,
         supergraph: &'exec SupergraphSnapshot,
         variable_payload: &'exec CoerceVariablesPayload,
-        query_plan: &'exec QueryPlan,
-        operation_for_plan: &'exec OperationDefinition,
-        root_type_name: &'exec str,
-        normalized_operation_hash: u64,
+        compiled_plan: &'exec DemandControlFormulaPlan,
         operation_identity: GraphQLSpanOperationIdentity<'exec>,
     ) -> Result<DemandControlExecutionContext, PipelineError> {
         let operation_name = operation_identity.name;
-        let compiled_plan = self
-            .formula_cache
-            .entry(normalized_operation_hash)
-            .or_insert_with(async {
-                Arc::new(self.compile_demand_control_plan(
-                    query_plan,
-                    operation_for_plan,
-                    root_type_name,
-                    &supergraph.planner.supergraph,
-                ))
-            })
-            .await
-            .into_value();
 
         let evaluation = evaluate_formula_plan(
-            compiled_plan.as_ref(),
+            compiled_plan,
             &supergraph.planner.supergraph,
             variable_payload,
         )?;
@@ -251,7 +227,9 @@ impl DemandControlRuntime {
         over_limit
     }
 
-    fn compile_demand_control_plan(
+    /// Compiled once per plan-cache entry, while the plan is being built. The result is stored
+    /// with the plan, so it is keyed exactly like the plan it describes.
+    pub(crate) fn compile_plan(
         &self,
         query_plan: &QueryPlan,
         operation_for_plan: &OperationDefinition,

--- a/bin/router/src/pipeline/demand_control/runtime.rs
+++ b/bin/router/src/pipeline/demand_control/runtime.rs
@@ -227,8 +227,6 @@ impl DemandControlRuntime {
         over_limit
     }
 
-    /// Compiled once per plan-cache entry, while the plan is being built. The result is stored
-    /// with the plan, so it is keyed exactly like the plan it describes.
     pub(crate) fn compile_plan(
         &self,
         query_plan: &QueryPlan,

--- a/bin/router/src/pipeline/mod.rs
+++ b/bin/router/src/pipeline/mod.rs
@@ -935,33 +935,29 @@ pub async fn execute_pipeline<'exec>(
     )
     .await?;
 
-    let query_plan_payload = match query_plan_result {
-        QueryPlanResult::QueryPlan(plan) => plan,
+    let prepared_query_plan = match query_plan_result {
+        QueryPlanResult::QueryPlan(prepared) => prepared,
         QueryPlanResult::EarlyResponse(response) => {
             return Ok(QueryPlanExecutionResult::Single(response));
         }
     };
+    let query_plan_payload = prepared_query_plan.plan;
 
     let variable_payload = Arc::new(variable_payload);
 
-    let demand_control_execution_context = match supergraph.runtime.demand_control_runtime.as_ref()
-    {
-        Some(demand_control_runtime) => match demand_control_runtime
-            .evaluate(
+    let demand_control_execution_context = match (
+        supergraph.runtime.demand_control_runtime.as_ref(),
+        prepared_query_plan.demand_control.as_ref(),
+    ) {
+        (Some(demand_control_runtime), Some(compiled_plan)) => {
+            Some(demand_control_runtime.evaluate(
                 &supergraph.snapshot,
                 &variable_payload,
-                &query_plan_payload,
-                normalize_payload.operation_for_plan.as_ref(),
-                normalize_payload.root_type_name.as_str(),
-                normalize_payload.normalized_operation_hash,
+                compiled_plan,
                 (&normalize_payload.operation_identity).into(),
-            )
-            .await
-        {
-            Ok(context) => Some(context),
-            Err(err) => return Err(err),
-        },
-        None => None,
+            )?)
+        }
+        _ => None,
     };
 
     let planned_request = PlannedRequest {

--- a/bin/router/src/pipeline/query_plan.rs
+++ b/bin/router/src/pipeline/query_plan.rs
@@ -26,9 +26,6 @@ pub enum QueryPlanResult {
     EarlyResponse(PlanExecutionOutput),
 }
 
-/// A plan and the demand-control cost formula compiled from it. The formula describes this exact
-/// plan, so it shares the plan's cache entry and key - which includes the override context and any
-/// plugin operation filtering, not just the operation hash.
 #[derive(Clone)]
 pub struct PlannedQuery {
     pub plan: Arc<QueryPlan>,

--- a/bin/router/src/pipeline/query_plan.rs
+++ b/bin/router/src/pipeline/query_plan.rs
@@ -9,6 +9,7 @@ use crate::executor::hooks::on_query_plan::{
 use crate::executor::plugin_context::PluginRequestState;
 use crate::executor::plugin_trait::{CacheHint, EndControlFlow, StartControlFlow};
 use crate::executor::plugins::hooks;
+use crate::pipeline::demand_control::formula::DemandControlFormulaPlan;
 use crate::pipeline::error::PipelineError;
 use crate::pipeline::normalize::GraphQLNormalizationPayload;
 use crate::pipeline::progressive_override::{RequestOverrideContext, StableOverrideContext};
@@ -21,8 +22,17 @@ use tracing::Instrument;
 use xxhash_rust::xxh3::Xxh3;
 
 pub enum QueryPlanResult {
-    QueryPlan(Arc<QueryPlan>),
+    QueryPlan(PlannedQuery),
     EarlyResponse(PlanExecutionOutput),
+}
+
+/// A plan and the demand-control cost formula compiled from it. The formula describes this exact
+/// plan, so it shares the plan's cache entry and key - which includes the override context and any
+/// plugin operation filtering, not just the operation hash.
+#[derive(Clone)]
+pub struct PlannedQuery {
+    pub plan: Arc<QueryPlan>,
+    pub demand_control: Option<Arc<DemandControlFormulaPlan>>,
 }
 static EMPTY_QUERY_PLAN: LazyLock<Arc<QueryPlan>> = LazyLock::new(|| {
     Arc::new(QueryPlan {
@@ -97,15 +107,33 @@ pub async fn plan_operation_with_cache(
         let contains_introspection = normalized_operation.operation_for_introspection.is_some();
         let is_pure_introspection = is_plan_operation_empty && contains_introspection;
 
+        let compile_demand_control = |plan: &QueryPlan| {
+            supergraph
+                .runtime
+                .demand_control_runtime
+                .as_ref()
+                .map(|runtime| {
+                    Arc::new(runtime.compile_plan(
+                        plan,
+                        filtered_operation_for_plan,
+                        &normalized_operation.root_type_name,
+                        &supergraph.snapshot.planner.supergraph,
+                    ))
+                })
+        };
+
         let mut cache_hint = CacheHint::Hit;
         plan_span.record_cache_hit(true);
-        let mut plan = supergraph
+        let mut prepared = supergraph
             .runtime
             .plan_cache
             .entry(plan_cache_key)
             .or_try_insert_with(async {
                 if is_pure_introspection {
-                    return Ok(EMPTY_QUERY_PLAN.clone());
+                    return Ok(PlannedQuery {
+                        plan: EMPTY_QUERY_PLAN.clone(),
+                        demand_control: compile_demand_control(&EMPTY_QUERY_PLAN),
+                    });
                 }
 
                 // If the operation is empty, but the projection plan is not,,
@@ -121,7 +149,10 @@ pub async fn plan_operation_with_cache(
                 // That's why we return an empty plan,
                 // and allow for response projection to happen later.
                 if is_plan_operation_empty && !is_projection_plan_empty {
-                    return Ok(EMPTY_QUERY_PLAN.clone());
+                    return Ok(PlannedQuery {
+                        plan: EMPTY_QUERY_PLAN.clone(),
+                        demand_control: compile_demand_control(&EMPTY_QUERY_PLAN),
+                    });
                 }
 
                 supergraph
@@ -132,7 +163,10 @@ pub async fn plan_operation_with_cache(
                         (&request_override_context.clone()).into(),
                         cancellation_token,
                     )
-                    .map(Arc::new)
+                    .map(|plan| PlannedQuery {
+                        demand_control: compile_demand_control(&plan),
+                        plan: Arc::new(plan),
+                    })
             })
             .await
             .map_err(PipelineError::from)
@@ -151,7 +185,7 @@ pub async fn plan_operation_with_cache(
 
         if !on_end_callbacks.is_empty() {
             let mut end_payload = OnQueryPlanEndHookPayload {
-                query_plan: plan,
+                query_plan: prepared.plan,
                 cache_hint,
                 request_context: plugin_req_state
                     .as_ref()
@@ -171,10 +205,10 @@ pub async fn plan_operation_with_cache(
                 }
             }
             // Give the ownership back to variables
-            plan = end_payload.into_query_plan();
+            prepared.plan = end_payload.into_query_plan();
         }
 
-        Ok(QueryPlanResult::QueryPlan(plan))
+        Ok(QueryPlanResult::QueryPlan(prepared))
     }
     .instrument(plan_span.clone())
     .await

--- a/bin/router/src/schema_state.rs
+++ b/bin/router/src/schema_state.rs
@@ -17,7 +17,8 @@ use crate::executor::{
 };
 use crate::pipeline::active_subscriptions::ActiveSubscriptions;
 use crate::pipeline::authorization::metadata::AuthorizationMetadata;
-use crate::query_planner::{planner::plan_nodes::QueryPlan, utils::parsing::safe_parse_schema};
+use crate::pipeline::query_plan::PlannedQuery;
+use crate::query_planner::utils::parsing::safe_parse_schema;
 use crate::storage::StorageManager;
 use crate::telemetry::logging::targets;
 use crate::telemetry::utils::resolve_value_or_expression;
@@ -109,7 +110,7 @@ pub struct RouterSupergraphRuntime {
     pub authorization: AuthorizationMetadata,
     pub validate_cache: Cache<u64, Arc<Vec<ValidationError>>>,
     pub normalize_cache: Cache<u64, Arc<GraphQLNormalizationPayload>>,
-    pub plan_cache: Cache<u64, Arc<QueryPlan>>,
+    pub plan_cache: Cache<u64, PlannedQuery>,
     pub demand_control_runtime: Option<DemandControlRuntime>,
     /// Controls background work belonging to this selected supergraph runtime.
     ///

--- a/bin/router/src/telemetry/traces/spans/attributes.rs
+++ b/bin/router/src/telemetry/traces/spans/attributes.rs
@@ -36,7 +36,6 @@ pub const COST_ESTIMATED: &str = "cost.estimated";
 pub const COST_ACTUAL: &str = "cost.actual";
 pub const COST_DELTA: &str = "cost.delta";
 pub const COST_RESULT: &str = "cost.result";
-pub const COST_FORMULA_CACHE_HIT: &str = "cost.formula_cache_hit";
 
 /// Hive-specific attributes
 pub const HIVE_KIND: &str = "hive.kind";

--- a/bin/router/src/telemetry/traces/spans/graphql.rs
+++ b/bin/router/src/telemetry/traces/spans/graphql.rs
@@ -354,7 +354,6 @@ impl GraphQLOperationSpan {
             "hive.client.name" = Empty,
             "hive.client.version" = Empty,
             "hive.target" = Empty,
-            "cost.formula_cache_hit" = Empty,
         );
         GraphQLOperationSpan { span }
     }

--- a/bin/router/src/telemetry/traces/spans/tests.rs
+++ b/bin/router/src/telemetry/traces/spans/tests.rs
@@ -827,7 +827,6 @@ fn test_graphql_operation_span() {
                 attributes::COST_ACTUAL,
                 attributes::COST_DELTA,
                 attributes::COST_RESULT,
-                attributes::COST_FORMULA_CACHE_HIT,
                 attributes::HIVE_GRAPHQL_ERROR_COUNT,
                 attributes::HIVE_GRAPHQL_ERROR_CODES,
                 attributes::HIVE_CLIENT_NAME,

--- a/e2e/src/demand_control/metrics.rs
+++ b/e2e/src/demand_control/metrics.rs
@@ -577,12 +577,5 @@ mod metrics_tests {
             operation_span.attributes.get("cost.result").is_none(),
             "operation span should not include cost.result when demand control is disabled"
         );
-        assert!(
-            operation_span
-                .attributes
-                .get("cost.formula_cache_hit")
-                .is_none(),
-            "operation span should not include cost.formula_cache_hit when demand control is disabled"
-        );
     }
 }


### PR DESCRIPTION
The cost formula was cached only by the normalized operation hash, in a separate 1,000-entry demand control cache.

The query plan uses a more specific cache key: the operation hash, `StableOverrideContext`, and any plugin filtering. This means requests with different override labels could get different query plans but still reuse the same cost formula. A request could then be charged based on a plan it was not actually running, including the wrong per-subgraph costs.

Compile the cost formula together with the query plan and store both in the same cache entry. This makes sure they always use the same cache key. The separate demand control cache can then be removed.

`evaluate` no longer needs to look anything up. It receives the formula directly from the plan cache, so it is no longer async.

`cost.formula_cache_hit` is removed as well. It was declared in three places but never recorded, and there is no separate formula cache anymore.
