### PR TITLE
Make query plan read-only in plugins 

### DIFF
--- a/.changeset/hello-iphone-duo.md
+++ b/.changeset/hello-iphone-duo.md
@@ -1,0 +1,7 @@
+---
+hive-router: minor
+---
+
+# BREAKING: Make plugin query plans read-only
+
+Plugins can still inspect generated query plans in `on_query_plan`, but can no longer replace the plan that the router executes.

--- a/.changeset/hello-iphone-duo.md
+++ b/.changeset/hello-iphone-duo.md
@@ -2,6 +2,6 @@
 hive-router: minor
 ---
 
-# BREAKING: Make plugin query plans read-only
+# BREAKING: Make query plans read-only in plugins
 
 Plugins can still inspect generated query plans in `on_query_plan`, but can no longer replace the plan that the router executes.

--- a/bin/router/src/executor/plugins/hooks/on_query_plan.rs
+++ b/bin/router/src/executor/plugins/hooks/on_query_plan.rs
@@ -54,12 +54,23 @@ pub type OnQueryPlanStartHookResult<'exec> = StartHookResult<
 
 pub struct OnQueryPlanEndHookPayload {
     /// The generated query plan for the incoming GraphQL request.
-    pub query_plan: Arc<QueryPlan>,
+    pub(crate) query_plan: Arc<QueryPlan>,
     /// The cache hint for the generated query plan.
     /// - If this is `CacheHint::Hit`, it means the query planning process didn't happen because the result was retrieved from the cache.
     /// - If this is `CacheHint::Miss`, it means the query planning process happened and the result was not retrieved from the cache.
     pub cache_hint: CacheHint,
     pub request_context: RequestContextApi,
+}
+
+impl OnQueryPlanEndHookPayload {
+    /// Returns the generated query plan for the incoming GraphQL request.
+    pub fn query_plan(&self) -> &QueryPlan {
+        &self.query_plan
+    }
+
+    pub(crate) fn into_query_plan(self) -> Arc<QueryPlan> {
+        self.query_plan
+    }
 }
 
 impl EndHookPayload<PlanExecutionOutput> for OnQueryPlanEndHookPayload {}

--- a/bin/router/src/pipeline/query_plan.rs
+++ b/bin/router/src/pipeline/query_plan.rs
@@ -171,7 +171,7 @@ pub async fn plan_operation_with_cache(
                 }
             }
             // Give the ownership back to variables
-            plan = end_payload.query_plan;
+            plan = end_payload.into_query_plan();
         }
 
         Ok(QueryPlanResult::QueryPlan(plan))


### PR DESCRIPTION
Plugins can inspect query plans via a getter but no longer have direct
access.