### PR TITLE
perf(router): box the plan nodes

### DIFF
--- a/.changeset/plan_node_boxed_variants.md
+++ b/.changeset/plan_node_boxed_variants.md
@@ -1,0 +1,15 @@
+---
+hive-router: patch
+---
+
+# Smaller query plan nodes in the plan cache
+
+A plan node is an enum, so every one of its slots is as large as its largest variant - including the
+slots in a sequence or a parallel list that hold something small. The four variants that carry a
+subgraph fetch were an order of magnitude larger than the rest and set that size for all of them.
+
+Those four are now boxed. A stored plan node goes from 224 to 40 bytes, and a plan holds one per
+node, so the saving scales with plan size rather than with fetch count. The new ceiling is the
+condition node, which is pinned by a test so it stays visible if it grows.
+
+Plans on the wire are unchanged - boxing is invisible to serialization.

--- a/.changeset/plan_node_boxed_variants.md
+++ b/.changeset/plan_node_boxed_variants.md
@@ -4,17 +4,6 @@ hive-router: patch
 
 # Smaller query plan nodes in the plan cache
 
-A plan node is an enum, so every plan node takes as much space as its largest variant. This is
-true even for the slots in a sequence or a parallel list that hold something small.
-
-Four of the variants carry a subgraph fetch, and those four were much larger than the rest. They
-set the size for every plan node.
-
-Those four variants are now boxed, so the large data is stored separately and the node itself stays
-small. A stored plan node goes from 224 to 40 bytes. A plan holds one node per step, so the saving
-grows with the size of the plan rather than with the number of fetches.
-
-The largest variant is now the condition node. A test checks its size, so it stays visible if it
-grows.
-
-Query plans on the wire are unchanged. Boxing a variant does not change how it is serialized.
+PlanNode is an enum, so every variant takes as much space as its largest variant. 
+Some of the variants have a subgraph fetch, and those were much larger than the rest. 
+They are now boxed.

--- a/.changeset/plan_node_boxed_variants.md
+++ b/.changeset/plan_node_boxed_variants.md
@@ -4,12 +4,17 @@ hive-router: patch
 
 # Smaller query plan nodes in the plan cache
 
-A plan node is an enum, so every one of its slots is as large as its largest variant - including the
-slots in a sequence or a parallel list that hold something small. The four variants that carry a
-subgraph fetch were an order of magnitude larger than the rest and set that size for all of them.
+A plan node is an enum, so every plan node takes as much space as its largest variant. This is
+true even for the slots in a sequence or a parallel list that hold something small.
 
-Those four are now boxed. A stored plan node goes from 224 to 40 bytes, and a plan holds one per
-node, so the saving scales with plan size rather than with fetch count. The new ceiling is the
-condition node, which is pinned by a test so it stays visible if it grows.
+Four of the variants carry a subgraph fetch, and those four were much larger than the rest. They
+set the size for every plan node.
 
-Plans on the wire are unchanged - boxing is invisible to serialization.
+Those four variants are now boxed, so the large data is stored separately and the node itself stays
+small. A stored plan node goes from 224 to 40 bytes. A plan holds one node per step, so the saving
+grows with the size of the plan rather than with the number of fetches.
+
+The largest variant is now the condition node. A test checks its size, so it stays visible if it
+grows.
+
+Query plans on the wire are unchanged. Boxing a variant does not change how it is serialized.

--- a/bin/router/src/executor/execution/plan.rs
+++ b/bin/router/src/executor/execution/plan.rs
@@ -2129,7 +2129,7 @@ mod tests {
                 &mut exec_ctx,
                 &PlanNode::Parallel(ParallelNode {
                     nodes: vec![
-                        PlanNode::Fetch(FetchNode {
+                        PlanNode::Fetch(Box::new(FetchNode {
                             id: 1,
                             service_name: "subgraph_a".to_string(),
                             operation: PlanningFetchOperation::from_anonymous_operation(
@@ -2142,8 +2142,8 @@ mod tests {
                             output_rewrites: None,
                             variable_usages: None,
                             operation_kind: None,
-                        }),
-                        PlanNode::Fetch(FetchNode {
+                        })),
+                        PlanNode::Fetch(Box::new(FetchNode {
                             id: 2,
                             service_name: "subgraph_b".to_string(),
                             operation: PlanningFetchOperation::from_anonymous_operation(
@@ -2156,7 +2156,7 @@ mod tests {
                             output_rewrites: None,
                             variable_usages: None,
                             operation_kind: None,
-                        }),
+                        })),
                     ],
                 }),
             )

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -54,8 +54,8 @@ pub struct QueryPlan<S: PlanState = Executable> {
 }
 
 #[allow(clippy::large_enum_variant)]
-/// The fetch-carrying variants are boxed: this enum sizes every slot of every `Sequence` and
-/// `Parallel` list, and those four variants are an order of magnitude larger than the rest.
+/// The four variants that carry a fetch are boxed. Every slot of every `Sequence` and `Parallel`
+/// list is as large as the largest variant, and those four were much larger than the rest.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "kind")]
 #[serde(bound = "")]

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -54,8 +54,6 @@ pub struct QueryPlan<S: PlanState = Executable> {
 }
 
 #[allow(clippy::large_enum_variant)]
-/// The four variants that carry a fetch are boxed. Every slot of every `Sequence` and `Parallel`
-/// list is as large as the largest variant, and those four were much larger than the rest.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "kind")]
 #[serde(bound = "")]
@@ -1094,15 +1092,6 @@ mod stored_size_tests {
     use super::*;
     use std::mem::size_of;
 
-    /// Checks the size of the stored types. This is not the total memory a plan keeps, and not
-    /// the number of allocations. A cached plan holds one of these per node and per fetch, so
-    /// these sizes are what the plan cache costs in memory.
-    ///
-    /// `PlanNode` is the one that adds up. Every slot of every `Sequence` and `Parallel` list is
-    /// this size, whether or not that slot holds a fetch. Now that the fetch variants are boxed,
-    /// the largest variant is `ConditionNode`. Its size is checked here so it stays visible if it
-    /// grows.
-    #[test]
     fn stored_sizes_stay_small() {
         for (name, actual, expected) in [
             ("PlanNode", size_of::<PlanNode>(), 40),

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -54,18 +54,20 @@ pub struct QueryPlan<S: PlanState = Executable> {
 }
 
 #[allow(clippy::large_enum_variant)]
+/// The fetch-carrying variants are boxed: this enum sizes every slot of every `Sequence` and
+/// `Parallel` list, and those four variants are an order of magnitude larger than the rest.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "kind")]
 #[serde(bound = "")]
 pub enum PlanNode<S: PlanState = Executable> {
-    Fetch(FetchNode<S>),
-    BatchFetch(BatchFetchNode<S>),
+    Fetch(Box<FetchNode<S>>),
+    BatchFetch(Box<BatchFetchNode<S>>),
     Sequence(SequenceNode<S>),
     Parallel(ParallelNode<S>),
     Flatten(FlattenNode<S>),
     Condition(ConditionNode<S>),
-    Subscription(SubscriptionNode<S>),
-    Defer(DeferNode<S>),
+    Subscription(Box<SubscriptionNode<S>>),
+    Defer(Box<DeferNode<S>>),
 }
 
 impl<S: PlanState> PlanNode<S> {
@@ -799,12 +801,12 @@ impl PlanNode<Planning> {
         let node = if !step.response_path.is_empty() {
             PlanNode::Flatten(FlattenNode {
                 path: step.response_path.clone().into(),
-                node: Box::new(PlanNode::Fetch(fetch)),
+                node: Box::new(PlanNode::Fetch(Box::new(fetch))),
             })
         } else if matches!(fetch.operation_kind, Some(OperationKind::Subscription)) {
-            PlanNode::Subscription(SubscriptionNode { primary: fetch })
+            PlanNode::Subscription(Box::new(SubscriptionNode { primary: fetch }))
         } else {
-            PlanNode::Fetch(fetch)
+            PlanNode::Fetch(Box::new(fetch))
         };
 
         match step.condition.as_ref() {
@@ -1096,13 +1098,15 @@ mod stored_size_tests {
     /// the number of allocations. A cached plan holds one of these per node and per fetch, so
     /// these sizes are what the plan cache costs in memory.
     ///
-    /// Each type is 104 bytes smaller than before. That is the parsed `Document` that used to sit
-    /// inside `SubgraphFetchOperation`. Every fetch carried one, and nothing on the execution path
-    /// read it.
+    /// `PlanNode` is the one that adds up. Every slot of every `Sequence` and `Parallel` list is
+    /// this size, whether or not that slot holds a fetch. Now that the fetch variants are boxed,
+    /// the largest variant is `ConditionNode`. Its size is checked here so it stays visible if it
+    /// grows.
     #[test]
     fn stored_sizes_stay_small() {
         for (name, actual, expected) in [
-            ("PlanNode", size_of::<PlanNode>(), 224),
+            ("PlanNode", size_of::<PlanNode>(), 40),
+            ("ConditionNode", size_of::<ConditionNode>(), 40),
             ("FetchNode", size_of::<FetchNode>(), 216),
             ("BatchFetchNode", size_of::<BatchFetchNode>(), 168),
             (

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -1092,6 +1092,7 @@ mod stored_size_tests {
     use super::*;
     use std::mem::size_of;
 
+    #[test]
     fn stored_sizes_stay_small() {
         for (name, actual, expected) in [
             ("PlanNode", size_of::<PlanNode>(), 40),

--- a/bin/router/src/query_planner/planner/plan_nodes/prepare.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/prepare.rs
@@ -33,8 +33,8 @@ impl PlanNode<Planning> {
             Box::new(node.into_executable())
         }
         match self {
-            Self::Fetch(fetch) => PlanNode::Fetch(fetch.into_executable()),
-            Self::BatchFetch(batch) => PlanNode::BatchFetch(BatchFetchNode {
+            Self::Fetch(fetch) => PlanNode::Fetch(Box::new(fetch.into_executable())),
+            Self::BatchFetch(batch) => PlanNode::BatchFetch(Box::new(BatchFetchNode {
                 id: batch.id,
                 service_name: batch.service_name,
                 variable_usages: batch.variable_usages,
@@ -42,7 +42,7 @@ impl PlanNode<Planning> {
                 operation: batch.operation.operation,
                 custom_scalar_paths: batch.custom_scalar_paths,
                 entity_batch: batch.entity_batch,
-            }),
+            })),
             Self::Flatten(flatten) => PlanNode::Flatten(FlattenNode {
                 path: flatten.path,
                 node: boxed(*flatten.node),
@@ -66,10 +66,12 @@ impl PlanNode<Planning> {
                 if_clause: condition.if_clause.map(|node| boxed(*node)),
                 else_clause: condition.else_clause.map(|node| boxed(*node)),
             }),
-            Self::Subscription(subscription) => PlanNode::Subscription(SubscriptionNode {
-                primary: subscription.primary.into_executable(),
-            }),
-            Self::Defer(defer) => PlanNode::Defer(DeferNode {
+            Self::Subscription(subscription) => {
+                PlanNode::Subscription(Box::new(SubscriptionNode {
+                    primary: subscription.primary.into_executable(),
+                }))
+            }
+            Self::Defer(defer) => PlanNode::Defer(Box::new(DeferNode {
                 primary: DeferPrimary {
                     subselection: defer.primary.subselection,
                     node: defer.primary.node.map(|node| boxed(*node)),
@@ -85,7 +87,7 @@ impl PlanNode<Planning> {
                         node: node.node.map(|node| boxed(*node)),
                     })
                     .collect(),
-            }),
+            })),
         }
     }
 }

--- a/bin/router/src/query_planner/planner/query_plan/optimize.rs
+++ b/bin/router/src/query_planner/planner/query_plan/optimize.rs
@@ -562,7 +562,10 @@ fn optimize_parallel_node(
             let batch_fetch_node =
                 build_batched_fetch_node(&shape_groups, &variable_group.variables, supergraph)?;
 
-            batch_node_replacements.insert(first_index, PlanNode::BatchFetch(batch_fetch_node));
+            batch_node_replacements.insert(
+                first_index,
+                PlanNode::BatchFetch(Box::new(batch_fetch_node)),
+            );
 
             for group in &shape_groups {
                 for candidate in group {
@@ -908,7 +911,7 @@ mod tests {
           }
         ";
 
-        let passthrough = PlanNode::Fetch(non_entity_fetch_node(100, "products"));
+        let passthrough = PlanNode::Fetch(Box::new(non_entity_fetch_node(100, "products")));
         let candidate_a =
             flatten_entity_fetch_node(1, "inventory", "products", requires_query, &entities_query);
         let candidate_b =
@@ -2046,8 +2049,8 @@ mod tests {
     fn optimize_parallel_node_returns_original_when_no_entity_candidates() {
         let supergraph = test_supergraph_state();
 
-        let first = PlanNode::Fetch(non_entity_fetch_node(1, "products"));
-        let second = PlanNode::Fetch(non_entity_fetch_node(2, "inventory"));
+        let first = PlanNode::Fetch(Box::new(non_entity_fetch_node(1, "products")));
+        let second = PlanNode::Fetch(Box::new(non_entity_fetch_node(2, "inventory")));
 
         let nodes = vec![first, second];
 
@@ -2283,7 +2286,7 @@ mod tests {
 
         PlanNode::Flatten(FlattenNode {
             path,
-            node: Box::new(PlanNode::Fetch(fetch_node)),
+            node: Box::new(PlanNode::Fetch(Box::new(fetch_node))),
         })
     }
 


### PR DESCRIPTION
PlanNode is an enum, so every variant takes as much space as its largest variant. Some of the variants have a subgraph fetch, and those were much larger than the rest. They are now boxed.