### PR TITLE
perf(router): store fetch's `requires` as a flat arena

### DIFF
--- a/.changeset/requires_flat_arena.md
+++ b/.changeset/requires_flat_arena.md
@@ -1,0 +1,20 @@
+---
+hive-router: patch
+---
+
+# Entity `requires` selections are stored in a compact form
+
+The entity key selection on a fetch was stored as a tree of selection items, each 160 bytes, each
+owning its own vectors and strings. It is now stored as a flat array of 24-byte nodes addressed by
+index, with one table of names shared across the selection, since it is built once and then only
+read.
+
+Measured on the two entity fetches this repository's fixtures reach, the selection goes from 665 to
+185 bytes of heap - 72.2% smaller - at an unchanged number of allocations. Two fetches is the shape
+of the change, not a corpus average.
+
+A stored fetch grows from 208 to 224 bytes, because the compact form is two boxed slices and a
+length where the tree was one vector. That is 16 bytes per entity fetch against several hundred
+saved on the heap for the same selection. The stored plan node is unaffected.
+
+Query plans on the wire, including the `requires` selections in them, are unchanged byte for byte.

--- a/.changeset/requires_flat_arena.md
+++ b/.changeset/requires_flat_arena.md
@@ -4,17 +4,19 @@ hive-router: patch
 
 # Entity `requires` selections are stored in a compact form
 
-The entity key selection on a fetch was stored as a tree of selection items, each 160 bytes, each
-owning its own vectors and strings. It is now stored as a flat array of 24-byte nodes addressed by
-index, with one table of names shared across the selection, since it is built once and then only
-read.
+A fetch stores the entity key selection it needs from a subgraph. It used to be stored as a tree
+of selection items. Each item was 160 bytes and owned its own vectors and strings.
+
+It is now stored as a flat array of 24-byte nodes that refer to each other by index, with one
+table of names shared across the whole selection. This works because the selection is built once
+and then only read.
 
 Measured on the two entity fetches this repository's fixtures reach, the selection goes from 665 to
-185 bytes of heap - 72.2% smaller - at an unchanged number of allocations. Two fetches is the shape
-of the change, not a corpus average.
+185 bytes on the heap. That is 72.2% smaller, with the same number of allocations. Two fetches is a
+small sample, so read this as the shape of the change rather than an average.
 
-A stored fetch grows from 208 to 224 bytes, because the compact form is two boxed slices and a
-length where the tree was one vector. That is 16 bytes per entity fetch against several hundred
-saved on the heap for the same selection. The stored plan node is unaffected.
+A stored fetch grows from 208 to 224 bytes, because the compact form holds two boxed slices and a
+length where the tree held one vector. That is 16 bytes more per entity fetch, against several
+hundred bytes saved on the heap for the same selection. The stored plan node does not change.
 
 Query plans on the wire, including the `requires` selections in them, are unchanged byte for byte.

--- a/.changeset/requires_flat_arena.md
+++ b/.changeset/requires_flat_arena.md
@@ -2,21 +2,13 @@
 hive-router: patch
 ---
 
-# Entity `requires` selections are stored in a compact form
+# Entity `requires` selections use less memory
 
-A fetch stores the entity key selection it needs from a subgraph. It used to be stored as a tree
-of selection items. Each item was 160 bytes and owned its own vectors and strings.
+A fetch stores the fields it needs to build an entity representation. These selections used to be
+stored as a tree, where each item was 160 bytes and had its own vectors and strings.
 
-It is now stored as a flat array of 24-byte nodes that refer to each other by index, with one
-table of names shared across the whole selection. This works because the selection is built once
-and then only read.
+They are now stored as a flat array of 24-byte nodes. Nodes refer to each other by index and share
+one table of names. This works well because the selection is built once and only read after that.
 
-Measured on the two entity fetches this repository's fixtures reach, the selection goes from 665 to
-185 bytes on the heap. That is 72.2% smaller, with the same number of allocations. Two fetches is a
-small sample, so read this as the shape of the change rather than an average.
-
-A stored fetch grows from 208 to 224 bytes, because the compact form holds two boxed slices and a
-length where the tree held one vector. That is 16 bytes more per entity fetch, against several
-hundred bytes saved on the heap for the same selection. The stored plan node does not change.
-
-Query plans on the wire, including the `requires` selections in them, are unchanged byte for byte.
+A stored fetch itself grows from 208 to 224 bytes. The new format needs two boxed slices and a
+length instead of one vector.

--- a/bin/router/benches/projection/mod.rs
+++ b/bin/router/benches/projection/mod.rs
@@ -8,6 +8,7 @@ use hive_router::executor::{
     },
     response::value::Value,
 };
+use hive_router::query_planner::ast::requires::RequiresSelectionSet;
 use std::{hint::black_box, sync::Arc};
 
 fn field(name: &str, selections: Option<Vec<FieldProjectionPlan>>) -> FieldProjectionPlan {
@@ -186,11 +187,21 @@ fn requires_benchmarks(c: &mut Criterion) {
         ast::selection_set::SelectionSet, utils::parsing::parse_operation,
     };
 
+    let requires_from = |body: &str| {
+        let document = parse_operation(&format!("{{ {body} }}"));
+        let Definition::Operation(OperationDefinition::SelectionSet(selections)) =
+            document.definitions.into_iter().next().unwrap()
+        else {
+            unreachable!()
+        };
+        let selections: SelectionSet = selections.into();
+        RequiresSelectionSet::from(&selections)
+    };
+
     let keys: Vec<_> = (0..50).map(|i| format!("field_{i:02}")).collect();
     let mut entries = vec![("__typename", Value::String("Item".into()))];
     entries.extend(keys.iter().map(|key| (key.as_str(), Value::U64(42))));
     let data = Value::Object(entries);
-    let types = Default::default();
     let mut group = c.benchmark_group("requires_loops");
     for fragments in [0, 1, 8] {
         // Keep all eight fields selected; vary only how many are wrapped in fragments.
@@ -204,32 +215,67 @@ fn requires_benchmarks(c: &mut Criterion) {
             })
             .collect::<Vec<_>>()
             .join(" ");
-        let document = parse_operation(&format!("{{ {fields} }}"));
-        let Definition::Operation(OperationDefinition::SelectionSet(selections)) =
-            document.definitions.into_iter().next().unwrap()
-        else {
-            unreachable!()
-        };
-        let selections: SelectionSet = selections.into();
+        let requires = requires_from(&fields);
         let input = format!("{fragments}_fragments");
-        group.bench_function(BenchmarkId::new("hash_8_fields", &input), |b| {
-            b.iter(|| black_box(black_box(&data).to_hash(black_box(&selections.items), &types)));
-        });
-        group.bench_function(BenchmarkId::new("project_8_fields", &input), |b| {
-            let mut buffer = Vec::with_capacity(512);
-            b.iter(|| {
-                buffer.clear();
-                project_requires(
-                    &types,
-                    black_box(&selections.items),
-                    black_box(&data),
-                    &mut buffer,
-                    true,
-                    None,
-                );
-                black_box(&buffer);
-            });
-        });
+        bench_execution(&mut group, &requires, &data, &input);
+        bench_serialization(&mut group, &requires, &input);
     }
+
+    const NESTED: &str = "a: id b: sku nested { c: inner deep { d: leaf } } \
+                          ... on Product @skip(if: $s) @include(if: $i) { upc dimensions { size weight } }";
+    let nested_requires = requires_from(NESTED);
+    let nested_json: sonic_rs::Value = sonic_rs::from_str(
+        r#"{"__typename":"Product","id":1,"sku":2,
+            "nested":{"inner":3,"deep":{"leaf":4}},
+            "upc":5,"dimensions":{"size":6,"weight":7}}"#,
+    )
+    .unwrap();
+    let nested_data = Value::from(nested_json.as_ref());
+    bench_execution(
+        &mut group,
+        &nested_requires,
+        &nested_data,
+        "nested_aliased_directives",
+    );
+    bench_serialization(&mut group, &nested_requires, "nested_aliased_directives");
     group.finish();
+}
+
+fn bench_execution(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    requires: &RequiresSelectionSet,
+    data: &Value<'_>,
+    input: &str,
+) {
+    let types = Default::default();
+    group.bench_function(BenchmarkId::new("hash", input), |b| {
+        b.iter(|| {
+            black_box(black_box(data).to_hash(black_box(requires.root_selections()), &types))
+        });
+    });
+    group.bench_function(BenchmarkId::new("project", input), |b| {
+        let mut buffer = Vec::with_capacity(512);
+        b.iter(|| {
+            buffer.clear();
+            project_requires(
+                &types,
+                black_box(requires.root_selections()),
+                black_box(data),
+                &mut buffer,
+                true,
+                None,
+            );
+            black_box(&buffer);
+        });
+    });
+}
+
+fn bench_serialization(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    requires: &RequiresSelectionSet,
+    input: &str,
+) {
+    group.bench_function(BenchmarkId::new("serialize", input), |b| {
+        b.iter(|| black_box(serde_json::to_string(black_box(requires)).unwrap()));
+    });
 }

--- a/bin/router/src/executor/execution/plan.rs
+++ b/bin/router/src/executor/execution/plan.rs
@@ -982,8 +982,8 @@ impl<'exec> Executor<'exec> {
                 let mut representation_hash_to_index: AHashMap<u64, usize> = AHashMap::new();
                 let arena = bumpalo::Bump::new();
 
-                // The `requires` selections to walk for each entity. Take the view once rather
-                // than per entity; it borrows the plan, so this is not new work.
+                // The `requires` selections to walk for each entity. Take the view once here
+                // instead of once per entity. It only borrows the plan, so this costs nothing.
                 let required_selections = requires_nodes.root_selections();
 
                 traverse_and_callback(
@@ -1998,7 +1998,7 @@ mod tests {
                 .clone()
         }
 
-        /// The parser's selection set, lowered the way the planner lowers it.
+        /// The selection set from the parser, converted the same way the planner converts it.
         fn requires_from(selection: query::SelectionSet<'_, String>) -> RequiresSelectionSet {
             let set: crate::query_planner::ast::selection_set::SelectionSet = selection.into();
             RequiresSelectionSet::from(&set)

--- a/bin/router/src/executor/execution/plan.rs
+++ b/bin/router/src/executor/execution/plan.rs
@@ -982,6 +982,10 @@ impl<'exec> Executor<'exec> {
                 let mut representation_hash_to_index: AHashMap<u64, usize> = AHashMap::new();
                 let arena = bumpalo::Bump::new();
 
+                // The `requires` selections to walk for each entity. Take the view once rather
+                // than per entity; it borrows the plan, so this is not new work.
+                let required_selections = requires_nodes.root_selections();
+
                 traverse_and_callback(
                     data,
                     normalized_path,
@@ -992,7 +996,7 @@ impl<'exec> Executor<'exec> {
                             return;
                         }
 
-                        let hash = entity.to_hash(&requires_nodes.items, possible_types);
+                        let hash = entity.to_hash(required_selections, possible_types);
                         representation_hashes.push(Some(hash));
                         let is_first_representation = representation_hash_to_index.is_empty();
                         let vacant_entry = match representation_hash_to_index.entry(hash) {
@@ -1013,7 +1017,7 @@ impl<'exec> Executor<'exec> {
 
                         let is_projected = project_requires(
                             possible_types,
-                            &requires_nodes.items,
+                            required_selections,
                             entity,
                             &mut filtered_representations,
                             is_first_representation,
@@ -1524,13 +1528,15 @@ impl<'exec> Executor<'exec> {
             for (merge_path, grouped_target_indices) in path_groups {
                 let mut representation_hashes: Vec<Option<u64>> = Vec::new();
 
+                let required_selections = alias_spec.requires.root_selections();
+
                 traverse_and_callback(data, merge_path.as_slice(), possible_types, &mut |entity| {
                     if entity.is_null() {
                         representation_hashes.push(None);
                         return;
                     }
 
-                    let hash = entity.to_hash(&alias_spec.requires.items, possible_types);
+                    let hash = entity.to_hash(required_selections, possible_types);
                     representation_hashes.push(Some(hash));
                     let is_first_representation = representation_hash_to_index.is_empty();
                     let vacant_entry = match representation_hash_to_index.entry(hash) {
@@ -1550,7 +1556,7 @@ impl<'exec> Executor<'exec> {
 
                     let is_projected = project_requires(
                         possible_types,
-                        &alias_spec.requires.items,
+                        required_selections,
                         entity,
                         &mut filtered_representations,
                         is_first_representation,
@@ -1757,7 +1763,9 @@ mod tests {
 
     use super::select_fetch_variables;
     use crate::query_planner::{
-        ast::{document::Document, operation::PlanningFetchOperation},
+        ast::{
+            document::Document, operation::PlanningFetchOperation, requires::RequiresSelectionSet,
+        },
         planner::plan_nodes::{EntityBatch, EntityBatchAlias, FetchNode, ParallelNode, PlanNode},
         utils::parsing::parse_operation,
     };
@@ -1990,6 +1998,12 @@ mod tests {
                 .clone()
         }
 
+        /// The parser's selection set, lowered the way the planner lowers it.
+        fn requires_from(selection: query::SelectionSet<'_, String>) -> RequiresSelectionSet {
+            let set: crate::query_planner::ast::selection_set::SelectionSet = selection.into();
+            RequiresSelectionSet::from(&set)
+        }
+
         let requires_query = parse_operation("{ ... on Product { upc } }");
         let requires_selection = document_into_selection(requires_query);
 
@@ -2000,7 +2014,7 @@ mod tests {
                     alias: "_e0".to_string(),
                     representations_variable_name: shared_var.clone(),
                     merge_paths: vec![],
-                    requires: requires_selection.clone().into(),
+                    requires: requires_from(requires_selection.clone()),
                     input_rewrites: None,
                     output_rewrites: None,
                 },
@@ -2008,7 +2022,7 @@ mod tests {
                     alias: "_e1".to_string(),
                     representations_variable_name: shared_var,
                     merge_paths: vec![],
-                    requires: requires_selection.into(),
+                    requires: requires_from(requires_selection),
                     input_rewrites: None,
                     output_rewrites: None,
                 },
@@ -2131,6 +2145,7 @@ mod tests {
                     nodes: vec![
                         PlanNode::Fetch(Box::new(FetchNode {
                             id: 1,
+                            planner_requires: (),
                             service_name: "subgraph_a".to_string(),
                             operation: PlanningFetchOperation::from_anonymous_operation(
                                 parse_document("{ from_a }"),
@@ -2145,6 +2160,7 @@ mod tests {
                         })),
                         PlanNode::Fetch(Box::new(FetchNode {
                             id: 2,
+                            planner_requires: (),
                             service_name: "subgraph_b".to_string(),
                             operation: PlanningFetchOperation::from_anonymous_operation(
                                 parse_document("{ from_b }"),

--- a/bin/router/src/executor/projection/request.rs
+++ b/bin/router/src/executor/projection/request.rs
@@ -1,4 +1,4 @@
-use crate::query_planner::ast::selection_item::SelectionItem;
+use crate::query_planner::ast::requires::{RequiresSelection, RequiresSelectionSetRef};
 use bytes::BufMut;
 
 use crate::executor::{
@@ -32,7 +32,7 @@ fn write_typename_field(buffer: &mut Vec<u8>, type_name: &str) {
 
 pub fn project_requires(
     possible_types: &PossibleTypes,
-    requires_selections: &Vec<SelectionItem>,
+    requires_selections: RequiresSelectionSetRef<'_>,
     entity: &Value,
     buffer: &mut Vec<u8>,
     first: bool,
@@ -123,7 +123,7 @@ pub fn project_requires(
 
 fn project_requires_map_mut(
     possible_types: &PossibleTypes,
-    requires_selections: &Vec<SelectionItem>,
+    requires_selections: RequiresSelectionSetRef<'_>,
     entity_obj: &Vec<(&str, Value<'_>)>,
     buffer: &mut Vec<u8>,
     first: &mut bool,
@@ -139,9 +139,13 @@ fn project_requires_map_mut(
     // An indicator that only `__typename` is used for the key fields.
     // This is an edge case that we need to identify, in order to detect when
     // `__typename` alone is a valid key but other fields are also required
-    let only_typename = requires_selections.len() == 1 && requires_selections.iter().all(|selection| {
-        matches!(selection, SelectionItem::Field(field) if field.selection_identifier() == TYPENAME_FIELD_NAME)
-    });
+    let only_typename = requires_selections.len() == 1
+        && requires_selections.iter().all(|selection| {
+            matches!(
+                selection,
+                RequiresSelection::Field { name, alias, .. } if alias.unwrap_or(name) == TYPENAME_FIELD_NAME
+            )
+        });
 
     // If the requires selection is only `__typename`, we can skip the rest of the logic, and just write the `__typename` field
     if only_typename {
@@ -155,18 +159,21 @@ fn project_requires_map_mut(
         }
     }
 
-    for requires_selection in requires_selections {
-        match &requires_selection {
-            SelectionItem::Field(requires_selection) => {
-                let field_name = &requires_selection.name;
-                let response_key = requires_selection.selection_identifier();
-
+    for requires_selection in requires_selections.iter() {
+        match requires_selection {
+            RequiresSelection::Field {
+                name: field_name,
+                alias,
+                selections,
+                ..
+            } => {
+                let response_key = alias.unwrap_or(field_name);
                 if response_key == TYPENAME_FIELD_NAME {
                     continue;
                 }
 
                 let original = entity_obj
-                    .binary_search_by_key(&field_name.as_str(), |(k, _)| k)
+                    .binary_search_by_key(&field_name, |(k, _)| k)
                     .ok()
                     .or_else(|| {
                         entity_obj
@@ -205,7 +212,7 @@ fn project_requires_map_mut(
 
                 let projected = project_requires(
                     possible_types,
-                    &requires_selection.selections.items,
+                    selections,
                     original,
                     buffer,
                     *first,
@@ -222,9 +229,11 @@ fn project_requires_map_mut(
                     }
                 }
             }
-            SelectionItem::InlineFragment(requires_selection) => {
-                let type_condition = &requires_selection.type_condition;
-
+            RequiresSelection::InlineFragment {
+                type_condition,
+                selections,
+                ..
+            } => {
                 let type_name = type_name.unwrap_or(type_condition);
                 // For projection, both sides of the condition are valid
                 if possible_types.entity_satisfies_type_condition(type_name, type_condition)
@@ -232,7 +241,7 @@ fn project_requires_map_mut(
                 {
                     project_requires_map_mut(
                         possible_types,
-                        &requires_selection.selections.items,
+                        selections,
                         entity_obj,
                         buffer,
                         first,
@@ -241,7 +250,7 @@ fn project_requires_map_mut(
                     );
                 }
             }
-            SelectionItem::FragmentSpread(_name_ref) => {
+            RequiresSelection::FragmentSpread(_) => {
                 // We only minify the queries to subgraphs, so we never have fragment spreads here.
             }
         }
@@ -252,12 +261,12 @@ fn project_requires_map_mut(
 mod tests {
     use super::project_requires;
     use crate::executor::{introspection::schema::PossibleTypes, response::value::Value};
-    use crate::query_planner::ast::{selection_item::SelectionItem, selection_set::SelectionSet};
+    use crate::query_planner::ast::{requires::RequiresSelectionSet, selection_set::SelectionSet};
     use crate::query_planner::utils::parsing::parse_operation;
     use graphql_tools::parser::query;
     use sonic_rs::json;
 
-    fn requires_from_str(requires: &str) -> Vec<SelectionItem> {
+    fn requires_from_str(requires: &str) -> RequiresSelectionSet {
         let operation = parse_operation(&format!("query {{ {requires} }}"));
 
         let selection_set = operation
@@ -278,7 +287,7 @@ mod tests {
             .expect("operation must contain a selection set");
 
         let selection_set: SelectionSet = selection_set.into();
-        selection_set.items
+        RequiresSelectionSet::from(&selection_set)
     }
 
     fn project_requires_pretty(requires: &str, entity_json: sonic_rs::Value) -> Option<String> {
@@ -288,7 +297,7 @@ mod tests {
         let mut buffer = Vec::new();
         let projected = project_requires(
             &PossibleTypes::default(),
-            &requires,
+            requires.root_selections(),
             &entity,
             &mut buffer,
             true,
@@ -301,6 +310,32 @@ mod tests {
 
         let json: Value = sonic_rs::from_slice(&buffer).unwrap();
         Some(sonic_rs::to_string_pretty(&json).unwrap())
+    }
+
+    #[test]
+    fn project_requires_preserves_aliases_at_each_depth() {
+        let projected = project_requires_pretty(
+            "key: id nested { renamed: value } ... on Product { code: upc }",
+            json!({
+                "__typename": "Product",
+                "id": "original",
+                "key": "fallback",
+                "nested": { "renamed": 2 },
+                "upc": "123"
+            }),
+        )
+        .expect("projection should produce output");
+
+        let actual: serde_json::Value = serde_json::from_str(&projected).unwrap();
+        assert_eq!(
+            actual,
+            serde_json::json!({
+                "__typename": "Product",
+                "key": "original",
+                "nested": { "renamed": 2 },
+                "code": "123"
+            })
+        );
     }
 
     #[test]

--- a/bin/router/src/executor/response/value.rs
+++ b/bin/router/src/executor/response/value.rs
@@ -1,4 +1,4 @@
-use crate::query_planner::ast::selection_item::SelectionItem;
+use crate::query_planner::ast::requires::{RequiresSelection, RequiresSelectionSetRef};
 use core::fmt;
 use serde::{
     de::{self, Deserializer, MapAccess, SeqAccess, Visitor},
@@ -71,32 +71,32 @@ impl<'a> Value<'a> {
 
     pub fn to_hash(
         &self,
-        selection_items: &[SelectionItem],
+        selections: RequiresSelectionSetRef<'_>,
         possible_types: &PossibleTypes,
     ) -> u64 {
         let mut hasher = Xxh3::new();
-        self.hash_with_requires(&mut hasher, selection_items, possible_types);
+        self.hash_with_requires(&mut hasher, selections, possible_types);
         hasher.finish()
     }
 
     fn hash_with_requires<H: Hasher>(
         &self,
         state: &mut H,
-        selection_items: &[SelectionItem],
+        selections: RequiresSelectionSetRef<'_>,
         possible_types: &PossibleTypes,
     ) {
-        if selection_items.is_empty() {
+        if selections.is_empty() {
             self.hash(state);
             return;
         }
 
         match self {
             Value::Object(obj) => {
-                Value::hash_object_with_requires(state, obj, selection_items, possible_types);
+                Value::hash_object_with_requires(state, obj, selections, possible_types);
             }
             Value::Array(arr) => {
                 for item in arr {
-                    item.hash_with_requires(state, selection_items, possible_types);
+                    item.hash_with_requires(state, selections, possible_types);
                 }
             }
             _ => {
@@ -108,29 +108,29 @@ impl<'a> Value<'a> {
     fn hash_object_with_requires<H: Hasher>(
         state: &mut H,
         obj: &[(&'a str, Value<'a>)],
-        selection_items: &[SelectionItem],
+        selections: RequiresSelectionSetRef<'_>,
         possible_types: &PossibleTypes,
     ) {
         // Read __typename at most once per object, and only when a fragment
         // needs it. Also remember when it is missing: each fragment then
         // falls back to its own type instead.
         let mut type_name = None;
-        for item in selection_items {
+        for item in selections.iter() {
             match item {
-                SelectionItem::Field(field_selection) => {
-                    let field_name = &field_selection.name;
-                    if let Ok(idx) = obj.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
+                RequiresSelection::Field {
+                    name, selections, ..
+                } => {
+                    if let Ok(idx) = obj.binary_search_by_key(&name, |(k, _)| k) {
                         let (key, value) = &obj[idx];
                         key.hash(state);
-                        value.hash_with_requires(
-                            state,
-                            &field_selection.selections.items,
-                            possible_types,
-                        );
+                        value.hash_with_requires(state, selections, possible_types);
                     }
                 }
-                SelectionItem::InlineFragment(inline_fragment) => {
-                    let type_condition = &inline_fragment.type_condition;
+                RequiresSelection::InlineFragment {
+                    type_condition,
+                    selections,
+                    ..
+                } => {
                     let type_name = type_name
                         .get_or_insert_with(|| {
                             obj.binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
@@ -140,15 +140,10 @@ impl<'a> Value<'a> {
                         .unwrap_or(type_condition);
 
                     if possible_types.entity_satisfies_type_condition(type_name, type_condition) {
-                        Value::hash_object_with_requires(
-                            state,
-                            obj,
-                            &inline_fragment.selections.items,
-                            possible_types,
-                        );
+                        Value::hash_object_with_requires(state, obj, selections, possible_types);
                     }
                 }
-                SelectionItem::FragmentSpread(_) => {
+                RequiresSelection::FragmentSpread(_) => {
                     unreachable!("Fragment spreads should not exist in FetchNode::requires.")
                 }
             }

--- a/bin/router/src/query_planner/ast/mod.rs
+++ b/bin/router/src/query_planner/ast/mod.rs
@@ -5,6 +5,7 @@ pub mod hash;
 pub mod minification;
 pub mod normalization;
 pub mod operation;
+pub mod requires;
 pub mod selection_item;
 pub mod selection_set;
 pub mod semantic_eq;

--- a/bin/router/src/query_planner/ast/requires.rs
+++ b/bin/router/src/query_planner/ast/requires.rs
@@ -1,35 +1,13 @@
-//! Entity key selections used to build and hash subgraph representations.
+//! Selections are stored in one flat array. Child selections are stored next to each other and
+//! referenced by a range.
 //!
-//! A fetch's `requires` lists the fields a subgraph needs to resolve an entity.
-//! Execution reads it twice per entity: once to hash the entity and remove duplicates
-//! (`Value::to_hash`) and once to write the representation that is sent
-//! (`project_requires`).
+//! Field names, aliases, and type names are stored separately and referenced by small IDs.
 //!
-//! # Shape
+//! `RequiresSelection` provides a view over this stored data and is shared by execution,
+//! serialization, and printing.
 //!
-//! For `{ id ... on Product { upc } }`, the *root selections* are `id` and the inline fragment.
-//! `upc` is inside the fragment. Execution starts at the roots and follows the children:
-//!
-//! ```text
-//! root_selections() -> [ Field(id), InlineFragment(on Product) ]
-//!                                     |
-//!                                     +-- [ Field(upc) ]
-//! ```
-//!
-//! # Storage
-//!
-//! Nodes live in one flat array. Each node's children are next to each other, and nodes use a
-//! separate name table. Walking starts with [`RequiresSelectionSet::root_selections`] and uses
-//! [`RequiresSelection`] to read each node. The indexes and name table stay inside this module.
-//!
-//! Execution, serialization, and printing share [`RequiresSelection`], a view of the stored data.
-//!
-//! The name table belongs to one `requires` value. Response keys and aliases come from the client,
-//! so a shared table could grow forever if a client sent many names. These strings go away with the
-//! plan-cache entry.
-//!
-//! The JSON must match `SelectionSet` byte for byte. This is the format sent by `lib/node-addon` to
-//! Hive Gateway and returned by `hive-expose-query-plan`.
+//! The serialized JSON stays identical to `SelectionSet`, because it is part of the query-plan
+//! format exposed to Hive Gateway.
 
 use std::{fmt, num::NonZeroU32};
 
@@ -419,8 +397,6 @@ mod tests {
         selection_set.into()
     }
 
-    /// Compares the raw JSON text, including the order of the keys. The output has to match
-    /// `SelectionSet` exactly, so these tests do not sort the keys before comparing.
     fn json<T: Serialize>(value: &T) -> String {
         serde_json::to_string(value).expect("serializes")
     }
@@ -449,9 +425,8 @@ mod tests {
         }
     }
 
-    /// The optimizer expands fragment spreads before a plan is cached, so a cached plan should
-    /// never contain one. If a spread does reach serialization, it must fail rather than write
-    /// invalid `SelectionSet` JSON.
+    /// Fragment spreads should be removed before a plan is cached.
+    /// If one remains, serialization must fail instead of producing invalid JSON.
     #[test]
     fn serializing_a_fragment_spread_fails_the_way_the_selection_set_does() {
         let set = selection_set_from_str("id ...Foo");
@@ -618,7 +593,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<Option<NameId>>(), 4);
         assert!(
             std::mem::size_of::<StoredSelection>() <= 24,
-            "arena node grew to {} B; the point of this type is that it stays small",
+            "stored selection grew to {} B; this type should stay small",
             std::mem::size_of::<StoredSelection>()
         );
     }

--- a/bin/router/src/query_planner/ast/requires.rs
+++ b/bin/router/src/query_planner/ast/requires.rs
@@ -419,8 +419,8 @@ mod tests {
         selection_set.into()
     }
 
-    /// Raw JSON, including key order. The output must match `SelectionSet`, so these tests compare
-    /// the actual text instead of sorting keys first.
+    /// Compares the raw JSON text, including the order of the keys. The output has to match
+    /// `SelectionSet` exactly, so these tests do not sort the keys before comparing.
     fn json<T: Serialize>(value: &T) -> String {
         serde_json::to_string(value).expect("serializes")
     }
@@ -449,8 +449,9 @@ mod tests {
         }
     }
 
-    /// The optimizer expands spreads before caching, so cached plans should not contain one. If a
-    /// spread reaches serialization, it must fail instead of producing invalid `SelectionSet` JSON.
+    /// The optimizer expands fragment spreads before a plan is cached, so a cached plan should
+    /// never contain one. If a spread does reach serialization, it must fail rather than write
+    /// invalid `SelectionSet` JSON.
     #[test]
     fn serializing_a_fragment_spread_fails_the_way_the_selection_set_does() {
         let set = selection_set_from_str("id ...Foo");

--- a/bin/router/src/query_planner/ast/requires.rs
+++ b/bin/router/src/query_planner/ast/requires.rs
@@ -1,0 +1,624 @@
+//! Entity key selections used to build and hash subgraph representations.
+//!
+//! A fetch's `requires` lists the fields a subgraph needs to resolve an entity.
+//! Execution reads it twice per entity: once to hash the entity and remove duplicates
+//! (`Value::to_hash`) and once to write the representation that is sent
+//! (`project_requires`).
+//!
+//! # Shape
+//!
+//! For `{ id ... on Product { upc } }`, the *root selections* are `id` and the inline fragment.
+//! `upc` is inside the fragment. Execution starts at the roots and follows the children:
+//!
+//! ```text
+//! root_selections() -> [ Field(id), InlineFragment(on Product) ]
+//!                                     |
+//!                                     +-- [ Field(upc) ]
+//! ```
+//!
+//! # Storage
+//!
+//! Nodes live in one flat array. Each node's children are next to each other, and nodes use a
+//! separate name table. Walking starts with [`RequiresSelectionSet::root_selections`] and uses
+//! [`RequiresSelection`] to read each node. The indexes and name table stay inside this module.
+//!
+//! Execution, serialization, and printing share [`RequiresSelection`], a view of the stored data.
+//!
+//! The name table belongs to one `requires` value. Response keys and aliases come from the client,
+//! so a shared table could grow forever if a client sent many names. These strings go away with the
+//! plan-cache entry.
+//!
+//! The JSON must match `SelectionSet` byte for byte. This is the format sent by `lib/node-addon` to
+//! Hive Gateway and returned by `hive-expose-query-plan`.
+
+use std::{fmt, num::NonZeroU32};
+
+use serde::{
+    de::{Deserialize, Deserializer},
+    ser::{SerializeSeq, Serializer},
+    Serialize,
+};
+
+use crate::query_planner::{
+    ast::{
+        selection_item::SelectionItem,
+        selection_set::{FieldSelection, InlineFragmentSelection, SelectionSet},
+    },
+    utils::pretty_display::{get_indent, PrettyDisplay},
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct RequiresSelectionSet {
+    names: Box<[Box<str>]>,
+    nodes: Box<[StoredSelection]>,
+    root_len: u32,
+}
+
+#[derive(Clone, Copy)]
+pub struct RequiresSelectionSetRef<'a> {
+    owner: &'a RequiresSelectionSet,
+    range: SelectionRange,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind")]
+pub enum RequiresSelection<'a> {
+    Field {
+        name: &'a str,
+        #[serde(skip_serializing_if = "RequiresSelectionSetRef::is_empty")]
+        selections: RequiresSelectionSetRef<'a>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        alias: Option<&'a str>,
+        #[serde(skip_serializing_if = "std::ops::Not::not")]
+        omit_from_response: bool,
+    },
+    #[serde(rename_all = "camelCase")]
+    InlineFragment {
+        type_condition: &'a str,
+        selections: RequiresSelectionSetRef<'a>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        skip_if: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        include_if: Option<&'a str>,
+    },
+    FragmentSpread(&'a str),
+}
+
+impl<'a> RequiresSelectionSetRef<'a> {
+    pub fn is_empty(&self) -> bool {
+        self.range.len == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.range.len as usize
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = RequiresSelection<'a>> + 'a {
+        let owner = self.owner;
+        self.range.indices().map(move |i| owner.selection(i))
+    }
+}
+
+impl RequiresSelectionSet {
+    pub fn root_selections(&self) -> RequiresSelectionSetRef<'_> {
+        self.selections(SelectionRange {
+            start: 0,
+            len: self.root_len,
+        })
+    }
+
+    fn selections(&self, range: SelectionRange) -> RequiresSelectionSetRef<'_> {
+        RequiresSelectionSetRef { owner: self, range }
+    }
+
+    fn opt_name(&self, id: Option<NameId>) -> Option<&str> {
+        id.map(|id| self.name(id))
+    }
+
+    fn name(&self, id: NameId) -> &str {
+        &self.names[id.index()]
+    }
+
+    fn selection(&self, i: usize) -> RequiresSelection<'_> {
+        match &self.nodes[i] {
+            StoredSelection::Field {
+                name,
+                alias,
+                children,
+                omit_from_response,
+            } => RequiresSelection::Field {
+                name: self.name(*name),
+                selections: self.selections(*children),
+                alias: self.opt_name(*alias),
+                omit_from_response: *omit_from_response,
+            },
+            StoredSelection::InlineFragment {
+                type_condition,
+                skip_if,
+                include_if,
+                children,
+            } => RequiresSelection::InlineFragment {
+                type_condition: self.name(*type_condition),
+                selections: self.selections(*children),
+                skip_if: self.opt_name(*skip_if),
+                include_if: self.opt_name(*include_if),
+            },
+            StoredSelection::FragmentSpread { name } => {
+                RequiresSelection::FragmentSpread(self.name(*name))
+            }
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct NameId(NonZeroU32);
+
+impl NameId {
+    fn new(index: usize) -> Self {
+        let raw = u32::try_from(index)
+            .ok()
+            .and_then(|index| index.checked_add(1))
+            .and_then(NonZeroU32::new)
+            .expect("name table outgrew u32");
+        Self(raw)
+    }
+
+    fn index(self) -> usize {
+        self.0.get() as usize - 1
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+struct SelectionRange {
+    start: u32,
+    len: u32,
+}
+
+impl SelectionRange {
+    fn indices(self) -> std::ops::Range<usize> {
+        let start = self.start as usize;
+        start..start + self.len as usize
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StoredSelection {
+    Field {
+        name: NameId,
+        alias: Option<NameId>,
+        children: SelectionRange,
+        omit_from_response: bool,
+    },
+    InlineFragment {
+        type_condition: NameId,
+        skip_if: Option<NameId>,
+        include_if: Option<NameId>,
+        children: SelectionRange,
+    },
+    FragmentSpread {
+        name: NameId,
+    },
+}
+
+impl StoredSelection {
+    fn set_children(&mut self, range: SelectionRange) {
+        match self {
+            Self::Field { children, .. } | Self::InlineFragment { children, .. } => {
+                *children = range;
+            }
+            Self::FragmentSpread { .. } => unreachable!("fragment spreads have no child list"),
+        }
+    }
+}
+
+impl From<&SelectionSet> for RequiresSelectionSet {
+    fn from(set: &SelectionSet) -> Self {
+        let mut builder = Builder::default();
+        let roots = builder.append_siblings(&set.items);
+
+        let mut cursor = 0;
+        while let Some(&(node_index, items)) = builder.pending_children.get(cursor) {
+            cursor += 1;
+            let children = builder.append_siblings(items);
+            builder.nodes[node_index].set_children(children);
+        }
+
+        Self {
+            names: builder.names.into_boxed_slice(),
+            nodes: builder.nodes.into_boxed_slice(),
+            root_len: roots.len,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Builder<'a> {
+    names: Vec<Box<str>>,
+    nodes: Vec<StoredSelection>,
+    pending_children: Vec<(usize, &'a [SelectionItem])>,
+}
+
+impl<'a> Builder<'a> {
+    fn intern(&mut self, value: &str) -> NameId {
+        if let Some(i) = self.names.iter().position(|n| &**n == value) {
+            return NameId::new(i);
+        }
+        self.names.push(value.into());
+        NameId::new(self.names.len() - 1)
+    }
+
+    fn intern_opt(&mut self, value: Option<&str>) -> Option<NameId> {
+        value.map(|value| self.intern(value))
+    }
+
+    fn append_siblings(&mut self, items: &'a [SelectionItem]) -> SelectionRange {
+        let start = u32::try_from(self.nodes.len()).expect("node array outgrew u32");
+        for item in items {
+            let node_index = self.nodes.len();
+            match item {
+                SelectionItem::Field(FieldSelection {
+                    name,
+                    selections,
+                    alias,
+                    omit_from_response,
+                    ..
+                }) => {
+                    let name = self.intern(name);
+                    let alias = self.intern_opt(alias.as_deref());
+                    self.nodes.push(StoredSelection::Field {
+                        name,
+                        alias,
+                        children: SelectionRange::default(),
+                        omit_from_response: *omit_from_response,
+                    });
+                    if !selections.items.is_empty() {
+                        self.pending_children.push((node_index, &selections.items));
+                    }
+                }
+                SelectionItem::InlineFragment(InlineFragmentSelection {
+                    type_condition,
+                    selections,
+                    skip_if,
+                    include_if,
+                }) => {
+                    let type_condition = self.intern(type_condition);
+                    let skip_if = self.intern_opt(skip_if.as_deref());
+                    let include_if = self.intern_opt(include_if.as_deref());
+                    self.nodes.push(StoredSelection::InlineFragment {
+                        type_condition,
+                        skip_if,
+                        include_if,
+                        children: SelectionRange::default(),
+                    });
+                    self.pending_children.push((node_index, &selections.items));
+                }
+                SelectionItem::FragmentSpread(name) => {
+                    let name = self.intern(name);
+                    self.nodes.push(StoredSelection::FragmentSpread { name });
+                }
+            }
+        }
+        let end = u32::try_from(self.nodes.len()).expect("node array outgrew u32");
+        SelectionRange {
+            start,
+            len: end - start,
+        }
+    }
+}
+
+impl Serialize for RequiresSelectionSet {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.root_selections().serialize(serializer)
+    }
+}
+
+impl Serialize for RequiresSelectionSetRef<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for i in self.range.indices() {
+            seq.serialize_element(&self.owner.selection(i))?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for RequiresSelectionSet {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let items = Vec::<SelectionItem>::deserialize(deserializer)?;
+        Ok(Self::from(&SelectionSet { items }))
+    }
+}
+
+impl PrettyDisplay for RequiresSelectionSet {
+    fn pretty_fmt(&self, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+        self.pretty_slice(f, self.root_selections(), depth)
+    }
+}
+
+impl RequiresSelectionSet {
+    fn pretty_slice(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        slice: RequiresSelectionSetRef<'_>,
+        depth: usize,
+    ) -> fmt::Result {
+        let indent = get_indent(depth);
+        for i in slice.range.indices() {
+            match self.selection(i) {
+                RequiresSelection::Field {
+                    name,
+                    selections,
+                    alias,
+                    ..
+                } => {
+                    if let Some(alias) = alias {
+                        write!(f, "{indent}{alias}: ")?;
+                    } else {
+                        write!(f, "{indent}")?;
+                    }
+                    write!(f, "{name}")?;
+                    if selections.is_empty() {
+                        writeln!(f)?;
+                        continue;
+                    }
+                    writeln!(f, " {{")?;
+                    self.pretty_slice(f, selections, depth + 1)?;
+                    writeln!(f, "{indent}}}")?;
+                }
+                RequiresSelection::InlineFragment {
+                    type_condition,
+                    selections,
+                    skip_if,
+                    include_if,
+                } => {
+                    write!(f, "{indent}... on {type_condition} ")?;
+                    if let Some(skip_if) = skip_if {
+                        write!(f, "@skip(if: ${skip_if}) ")?;
+                    }
+                    if let Some(include_if) = include_if {
+                        write!(f, "@include(if: ${include_if}) ")?;
+                    }
+                    writeln!(f, "{{")?;
+                    self.pretty_slice(f, selections, depth + 1)?;
+                    writeln!(f, "{indent}}}")?;
+                }
+                RequiresSelection::FragmentSpread(name) => {
+                    writeln!(f, "{indent}...{name}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_planner::utils::parsing::parse_operation;
+    use graphql_tools::parser::query;
+    use std::fmt::Display;
+
+    fn selection_set_from_str(requires: &str) -> SelectionSet {
+        let operation = parse_operation(&format!("query {{ {requires} }}"));
+        let selection_set = operation
+            .definitions
+            .into_iter()
+            .find_map(|def| {
+                let query::Definition::Operation(op) = def else {
+                    return None;
+                };
+                match op {
+                    query::OperationDefinition::SelectionSet(sel) => Some(sel),
+                    query::OperationDefinition::Query(q) => Some(q.selection_set),
+                    query::OperationDefinition::Mutation(m) => Some(m.selection_set),
+                    query::OperationDefinition::Subscription(s) => Some(s.selection_set),
+                }
+            })
+            .expect("operation must contain a selection set");
+        selection_set.into()
+    }
+
+    /// Raw JSON, including key order. The output must match `SelectionSet`, so these tests compare
+    /// the actual text instead of sorting keys first.
+    fn json<T: Serialize>(value: &T) -> String {
+        serde_json::to_string(value).expect("serializes")
+    }
+
+    const SHAPES: &[&str] = &[
+        "id",
+        "__typename id",
+        "upc price { amount currency }",
+        "... on Product { __typename upc }",
+        "__typename ... on Product { upc dimensions { size weight } }",
+        "alias: id",
+        "a: id b: sku nested { c: inner }",
+        "... on A { x } ... on B { y }",
+        "__typename ... on Product { __typename }",
+        "... on Product @skip(if: $s) { upc }",
+        "... on Product @include(if: $i) { upc }",
+        "... on Product @skip(if: $s) @include(if: $i) { upc }",
+    ];
+
+    #[test]
+    fn serializes_identically_to_the_selection_set_it_replaces() {
+        for source in SHAPES {
+            let set = selection_set_from_str(source);
+            let compact = RequiresSelectionSet::from(&set);
+            assert_eq!(json(&set), json(&compact), "JSON diverged for `{source}`");
+        }
+    }
+
+    /// The optimizer expands spreads before caching, so cached plans should not contain one. If a
+    /// spread reaches serialization, it must fail instead of producing invalid `SelectionSet` JSON.
+    #[test]
+    fn serializing_a_fragment_spread_fails_the_way_the_selection_set_does() {
+        let set = selection_set_from_str("id ...Foo");
+        let compact = RequiresSelectionSet::from(&set);
+        assert!(
+            serde_json::to_string(&set).is_err(),
+            "the type being matched must also refuse to serialize a spread"
+        );
+        assert!(serde_json::to_string(&compact).is_err());
+    }
+
+    #[test]
+    fn omit_from_response_survives_lowering() {
+        fn field(name: &str, omit: bool, selections: Vec<SelectionItem>) -> SelectionItem {
+            SelectionItem::Field(FieldSelection {
+                name: name.to_string(),
+                selections: SelectionSet { items: selections },
+                alias: None,
+                arguments: None,
+                skip_if: None,
+                include_if: None,
+                omit_from_response: omit,
+            })
+        }
+
+        let set = SelectionSet {
+            items: vec![
+                field("omitted", true, vec![]),
+                field("kept", false, vec![]),
+                field(
+                    "parent",
+                    false,
+                    vec![
+                        field("omittedChild", true, vec![]),
+                        field("keptChild", false, vec![]),
+                    ],
+                ),
+                SelectionItem::InlineFragment(InlineFragmentSelection {
+                    type_condition: "Product".to_string(),
+                    selections: SelectionSet {
+                        items: vec![field("omittedInFragment", true, vec![])],
+                    },
+                    skip_if: None,
+                    include_if: None,
+                }),
+            ],
+        };
+
+        let compact = RequiresSelectionSet::from(&set);
+        assert_eq!(
+            json(&set),
+            json(&compact),
+            "JSON diverged for a programmatically built `omit_from_response` selection"
+        );
+
+        let json = serde_json::to_string(&compact).expect("serializes");
+        assert_eq!(
+            json.matches("\"omit_from_response\":true").count(),
+            3,
+            "expected exactly the three omitted fields to serialize the flag: {json}"
+        );
+    }
+
+    #[test]
+    fn pretty_prints_identically_to_the_selection_set_it_replaces() {
+        struct Pretty<'a, T: PrettyDisplay>(&'a T, usize);
+        impl<T: PrettyDisplay> Display for Pretty<'_, T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.pretty_fmt(f, self.1)
+            }
+        }
+
+        for source in SHAPES {
+            let set = selection_set_from_str(source);
+            let compact = RequiresSelectionSet::from(&set);
+            for depth in [0, 3] {
+                assert_eq!(
+                    Pretty(&set, depth).to_string(),
+                    Pretty(&compact, depth).to_string(),
+                    "pretty output diverged for `{source}` at depth {depth}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn response_key_prefers_the_alias() {
+        let compact = RequiresSelectionSet::from(&selection_set_from_str("alias: id plain"));
+        let keys: Vec<_> = compact
+            .root_selections()
+            .iter()
+            .map(|item| match item {
+                RequiresSelection::Field { name, alias, .. } => {
+                    (name.to_string(), alias.unwrap_or(name).to_string())
+                }
+                _ => panic!("expected fields"),
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                ("id".to_string(), "alias".to_string()),
+                ("plain".to_string(), "plain".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn nesting_survives_the_flattening() {
+        let compact = RequiresSelectionSet::from(&selection_set_from_str(
+            "a { b { c } d } e { f } ... on T { g { h } }",
+        ));
+        let mut shape = Vec::new();
+        fn walk(slice: RequiresSelectionSetRef<'_>, depth: usize, out: &mut Vec<(usize, String)>) {
+            for item in slice.iter() {
+                match item {
+                    RequiresSelection::Field {
+                        name, selections, ..
+                    } => {
+                        out.push((depth, name.to_string()));
+                        walk(selections, depth + 1, out);
+                    }
+                    RequiresSelection::InlineFragment {
+                        type_condition,
+                        selections,
+                        ..
+                    } => {
+                        out.push((depth, format!("...on {type_condition}")));
+                        walk(selections, depth + 1, out);
+                    }
+                    RequiresSelection::FragmentSpread(_) => out.push((depth, "...".to_string())),
+                }
+            }
+        }
+        walk(compact.root_selections(), 0, &mut shape);
+        assert_eq!(
+            shape,
+            vec![
+                (0, "a".into()),
+                (1, "b".into()),
+                (2, "c".into()),
+                (1, "d".into()),
+                (0, "e".into()),
+                (1, "f".into()),
+                (0, "...on T".into()),
+                (1, "g".into()),
+                (2, "h".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn name_ids_check_the_index_boundary() {
+        for index in [0, u32::MAX as usize - 1] {
+            assert_eq!(NameId::new(index).index(), index);
+        }
+        for index in [u32::MAX as usize, usize::MAX] {
+            assert!(std::panic::catch_unwind(|| NameId::new(index)).is_err());
+        }
+    }
+
+    #[test]
+    fn stays_small() {
+        assert_eq!(std::mem::size_of::<Option<NameId>>(), 4);
+        assert!(
+            std::mem::size_of::<StoredSelection>() <= 24,
+            "arena node grew to {} B; the point of this type is that it stays small",
+            std::mem::size_of::<StoredSelection>()
+        );
+    }
+}

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -1,3 +1,4 @@
+use crate::query_planner::ast::requires::RequiresSelectionSet;
 use crate::query_planner::{
     ast::{
         merge_path::{Condition, MergePath, Segment},
@@ -140,8 +141,13 @@ pub struct FetchNode<S: PlanState = Executable> {
     pub operation: S::Operation,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_scalar_paths: Option<CustomScalarPaths>,
+    /// The entity key selection used by execution. Its JSON must match [`SelectionSet`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requires: Option<SelectionSet>,
+    pub requires: Option<RequiresSelectionSet>,
+    /// The same selection, parsed, kept only while planning: batching expands fragment spreads
+    /// against it. A box keeps the field small in the state that has one.
+    #[serde(skip)]
+    pub planner_requires: S::Requires,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_rewrites: Option<Vec<FetchRewrite>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -374,7 +380,7 @@ pub struct EntityBatchAlias {
     pub representations_variable_name: String,
     #[serde(rename = "paths")]
     pub merge_paths: Vec<FlattenNodePath>,
-    pub requires: SelectionSet,
+    pub requires: RequiresSelectionSet,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_rewrites: Option<Vec<FetchRewrite>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -743,21 +749,25 @@ impl FetchNode<Planning> {
         supergraph: &SupergraphState,
     ) -> Self {
         match step.is_entity_call() {
-            true => FetchNode {
-                id: step.id,
-                service_name: step.service_name.0.clone(),
-                variable_usages: step.variable_usages.clone(),
-                operation_kind: Some(OperationKind::Query),
-                operation: create_output_operation(step, supergraph),
-                custom_scalar_paths: custom_scalar_paths_from_fetch_output(
-                    &step.output,
-                    supergraph,
-                    Some("_entities"),
-                ),
-                requires: Some(create_input_selection_set(&step.input)),
-                input_rewrites: step.input_rewrites.clone(),
-                output_rewrites: step.output_rewrites.clone(),
-            },
+            true => {
+                let planner_requires = create_input_selection_set(&step.input);
+                FetchNode {
+                    id: step.id,
+                    service_name: step.service_name.0.clone(),
+                    variable_usages: step.variable_usages.clone(),
+                    operation_kind: Some(OperationKind::Query),
+                    operation: create_output_operation(step, supergraph),
+                    custom_scalar_paths: custom_scalar_paths_from_fetch_output(
+                        &step.output,
+                        supergraph,
+                        Some("_entities"),
+                    ),
+                    requires: Some(RequiresSelectionSet::from(&planner_requires)),
+                    planner_requires: Some(Box::new(planner_requires)),
+                    input_rewrites: step.input_rewrites.clone(),
+                    output_rewrites: step.output_rewrites.clone(),
+                }
+            }
             false => {
                 let root_type_name = supergraph.expect_root_type_name(Some(&step.operation_kind));
                 let operation_def = OperationDefinition {
@@ -774,6 +784,7 @@ impl FetchNode<Planning> {
                     service_name: step.service_name.0.clone(),
                     variable_usages: step.variable_usages.clone(),
                     operation_kind: Some(step.operation_kind.clone()),
+                    planner_requires: None,
                     operation: PlanningFetchOperation::from_anonymous_operation(document),
                     custom_scalar_paths: custom_scalar_paths_from_fetch_output(
                         &step.output,
@@ -1097,7 +1108,7 @@ mod stored_size_tests {
         for (name, actual, expected) in [
             ("PlanNode", size_of::<PlanNode>(), 40),
             ("ConditionNode", size_of::<ConditionNode>(), 40),
-            ("FetchNode", size_of::<FetchNode>(), 208),
+            ("FetchNode", size_of::<FetchNode>(), 224),
             ("BatchFetchNode", size_of::<BatchFetchNode>(), 160),
             (
                 "SubgraphFetchOperation",

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -141,11 +141,11 @@ pub struct FetchNode<S: PlanState = Executable> {
     pub operation: S::Operation,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_scalar_paths: Option<CustomScalarPaths>,
-    /// The entity key selection used by execution. Its JSON must match [`SelectionSet`].
+    /// The entity key selection that execution uses. Its JSON must match [`SelectionSet`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequiresSelectionSet>,
-    /// The same selection, parsed, kept only while planning: batching expands fragment spreads
-    /// against it. A box keeps the field small in the state that has one.
+    /// The same selection in parsed form, kept only while planning. Batching needs it to expand
+    /// fragment spreads. It is boxed so the field stays small in the state that has one.
     #[serde(skip)]
     pub planner_requires: S::Requires,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -141,11 +141,8 @@ pub struct FetchNode<S: PlanState = Executable> {
     pub operation: S::Operation,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_scalar_paths: Option<CustomScalarPaths>,
-    /// The entity key selection that execution uses. Its JSON must match [`SelectionSet`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequiresSelectionSet>,
-    /// The same selection in parsed form, kept only while planning. Batching needs it to expand
-    /// fragment spreads. It is boxed so the field stays small in the state that has one.
     #[serde(skip)]
     pub planner_requires: S::Requires,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/bin/router/src/query_planner/planner/plan_nodes/prepare.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/prepare.rs
@@ -21,6 +21,7 @@ impl FetchNode<Planning> {
             operation: self.operation.operation,
             custom_scalar_paths: self.custom_scalar_paths,
             requires: self.requires,
+            planner_requires: (),
             input_rewrites: self.input_rewrites,
             output_rewrites: self.output_rewrites,
         }

--- a/bin/router/src/query_planner/planner/plan_nodes/state.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/state.rs
@@ -1,5 +1,8 @@
 use crate::query_planner::{
-    ast::operation::{PlanningFetchOperation, SubgraphFetchOperation},
+    ast::{
+        operation::{PlanningFetchOperation, SubgraphFetchOperation},
+        selection_set::SelectionSet,
+    },
     utils::pretty_display::PrettyDisplay,
 };
 use serde::{de::DeserializeOwned, Serialize};
@@ -13,6 +16,8 @@ pub trait PlanState: private::Sealed + Debug + Clone {
         + DeserializeOwned
         + PrettyDisplay
         + AsRef<SubgraphFetchOperation>;
+    /// The parsed entity requirements, which only the planner needs.
+    type Requires: Debug + Clone + Default;
 }
 
 /// A query plan that is still being built
@@ -25,10 +30,12 @@ pub struct Executable;
 
 impl PlanState for Planning {
     type Operation = PlanningFetchOperation;
+    type Requires = Option<Box<SelectionSet>>;
 }
 
 impl PlanState for Executable {
     type Operation = SubgraphFetchOperation;
+    type Requires = ();
 }
 
 mod private {

--- a/bin/router/src/query_planner/planner/plan_nodes/state.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/state.rs
@@ -16,7 +16,6 @@ pub trait PlanState: private::Sealed + Debug + Clone {
         + DeserializeOwned
         + PrettyDisplay
         + AsRef<SubgraphFetchOperation>;
-    /// The parsed entity requirements, which only the planner needs.
     type Requires: Debug + Clone + Default;
 }
 

--- a/bin/router/src/query_planner/planner/query_plan/optimize.rs
+++ b/bin/router/src/query_planner/planner/query_plan/optimize.rs
@@ -357,8 +357,6 @@ impl EntityFetch {
             return Ok(None);
         };
 
-        // Batching expands fragment spreads. The compact `requires` form cannot represent
-        // those, which is why the planner keeps the parsed copy.
         let Some(requires) = fetch_node.planner_requires.clone() else {
             return Ok(None);
         };

--- a/bin/router/src/query_planner/planner/query_plan/optimize.rs
+++ b/bin/router/src/query_planner/planner/query_plan/optimize.rs
@@ -357,8 +357,8 @@ impl EntityFetch {
             return Ok(None);
         };
 
-        // Batching expands fragment spreads, which the compact `requires` cannot represent.
-        // The planner keeps the parsed copy for exactly this.
+        // Batching expands fragment spreads. The compact `requires` form cannot represent
+        // those, which is why the planner keeps the parsed copy.
         let Some(requires) = fetch_node.planner_requires.clone() else {
             return Ok(None);
         };

--- a/bin/router/src/query_planner/planner/query_plan/optimize.rs
+++ b/bin/router/src/query_planner/planner/query_plan/optimize.rs
@@ -59,6 +59,7 @@ use std::{
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::query_planner::{
+    ast::requires::RequiresSelectionSet,
     ast::{
         hash::{ASTHash, SemanticShapeHashContext},
         minification::minify_operation,
@@ -183,7 +184,7 @@ impl<'a> BatchFetchBuilder<'a> {
             alias,
             representations_variable_name,
             merge_paths,
-            requires: representative.requires.clone(),
+            requires: RequiresSelectionSet::from(&representative.requires),
             input_rewrites: representative.input_rewrites.clone(),
             output_rewrites: representative.output_rewrites.clone(),
         });
@@ -356,7 +357,9 @@ impl EntityFetch {
             return Ok(None);
         };
 
-        let Some(requires) = fetch_node.requires.clone() else {
+        // Batching expands fragment spreads, which the compact `requires` cannot represent.
+        // The planner keeps the parsed copy for exactly this.
+        let Some(requires) = fetch_node.planner_requires.clone() else {
             return Ok(None);
         };
 
@@ -874,6 +877,7 @@ mod tests {
             document::Document,
             merge_path::{FieldPathSegment, MergePath, Segment},
             operation::PlanningFetchOperation,
+            requires::RequiresSelectionSet,
         },
         planner::plan_nodes::planning::{
             FetchNode, FetchNodePathSegment, FetchRewrite, FlattenNode, FlattenNodePath, PlanNode,
@@ -2270,7 +2274,8 @@ mod tests {
             operation_kind: Some(OperationKind::Query),
             operation,
             custom_scalar_paths: None,
-            requires: Some(requires),
+            requires: Some(RequiresSelectionSet::from(&requires)),
+            planner_requires: Some(Box::new(requires)),
             input_rewrites: None,
             output_rewrites: None,
         };
@@ -2338,6 +2343,7 @@ mod tests {
             operation,
             custom_scalar_paths: None,
             requires: None,
+            planner_requires: None,
             input_rewrites: None,
             output_rewrites: None,
         }


### PR DESCRIPTION
A fetch stores the fields it needs to build an entity representation. These selections used to be
stored as a tree, where each item was 160 bytes and had its own vectors and strings.

They are now stored as a flat array of 24-byte nodes. Nodes refer to each other by index and share
one table of names. This works well because the selection is built once and only read after that.

A stored fetch itself grows from 208 to 224 bytes. The new format needs two boxed slices and a
length instead of one vector.
