### PR TITLE
perf(router): build subgraph error paths by push and pop

### DIFF
--- a/.changeset/error_path_push_pop.md
+++ b/.changeset/error_path_push_pop.md
@@ -4,13 +4,18 @@ hive-router: patch
 
 # Error paths in a subgraph response are no longer rebuilt at every step
 
-When a subgraph response carries errors, the router walks the response data building a GraphQL error
-path for each entity it visits. It built that path by cloning: the whole path accumulated so far was
-copied, and one segment appended, once per level per visited item. The path is now carried through
-the walk and pushed and popped as it descends, so only the leaf - the one place that needs to own a
-path - pays for one.
+When a subgraph response contains errors, the router walks the response data and builds a GraphQL
+error path for each entity it visits.
 
-A transcription of the two walks over the same data, counting allocations, puts the saving at around
-a third for the shallow two-level paths that dominate, and at half to three fifths for deeper ones.
-This only runs when a subgraph returns an error; responses without errors build no path in either
-form.
+It used to build that path by copying. At every level, for every item it visited, it copied the
+whole path built so far and added one segment.
+
+The path is now carried through the walk. A segment is added when the walk goes deeper, and
+removed when it comes back. Only the leaf needs to own a path, so only the leaf allocates one.
+
+Counting the allocations both versions make over the same data, the saving is around a third for
+the shallow two-level paths that are most common, and between a half and three fifths for deeper
+ones.
+
+This only runs when a subgraph returns an error. Responses without errors build no path in either
+version.

--- a/.changeset/error_path_push_pop.md
+++ b/.changeset/error_path_push_pop.md
@@ -2,20 +2,11 @@
 hive-router: patch
 ---
 
-# Error paths in a subgraph response are no longer rebuilt at every step
+# Error paths in subgraph responses use fewer allocations
 
-When a subgraph response contains errors, the router walks the response data and builds a GraphQL
-error path for each entity it visits.
+When a subgraph returns errors, the router builds a GraphQL error path while walking the response.
 
-It used to build that path by copying. At every level, for every item it visited, it copied the
-whole path built so far and added one segment.
+Previously, each step cloned the whole path built so far and then added one more segment. That meant repeated allocations as the path got deeper.
 
-The path is now carried through the walk. A segment is added when the walk goes deeper, and
-removed when it comes back. Only the leaf needs to own a path, so only the leaf allocates one.
-
-Counting the allocations both versions make over the same data, the saving is around a third for
-the shallow two-level paths that are most common, and between a half and three fifths for deeper
-ones.
-
-This only runs when a subgraph returns an error. Responses without errors build no path in either
-version.
+The router now reuses one path while walking the response. It pushes a segment when going deeper and pops it when going back. 
+The path is only cloned when an error actually needs to keep it.

--- a/.changeset/error_path_push_pop.md
+++ b/.changeset/error_path_push_pop.md
@@ -1,0 +1,16 @@
+---
+hive-router: patch
+---
+
+# Error paths in a subgraph response are no longer rebuilt at every step
+
+When a subgraph response carries errors, the router walks the response data building a GraphQL error
+path for each entity it visits. It built that path by cloning: the whole path accumulated so far was
+copied, and one segment appended, once per level per visited item. The path is now carried through
+the walk and pushed and popped as it descends, so only the leaf - the one place that needs to own a
+path - pays for one.
+
+A transcription of the two walks over the same data, counting allocations, puts the saving at around
+a third for the shallow two-level paths that dominate, and at half to three fifths for deeper ones.
+This only runs when a subgraph returns an error; responses without errors build no path in either
+form.

--- a/bin/router/src/executor/response/graphql_error.rs
+++ b/bin/router/src/executor/response/graphql_error.rs
@@ -257,18 +257,17 @@ impl GraphQLErrorPath {
             segments: Vec::with_capacity(capacity),
         }
     }
-    pub fn concat(&self, segment: GraphQLErrorPathSegment) -> Self {
-        let mut new_path = self.segments.clone();
-        new_path.push(segment);
-        GraphQLErrorPath { segments: new_path }
+    pub fn push_index(&mut self, index: usize) {
+        self.segments.push(GraphQLErrorPathSegment::Index(index));
     }
 
-    pub fn concat_index(&self, index: usize) -> Self {
-        self.concat(GraphQLErrorPathSegment::Index(index))
+    pub fn push_field(&mut self, field: &str) {
+        self.segments
+            .push(GraphQLErrorPathSegment::String(field.to_string()));
     }
 
-    pub fn concat_str(&self, field: String) -> Self {
-        self.concat(GraphQLErrorPathSegment::String(field))
+    pub fn pop(&mut self) -> Option<GraphQLErrorPathSegment> {
+        self.segments.pop()
     }
 
     pub fn extend_from_slice(&mut self, other: &[GraphQLErrorPathSegment]) {

--- a/bin/router/src/executor/utils/traverse.rs
+++ b/bin/router/src/executor/utils/traverse.rs
@@ -55,9 +55,9 @@ fn pop(error_path: &mut Option<GraphQLErrorPath>) {
     }
 }
 
-/// Walks `remaining_path` carrying one error path that is pushed and popped as it descends,
-/// rather than cloning the path built so far at every step. Only the callback needs an owned
-/// path, so only the callback pays for one.
+/// Walks `remaining_path` while carrying a single error path. Steps are added as the walk goes
+/// deeper and removed as it comes back, instead of copying the path built so far at every step.
+/// Only the callback needs to own a path, so only the callback allocates one.
 fn walk_mut<'a, Callback>(
     current_data: &mut Value<'a>,
     remaining_path: &[FlattenNodePathSegment],
@@ -142,8 +142,8 @@ fn walk_mut<'a, Callback>(
                 // If the current data is an array, we need to check each item
                 for (index, item) in arr.iter_mut().enumerate() {
                     push_index(error_path, index);
-                    // Use `remaining_path`, not the rest, so the type condition is checked again
-                    // for each item.
+                    // Pass `remaining_path` rather than the rest of it, so the type condition
+                    // is checked again for each item.
                     walk_mut(item, remaining_path, schema_metadata, error_path, callback);
                     pop(error_path);
                 }
@@ -343,9 +343,9 @@ mod tests {
         );
     }
 
-    /// The walker now shares one mutable error path across siblings instead of giving each
-    /// recursion its own clone, so a missing `pop` would leak steps from one entity into the
-    /// next. Type conditions are the delicate case: they descend without adding a step.
+    /// The walker shares one error path across siblings instead of giving each level its own
+    /// copy. If a step is added and not removed again, it would leak from one entity into the
+    /// next. Type conditions are the tricky case, because they go deeper without adding a step.
     #[test]
     fn error_paths_survive_type_conditions_and_sibling_branches() {
         let mut data = Value::Object(vec![(

--- a/bin/router/src/executor/utils/traverse.rs
+++ b/bin/router/src/executor/utils/traverse.rs
@@ -27,19 +27,58 @@ pub fn traverse_and_callback_mut<'a, Callback>(
 ) where
     Callback: FnMut(&mut Value<'a>, Option<GraphQLErrorPath>),
 {
+    let mut error_path = current_error_path;
+    walk_mut(
+        current_data,
+        remaining_path,
+        schema_metadata,
+        &mut error_path,
+        callback,
+    );
+}
+
+fn push_index(error_path: &mut Option<GraphQLErrorPath>, index: usize) {
+    if let Some(error_path) = error_path.as_mut() {
+        error_path.push_index(index);
+    }
+}
+
+fn push_field(error_path: &mut Option<GraphQLErrorPath>, field: &str) {
+    if let Some(error_path) = error_path.as_mut() {
+        error_path.push_field(field);
+    }
+}
+
+fn pop(error_path: &mut Option<GraphQLErrorPath>) {
+    if let Some(error_path) = error_path.as_mut() {
+        error_path.pop();
+    }
+}
+
+/// Walks `remaining_path` carrying one error path that is pushed and popped as it descends,
+/// rather than cloning the path built so far at every step. Only the callback needs an owned
+/// path, so only the callback pays for one.
+fn walk_mut<'a, Callback>(
+    current_data: &mut Value<'a>,
+    remaining_path: &[FlattenNodePathSegment],
+    schema_metadata: &SchemaMetadata,
+    error_path: &mut Option<GraphQLErrorPath>,
+    callback: &mut Callback,
+) where
+    Callback: FnMut(&mut Value<'a>, Option<GraphQLErrorPath>),
+{
     if remaining_path.is_empty() {
         if let Value::Array(arr) = current_data {
             // If the path is empty, we call the callback on each item in the array
             // We iterate because we want the entity objects directly
             for (index, item) in arr.iter_mut().enumerate() {
-                let current_error_path_for_index = current_error_path
-                    .as_ref()
-                    .map(|current_error_path| current_error_path.concat_index(index));
-                callback(item, current_error_path_for_index);
+                push_index(error_path, index);
+                callback(item, error_path.clone());
+                pop(error_path);
             }
         } else {
             // If the path is empty and current_data is not an array, just call the callback
-            callback(current_data, current_error_path);
+            callback(current_data, error_path.clone());
         }
         return;
     }
@@ -50,16 +89,9 @@ pub fn traverse_and_callback_mut<'a, Callback>(
             if let Value::Array(arr) = current_data {
                 let rest_of_path = &remaining_path[1..];
                 for (index, item) in arr.iter_mut().enumerate() {
-                    let current_error_path_for_index = current_error_path
-                        .as_ref()
-                        .map(|current_error_path| current_error_path.concat_index(index));
-                    traverse_and_callback_mut(
-                        item,
-                        rest_of_path,
-                        schema_metadata,
-                        current_error_path_for_index,
-                        callback,
-                    );
+                    push_index(error_path, index);
+                    walk_mut(item, rest_of_path, schema_metadata, error_path, callback);
+                    pop(error_path);
                 }
             }
         }
@@ -69,17 +101,15 @@ pub fn traverse_and_callback_mut<'a, Callback>(
                 if let Ok(idx) = map.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
                     let (_, next_data) = map.get_mut(idx).unwrap();
                     let rest_of_path = &remaining_path[1..];
-                    let current_error_path_for_field =
-                        current_error_path.map(|current_error_path| {
-                            current_error_path.concat_str(field_name.clone())
-                        });
-                    traverse_and_callback_mut(
+                    push_field(error_path, field_name);
+                    walk_mut(
                         next_data,
                         rest_of_path,
                         schema_metadata,
-                        current_error_path_for_field,
+                        error_path,
                         callback,
                     );
+                    pop(error_path);
                 }
             }
         }
@@ -99,27 +129,23 @@ pub fn traverse_and_callback_mut<'a, Callback>(
                     )
                 }) {
                     let rest_of_path = &remaining_path[1..];
-                    traverse_and_callback_mut(
+                    // A type condition does not add a path step.
+                    walk_mut(
                         current_data,
                         rest_of_path,
                         schema_metadata,
-                        current_error_path,
+                        error_path,
                         callback,
                     );
                 }
             } else if let Value::Array(arr) = current_data {
                 // If the current data is an array, we need to check each item
                 for (index, item) in arr.iter_mut().enumerate() {
-                    let current_error_path_for_index = current_error_path
-                        .as_ref()
-                        .map(|current_error_path| current_error_path.concat_index(index));
-                    traverse_and_callback_mut(
-                        item,
-                        remaining_path,
-                        schema_metadata,
-                        current_error_path_for_index,
-                        callback,
-                    );
+                    push_index(error_path, index);
+                    // Use `remaining_path`, not the rest, so the type condition is checked again
+                    // for each item.
+                    walk_mut(item, remaining_path, schema_metadata, error_path, callback);
+                    pop(error_path);
                 }
             }
         }
@@ -314,6 +340,70 @@ mod tests {
                 GraphQLErrorPathSegment::String("posts".into()),
                 GraphQLErrorPathSegment::Index(0),
             ]
+        );
+    }
+
+    /// The walker now shares one mutable error path across siblings instead of giving each
+    /// recursion its own clone, so a missing `pop` would leak steps from one entity into the
+    /// next. Type conditions are the delicate case: they descend without adding a step.
+    #[test]
+    fn error_paths_survive_type_conditions_and_sibling_branches() {
+        let mut data = Value::Object(vec![(
+            "media",
+            Value::Array(vec![
+                Value::Object(vec![
+                    ("__typename", Value::String("Book".into())),
+                    (
+                        "pages",
+                        Value::Array(vec![Value::Object(vec![("id", Value::String("a".into()))])]),
+                    ),
+                ]),
+                Value::Object(vec![
+                    ("__typename", Value::String("Book".into())),
+                    (
+                        "pages",
+                        Value::Array(vec![Value::Object(vec![("id", Value::String("b".into()))])]),
+                    ),
+                ]),
+            ]),
+        )]);
+
+        let path = vec![
+            FlattenNodePathSegment::Field("media".into()),
+            FlattenNodePathSegment::List,
+            FlattenNodePathSegment::TypeCondition(["Book".to_string()].into_iter().collect()),
+            FlattenNodePathSegment::Field("pages".into()),
+            FlattenNodePathSegment::List,
+        ];
+        let mut collected = vec![];
+        super::traverse_and_callback_mut(
+            &mut data,
+            &path,
+            &SchemaMetadata::default(),
+            Some(GraphQLErrorPath::default()),
+            &mut |_item, error_path| {
+                collected.push(error_path.expect("error path is tracked").segments);
+            },
+        );
+
+        use crate::executor::response::graphql_error::GraphQLErrorPathSegment::{Index, String};
+        assert_eq!(
+            collected,
+            vec![
+                vec![
+                    String("media".into()),
+                    Index(0),
+                    String("pages".into()),
+                    Index(0)
+                ],
+                vec![
+                    String("media".into()),
+                    Index(1),
+                    String("pages".into()),
+                    Index(0)
+                ],
+            ],
+            "the second entity's path must not inherit steps from the first"
         );
     }
 


### PR DESCRIPTION
Error paths in subgraph responses use now fewer allocations.

When a subgraph returns errors, the router builds a GraphQL error path while walking the response.

Previously, each step cloned the whole path built so far and then added one more segment. That meant repeated allocations as the path got deeper. The router now reuses one path while walking the response. It pushes a segment when going deeper and pops it when going back. 
The path is only cloned when an error actually needs to keep it.