### PR TITLE
perf(router): give response path steps their own owned representation 

### DIFF
--- a/.changeset/response_path_steps.md
+++ b/.changeset/response_path_steps.md
@@ -4,22 +4,29 @@ hive-router: patch
 
 # Response paths in a query plan own their steps
 
-A flatten node's path, and the merge paths on a batched entity fetch, were a `Vec` of steps whose
-field names were `String`s and whose type conditions were an inline `BTreeSet<String>`. A path is
-built once when the plan is built and then only read, so it is now a boxed slice of steps that own
-exactly what they hold: a boxed field name, and a boxed type condition of boxed names. Code that
-walks a path takes a borrowed view of it rather than a reference to the owner.
+A flatten node has a path, and a batched entity fetch has merge paths. Both were stored as a `Vec`
+of steps. Each step held a `String` field name and an inline `BTreeSet<String>` of type conditions.
 
-A stored path step goes from 32 to 24 bytes, a stored path from 24 to 16, and the merge-path list on
-an entity batch alias from 24 to 16. This is not a memory change overall: boxing the type condition
-adds an allocation for each step that has one, roughly offsetting the smaller steps. It is a change
-to how paths are held, made for the type-level guarantees below.
+A path is built once when the plan is built, and then only read. It is now stored as a boxed slice
+of steps, and each step owns exactly what it holds: a boxed field name, and a boxed type condition
+made of boxed names. Code that walks a path now takes a borrowed view of it instead of a reference
+to the owner.
 
-The type names in a condition are sorted and deduplicated when the condition is built, whichever
-direction it is built from - the planner, or deserialization of a plan that came back from a plugin
-or `node-addon`. `main` gets that from `BTreeSet` for free; a plain slice does not, and two paths
-that differ only in the order their type names were written would then compare, hash and serialize
-differently, and a batched entity fetch would walk the same path twice instead of sharing it. Three
-tests pin the normalization so the guarantee survives the change of representation.
+A stored path step goes from 32 to 24 bytes, a stored path from 24 to 16, and the merge-path list
+on an entity batch alias from 24 to 16.
+
+This does not reduce memory overall. Boxing the type condition adds one allocation for every step
+that has one, which roughly cancels out the smaller steps. The change is about how paths are held,
+so that the guarantee below can be enforced.
+
+The type names in a condition are sorted, and duplicates are removed, when the condition is built.
+This happens whichever way it is built: by the planner, or by deserializing a plan that came back
+from a plugin or from `node-addon`. `BTreeSet` did this automatically on `main`, and a plain slice
+does not.
+
+Without it, two paths that list the same type names in a different order would compare, hash and
+serialize differently. A batched entity fetch would then walk the same path twice instead of
+sharing it. Three tests check the sorting and deduplication, so the guarantee still holds with the
+new representation.
 
 Query plans on the wire are unchanged, byte for byte.

--- a/.changeset/response_path_steps.md
+++ b/.changeset/response_path_steps.md
@@ -2,31 +2,11 @@
 hive-router: patch
 ---
 
-# Response paths in a query plan own their steps
+# Response paths in query plans use a simpler stored form
 
-A flatten node has a path, and a batched entity fetch has merge paths. Both were stored as a `Vec`
-of steps. Each step held a `String` field name and an inline `BTreeSet<String>` of type conditions.
+Response paths are built once with the query plan and only read after that, so they now use boxed
+slices and boxed strings instead of `Vec`, `String`, and `BTreeSet<String>`.
 
-A path is built once when the plan is built, and then only read. It is now stored as a boxed slice
-of steps, and each step owns exactly what it holds: a boxed field name, and a boxed type condition
-made of boxed names. Code that walks a path now takes a borrowed view of it instead of a reference
-to the owner.
-
-A stored path step goes from 32 to 24 bytes, a stored path from 24 to 16, and the merge-path list
-on an entity batch alias from 24 to 16.
-
-This does not reduce memory overall. Boxing the type condition adds one allocation for every step
-that has one, which roughly cancels out the smaller steps. The change is about how paths are held,
-so that the guarantee below can be enforced.
-
-The type names in a condition are sorted, and duplicates are removed, when the condition is built.
-This happens whichever way it is built: by the planner, or by deserializing a plan that came back
-from a plugin or from `node-addon`. `BTreeSet` did this automatically on `main`, and a plain slice
-does not.
-
-Without it, two paths that list the same type names in a different order would compare, hash and
-serialize differently. A batched entity fetch would then walk the same path twice instead of
-sharing it. Three tests check the sorting and deduplication, so the guarantee still holds with the
-new representation.
-
-Query plans on the wire are unchanged, byte for byte.
+This makes the stored path types smaller and gives them a simpler owned representation. Type
+conditions are still sorted and deduplicated so equivalent paths compare, hash, and serialize the
+same way.

--- a/.changeset/response_path_steps.md
+++ b/.changeset/response_path_steps.md
@@ -1,0 +1,25 @@
+---
+hive-router: patch
+---
+
+# Response paths in a query plan own their steps
+
+A flatten node's path, and the merge paths on a batched entity fetch, were a `Vec` of steps whose
+field names were `String`s and whose type conditions were an inline `BTreeSet<String>`. A path is
+built once when the plan is built and then only read, so it is now a boxed slice of steps that own
+exactly what they hold: a boxed field name, and a boxed type condition of boxed names. Code that
+walks a path takes a borrowed view of it rather than a reference to the owner.
+
+A stored path step goes from 32 to 24 bytes, a stored path from 24 to 16, and the merge-path list on
+an entity batch alias from 24 to 16. This is not a memory change overall: boxing the type condition
+adds an allocation for each step that has one, roughly offsetting the smaller steps. It is a change
+to how paths are held, made for the type-level guarantees below.
+
+The type names in a condition are sorted and deduplicated when the condition is built, whichever
+direction it is built from - the planner, or deserialization of a plan that came back from a plugin
+or `node-addon`. `main` gets that from `BTreeSet` for free; a plain slice does not, and two paths
+that differ only in the order their type names were written would then compare, hash and serialize
+differently, and a batched entity fetch would walk the same path twice instead of sharing it. Three
+tests pin the normalization so the guarantee survives the change of representation.
+
+Query plans on the wire are unchanged, byte for byte.

--- a/bin/router/src/executor/execution/plan.rs
+++ b/bin/router/src/executor/execution/plan.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::vec;
 
 use crate::query_planner::ast::operation::SubgraphFetchOperation;
-use crate::query_planner::planner::plan_nodes::{CustomScalarPaths, FetchNode, FlattenNode};
+use crate::query_planner::planner::plan_nodes::{
+    CustomScalarPaths, FetchNode, FlattenNode, ResponsePathRef,
+};
 use crate::query_planner::planner::query_plan::QUERY_PLAN_KIND;
 use crate::query_planner::{
     ast::operation::OperationDefinition,
@@ -720,7 +722,7 @@ pub enum ExecutionJob<'exec> {
         output_rewrites: Option<&'exec [FetchRewrite]>,
         // By default, this job is merged at the root. When this is set, we merge at
         // a specific path instead of the root (used for root re-entry fetches)
-        merge_path: Option<&'exec FlattenNodePath>,
+        merge_path: Option<ResponsePathRef<'exec>>,
     },
     FlattenFetch {
         subgraph_name: &'exec str,
@@ -746,7 +748,7 @@ pub struct AliasBatchState<'exec> {
 }
 
 struct AliasPathState<'exec> {
-    merge_path: &'exec FlattenNodePath,
+    merge_path: ResponsePathRef<'exec>,
     representation_hashes: Arc<Vec<Option<u64>>>,
 }
 
@@ -792,12 +794,12 @@ impl<'exec> ExecutionJob<'exec> {
         }
     }
 
-    fn affected_path(&self) -> Option<&'exec FlattenNodePath> {
+    fn affected_path(&self) -> Option<ResponsePathRef<'exec>> {
         match self {
             ExecutionJob::Fetch { merge_path, .. } => *merge_path,
             ExecutionJob::FlattenFetch {
                 flatten_node_path, ..
-            } => Some(flatten_node_path),
+            } => Some(flatten_node_path.as_ref()),
             ExecutionJob::BatchFetch { .. } => None,
         }
     }
@@ -821,7 +823,7 @@ struct PrepareExecutionJobOpts<'exec> {
     // If the fetch job is for a flatten node, we pass the filtered representations,
     raw_variable_values: Option<Vec<(&'exec str, Vec<u8>)>>,
     // and the path to the representations in the original response for error handling and normalization
-    affected_path: Option<&'exec FlattenNodePath>,
+    affected_path: Option<ResponsePathRef<'exec>>,
 }
 
 impl<'exec> Executor<'exec> {
@@ -883,7 +885,7 @@ impl<'exec> Executor<'exec> {
             output_rewrites: fetch_node.output_rewrites.as_deref(),
             custom_scalar_paths: fetch_node.custom_scalar_paths.as_ref(),
             raw_variable_values: None,
-            affected_path: Some(&flatten_node.path),
+            affected_path: Some(flatten_node.path.as_ref()),
         })
         .boxed()
     }
@@ -1053,7 +1055,7 @@ impl<'exec> Executor<'exec> {
                             "representations",
                             filtered_representations,
                         )]),
-                        affected_path: Some(&flatten_node.path),
+                        affected_path: Some(flatten_node.path.as_ref()),
                     })
                     .map_ok(|fetch_job| ExecutionJob::FlattenFetch {
                         operation: fetch_job.operation(),
@@ -1442,7 +1444,7 @@ impl<'exec> Executor<'exec> {
         // We walk each merge path
         for path_state in &alias_state.paths {
             let mut index = 0;
-            let normalized_path = path_state.merge_path.as_slice();
+            let normalized_path = path_state.merge_path;
             let initial_error_path = has_alias_errors
                 // Small extra capacity for path segments that will be appended later.
                 .then(|| GraphQLErrorPath::with_capacity(normalized_path.len() + 2));
@@ -1450,7 +1452,7 @@ impl<'exec> Executor<'exec> {
             // For each visited target:
             traverse_and_callback_mut(
                 &mut ctx.data,
-                normalized_path,
+                normalized_path.as_slice(),
                 self.schema_metadata,
                 initial_error_path,
                 &mut |target_data, error_path| {
@@ -1513,7 +1515,7 @@ impl<'exec> Executor<'exec> {
             let mut path_hashes_by_index: Vec<Option<Arc<Vec<Option<u64>>>>> =
                 vec![None; alias_spec.merge_paths.len()];
 
-            let mut path_groups: Vec<(&FlattenNodePath, Vec<usize>)> =
+            let mut path_groups: Vec<(ResponsePathRef<'_>, Vec<usize>)> =
                 Vec::with_capacity(alias_spec.merge_paths.len());
             for (path_index, merge_path) in alias_spec.merge_paths.iter().enumerate() {
                 if let Some((_, target_indices)) =
@@ -2013,7 +2015,7 @@ mod tests {
                 EntityBatchAlias {
                     alias: "_e0".to_string(),
                     representations_variable_name: shared_var.clone(),
-                    merge_paths: vec![],
+                    merge_paths: Default::default(),
                     requires: requires_from(requires_selection.clone()),
                     input_rewrites: None,
                     output_rewrites: None,
@@ -2021,7 +2023,7 @@ mod tests {
                 EntityBatchAlias {
                     alias: "_e1".to_string(),
                     representations_variable_name: shared_var,
-                    merge_paths: vec![],
+                    merge_paths: Default::default(),
                     requires: requires_from(requires_selection),
                     input_rewrites: None,
                     output_rewrites: None,

--- a/bin/router/src/executor/execution_context.rs
+++ b/bin/router/src/executor/execution_context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::query_planner::planner::plan_nodes::FlattenNodePath;
+use crate::query_planner::planner::plan_nodes::ResponsePathRef;
 
 use crate::executor::{
     execution::demand_control::subgraph_response_tracker::SubgraphResponseCostTracker,
@@ -47,7 +47,7 @@ impl<'a> ExecutionContext<'a> {
     pub fn handle_errors(
         &mut self,
         subgraph_name: &str,
-        affected_path: Option<&FlattenNodePath>,
+        affected_path: Option<ResponsePathRef<'_>>,
         errors: Option<Vec<GraphQLError>>,
         entity_index_error_map: Option<HashMap<&usize, Vec<GraphQLErrorPath>>>,
     ) {

--- a/bin/router/src/executor/utils/traverse.rs
+++ b/bin/router/src/executor/utils/traverse.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeSet;
-
-use crate::query_planner::planner::plan_nodes::FlattenNodePathSegment;
+use crate::query_planner::planner::plan_nodes::{PathSegment, TypeCondition};
 
 use crate::executor::{
     introspection::schema::{PossibleTypes, SchemaMetadata},
@@ -11,16 +9,17 @@ use crate::executor::{
 fn entity_satisfies_any_type_condition(
     possible_types: &PossibleTypes,
     type_name: &str,
-    type_conditions: &BTreeSet<String>,
+    condition: &TypeCondition,
 ) -> bool {
-    type_conditions
+    condition
+        .names()
         .iter()
-        .any(|condition| possible_types.entity_satisfies_type_condition(type_name, condition))
+        .any(|name| possible_types.entity_satisfies_type_condition(type_name, name))
 }
 
 pub fn traverse_and_callback_mut<'a, Callback>(
     current_data: &mut Value<'a>,
-    remaining_path: &[FlattenNodePathSegment],
+    remaining_path: &[PathSegment],
     schema_metadata: &SchemaMetadata,
     current_error_path: Option<GraphQLErrorPath>,
     callback: &mut Callback,
@@ -60,7 +59,7 @@ fn pop(error_path: &mut Option<GraphQLErrorPath>) {
 /// Only the callback needs to own a path, so only the callback allocates one.
 fn walk_mut<'a, Callback>(
     current_data: &mut Value<'a>,
-    remaining_path: &[FlattenNodePathSegment],
+    remaining_path: &[PathSegment],
     schema_metadata: &SchemaMetadata,
     error_path: &mut Option<GraphQLErrorPath>,
     callback: &mut Callback,
@@ -83,11 +82,14 @@ fn walk_mut<'a, Callback>(
         return;
     }
 
-    match &remaining_path[0] {
-        FlattenNodePathSegment::List => {
+    let Some((first, rest_of_path)) = remaining_path.split_first() else {
+        return;
+    };
+
+    match first {
+        PathSegment::List => {
             // If the key is List, we expect current_data to be an array
             if let Value::Array(arr) = current_data {
-                let rest_of_path = &remaining_path[1..];
                 for (index, item) in arr.iter_mut().enumerate() {
                     push_index(error_path, index);
                     walk_mut(item, rest_of_path, schema_metadata, error_path, callback);
@@ -95,12 +97,12 @@ fn walk_mut<'a, Callback>(
                 }
             }
         }
-        FlattenNodePathSegment::Field(field_name) => {
+        PathSegment::Field(field_name) => {
             // If the key is Field, we expect current_data to be an object
             if let Value::Object(map) = current_data {
-                if let Ok(idx) = map.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
+                let field_name: &str = field_name.as_ref();
+                if let Ok(idx) = map.binary_search_by_key(&field_name, |(key, _)| key) {
                     let (_, next_data) = map.get_mut(idx).unwrap();
-                    let rest_of_path = &remaining_path[1..];
                     push_field(error_path, field_name);
                     walk_mut(
                         next_data,
@@ -113,7 +115,7 @@ fn walk_mut<'a, Callback>(
                 }
             }
         }
-        FlattenNodePathSegment::TypeCondition(type_condition) => {
+        PathSegment::TypeCondition(type_condition) => {
             // If the key is Cast, we expect current_data to be an object or an array
             if let Value::Object(obj) = current_data {
                 let maybe_type_name = obj
@@ -128,7 +130,6 @@ fn walk_mut<'a, Callback>(
                         type_condition,
                     )
                 }) {
-                    let rest_of_path = &remaining_path[1..];
                     // A type condition does not add a path step.
                     walk_mut(
                         current_data,
@@ -142,7 +143,7 @@ fn walk_mut<'a, Callback>(
                 // If the current data is an array, we need to check each item
                 for (index, item) in arr.iter_mut().enumerate() {
                     push_index(error_path, index);
-                    // Pass `remaining_path` rather than the rest of it, so the type condition
+                    // Pass `remaining_path` rather than `rest_of_path`, so the type condition
                     // is checked again for each item.
                     walk_mut(item, remaining_path, schema_metadata, error_path, callback);
                     pop(error_path);
@@ -154,7 +155,7 @@ fn walk_mut<'a, Callback>(
 
 pub fn traverse_and_callback<'a, Callback>(
     current_data: &'a Value<'a>,
-    remaining_path: &'a [FlattenNodePathSegment],
+    remaining_path: &'a [PathSegment],
     possible_types: &'a PossibleTypes,
     callback: &mut Callback,
 ) where
@@ -171,25 +172,28 @@ pub fn traverse_and_callback<'a, Callback>(
         return;
     }
 
-    match &remaining_path[0] {
-        FlattenNodePathSegment::List => {
+    let Some((first, rest_of_path)) = remaining_path.split_first() else {
+        return;
+    };
+
+    match first {
+        PathSegment::List => {
             if let Value::Array(arr) = current_data {
-                let rest_of_path = &remaining_path[1..];
                 for item in arr.iter() {
                     traverse_and_callback(item, rest_of_path, possible_types, callback);
                 }
             }
         }
-        FlattenNodePathSegment::Field(field_name) => {
+        PathSegment::Field(field_name) => {
             if let Value::Object(map) = current_data {
-                if let Ok(idx) = map.binary_search_by_key(&field_name.as_str(), |(k, _)| k) {
+                let field_name: &str = field_name.as_ref();
+                if let Ok(idx) = map.binary_search_by_key(&field_name, |(key, _)| key) {
                     let (_, next_data) = &map[idx];
-                    let rest_of_path = &remaining_path[1..];
                     traverse_and_callback(next_data, rest_of_path, possible_types, callback);
                 }
             }
         }
-        FlattenNodePathSegment::TypeCondition(type_condition) => {
+        PathSegment::TypeCondition(type_condition) => {
             if let Value::Object(obj) = current_data {
                 let maybe_type_name = obj
                     .binary_search_by_key(&TYPENAME_FIELD_NAME, |(k, _)| k)
@@ -199,7 +203,6 @@ pub fn traverse_and_callback<'a, Callback>(
                 if maybe_type_name.is_none_or(|type_name| {
                     entity_satisfies_any_type_condition(possible_types, type_name, type_condition)
                 }) {
-                    let rest_of_path = &remaining_path[1..];
                     traverse_and_callback(current_data, rest_of_path, possible_types, callback);
                 }
             } else if let Value::Array(arr) = current_data {
@@ -213,7 +216,22 @@ pub fn traverse_and_callback<'a, Callback>(
 
 #[cfg(test)]
 mod tests {
-    use crate::query_planner::planner::plan_nodes::FlattenNodePathSegment;
+    use crate::query_planner::planner::plan_nodes::{FlattenNodePath, PathSegment, TypeCondition};
+
+    /// `@` is a list step, `|A|B` a type condition, anything else a field.
+    fn path(steps: &[&str]) -> FlattenNodePath {
+        steps
+            .iter()
+            .map(|step| match *step {
+                "@" => PathSegment::List,
+                s if s.starts_with('|') => PathSegment::TypeCondition(Box::new(
+                    TypeCondition::from_names(s.trim_start_matches('|').split('|')),
+                )),
+                field => PathSegment::Field(field.into()),
+            })
+            .collect::<Vec<_>>()
+            .into()
+    }
 
     use crate::executor::{
         introspection::schema::SchemaMetadata,
@@ -237,14 +255,11 @@ mod tests {
                 Value::Object(vec![("id", Value::String("2".into()))]),
             ]),
         )]);
-        let path = vec![
-            FlattenNodePathSegment::Field("items".into()),
-            FlattenNodePathSegment::List,
-        ];
+        let path = path(&["items", "@"]);
         let mut collected = vec![];
         super::traverse_and_callback_mut(
             &mut data,
-            &path,
+            path.as_slice(),
             &SchemaMetadata::default(),
             Some(GraphQLErrorPath::default()),
             &mut |_item, error_path| {
@@ -297,16 +312,11 @@ mod tests {
                 ]),
             ]),
         )]);
-        let path = vec![
-            FlattenNodePathSegment::Field("users".into()),
-            FlattenNodePathSegment::List,
-            FlattenNodePathSegment::Field("posts".into()),
-            FlattenNodePathSegment::List,
-        ];
+        let path = path(&["users", "@", "posts", "@"]);
         let mut collected = vec![];
         super::traverse_and_callback_mut(
             &mut data,
-            &path,
+            path.as_slice(),
             &SchemaMetadata::default(),
             Some(GraphQLErrorPath::default()),
             &mut |_item, error_path| {
@@ -368,17 +378,11 @@ mod tests {
             ]),
         )]);
 
-        let path = vec![
-            FlattenNodePathSegment::Field("media".into()),
-            FlattenNodePathSegment::List,
-            FlattenNodePathSegment::TypeCondition(["Book".to_string()].into_iter().collect()),
-            FlattenNodePathSegment::Field("pages".into()),
-            FlattenNodePathSegment::List,
-        ];
+        let path = path(&["media", "@", "|Book", "pages", "@"]);
         let mut collected = vec![];
         super::traverse_and_callback_mut(
             &mut data,
-            &path,
+            path.as_slice(),
             &SchemaMetadata::default(),
             Some(GraphQLErrorPath::default()),
             &mut |_item, error_path| {
@@ -410,14 +414,10 @@ mod tests {
     #[test]
     fn traverse_matches_multi_type_cast() {
         let data = Value::Object(vec![("__typename", Value::String("Book".into()))]);
-        let path = vec![FlattenNodePathSegment::TypeCondition(
-            ["Book".to_string(), "User".to_string()]
-                .into_iter()
-                .collect(),
-        )];
+        let path = path(&["|Book|User"]);
         let mut matched = false;
 
-        super::traverse_and_callback(&data, &path, &Default::default(), &mut |_value| {
+        super::traverse_and_callback(&data, path.as_slice(), &Default::default(), &mut |_value| {
             matched = true;
         });
 
@@ -427,14 +427,10 @@ mod tests {
     #[test]
     fn traverse_rejects_non_matching_multi_type_cast() {
         let data = Value::Object(vec![("__typename", Value::String("Magazine".into()))]);
-        let path = vec![FlattenNodePathSegment::TypeCondition(
-            ["Book".to_string(), "User".to_string()]
-                .into_iter()
-                .collect(),
-        )];
+        let path = path(&["|Book|User"]);
         let mut matched = false;
 
-        super::traverse_and_callback(&data, &path, &Default::default(), &mut |_value| {
+        super::traverse_and_callback(&data, path.as_slice(), &Default::default(), &mut |_value| {
             matched = true;
         });
 

--- a/bin/router/src/executor/utils/traverse.rs
+++ b/bin/router/src/executor/utils/traverse.rs
@@ -218,7 +218,7 @@ pub fn traverse_and_callback<'a, Callback>(
 mod tests {
     use crate::query_planner::planner::plan_nodes::{FlattenNodePath, PathSegment, TypeCondition};
 
-    /// `@` is a list step, `|A|B` a type condition, anything else a field.
+    /// `@` means a list step, `|A|B` means a type condition, and anything else is a field.
     fn path(steps: &[&str]) -> FlattenNodePath {
         steps
             .iter()

--- a/bin/router/src/query_planner/planner/plan_nodes/mod.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/mod.rs
@@ -1,7 +1,7 @@
 use crate::query_planner::ast::requires::RequiresSelectionSet;
 use crate::query_planner::{
     ast::{
-        merge_path::{Condition, MergePath, Segment},
+        merge_path::Condition,
         minification::minify_operation,
         operation::{OperationDefinition, PlanningFetchOperation, VariableDefinition},
         selection_item::SelectionItem,
@@ -35,6 +35,9 @@ pub mod planning {
     pub type DeferPrimary = super::DeferPrimary<Planning>;
     pub type DeferredNode = super::DeferredNode<Planning>;
 }
+
+mod path;
+pub use path::{FlattenNodePath, MergePaths, PathSegment, ResponsePathRef, TypeCondition};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter as FmtFormatter, Result as FmtResult},
@@ -376,7 +379,7 @@ pub struct EntityBatchAlias {
     pub alias: String,
     pub representations_variable_name: String,
     #[serde(rename = "paths")]
-    pub merge_paths: Vec<FlattenNodePath>,
+    pub merge_paths: MergePaths,
     pub requires: RequiresSelectionSet,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_rewrites: Option<Vec<FetchRewrite>>,
@@ -473,110 +476,6 @@ impl FetchNodePathSegment {
 pub enum FetchRewrite {
     ValueSetter(ValueSetter),
     KeyRenamer(KeyRenamer),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FlattenNodePathSegment {
-    Field(String),
-    TypeCondition(BTreeSet<String>),
-    #[serde(rename = "@")]
-    List,
-}
-
-impl From<&MergePath> for Vec<FetchNodePathSegment> {
-    fn from(value: &MergePath) -> Self {
-        value
-            .inner
-            .iter()
-            .filter_map(|path_segment| match path_segment {
-                Segment::TypeCondition(type_names, _) => {
-                    Some(FetchNodePathSegment::TypenameEquals(type_names.clone()))
-                }
-                Segment::Field(field_seg, _args_hash, _) => Some(FetchNodePathSegment::Key(
-                    field_seg.response_key().to_string(),
-                )),
-                Segment::List => None,
-            })
-            .collect()
-    }
-}
-
-impl FlattenNodePathSegment {
-    pub fn to_field(&self) -> Option<&String> {
-        match self {
-            FlattenNodePathSegment::Field(field_name) => Some(field_name),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FlattenNodePath(Vec<FlattenNodePathSegment>);
-
-impl FlattenNodePath {
-    pub fn as_slice(&self) -> &[FlattenNodePathSegment] {
-        &self.0
-    }
-}
-
-impl Display for FlattenNodePathSegment {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FlattenNodePathSegment::Field(field_name) => write!(f, "{}", field_name),
-            FlattenNodePathSegment::TypeCondition(type_names) => {
-                write!(
-                    f,
-                    "|[{}]",
-                    type_names.iter().cloned().collect::<Vec<_>>().join("|")
-                )
-            }
-            FlattenNodePathSegment::List => write!(f, "@"),
-        }
-    }
-}
-
-impl Display for FlattenNodePath {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut segments_iter = self.0.iter().peekable();
-
-        while let Some(segment) = segments_iter.next() {
-            write!(f, "{}", segment)?;
-            if let Some(peeked) = segments_iter.peek() {
-                match peeked {
-                    FlattenNodePathSegment::TypeCondition(_) => {
-                        // Don't add a dot before TypeCondition
-                    }
-                    _ => write!(f, ".")?,
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-impl From<&MergePath> for FlattenNodePath {
-    fn from(path: &MergePath) -> Self {
-        FlattenNodePath(
-            path.inner
-                .iter()
-                .map(|seg| match seg {
-                    Segment::TypeCondition(type_names, _) => {
-                        FlattenNodePathSegment::TypeCondition(type_names.clone())
-                    }
-                    Segment::Field(field_seg, _args_hash, _) => {
-                        FlattenNodePathSegment::Field(field_seg.response_key().to_string())
-                    }
-                    Segment::List => FlattenNodePathSegment::List,
-                })
-                .collect(),
-        )
-    }
-}
-
-impl From<MergePath> for FlattenNodePath {
-    fn from(path: MergePath) -> Self {
-        (&path).into()
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
@@ -923,7 +822,7 @@ impl<S: PlanState> PrettyDisplay for BatchFetchNode<S> {
         for alias in &self.entity_batch.aliases {
             writeln!(f, "{indent}    {} {{", alias.alias)?;
             writeln!(f, "{indent}      paths: [")?;
-            for merge_path in &alias.merge_paths {
+            for merge_path in alias.merge_paths.iter() {
                 writeln!(f, "{indent}        \"{}\"", merge_path)?;
             }
             writeln!(f, "{indent}      ]")?;

--- a/bin/router/src/query_planner/planner/plan_nodes/path.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/path.rs
@@ -7,18 +7,18 @@ use crate::query_planner::ast::merge_path::{MergePath, Segment};
 
 use super::FetchNodePathSegment;
 
-/// Uses the tagged format expected by `lib/node-addon` and `hive-expose-query-plan`:
+/// Uses the tagged format that `lib/node-addon` and `hive-expose-query-plan` expect:
 /// `{"Field": name}`, `{"TypeCondition": [..]}`, and a plain `"@"` for a list step.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PathSegment {
     Field(Box<str>),
-    /// A box keeps every path step small.
+    /// Boxing this keeps every path step small.
     TypeCondition(Box<TypeCondition>),
     #[serde(rename = "@")]
     List,
 }
 
-/// Type names that an entity may match, sorted with duplicates removed.
+/// The type names an entity may match. Sorted, with duplicates removed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct TypeCondition {
@@ -26,7 +26,8 @@ pub struct TypeCondition {
 }
 
 impl TypeCondition {
-    /// Sort names and remove duplicates so equal sets compare, hash, and serialize the same way.
+    /// Sorts the names and removes duplicates, so that two sets holding the same names
+    /// compare, hash, and serialize the same way.
     pub fn from_names<'a>(names: impl IntoIterator<Item = &'a str>) -> Self {
         let unique: BTreeSet<&str> = names.into_iter().collect();
         Self {
@@ -139,7 +140,7 @@ impl Display for ResponsePathRef<'_> {
         let mut steps = self.0.iter().peekable();
         while let Some(step) = steps.next() {
             write!(f, "{step}")?;
-            // A type condition belongs to the step before it, so do not add a separator.
+            // A type condition belongs to the step before it, so no separator is added.
             if let Some(peeked) = steps.peek() {
                 if !matches!(peeked, PathSegment::TypeCondition(_)) {
                     write!(f, ".")?;

--- a/bin/router/src/query_planner/planner/plan_nodes/path.rs
+++ b/bin/router/src/query_planner/planner/plan_nodes/path.rs
@@ -1,0 +1,274 @@
+use std::collections::BTreeSet;
+use std::fmt::Display;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::query_planner::ast::merge_path::{MergePath, Segment};
+
+use super::FetchNodePathSegment;
+
+/// Uses the tagged format expected by `lib/node-addon` and `hive-expose-query-plan`:
+/// `{"Field": name}`, `{"TypeCondition": [..]}`, and a plain `"@"` for a list step.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PathSegment {
+    Field(Box<str>),
+    /// A box keeps every path step small.
+    TypeCondition(Box<TypeCondition>),
+    #[serde(rename = "@")]
+    List,
+}
+
+/// Type names that an entity may match, sorted with duplicates removed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct TypeCondition {
+    names: Box<[Box<str>]>,
+}
+
+impl TypeCondition {
+    /// Sort names and remove duplicates so equal sets compare, hash, and serialize the same way.
+    pub fn from_names<'a>(names: impl IntoIterator<Item = &'a str>) -> Self {
+        let unique: BTreeSet<&str> = names.into_iter().collect();
+        Self {
+            names: unique.into_iter().map(Box::<str>::from).collect(),
+        }
+    }
+
+    pub fn names(&self) -> &[Box<str>] {
+        &self.names
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FlattenNodePath(Box<[PathSegment]>);
+
+impl FlattenNodePath {
+    pub fn as_ref(&self) -> ResponsePathRef<'_> {
+        ResponsePathRef(&self.0)
+    }
+
+    pub fn as_slice(&self) -> &[PathSegment] {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl From<Vec<PathSegment>> for FlattenNodePath {
+    fn from(segments: Vec<PathSegment>) -> Self {
+        Self(segments.into_boxed_slice())
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MergePaths(Box<[FlattenNodePath]>);
+
+impl MergePaths {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ResponsePathRef<'_>> + '_ {
+        self.0.iter().map(FlattenNodePath::as_ref)
+    }
+}
+
+impl From<Vec<FlattenNodePath>> for MergePaths {
+    fn from(paths: Vec<FlattenNodePath>) -> Self {
+        Self(paths.into_boxed_slice())
+    }
+}
+
+impl<'de> Deserialize<'de> for TypeCondition {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let names = Vec::<String>::deserialize(deserializer)?;
+        Ok(Self::from_names(names.iter().map(String::as_str)))
+    }
+}
+
+impl Display for PathSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathSegment::Field(name) => write!(f, "{name}"),
+            PathSegment::TypeCondition(condition) => {
+                write!(f, "|[")?;
+                for (i, name) in condition.names.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "|")?;
+                    }
+                    write!(f, "{name}")?;
+                }
+                write!(f, "]")
+            }
+            PathSegment::List => write!(f, "@"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResponsePathRef<'a>(&'a [PathSegment]);
+
+impl<'a> ResponsePathRef<'a> {
+    pub fn as_slice(&self) -> &'a [PathSegment] {
+        self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Display for ResponsePathRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut steps = self.0.iter().peekable();
+        while let Some(step) = steps.next() {
+            write!(f, "{step}")?;
+            // A type condition belongs to the step before it, so do not add a separator.
+            if let Some(peeked) = steps.peek() {
+                if !matches!(peeked, PathSegment::TypeCondition(_)) {
+                    write!(f, ".")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Display for FlattenNodePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.as_ref(), f)
+    }
+}
+
+impl From<&MergePath> for FlattenNodePath {
+    fn from(path: &MergePath) -> Self {
+        path.inner
+            .iter()
+            .map(|segment| match segment {
+                Segment::TypeCondition(type_names, _) => PathSegment::TypeCondition(Box::new(
+                    TypeCondition::from_names(type_names.iter().map(String::as_str)),
+                )),
+                Segment::Field(field_seg, _args_hash, _) => {
+                    PathSegment::Field(field_seg.response_key().into())
+                }
+                Segment::List => PathSegment::List,
+            })
+            .collect::<Vec<_>>()
+            .into()
+    }
+}
+
+impl From<MergePath> for FlattenNodePath {
+    fn from(path: MergePath) -> Self {
+        (&path).into()
+    }
+}
+
+impl From<&MergePath> for Vec<FetchNodePathSegment> {
+    fn from(value: &MergePath) -> Self {
+        value
+            .inner
+            .iter()
+            .filter_map(|path_segment| match path_segment {
+                Segment::TypeCondition(type_names, _) => {
+                    Some(FetchNodePathSegment::TypenameEquals(type_names.clone()))
+                }
+                Segment::Field(field_seg, _args_hash, _) => Some(FetchNodePathSegment::Key(
+                    field_seg.response_key().to_string(),
+                )),
+                Segment::List => None,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod type_condition_tests {
+    use super::*;
+
+    #[test]
+    fn names_are_sorted_and_deduplicated() {
+        let messy = TypeCondition::from_names(["User", "Book", "User"]);
+        let tidy = TypeCondition::from_names(["Book", "User"]);
+
+        assert_eq!(
+            messy.names(),
+            tidy.names(),
+            "not normalized on construction"
+        );
+        assert_eq!(messy, tidy, "equality depends on that normalization");
+
+        let hash = |c: &TypeCondition| {
+            use std::hash::{DefaultHasher, Hash, Hasher};
+            let mut h = DefaultHasher::new();
+            c.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&messy), hash(&tidy), "hashing depends on it too");
+
+        assert_eq!(
+            serde_json::to_string(&messy).expect("serializes"),
+            r#"["Book","User"]"#,
+            "the serialized order must not depend on how the condition was built"
+        );
+    }
+
+    #[test]
+    fn deserialization_normalizes_too() {
+        let from_json: TypeCondition =
+            serde_json::from_str(r#"["User","Book","User"]"#).expect("deserializes");
+        assert_eq!(from_json, TypeCondition::from_names(["Book", "User"]));
+        assert_eq!(
+            from_json.names().len(),
+            2,
+            "duplicate survived deserialization"
+        );
+    }
+
+    #[test]
+    fn a_path_round_trips_through_an_unordered_condition() {
+        let expected: FlattenNodePath = vec![
+            PathSegment::Field("media".into()),
+            PathSegment::TypeCondition(Box::new(TypeCondition::from_names(["Book", "User"]))),
+        ]
+        .into();
+
+        let back: FlattenNodePath =
+            serde_json::from_str(r#"[{"Field":"media"},{"TypeCondition":["User","Book","User"]}]"#)
+                .expect("deserializes");
+        assert_eq!(back, expected);
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_pointer_width = "64")]
+mod stored_size_tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn a_stored_step_stays_small() {
+        assert_eq!(
+            size_of::<PathSegment>(),
+            24,
+            "a stored path step is {} B",
+            size_of::<PathSegment>()
+        );
+    }
+}

--- a/bin/router/src/query_planner/planner/query_plan/optimize.rs
+++ b/bin/router/src/query_planner/planner/query_plan/optimize.rs
@@ -183,7 +183,7 @@ impl<'a> BatchFetchBuilder<'a> {
         self.batched_aliases.push(EntityBatchAlias {
             alias,
             representations_variable_name,
-            merge_paths,
+            merge_paths: merge_paths.into(),
             requires: RequiresSelectionSet::from(&representative.requires),
             input_rewrites: representative.input_rewrites.clone(),
             output_rewrites: representative.output_rewrites.clone(),


### PR DESCRIPTION
Response paths are built once with the query plan and only read after that, so they now use boxed
slices and boxed strings instead of `Vec`, `String`, and `BTreeSet<String>`.

This makes the stored path types smaller and gives them a simpler owned representation. Type
conditions are still sorted and deduplicated so equivalent paths compare, hash, and serialize the
same way.
