### PR TITLE
fix(router): improve restrictive `Cache-Control` merging

### DIFF
--- a/.changeset/improved_cache_headers_merging.md
+++ b/.changeset/improved_cache_headers_merging.md
@@ -1,0 +1,15 @@
+---
+hive-router: patch
+---
+
+# Improve restrictive `Cache-Control` merging
+
+The router now preserves and safely merges standard `Cache-Control` directives instead of discarding an entire subgraph value when it contains a directive that was not previously modeled. This prevents restrictions such as `no-store` or `private` from being lost when they appear alongside another standard directive.
+
+The merge now supports `s-maxage`, `stale-while-revalidate`, and `stale-if-error` by selecting the minimum applicable duration. `s-maxage` is merged with awareness that shared caches prefer it over `max-age`, so mixed directives cannot extend the effective shared-cache lifetime.
+
+`private` now overrides `public` without being escalated to `no-store, no-cache`. Other directives are retained, allowing results such as `private, max-age=50` to remain available to private caches while still preventing shared-cache storage.
+
+The router also preserves `proxy-revalidate`, `must-understand`, and `no-transform` when any subgraph sets them. `immutable` is preserved only when every subgraph sets it, like `public`. Qualified `no-cache="field"` and `private="field"` forms are treated as their more restrictive unqualified forms.
+
+Unknown directives, missing or non-numeric duration values, and other malformed directives now conservatively produce `no-store, no-cache` instead of allowing the affected subgraph value to be ignored.

--- a/.changeset/improved_cache_headers_merging.md
+++ b/.changeset/improved_cache_headers_merging.md
@@ -13,3 +13,5 @@ The merge now supports `s-maxage`, `stale-while-revalidate`, and `stale-if-error
 The router also preserves `proxy-revalidate`, `must-understand`, and `no-transform` when any subgraph sets them. `immutable` is preserved only when every subgraph sets it, like `public`. Qualified `no-cache="field"` and `private="field"` forms are treated as their more restrictive unqualified forms.
 
 Unknown directives, missing or non-numeric duration values, and other malformed directives now conservatively produce `no-store, no-cache` instead of allowing the affected subgraph value to be ignored.
+
+Closes https://github.com/graphql-hive/router/issues/1373

--- a/bin/router/src/config/headers.rs
+++ b/bin/router/src/config/headers.rs
@@ -381,6 +381,7 @@ pub enum AggregationAlgo {
     /// - `no-store` or `no-cache` from any subgraph poisons the result.
     /// - `private` is preserved if any subgraph sets it and overrides `public`.
     /// - `max-age` and `s-maxage` use the minimum effective freshness lifetime.
+    /// - `stale-while-revalidate` and `stale-if-error` use their minimum durations.
     /// - `public` and `immutable` are only kept if every provided value carries them.
     /// - Revalidation and transformation restrictions are kept if any value carries them.
     /// - A malformed or unmodeled directive poisons the result to `no-store, no-cache`,

--- a/bin/router/src/config/headers.rs
+++ b/bin/router/src/config/headers.rs
@@ -382,6 +382,11 @@ pub enum AggregationAlgo {
     /// - `max-age` takes the minimum across all subgraphs that provide it.
     /// - `public` is only kept if every provided `Cache-Control` value carries it.
     /// - `must-revalidate` is set if any subgraph carries it.
+    /// - A value with a malformed directive (e.g. `max-age=abc`) or a directive
+    ///   the router does not model (such as `s-maxage`, `immutable`,
+    ///   `no-transform` or `stale-while-revalidate`) also poisons the result to
+    ///   `no-store, no-cache`, since the unrecognized directive may have been
+    ///   restrictive.
     ///
     /// The following conditions force `no-store, no-cache, must-revalidate`
     /// regardless of subgraph values:

--- a/bin/router/src/config/headers.rs
+++ b/bin/router/src/config/headers.rs
@@ -378,15 +378,13 @@ pub enum AggregationAlgo {
     ///
     /// **`cache-control` special case:** Instead of comma-joining, the router
     /// applies a restrictive merge across all subgraph values:
-    /// - `no-store`, `no-cache`, or `private` from any subgraph poisons the result.
-    /// - `max-age` takes the minimum across all subgraphs that provide it.
-    /// - `public` is only kept if every provided `Cache-Control` value carries it.
-    /// - `must-revalidate` is set if any subgraph carries it.
-    /// - A value with a malformed directive (e.g. `max-age=abc`) or a directive
-    ///   the router does not model (such as `s-maxage`, `immutable`,
-    ///   `no-transform` or `stale-while-revalidate`) also poisons the result to
-    ///   `no-store, no-cache`, since the unrecognized directive may have been
-    ///   restrictive.
+    /// - `no-store` or `no-cache` from any subgraph poisons the result.
+    /// - `private` is preserved if any subgraph sets it and overrides `public`.
+    /// - `max-age` and `s-maxage` use the minimum effective freshness lifetime.
+    /// - `public` and `immutable` are only kept if every provided value carries them.
+    /// - Revalidation and transformation restrictions are kept if any value carries them.
+    /// - A malformed or unmodeled directive poisons the result to `no-store, no-cache`,
+    ///   since it may have been restrictive.
     ///
     /// The following conditions force `no-store, no-cache, must-revalidate`
     /// regardless of subgraph values:

--- a/bin/router/src/executor/headers/cache_control.rs
+++ b/bin/router/src/executor/headers/cache_control.rs
@@ -15,9 +15,45 @@ struct CacheControl {
     no_store: bool,
     no_cache: bool,
     must_revalidate: bool,
+    proxy_revalidate: bool,
+    must_understand: bool,
+    no_transform: bool,
+    immutable: bool,
     is_private: bool,
     is_public: bool,
     max_age: Option<u32>,
+    s_maxage: Option<u32>,
+    stale_while_revalidate: Option<u32>,
+    stale_if_error: Option<u32>,
+}
+
+fn poison() -> CacheControl {
+    CacheControl {
+        no_store: true,
+        no_cache: true,
+        ..Default::default()
+    }
+}
+
+// directives like max-age require a numeric value; anything else
+// (missing or non-numeric) makes the whole header untrustworthy
+fn parse_u32(token: &str, value: Option<&str>) -> Result<u32, ()> {
+    match value {
+        Some(v) => v.parse::<u32>().map_err(|_| {
+            warn!(
+                directive = token,
+                value = v,
+                "cache-control directive has non-numeric value"
+            );
+        }),
+        None => {
+            warn!(
+                directive = token,
+                "cache-control directive is missing a value"
+            );
+            Err(())
+        }
+    }
 }
 
 fn parse(header: &str) -> Option<CacheControl> {
@@ -37,33 +73,37 @@ fn parse(header: &str) -> Option<CacheControl> {
             Some((t, v)) => (t.trim(), Some(v.trim())),
             None => (part, None),
         };
-        match token.to_ascii_lowercase().as_str() {
+        let token_lower = token.to_ascii_lowercase();
+        match token_lower.as_str() {
             "no-store" => p.no_store = true,
+            // note: no-cache may carry a field list (no-cache="set-cookie"); we treat the
+            // qualified form as the unqualified, more restrictive one. same for private below.
+            // a quoted list containing a comma splits into garbage parts which then hit the
+            // unknown-directive arm and poison - still safe, just noisier than necessary.
             "no-cache" => p.no_cache = true,
-            "must-revalidate" => p.must_revalidate = true,
             "private" => p.is_private = true,
             "public" => p.is_public = true,
-            "max-age" => {
-                let max_age = match value {
-                    Some(v) => match v.parse::<u32>() {
-                        Ok(n) => Some(n),
-                        Err(_) => {
-                            warn!(target: targets::CACHE_CONTROL, value = v, "cache-control max-age has non-numeric value");
-                            return None;
-                        }
-                    },
-                    None => {
-                        warn!(target: targets::CACHE_CONTROL, "cache-control max-age is missing a value");
-
-                        return None;
-                    }
+            "must-revalidate" => p.must_revalidate = true,
+            "proxy-revalidate" => p.proxy_revalidate = true,
+            "must-understand" => p.must_understand = true,
+            "no-transform" => p.no_transform = true,
+            "immutable" => p.immutable = true,
+            "max-age" | "s-maxage" | "stale-while-revalidate" | "stale-if-error" => {
+                let Ok(n) = parse_u32(&token_lower, value) else {
+                    return Some(poison());
                 };
-                p.max_age = max_age;
+                match token_lower.as_str() {
+                    "max-age" => p.max_age = Some(n),
+                    "s-maxage" => p.s_maxage = Some(n),
+                    "stale-while-revalidate" => p.stale_while_revalidate = Some(n),
+                    _ => p.stale_if_error = Some(n),
+                }
             }
             v => {
-                // one invalid part is enough to stop parsing and discard the header
+                // a directive we don't model may be restrictive, so dropping the
+                // value would be unsecure - poison the merge instead
                 warn!(target: targets::CACHE_CONTROL, directive = v, "cache-control has unrecognized directive");
-                return None;
+                return Some(poison());
             }
         }
     }
@@ -92,14 +132,31 @@ fn merge_into(acc: &mut Option<CacheControl>, incoming: CacheControl) {
         return;
     }
 
+    // grants (public, immutable) hold only if every side grants them: AND.
+    // restrictions (must-revalidate & friends, no-transform) hold if any side asks: OR.
+    // durations (max-age & friends) take the shortest present value: min.
     existing.is_public = existing.is_public && incoming.is_public;
+    existing.immutable = existing.immutable && incoming.immutable;
     existing.must_revalidate = existing.must_revalidate || incoming.must_revalidate;
-    existing.max_age = match (existing.max_age, incoming.max_age) {
+    existing.proxy_revalidate = existing.proxy_revalidate || incoming.proxy_revalidate;
+    existing.must_understand = existing.must_understand || incoming.must_understand;
+    existing.no_transform = existing.no_transform || incoming.no_transform;
+    existing.max_age = min_opt(existing.max_age, incoming.max_age);
+    existing.s_maxage = min_opt(existing.s_maxage, incoming.s_maxage);
+    existing.stale_while_revalidate = min_opt(
+        existing.stale_while_revalidate,
+        incoming.stale_while_revalidate,
+    );
+    existing.stale_if_error = min_opt(existing.stale_if_error, incoming.stale_if_error);
+}
+
+// a side without the duration doesn't pull the min down, it just abstains
+fn min_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+    match (a, b) {
         (Some(a), Some(b)) => Some(a.min(b)),
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (None, None) => None,
-    };
+        (a, None) => a,
+        (None, b) => b,
+    }
 }
 
 fn to_header_value(p: &CacheControl) -> String {
@@ -117,8 +174,36 @@ fn to_header_value(p: &CacheControl) -> String {
         parts.push(format!("max-age={age}"));
     }
 
+    if let Some(age) = p.s_maxage {
+        parts.push(format!("s-maxage={age}"));
+    }
+
+    if let Some(age) = p.stale_while_revalidate {
+        parts.push(format!("stale-while-revalidate={age}"));
+    }
+
+    if let Some(age) = p.stale_if_error {
+        parts.push(format!("stale-if-error={age}"));
+    }
+
     if p.must_revalidate {
         parts.push("must-revalidate".to_string());
+    }
+
+    if p.proxy_revalidate {
+        parts.push("proxy-revalidate".to_string());
+    }
+
+    if p.must_understand {
+        parts.push("must-understand".to_string());
+    }
+
+    if p.no_transform {
+        parts.push("no-transform".to_string());
+    }
+
+    if p.immutable {
+        parts.push("immutable".to_string());
     }
 
     parts.join(", ")
@@ -151,17 +236,20 @@ fn to_header_value(p: &CacheControl) -> String {
 ///
 /// 1. Poison check - if any value contains `no-store`, `no-cache`, or `private`, the
 ///    accumulated result is immediately locked to `no-store, no-cache` and all remaining
-///    directives (`public`, `max-age`, `must-revalidate`) are discarded. Further
-///    incoming values cannot "un-poison" this state.
-/// 2. max-age - the minimum of all present `max-age` values is kept. A subgraph that
-///    omits `max-age` entirely does not pull the min down; it is simply ignored for
-///    this field, letting a shorter age set by another subgraph win.
-/// 3. public - preserved only when every subgraph that returned a response also sent
-///    `public`. A subgraph that returned bytes but omitted `Cache-Control` entirely is
-///    counted through `total_responses` (the number of all subgraphs whose response
-///    counts) and is enough to strip `public` from the result, because silence is
-///    not consent.
-/// 4. must-revalidate - set if any subgraph sets it (logical OR). Cleared on poison.
+///    directives are discarded. Further incoming values cannot "un-poison" this state.
+/// 2. Durations (`max-age`, `s-maxage`, `stale-while-revalidate`, `stale-if-error`) -
+///    the minimum of all present values is kept, per directive. A subgraph that omits
+///    a duration entirely does not pull the min down; it is simply ignored for that
+///    field, letting a shorter value set by another subgraph win.
+/// 3. Grants (`public`, `immutable`) - preserved only when every subgraph that
+///    returned a response also sent them. A subgraph that returned bytes but omitted
+///    `Cache-Control` entirely is counted through `total_responses` (the number of
+///    all subgraphs whose response counts) and is enough to strip the grant from the
+///    result, because silence is not consent.
+/// 4. Restrictions (`must-revalidate`, `proxy-revalidate`, `must-understand`,
+///    `no-transform`) - set if any subgraph sets them (logical OR). Cleared on poison.
+/// 5. A value with a malformed directive, or a directive the router does not model,
+///    is treated like poison (rule 1), since it may have been restrictive.
 ///
 /// The merged result is serialised back to a `HeaderValue` and re-inserted into the
 /// aggregator under `Last` strategy so that any subsequent header-flush loop sees
@@ -199,10 +287,12 @@ pub fn finalize(
     }
 
     if let Some(mut merged) = acc {
-        // a silent subgraph (no cache-control header at all) did not assert public,
-        // so public cannot hold when not every contacted subgraph sent it
+        // a silent subgraph (no cache-control header at all) did not assert public
+        // or immutable, so these grants cannot hold when not every contacted subgraph
+        // sent them
         if total_responses > values.len() {
             merged.is_public = false;
+            merged.immutable = false;
         }
         let serialized = to_header_value(&merged);
         // safety: to_header_value only produces ASCII
@@ -737,24 +827,129 @@ mod tests {
     }
 
     #[test]
-    fn finalize_unrecognized_value_removes_header() {
+    fn finalize_unrecognized_value_poisons() {
         let mut agg = make_aggregator(&["bogus-directive"]);
         finalize(&mut agg, false, 1);
-        assert_eq!(cc_value(&agg).as_deref(), None);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
     }
 
     #[test]
-    fn finalize_single_unrecognized_directive_removes_header() {
+    fn finalize_single_unrecognized_directive_poisons() {
         let mut agg = make_aggregator(&["public, max-age=300, huh"]);
         finalize(&mut agg, false, 1);
-        assert_eq!(cc_value(&agg).as_deref(), None);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
     }
 
     #[test]
-    fn finalize_malformed_max_age_removes_header() {
+    fn finalize_malformed_max_age_poisons() {
         let mut agg = make_aggregator(&["public, max-age=woof"]);
         finalize(&mut agg, false, 1);
-        assert_eq!(cc_value(&agg).as_deref(), None);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
+    }
+
+    // the exact #1172 scenario: no-store next to s-maxage, sibling says public -
+    // result must not be cacheable
+    #[test]
+    fn finalize_no_store_with_s_maxage_not_dropped() {
+        let mut agg = make_aggregator(&["no-store, s-maxage=0", "public, max-age=300"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
+    }
+
+    // standard directives are modeled and no longer poison a clean merge
+    #[test]
+    fn finalize_standard_directives_pass_through() {
+        let mut agg = make_aggregator(&[
+            "public, max-age=300, s-maxage=600, stale-while-revalidate=30, stale-if-error=60, no-transform, immutable",
+        ]);
+        finalize(&mut agg, false, 1);
+        assert_eq!(
+            cc_value(&agg).as_deref(),
+            Some("public, max-age=300, s-maxage=600, stale-while-revalidate=30, stale-if-error=60, no-transform, immutable")
+        );
+    }
+
+    // durations take the min across subgraphs, independently per directive
+    #[test]
+    fn finalize_durations_take_min() {
+        let mut agg = make_aggregator(&[
+            "s-maxage=600, stale-while-revalidate=10, stale-if-error=120",
+            "s-maxage=60, stale-while-revalidate=30, stale-if-error=15",
+        ]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(
+            cc_value(&agg).as_deref(),
+            Some("s-maxage=60, stale-while-revalidate=10, stale-if-error=15")
+        );
+    }
+
+    // a subgraph without a duration abstains instead of pulling the min down
+    #[test]
+    fn finalize_missing_duration_abstains() {
+        let mut agg = make_aggregator(&["s-maxage=600", "max-age=100"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("max-age=100, s-maxage=600"));
+    }
+
+    // restrictions are OR: one subgraph asking is enough
+    #[test]
+    fn finalize_restrictions_are_or() {
+        let mut agg = make_aggregator(&[
+            "max-age=100, no-transform",
+            "max-age=200, proxy-revalidate, must-understand",
+        ]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(
+            cc_value(&agg).as_deref(),
+            Some("max-age=100, proxy-revalidate, must-understand, no-transform")
+        );
+    }
+
+    // immutable is a grant: dropped unless every subgraph sends it
+    #[test]
+    fn finalize_immutable_requires_all() {
+        let mut agg = make_aggregator(&["max-age=100, immutable", "max-age=100"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("max-age=100"));
+
+        let mut agg = make_aggregator(&["max-age=100, immutable", "max-age=100, immutable"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("max-age=100, immutable"));
+    }
+
+    // a silent subgraph strips immutable, same as public
+    #[test]
+    fn finalize_immutable_stripped_when_silent_subgraph() {
+        let mut agg = make_aggregator(&["public, max-age=100, immutable"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("max-age=100"));
+    }
+
+    // poison clears the new fields too
+    #[test]
+    fn finalize_poison_clears_new_fields() {
+        let mut agg = make_aggregator(&[
+            "s-maxage=600, stale-while-revalidate=30, no-transform, immutable",
+            "private",
+        ]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
+    }
+
+    // malformed duration values on the new directives still poison
+    #[test]
+    fn finalize_malformed_s_maxage_poisons() {
+        let mut agg = make_aggregator(&["public, s-maxage=woof"]);
+        finalize(&mut agg, false, 1);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
+    }
+
+    // qualified no-cache/private forms are treated as the unqualified restrictive form
+    #[test]
+    fn finalize_qualified_no_cache_poisons() {
+        let mut agg = make_aggregator(&["no-cache=\"set-cookie\", max-age=300"]);
+        finalize(&mut agg, false, 1);
+        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
     }
 
     #[test]

--- a/bin/router/src/executor/headers/cache_control.rs
+++ b/bin/router/src/executor/headers/cache_control.rs
@@ -41,6 +41,7 @@ fn parse_u32(token: &str, value: Option<&str>) -> Result<u32, ()> {
     match value {
         Some(v) => v.parse::<u32>().map_err(|_| {
             warn!(
+                target: targets::CACHE_CONTROL,
                 directive = token,
                 value = v,
                 "cache-control directive has non-numeric value"
@@ -48,6 +49,7 @@ fn parse_u32(token: &str, value: Option<&str>) -> Result<u32, ()> {
         }),
         None => {
             warn!(
+                target: targets::CACHE_CONTROL,
                 directive = token,
                 "cache-control directive is missing a value"
             );

--- a/bin/router/src/executor/headers/cache_control.rs
+++ b/bin/router/src/executor/headers/cache_control.rs
@@ -117,13 +117,7 @@ fn merge_into(acc: &mut Option<CacheControl>, incoming: CacheControl) {
         return;
     };
 
-    if existing.no_store
-        || existing.no_cache
-        || existing.is_private
-        || incoming.no_store
-        || incoming.no_cache
-        || incoming.is_private
-    {
+    if existing.no_store || existing.no_cache || incoming.no_store || incoming.no_cache {
         *existing = CacheControl {
             no_store: true,
             no_cache: true,
@@ -135,14 +129,24 @@ fn merge_into(acc: &mut Option<CacheControl>, incoming: CacheControl) {
     // grants (public, immutable) hold only if every side grants them: AND.
     // restrictions (must-revalidate & friends, no-transform) hold if any side asks: OR.
     // durations (max-age & friends) take the shortest present value: min.
-    existing.is_public = existing.is_public && incoming.is_public;
+    existing.is_private = existing.is_private || incoming.is_private;
+    existing.is_public = existing.is_public && incoming.is_public && !existing.is_private;
     existing.immutable = existing.immutable && incoming.immutable;
     existing.must_revalidate = existing.must_revalidate || incoming.must_revalidate;
     existing.proxy_revalidate = existing.proxy_revalidate || incoming.proxy_revalidate;
     existing.must_understand = existing.must_understand || incoming.must_understand;
     existing.no_transform = existing.no_transform || incoming.no_transform;
+
+    let shared_max_age = min_opt(
+        existing.s_maxage.or(existing.max_age),
+        incoming.s_maxage.or(incoming.max_age),
+    );
+    let all_have_s_maxage = existing.s_maxage.is_some() && incoming.s_maxage.is_some();
     existing.max_age = min_opt(existing.max_age, incoming.max_age);
-    existing.s_maxage = min_opt(existing.s_maxage, incoming.s_maxage);
+    existing.s_maxage = all_have_s_maxage.then_some(shared_max_age).flatten();
+    if !all_have_s_maxage {
+        existing.max_age = min_opt(existing.max_age, shared_max_age);
+    }
     existing.stale_while_revalidate = min_opt(
         existing.stale_while_revalidate,
         incoming.stale_while_revalidate,
@@ -160,13 +164,15 @@ fn min_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
 }
 
 fn to_header_value(p: &CacheControl) -> String {
-    if p.no_store || p.no_cache || p.is_private {
+    if p.no_store || p.no_cache {
         return "no-store, no-cache".to_string();
     }
 
     let mut parts: Vec<String> = Vec::new();
 
-    if p.is_public {
+    if p.is_private {
+        parts.push("private".to_string());
+    } else if p.is_public {
         parts.push("public".to_string());
     }
 
@@ -234,21 +240,22 @@ fn to_header_value(p: &CacheControl) -> String {
 /// When `force_no_store` is `false` the raw string values stored in the aggregator are
 /// parsed and folded left-to-right with the following policy:
 ///
-/// 1. Poison check - if any value contains `no-store`, `no-cache`, or `private`, the
-///    accumulated result is immediately locked to `no-store, no-cache` and all remaining
-///    directives are discarded. Further incoming values cannot "un-poison" this state.
-/// 2. Durations (`max-age`, `s-maxage`, `stale-while-revalidate`, `stale-if-error`) -
-///    the minimum of all present values is kept, per directive. A subgraph that omits
-///    a duration entirely does not pull the min down; it is simply ignored for that
-///    field, letting a shorter value set by another subgraph win.
-/// 3. Grants (`public`, `immutable`) - preserved only when every subgraph that
+/// 1. Poison check - if any value contains `no-store` or `no-cache`, the accumulated
+///    result is immediately locked to `no-store, no-cache` and all remaining directives
+///    are discarded. Further incoming values cannot "un-poison" this state.
+/// 2. `private` - preserved if any subgraph sets it and overrides `public`. Other
+///    directives, including freshness lifetimes, are retained.
+/// 3. Durations (`max-age`, `s-maxage`, `stale-while-revalidate`, `stale-if-error`) -
+///    the minimum of all present values is kept. Because shared caches prefer `s-maxage`
+///    over `max-age`, mixed inputs are capped by their minimum effective shared lifetime.
+/// 4. Grants (`public`, `immutable`) - preserved only when every subgraph that
 ///    returned a response also sent them. A subgraph that returned bytes but omitted
 ///    `Cache-Control` entirely is counted through `total_responses` (the number of
 ///    all subgraphs whose response counts) and is enough to strip the grant from the
 ///    result, because silence is not consent.
-/// 4. Restrictions (`must-revalidate`, `proxy-revalidate`, `must-understand`,
+/// 5. Restrictions (`must-revalidate`, `proxy-revalidate`, `must-understand`,
 ///    `no-transform`) - set if any subgraph sets them (logical OR). Cleared on poison.
-/// 5. A value with a malformed directive, or a directive the router does not model,
+/// 6. A value with a malformed directive, or a directive the router does not model,
 ///    is treated like poison (rule 1), since it may have been restrictive.
 ///
 /// The merged result is serialised back to a `HeaderValue` and re-inserted into the
@@ -380,9 +387,9 @@ mod tests {
         assert!(!result.is_public);
     }
 
-    // incoming private poisons the result
+    // incoming private overrides public without preventing private caches from storing
     #[test]
-    fn incoming_private_poisons() {
+    fn incoming_private_is_preserved() {
         let result = merge(
             Some(CacheControl {
                 is_public: true,
@@ -391,13 +398,15 @@ mod tests {
             }),
             CacheControl {
                 is_private: true,
+                max_age: Some(50),
                 ..Default::default()
             },
         );
-        assert!(result.no_store);
-        assert!(result.no_cache);
+        assert!(!result.no_store);
+        assert!(!result.no_cache);
         assert!(!result.is_public);
-        assert!(!result.is_private); // private is cleared, only no-store/no-cache remain
+        assert!(result.is_private);
+        assert_eq!(result.max_age, Some(50));
     }
 
     // existing no_store poisons even with a clean incoming
@@ -419,9 +428,9 @@ mod tests {
         assert!(!result.is_public);
     }
 
-    // existing private poisons even with a clean incoming
+    // existing private remains private when merged with a public response
     #[test]
-    fn existing_private_poisons() {
+    fn existing_private_is_preserved() {
         let result = merge(
             Some(CacheControl {
                 is_private: true,
@@ -433,8 +442,10 @@ mod tests {
                 ..Default::default()
             },
         );
-        assert!(result.no_store);
-        assert!(result.no_cache);
+        assert!(!result.no_store);
+        assert!(!result.no_cache);
+        assert!(result.is_private);
+        assert!(!result.is_public);
     }
 
     // both no_store: result is no_store, no_cache
@@ -791,10 +802,17 @@ mod tests {
     }
 
     #[test]
-    fn finalize_private_collapses_to_no_store() {
+    fn finalize_private_is_preserved() {
         let mut agg = make_aggregator(&["private"]);
         finalize(&mut agg, false, 1);
-        assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));
+        assert_eq!(cc_value(&agg).as_deref(), Some("private"));
+    }
+
+    #[test]
+    fn finalize_user_requirement_private_overrides_public_and_keeps_min_age() {
+        let mut agg = make_aggregator(&["public, max-age=100", "private, max-age=50"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("private, max-age=50"));
     }
 
     #[test]
@@ -869,6 +887,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn finalize_user_requirement_s_maxage_takes_min() {
+        let mut agg = make_aggregator(&["public, s-maxage=100", "public, s-maxage=20"]);
+        finalize(&mut agg, false, 2);
+        assert_eq!(cc_value(&agg).as_deref(), Some("public, s-maxage=20"));
+    }
+
     // durations take the min across subgraphs, independently per directive
     #[test]
     fn finalize_durations_take_min() {
@@ -883,12 +908,12 @@ mod tests {
         );
     }
 
-    // a subgraph without a duration abstains instead of pulling the min down
+    // shared caches prefer s-maxage, so mixed inputs use the lower effective lifetime
     #[test]
-    fn finalize_missing_duration_abstains() {
+    fn finalize_mixed_max_age_and_s_maxage_take_shared_min() {
         let mut agg = make_aggregator(&["s-maxage=600", "max-age=100"]);
         finalize(&mut agg, false, 2);
-        assert_eq!(cc_value(&agg).as_deref(), Some("max-age=100, s-maxage=600"));
+        assert_eq!(cc_value(&agg).as_deref(), Some("max-age=100"));
     }
 
     // restrictions are OR: one subgraph asking is enough
@@ -930,7 +955,7 @@ mod tests {
     fn finalize_poison_clears_new_fields() {
         let mut agg = make_aggregator(&[
             "s-maxage=600, stale-while-revalidate=30, no-transform, immutable",
-            "private",
+            "no-store",
         ]);
         finalize(&mut agg, false, 2);
         assert_eq!(cc_value(&agg).as_deref(), Some("no-store, no-cache"));


### PR DESCRIPTION
Relates to #1373

The router now preserves and safely merges standard `Cache-Control` directives instead of discarding an entire subgraph value when it contains a directive that was not previously modeled. This prevents restrictions such as `no-store` or `private` from being lost when they appear alongside another standard directive.

The merge now supports `s-maxage`, `stale-while-revalidate`, and `stale-if-error` by selecting the minimum applicable duration. `s-maxage` is merged with awareness that shared caches prefer it over `max-age`, so mixed directives cannot extend the effective shared-cache lifetime.

`private` now overrides `public` without being escalated to `no-store, no-cache`. Other directives are retained, allowing results such as `private, max-age=50` to remain available to private caches while still preventing shared-cache storage.

The router also preserves `proxy-revalidate`, `must-understand`, and `no-transform` when any subgraph sets them. `immutable` is preserved only when every subgraph sets it, like `public`. Qualified `no-cache="field"` and `private="field"` forms are treated as their more restrictive unqualified forms.

Unknown directives, missing or non-numeric duration values, and other malformed directives now conservatively produce `no-store, no-cache` instead of allowing the affected subgraph value to be ignored.